### PR TITLE
Update rating actions to remove finish-session button

### DIFF
--- a/frontend/src/pages/RollPage.jsx
+++ b/frontend/src/pages/RollPage.jsx
@@ -261,6 +261,8 @@ export default function RollPage() {
       await refetchThreads();
       setIsRatingView(false);
       setRolledResult(null);
+      setSelectedThreadId(null);
+      setActiveRatingThread(null);
     } catch (error) {
       setErrorMessage(error.response?.data?.detail || 'Failed to snooze thread');
     }

--- a/frontend/src/unit/RollPage.test.jsx
+++ b/frontend/src/unit/RollPage.test.jsx
@@ -533,6 +533,7 @@ describe('Rating View', () => {
     await user.click(screen.getByText('Read Now'))
 
     expect(screen.queryByText('Save & Finish Session')).not.toBeInTheDocument()
+    expect(screen.getByText('Snooze')).toBeInTheDocument()
     expect(mockRate).not.toHaveBeenCalled()
   })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Snooze action button to pause sessions; triggers a reset of the selected thread and active rating when used.

* **UI Updates**
  * Removed the "Save & Finish Session" action from the roll page.
  * Updated action button labels and pending states (e.g., "Snoozing..." / "Saving...").
  * Refined button styles and layout, consolidating Snooze into the main action area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->