### PR TITLE
Fix snooze+roll ladder bug causing incorrect die after rating

### DIFF
--- a/comic_pile/session.py
+++ b/comic_pile/session.py
@@ -186,9 +186,6 @@ def get_current_die(session_id: int, db: Session) -> int:
     start_die = _start_die()
     session = db.get(SessionModel, session_id)
 
-    if session and session.manual_die:
-        return session.manual_die
-
     last_rate_event = (
         db.execute(
             select(Event)
@@ -204,5 +201,8 @@ def get_current_die(session_id: int, db: Session) -> int:
     if last_rate_event:
         die_after = last_rate_event.die_after
         return die_after if die_after is not None else start_die
+
+    if session and session.manual_die:
+        return session.manual_die
 
     return session.start_die if session else start_die

--- a/tests/test_snooze_ladder_bug.py
+++ b/tests/test_snooze_ladder_bug.py
@@ -1,0 +1,142 @@
+"""Test for snooze + roll ladder bug.
+
+Reproduces the issue where multiple snooze operations followed by a rating
+cause incorrect die ladder behavior due to manual_die not being cleared.
+"""
+
+from datetime import UTC, datetime
+from sqlalchemy import select
+
+from app.models import Thread
+from app.models import Session as SessionModel
+from comic_pile.dice_ladder import step_down, step_up
+
+
+async def test_multiple_snooze_then_rate(auth_client, db, default_user):
+    """Reproduce bug: multiple snoozes followed by rating causes incorrect die.
+
+    Based on user's session log:
+    - Start at d6
+    - Roll and snooze (should step up to d8)
+    - Roll and snooze (should step up to d10)
+    - Roll and snooze (should step up to d12)
+    - Roll and snooze (should step up to d20)
+    - Roll and snooze (should stay at d20, max)
+    - Roll and rate 4.0/5.0 (should step down to d12)
+
+    Expected ladder path: 6 → 8 → 10 → 12 → 20 → 20 → 12
+    But due to bug, goes to: 6 → 4 (incorrect)
+    """
+    now = datetime.now(UTC)
+
+    threads = [
+        Thread(
+            title="Superman: All Star Superman",
+            format="Comic",
+            issues_remaining=5,
+            queue_position=1,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        ),
+        Thread(
+            title="Wolverine: Larry Hama run",
+            format="Comic",
+            issues_remaining=4,
+            queue_position=2,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        ),
+        Thread(
+            title="Starman: James Robison and Starman related comics",
+            format="Comic",
+            issues_remaining=3,
+            queue_position=3,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        ),
+        Thread(
+            title="Micronauts: Michael golden run",
+            format="Comic",
+            issues_remaining=4,
+            queue_position=4,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        ),
+        Thread(
+            title="Doom patrol",
+            format="Comic",
+            issues_remaining=3,
+            queue_position=5,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        ),
+        Thread(
+            title="conan saga: Conan readthrough",
+            format="Comic",
+            issues_remaining=4,
+            queue_position=6,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        ),
+    ]
+
+    for thread in threads:
+        db.add(thread)
+    db.commit()
+
+    first_roll = await auth_client.post("/api/roll/")
+    assert first_roll.status_code == 200
+
+    session = (
+        db.execute(select(SessionModel).where(SessionModel.user_id == default_user.id))
+        .scalars()
+        .first()
+    )
+    assert session is not None
+    assert session.start_die == 6
+
+    expected_dies = [6]
+
+    for i, _thread in enumerate(threads[:6]):
+        roll_response = await auth_client.post("/api/roll/")
+        assert roll_response.status_code == 200
+
+        if i < 5:
+            snooze_response = await auth_client.post("/api/snooze/")
+            assert snooze_response.status_code == 200
+            snooze_data = snooze_response.json()
+
+            current_die = snooze_data["current_die"]
+            expected_die = step_up(expected_dies[-1])
+            expected_dies.append(expected_die)
+
+            assert current_die == expected_die, (
+                f"After snooze #{i + 1}, expected die d{expected_die}, got d{current_die}"
+            )
+
+    final_roll_response = await auth_client.post("/api/roll/")
+    assert final_roll_response.status_code == 200
+
+    rate_response = await auth_client.post(
+        "/api/rate/",
+        json={"rating": 4.0, "issues_read": 1, "finish_session": False},
+    )
+    assert rate_response.status_code == 200
+
+    session_after_rate = await auth_client.get("/api/sessions/current/")
+    assert session_after_rate.status_code == 200
+    rated_data = session_after_rate.json()
+
+    expected_final_die = step_down(20)
+    actual_final_die = rated_data["current_die"]
+
+    assert actual_final_die == expected_final_die, (
+        f"After rating 4.0/5.0 from d20, expected die d{expected_final_die}, "
+        f"got d{actual_final_die}. Expected ladder path: {' → '.join(str(d) for d in expected_dies)} → {expected_final_die}"
+    )


### PR DESCRIPTION
Root cause: Both snooze and rate operations were setting manual_die, but get_current_die() prioritized manual_die over rate events. This caused rating to revert to an earlier die state instead of stepping correctly.

Fixes:
- Removed manual_die assignment from rate endpoint (rate.py:165)
- Changed rate endpoint to use get_current_die() instead of manual lookup
- Modified get_current_die() to prioritize rate event's die_after over manual_die
- Snooze operations still set manual_die (no rate event for snooze)

Test coverage:
- Added test_snooze_ladder_bug.py reproducing user's exact scenario
- Updated test_rate_api.py expectations for new behavior

Example scenario now works correctly:
- Start d6 → snooze 5x → d20 → rate 4.0/5.0 → d12 (was d4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected die progression calculation when rating items to ensure accurate ladder stepping.
  * Fixed snooze and roll ladder progression bug.

* **Tests**
  * Updated test coverage for rating mechanics and die transitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->