### PR TITLE
Fix dice animation not playing on consecutive rolls

### DIFF
--- a/frontend/src/pages/RollPage.jsx
+++ b/frontend/src/pages/RollPage.jsx
@@ -413,6 +413,7 @@ export default function RollPage() {
       });
 
       suppressPendingAutoOpenRef.current = true
+      setIsRolling(false)
       setIsRatingView(false);
       setRolledResult(null);
       setSelectedThreadId(null);
@@ -437,6 +438,7 @@ export default function RollPage() {
       await snoozeMutation.mutate();
       await refetchSession();
       await refetchThreads();
+      setIsRolling(false)
       setIsRatingView(false);
       setRolledResult(null);
       setSelectedThreadId(null);

--- a/frontend/src/test/roll.spec.ts
+++ b/frontend/src/test/roll.spec.ts
@@ -169,4 +169,29 @@ test.describe('Roll Dice Feature', () => {
     await expect(authenticatedWithThreadsPage.locator(SELECTORS.rate.ratingInput)).toBeVisible({ timeout: 2000 });
     expect(new URL(authenticatedWithThreadsPage.url()).pathname).toBe('/');
   });
+
+  test('regression: animation should play on consecutive rolls after rating', async ({ authenticatedWithThreadsPage }) => {
+    await authenticatedWithThreadsPage.goto('/');
+    await authenticatedWithThreadsPage.waitForSelector(SELECTORS.roll.mainDie, { timeout: 10000 });
+
+    // First roll
+    await authenticatedWithThreadsPage.click(SELECTORS.roll.mainDie);
+    await expect(authenticatedWithThreadsPage.locator(SELECTORS.rate.ratingInput)).toBeVisible({ timeout: 5000 });
+
+    // Submit rating to return to roll view
+    await authenticatedWithThreadsPage.fill(SELECTORS.rate.ratingInput, '5');
+    await authenticatedWithThreadsPage.click(SELECTORS.rate.submitButton);
+
+    // Wait to return to roll view
+    await expect(authenticatedWithThreadsPage.locator(SELECTORS.roll.mainDie)).toBeVisible({ timeout: 5000 });
+
+    // Second roll (same denomination) - animation should play
+    await authenticatedWithThreadsPage.click(SELECTORS.roll.mainDie);
+
+    // Verify rating view appears (means animation played and roll succeeded)
+    await expect(authenticatedWithThreadsPage.locator(SELECTORS.rate.ratingInput)).toBeVisible({ timeout: 5000 });
+
+    // Verify still on home page (not redirected)
+    expect(new URL(authenticatedWithThreadsPage.url()).pathname).toBe('/');
+  });
 });


### PR DESCRIPTION
## Bug Fix

Fixed an issue where rolling the same dice denomination twice in a row would not show the animation on the second roll.

## Root Cause

The `isRolling` state was not being reset when returning from the rating view or after snoozing a thread. This prevented the Dice3D component from detecting the state change needed to trigger the animation on subsequent rolls.

## Changes

- Added `setIsRolling(false)` to `handleSubmitRating()` function
- Added `setIsRolling(false)` to `handleSnooze()` function

This ensures the dice animation state is properly reset when returning to the roll view, allowing animations to play correctly on consecutive rolls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rolling/loading indicator remaining active after submitting ratings and refreshing session data; the indicator now resets so visual state reflects completion.

* **Tests**
  * Added a regression test to ensure animations and roll flow work correctly on consecutive rolls after submitting a rating, preventing unintended navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->