### PR TITLE
fix: exclude blocked threads from stale/reminder suggestions

### DIFF
--- a/app/api/thread.py
+++ b/app/api/thread.py
@@ -125,6 +125,7 @@ async def list_stale_threads(
         select(Thread)
         .where(Thread.user_id == current_user.id)
         .where(Thread.status == "active")
+        .where(Thread.is_blocked.is_(False))
         .where((Thread.last_activity_at < cutoff_date) | (Thread.last_activity_at.is_(None)))
         .order_by(Thread.last_activity_at.asc().nullsfirst())
     )

--- a/comic_pile/queue.py
+++ b/comic_pile/queue.py
@@ -250,6 +250,7 @@ async def get_stale_threads(user_id: int, db: AsyncSession, days: int = 7) -> li
         select(Thread)
         .where(Thread.user_id == user_id)
         .where(Thread.status == "active")
+        .where(Thread.is_blocked.is_(False))
         .where((Thread.last_activity_at < cutoff_date) | (Thread.last_activity_at.is_(None)))
         .order_by(Thread.last_activity_at.asc().nullsfirst())
     )

--- a/frontend/src/pages/RollPage.tsx
+++ b/frontend/src/pages/RollPage.tsx
@@ -418,8 +418,9 @@ export default function RollPage() {
     selectedThreadId,
   ])
   useEffect(() => {
-    if (staleThreads && staleThreads.length > 0) {
-      const thread = staleThreads[0]
+    const actionable = staleThreads?.filter(t => !t.is_blocked) ?? []
+    if (actionable.length > 0) {
+      const thread = actionable[0]
       const lastActivity = thread.last_activity_at ? new Date(thread.last_activity_at) : new Date(thread.created_at)
       const diffMs = Date.now() - lastActivity.getTime()
       const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))

--- a/tests/test_queue_edge_cases.py
+++ b/tests/test_queue_edge_cases.py
@@ -241,7 +241,19 @@ async def test_get_stale_threads(async_db: AsyncSession, default_user: User) -> 
         created_at=now,
     )
 
-    async_db.add_all([stale_thread, recent_thread, no_activity_thread])
+    blocked_stale_thread = Thread(
+        title="Blocked Stale Thread",
+        format="Comic",
+        issues_remaining=4,
+        queue_position=4,
+        status="active",
+        user_id=default_user.id,
+        last_activity_at=stale_date,
+        is_blocked=True,
+        created_at=now,
+    )
+
+    async_db.add_all([stale_thread, recent_thread, no_activity_thread, blocked_stale_thread])
     await async_db.commit()
 
     stale_threads = await get_stale_threads(default_user.id, async_db, days=7)
@@ -251,6 +263,7 @@ async def test_get_stale_threads(async_db: AsyncSession, default_user: User) -> 
     assert stale_thread.id in stale_thread_ids
     assert no_activity_thread.id in stale_thread_ids
     assert recent_thread.id not in stale_thread_ids
+    assert blocked_stale_thread.id not in stale_thread_ids
 
 
 @pytest.mark.asyncio

--- a/tests/test_thread_api.py
+++ b/tests/test_thread_api.py
@@ -1,7 +1,7 @@
 """Tests for Thread API endpoints."""
 
 import pytest
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -446,3 +446,63 @@ async def test_migration_enables_issue_tracking(
     result = await async_db.execute(select(Issue).where(Issue.thread_id == thread.id))
     issues = result.scalars().all()
     assert len(issues) == 25
+
+
+@pytest.mark.asyncio
+async def test_stale_endpoint_excludes_blocked_threads(
+    auth_client: AsyncClient, async_db: AsyncSession
+) -> None:
+    """Blocked stale threads should not appear in the stale endpoint."""
+    user = await get_or_create_user_async(async_db)
+    now = datetime.now(UTC)
+    stale_date = now - timedelta(days=60)
+
+    blocked_thread = Thread(
+        title="Blocked Stale Thread",
+        format="Comic",
+        issues_remaining=5,
+        queue_position=1,
+        status="active",
+        user_id=user.id,
+        last_activity_at=stale_date,
+        is_blocked=True,
+        created_at=now,
+    )
+    async_db.add(blocked_thread)
+    await async_db.commit()
+
+    response = await auth_client.get("/api/threads/stale?days=30")
+    assert response.status_code == 200
+    data = response.json()
+    thread_ids = {t["id"] for t in data}
+    assert blocked_thread.id not in thread_ids
+
+
+@pytest.mark.asyncio
+async def test_stale_endpoint_includes_unblocked_stale_threads(
+    auth_client: AsyncClient, async_db: AsyncSession
+) -> None:
+    """Unblocked stale threads should appear in the stale endpoint."""
+    user = await get_or_create_user_async(async_db)
+    now = datetime.now(UTC)
+    stale_date = now - timedelta(days=60)
+
+    unblocked_thread = Thread(
+        title="Unblocked Stale Thread",
+        format="Comic",
+        issues_remaining=5,
+        queue_position=1,
+        status="active",
+        user_id=user.id,
+        last_activity_at=stale_date,
+        is_blocked=False,
+        created_at=now,
+    )
+    async_db.add(unblocked_thread)
+    await async_db.commit()
+
+    response = await auth_client.get("/api/threads/stale?days=30")
+    assert response.status_code == 200
+    data = response.json()
+    thread_ids = {t["id"] for t in data}
+    assert unblocked_thread.id in thread_ids


### PR DESCRIPTION
## Summary
- Adds `is_blocked.is_(False)` filter to `/api/threads/stale` endpoint and `get_stale_threads()` utility so blocked threads no longer appear as stale reminders
- Adds defensive client-side filter in `RollPage.tsx` to guard against stale cached data
- Adds regression tests for both the API endpoint and the queue utility

## Test plan
- [x] New tests: `test_stale_endpoint_excludes_blocked_threads`, `test_stale_endpoint_includes_unblocked_stale_threads`
- [x] Updated test: `test_get_stale_threads` now includes a blocked thread and verifies exclusion
- [ ] Manual: create a blocked thread with old `last_activity_at`, confirm it doesn't appear in RollPage reminder

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)