### PR TITLE
Fix consecutive same-die rolls skipping animation

### DIFF
--- a/frontend/src/pages/RollPage.jsx
+++ b/frontend/src/pages/RollPage.jsx
@@ -489,7 +489,7 @@ export default function RollPage() {
 
   function handleRoll() {
     if (isRolling) return
-    if (session?.pending_thread_id) {
+    if (session?.pending_thread_id && !suppressPendingAutoOpenRef.current) {
       const pendingId = Number(session.pending_thread_id)
       const pendingMetadata =
         session?.active_thread && session.active_thread.id === pendingId


### PR DESCRIPTION
## Summary
- After Save & Continue, clicking Roll again with the same die skipped the spin animation and jumped straight to the rating view
- Root cause: `handleRoll()` fast-pathed through `session.pending_thread_id` without checking `suppressPendingAutoOpenRef`
- One-line fix: add `&& !suppressPendingAutoOpenRef.current` to the fast-path condition

## Test plan
- [ ] Roll d4, rate, Save & Continue, roll d4 again — animation should play on every roll

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed automatic pending thread opening to properly respect suppression state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->