### PR TITLE
Fix roll→rate sequencing and remove post-rate auto-pending

### DIFF
--- a/app/api/rate.py
+++ b/app/api/rate.py
@@ -18,7 +18,7 @@ from app.schemas import RateRequest, ThreadResponse
 from app.api.thread import thread_to_response
 from comic_pile.dependencies import refresh_user_blocked_status
 from comic_pile.dice_ladder import step_down, step_up
-from comic_pile.queue import get_roll_pool, move_to_back, move_to_front
+from comic_pile.queue import move_to_back, move_to_front
 from comic_pile.session import get_current_die
 
 router = APIRouter()
@@ -177,13 +177,16 @@ async def rate_thread(
         result = await db.execute(
             select(Event)
             .where(Event.session_id == current_session_id)
-            .where(Event.type == "roll")
-            .where(Event.selected_thread_id.is_not(None))
-            .order_by(Event.timestamp.desc())
+            .where(Event.type.in_(["roll", "rate", "snooze", "rolled_but_skipped"]))
+            .order_by(Event.timestamp.desc(), Event.id.desc())
         )
-        last_roll_event = result.scalars().first()
+        latest_action_event = result.scalars().first()
 
-        if not last_roll_event:
+        if (
+            not latest_action_event
+            or latest_action_event.type != "roll"
+            or latest_action_event.selected_thread_id is None
+        ):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="No active thread. Please roll the dice first.",
@@ -191,14 +194,14 @@ async def rate_thread(
 
         result = await db.execute(
             select(Thread)
-            .where(Thread.id == last_roll_event.selected_thread_id)
+            .where(Thread.id == latest_action_event.selected_thread_id)
             .where(Thread.user_id == user_id)
         )
         thread = result.scalar_one_or_none()
         if not thread:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Thread {last_roll_event.selected_thread_id} not found",
+                detail=f"Thread {latest_action_event.selected_thread_id} not found",
             )
     thread_id = thread.id
 
@@ -304,22 +307,8 @@ async def rate_thread(
     if clear_cache:
         clear_cache()
 
-    if rate_data.finish_session:
-        current_session.pending_thread_id = None
-        current_session.pending_thread_updated_at = None
-    else:
-        snoozed_ids = current_session.snoozed_thread_ids or []
-        roll_pool = await get_roll_pool(user_id, db, snoozed_ids)
-
-        next_pending_thread_id = next(
-            (candidate.id for candidate in roll_pool if candidate.id != thread_id),
-            roll_pool[0].id if roll_pool else None,
-        )
-
-        current_session.pending_thread_id = next_pending_thread_id
-        current_session.pending_thread_updated_at = (
-            datetime.now(UTC) if next_pending_thread_id is not None else None
-        )
+    current_session.pending_thread_id = None
+    current_session.pending_thread_updated_at = None
 
     await db.flush()
     await db.refresh(event)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -8,6 +8,7 @@ This index provides a comprehensive map of all documentation in the comic-pile p
 - [CONTRIBUTING.md](../CONTRIBUTING.md) — Development workflow, code quality standards, and testing guidelines.
 - [LOCAL_TESTING.md](../LOCAL_TESTING.md) — Local test environment setup with sample data and fixtures.
 - [FEATURES_SINCE_0cd5a462.md](FEATURES_SINCE_0cd5a462.md) — How to use new app features added after commit `0cd5a462ef405f96f591ec31abb66531a1e99a9e`.
+- [changelog.md](changelog.md) — User-facing behavior changes and migration notes.
 
 ## Architecture & Design
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 2026-03-03
+
+- Roll/rate sequencing fix: `Save & Continue` no longer auto-selects a new pending thread.
+- After a successful rate with `finish_session=false`, the session returns to roll state with
+  `pending_thread_id=null`.
+- Users must perform a new roll (or explicitly set pending) before submitting another rating.

--- a/frontend/src/pages/RollPage.tsx
+++ b/frontend/src/pages/RollPage.tsx
@@ -558,10 +558,10 @@ export default function RollPage() {
       return
     }
 
-    // After Save & Continue the backend pre-selects a pending thread.
-    // Dismiss it so the roll API can produce a fresh random result.
-    const needsDismiss = suppressPendingAutoOpenRef.current && session?.pending_thread_id
-    if (needsDismiss) {
+    // Ignore stale pending state once immediately after Save & Continue.
+    // The backend clears pending now, so this only guards against stale client session data.
+    const ignorePendingOnce = suppressPendingAutoOpenRef.current && session?.pending_thread_id
+    if (ignorePendingOnce) {
       suppressPendingAutoOpenRef.current = false
     }
 
@@ -588,9 +588,6 @@ export default function RollPage() {
         rollTimeoutRef.current = setTimeout(async () => {
           rollTimeoutRef.current = null
           try {
-            if (needsDismiss) {
-              await dismissPendingMutation.mutate()
-            }
             const response = await rollMutation.mutate()
             enterRatingView(response.thread_id, response.result, response)
             setIsRolling(false)

--- a/frontend/src/test/prod-smoke.spec.ts
+++ b/frontend/src/test/prod-smoke.spec.ts
@@ -120,7 +120,7 @@ test.describe('Production Smoke', () => {
     expect(chunkFailures, `Chunk load failures: ${chunkFailures.join(', ')}`).toEqual([]);
   });
 
-  test('roll, rate, save and continue routes back to roll view (existing prod user)', async ({
+  test('roll, rate, save and continue clears pending and returns to roll view (existing prod user)', async ({
     page,
   }) => {
     const health = await page.request.get('/health');
@@ -148,6 +148,14 @@ test.describe('Production Smoke', () => {
     await page.click(SELECTORS.rate.submitButton);
     await page.waitForURL('**/', { timeout: 10000 });
     await expect(page.locator(SELECTORS.roll.mainDie)).toBeVisible();
+    await expect(page.locator(SELECTORS.rate.ratingInput)).toHaveCount(0);
+
+    const currentSession = await page.request.get('/api/sessions/current/', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(currentSession.ok()).toBeTruthy();
+    const sessionData = await currentSession.json();
+    expect(sessionData.pending_thread_id).toBeNull();
   });
 
   test('leave and return to / before submit keeps same active thread (existing prod user)', async ({

--- a/frontend/src/test/rate.spec.ts
+++ b/frontend/src/test/rate.spec.ts
@@ -41,18 +41,26 @@ test.describe('Rate Thread Feature', () => {
       authenticatedWithThreadsPage.click(SELECTORS.rate.submitButton),
     ]);
     await authenticatedWithThreadsPage.waitForLoadState('networkidle');
-    // Wait a bit for UI to update
-    await authenticatedWithThreadsPage.waitForTimeout(500);
+    await expect(authenticatedWithThreadsPage.locator(SELECTORS.roll.mainDie)).toBeVisible();
+    await expect(authenticatedWithThreadsPage.locator(SELECTORS.rate.ratingInput)).toHaveCount(0);
+  });
 
-    const stillRating = await authenticatedWithThreadsPage
-      .locator(SELECTORS.rate.ratingInput)
-      .isVisible()
-      .catch(() => false);
-    const backToRoll = await authenticatedWithThreadsPage
-      .locator(SELECTORS.roll.mainDie)
-      .isVisible()
-      .catch(() => false);
-    expect(stillRating || backToRoll).toBeTruthy();
+  test('should require rolling again before rating again after save and continue', async ({ authenticatedWithThreadsPage }) => {
+    await setRangeInput(authenticatedWithThreadsPage, SELECTORS.rate.ratingInput, '4.0');
+    await Promise.all([
+      authenticatedWithThreadsPage.waitForResponse((response) =>
+        response.url().includes('/api/rate/') && response.request().method() === 'POST'
+      ),
+      authenticatedWithThreadsPage.click(SELECTORS.rate.submitButton),
+    ]);
+    await authenticatedWithThreadsPage.waitForLoadState('networkidle');
+    await expect(authenticatedWithThreadsPage.locator(SELECTORS.roll.mainDie)).toBeVisible();
+    await expect(authenticatedWithThreadsPage.locator(SELECTORS.rate.ratingInput)).toHaveCount(0);
+    await authenticatedWithThreadsPage.waitForTimeout(1000);
+    await expect(authenticatedWithThreadsPage.locator(SELECTORS.rate.ratingInput)).toHaveCount(0);
+
+    await authenticatedWithThreadsPage.click(SELECTORS.roll.mainDie);
+    await expect(authenticatedWithThreadsPage.locator(SELECTORS.rate.ratingInput)).toBeVisible();
   });
 
   test('should keep the same active thread when leaving and returning home before submit', async ({ authenticatedWithThreadsPage }) => {

--- a/tests/test_rate_api.py
+++ b/tests/test_rate_api.py
@@ -774,10 +774,10 @@ async def test_rate_final_issue_completes_thread_but_keeps_session_active(
 
 
 @pytest.mark.asyncio
-async def test_rate_auto_advance_skips_nonpositive_queue_positions(
+async def test_rate_save_and_continue_clears_pending_thread(
     auth_client: AsyncClient, async_db: AsyncSession
 ) -> None:
-    """Auto-advance should only select active threads with queue_position >= 1."""
+    """Save & Continue should clear pending instead of auto-advancing to another thread."""
     from tests.conftest import get_or_create_user_async
 
     user = await get_or_create_user_async(async_db)
@@ -803,18 +803,22 @@ async def test_rate_auto_advance_skips_nonpositive_queue_positions(
         status="active",
         user_id=user.id,
     )
-    next_thread = Thread(
-        title="Next Thread",
-        format="Comic",
-        issues_remaining=5,
-        queue_position=2,
-        status="active",
-        user_id=user.id,
+    async_db.add_all(
+        [
+            rated_thread,
+            skipped_thread,
+            Thread(
+                title="Next Thread",
+                format="Comic",
+                issues_remaining=5,
+                queue_position=2,
+                status="active",
+                user_id=user.id,
+            ),
+        ]
     )
-    async_db.add_all([rated_thread, skipped_thread, next_thread])
     await async_db.commit()
     await async_db.refresh(rated_thread)
-    await async_db.refresh(next_thread)
 
     roll_event = Event(
         type="roll",
@@ -833,9 +837,72 @@ async def test_rate_auto_advance_skips_nonpositive_queue_positions(
     )
     assert response.status_code == 200
 
-    # After rating, auto-advance should select the next eligible thread (queue_position >= 1).
     await async_db.refresh(session)
-    assert session.pending_thread_id == next_thread.id
+    assert session.pending_thread_id is None
+    assert session.pending_thread_updated_at is None
+
+
+@pytest.mark.asyncio
+async def test_rate_requires_new_roll_before_second_rating(
+    auth_client: AsyncClient, async_db: AsyncSession
+) -> None:
+    """Regression: roll(A)->rate(A) must not allow rating again without a fresh roll."""
+    from tests.conftest import get_or_create_user_async
+
+    user = await get_or_create_user_async(async_db)
+
+    session = SessionModel(start_die=10, user_id=user.id)
+    async_db.add(session)
+    await async_db.commit()
+    await async_db.refresh(session)
+
+    rated_thread = Thread(
+        title="Rated Thread",
+        format="Comic",
+        issues_remaining=5,
+        queue_position=1,
+        status="active",
+        user_id=user.id,
+    )
+    other_thread = Thread(
+        title="Other Thread",
+        format="Comic",
+        issues_remaining=5,
+        queue_position=2,
+        status="active",
+        user_id=user.id,
+    )
+    async_db.add_all([rated_thread, other_thread])
+    await async_db.commit()
+    await async_db.refresh(rated_thread)
+
+    session.pending_thread_id = rated_thread.id
+    roll_event = Event(
+        type="roll",
+        die=10,
+        result=1,
+        selected_thread_id=rated_thread.id,
+        session_id=session.id,
+        thread_id=rated_thread.id,
+    )
+    async_db.add(roll_event)
+    await async_db.commit()
+
+    first_rate = await auth_client.post(
+        "/api/rate/",
+        json={"rating": 4.0, "issues_read": 1, "finish_session": False},
+    )
+    assert first_rate.status_code == 200
+
+    await async_db.refresh(session)
+    assert session.pending_thread_id is None
+
+    second_rate = await auth_client.post(
+        "/api/rate/",
+        json={"rating": 4.0, "issues_read": 1, "finish_session": False},
+    )
+    assert second_rate.status_code == 400
+    assert "No active thread" in second_rate.json()["detail"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_rate_page.py
+++ b/tests/test_rate_page.py
@@ -470,10 +470,10 @@ async def test_rate_api_with_max_rating(auth_client: AsyncClient, async_db: Asyn
 
 
 @pytest.mark.asyncio
-async def test_rate_api_sets_pending_thread_to_next(
+async def test_rate_api_save_and_continue_clears_pending_thread(
     auth_client: AsyncClient, async_db: AsyncSession
 ) -> None:
-    """POST /rate/ sets pending_thread_id to next thread when threads remain after rating."""
+    """POST /rate/ with finish_session=False clears pending_thread_id after rating."""
     from tests.conftest import get_or_create_user_async
 
     user = await get_or_create_user_async(async_db)
@@ -520,16 +520,19 @@ async def test_rate_api_sets_pending_thread_to_next(
     response = await auth_client.post("/api/rate/", json={"rating": 4.0})
     assert response.status_code == 200
 
+    await async_db.refresh(thread2)
+    assert thread2.issues_remaining == 3
+
     await async_db.refresh(session)
-    assert session.pending_thread_id is not None
-    assert session.pending_thread_id != thread1.id
+    assert session.pending_thread_id is None
+    assert session.pending_thread_updated_at is None
 
 
 @pytest.mark.asyncio
-async def test_rate_api_redirects_pending_thread_to_next_available(
+async def test_rate_api_completed_thread_still_clears_pending_thread(
     auth_client: AsyncClient, async_db: AsyncSession
 ) -> None:
-    """POST /rate/ redirects pending_thread_id to next thread when one remains."""
+    """Completing a thread via rate still clears pending_thread_id after Save & Continue."""
     from tests.conftest import get_or_create_user_async
 
     user = await get_or_create_user_async(async_db)
@@ -577,15 +580,19 @@ async def test_rate_api_redirects_pending_thread_to_next_available(
     response = await auth_client.post("/api/rate/", json={"rating": 4.0})
     assert response.status_code == 200
 
+    await async_db.refresh(thread2)
+    assert thread2.issues_remaining == 5
+
     await async_db.refresh(session)
-    assert session.pending_thread_id == thread2.id
+    assert session.pending_thread_id is None
+    assert session.pending_thread_updated_at is None
 
 
 @pytest.mark.asyncio
-async def test_rate_api_sets_pending_thread_to_next_available(
+async def test_rate_api_with_multiple_threads_keeps_pending_cleared(
     auth_client: AsyncClient, async_db: AsyncSession
 ) -> None:
-    """POST /rate/ sets pending_thread_id to next available thread when multiple threads exist."""
+    """POST /rate/ should not auto-select a next thread even when multiple threads exist."""
     from tests.conftest import get_or_create_user_async
 
     user = await get_or_create_user_async(async_db)
@@ -633,9 +640,12 @@ async def test_rate_api_sets_pending_thread_to_next_available(
     response = await auth_client.post("/api/rate/", json={"rating": 4.0})
     assert response.status_code == 200
 
+    await async_db.refresh(thread2)
+    assert thread2.issues_remaining == 5
+
     await async_db.refresh(session)
-    assert session.pending_thread_id is not None
-    assert session.pending_thread_id != thread1.id
+    assert session.pending_thread_id is None
+    assert session.pending_thread_updated_at is None
 
 
 @pytest.mark.asyncio
@@ -739,6 +749,9 @@ async def test_rate_api_no_pending_thread_when_finish_session(
         json={"rating": 4.0, "finish_session": True},
     )
 
+    await async_db.refresh(thread2)
+    assert thread2.issues_remaining == 5
+
     await async_db.refresh(session)
     assert session.pending_thread_id is None
     assert session.pending_thread_updated_at is None
@@ -746,10 +759,10 @@ async def test_rate_api_no_pending_thread_when_finish_session(
 
 
 @pytest.mark.asyncio
-async def test_rate_api_sets_pending_thread_when_not_finish_session(
+async def test_rate_api_save_and_continue_does_not_set_pending_thread(
     auth_client: AsyncClient, async_db: AsyncSession
 ) -> None:
-    """POST /rate/ with finish_session=False sets pending_thread_id to next thread."""
+    """POST /rate/ with finish_session=False leaves session without pending thread."""
     from tests.conftest import get_or_create_user_async
 
     user = await get_or_create_user_async(async_db)
@@ -798,6 +811,9 @@ async def test_rate_api_sets_pending_thread_when_not_finish_session(
         json={"rating": 4.0, "finish_session": False},
     )
 
+    await async_db.refresh(thread2)
+    assert thread2.issues_remaining == 5
+
     await async_db.refresh(session)
-    assert session.pending_thread_id is not None
-    assert session.pending_thread_updated_at is not None
+    assert session.pending_thread_id is None
+    assert session.pending_thread_updated_at is None

--- a/tests/test_rate_ui.py
+++ b/tests/test_rate_ui.py
@@ -78,7 +78,7 @@ async def test_both_buttons_available_when_thread_complete(
 async def test_can_still_rate_after_thread_complete(
     auth_client: AsyncClient, async_db: AsyncSession
 ) -> None:
-    """After one thread completes, pending next thread can be resolved and rolled."""
+    """After one thread completes, user must roll again before rating another thread."""
     # Create user
     from tests.conftest import get_or_create_user_async
 
@@ -142,19 +142,12 @@ async def test_can_still_rate_after_thread_complete(
     await async_db.refresh(session)
     assert session.ended_at is None
 
-    # Backend auto-advances a pending thread. Confirm next thread is pending.
+    # Save & Continue should leave no pending thread selected.
     current_session_response = await auth_client.get("/api/sessions/current/")
     assert current_session_response.status_code == 200
-    assert current_session_response.json()["pending_thread_id"] == thread2.id
+    assert current_session_response.json()["pending_thread_id"] is None
 
-    # Rolling is blocked while pending exists.
-    blocked_roll = await auth_client.post("/api/roll/")
-    assert blocked_roll.status_code == 409
-
-    # After dismissing pending state, rolling should select thread2.
-    dismiss_response = await auth_client.post("/api/roll/dismiss-pending")
-    assert dismiss_response.status_code == 204
-
+    # User can roll again immediately.
     roll_response = await auth_client.post("/api/roll/")
     assert roll_response.status_code == 200
     data = roll_response.json()

--- a/tests/test_roll_rate_flow.py
+++ b/tests/test_roll_rate_flow.py
@@ -84,8 +84,16 @@ async def test_roll_rate_history_consistency(
 
     expected_die = step_down(roll_data["die_size"])
     assert rated_data["current_die"] == expected_die
-    
-    # After rating, backend preselects the next available thread.
-    assert rated_data["active_thread"] is not None
-    assert rated_data["active_thread"]["id"] != roll_data["thread_id"]
+
+    # After rating with Save & Continue, no new pending target is auto-selected.
+    assert rated_data["pending_thread_id"] is None
+    assert rated_data["active_thread"] is None
     assert rated_data["last_rolled_result"] is None
+
+    # Regression check: rating again without a new roll is blocked.
+    second_rate = await auth_client.post(
+        "/api/rate/",
+        json={"rating": 4.5, "issues_read": 1, "finish_session": False},
+    )
+    assert second_rate.status_code == 400
+    assert "No active thread" in second_rate.json()["detail"]


### PR DESCRIPTION
## Summary
- remove post-rate auto-advance in `POST /api/rate/`; pending is now cleared after every successful rate
- enforce strict sequencing when no pending exists: rate is allowed only when the latest actionable event is a roll
- keep queue movement + dice ladder behavior unchanged
- update Roll page to stop assuming backend auto-selects the next pending thread after Save & Continue
- add migration note in `docs/changelog.md` and index link

Closes #242.

## Tests Updated
- API regression coverage for blocking second rate without a fresh roll
- session/rate integration tests updated to assert pending is cleared after Save & Continue
- Playwright tests updated for new UX contract (return to roll UI, no auto re-opened rating)
- prod smoke coverage updated to validate pending is cleared after Save & Continue

## Verification Run Locally
- `make lint`
- `cd frontend && npm run typecheck`
- `set -a; source .env.test; set +a; .venv/bin/pytest tests/ --cov=comic_pile --cov-report=xml`
- `set -a; source .env.test; set +a; .venv/bin/pytest tests_e2e/test_api_workflows.py -v --no-cov`
- `set -a; source .env.test; set +a; .venv/bin/pytest tests_e2e/test_dice_ladder_e2e.py -v --no-cov`
- Playwright CI-style shards with `CI=true`:
  - `cd frontend && npx playwright test --project=chromium --shard=1/4`
  - `cd frontend && npx playwright test --project=chromium --shard=2/4`
  - `cd frontend && npx playwright test --project=chromium --shard=3/4`
  - `cd frontend && npx playwright test --project=chromium --shard=4/4`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed session state management after "Save & Continue": the system no longer auto-selects the next thread, requiring users to perform a new roll before submitting another rating.

* **Documentation**
  * Added release notes documenting session behavior changes for save and continue operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->