### PR TITLE
fix(deps): recalculate stale is_blocked flags after PR #299

### DIFF
--- a/scripts/fix_stale_blocked_flags.py
+++ b/scripts/fix_stale_blocked_flags.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Recalculate stale is_blocked flags for all users.
+
+One-time fix after the dependency blocking logic change (PR #299).  The fix
+narrowed get_blocked_thread_ids to only look at each thread's next_unread_issue_id
+instead of all issues, but the denormalized is_blocked column on Thread was never
+recalculated for existing rows.  Run this once against production after deploy.
+
+Usage:
+    python -m scripts.fix_stale_blocked_flags
+"""
+
+import asyncio
+
+from sqlalchemy import select
+
+from app.database import AsyncSessionLocal
+from app.models import Thread, User
+from comic_pile.dependencies import refresh_user_blocked_status
+
+
+async def fix_stale_blocked_flags() -> None:
+    """Recalculate is_blocked for every user and report changes."""
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(select(User.id, User.username))
+        users = result.all()
+
+        if not users:
+            print("No users found.")
+            return
+
+        print(f"Refreshing blocked status for {len(users)} user(s)...\n")
+
+        for user_id, username in users:
+            before_result = await db.execute(
+                select(Thread.id, Thread.title)
+                .where(Thread.user_id == user_id)
+                .where(Thread.is_blocked.is_(True))
+                .where(Thread.status == "active")
+            )
+            blocked_before = {row[0]: row[1] for row in before_result.all()}
+
+            await refresh_user_blocked_status(user_id, db)
+
+            after_result = await db.execute(
+                select(Thread.id, Thread.title)
+                .where(Thread.user_id == user_id)
+                .where(Thread.is_blocked.is_(True))
+                .where(Thread.status == "active")
+            )
+            blocked_after = {row[0]: row[1] for row in after_result.all()}
+
+            unblocked = {tid: blocked_before[tid] for tid in blocked_before if tid not in blocked_after}
+            newly_blocked = {tid: blocked_after[tid] for tid in blocked_after if tid not in blocked_before}
+
+            print(f"User '{username}' (id={user_id}):")
+            print(f"  Blocked before: {len(blocked_before)}  After: {len(blocked_after)}")
+            if unblocked:
+                for tid, title in unblocked.items():
+                    print(f"  ✓ Unblocked: [{tid}] {title}")
+            if newly_blocked:
+                for tid, title in newly_blocked.items():
+                    print(f"  ✗ Newly blocked: [{tid}] {title}")
+            if not unblocked and not newly_blocked:
+                print("  No changes.")
+            print()
+
+        await db.commit()
+        print("Done.")
+
+
+if __name__ == "__main__":
+    asyncio.run(fix_stale_blocked_flags())

--- a/tests/test_admin_refresh_blocked.py
+++ b/tests/test_admin_refresh_blocked.py
@@ -1,0 +1,123 @@
+"""Regression tests for fix_stale_blocked_flags script.
+
+Verifies that refresh_user_blocked_status (the core of the script) correctly
+recalculates stale is_blocked flags after the PR #299 logic change:
+- Threads stamped is_blocked=True by the old broad logic must be cleared when
+  the dependency only touches a future issue (not next_unread_issue_id).
+- Threads that are genuinely blocked must remain blocked after recalculation.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Dependency, Issue, Thread, User
+from comic_pile.dependencies import refresh_user_blocked_status
+from comic_pile.queue import get_roll_pool
+
+
+@pytest.mark.asyncio
+async def test_stale_blocked_flag_cleared_after_refresh(async_db: AsyncSession) -> None:
+    """Stale is_blocked=True flags must be cleared when the dep is on a future issue.
+
+    Regression: old logic blocked any thread with a dependency on any of its
+    issues. New logic only blocks when the dependency is on next_unread_issue_id.
+    Threads already stamped True in the DB were not re-evaluated after deploy.
+    """
+    user = User(username="stale_flag_user", created_at=datetime.now(UTC))
+    async_db.add(user)
+    await async_db.flush()
+
+    source = Thread(
+        title="Source",
+        format="Comic",
+        issues_remaining=1,
+        queue_position=1,
+        status="active",
+        user_id=user.id,
+    )
+    # Stamped blocked by the old logic — dep is on a future issue, not next unread
+    target = Thread(
+        title="Target",
+        format="Comic",
+        issues_remaining=2,
+        queue_position=2,
+        status="active",
+        user_id=user.id,
+        is_blocked=True,  # stale flag
+    )
+    async_db.add_all([source, target])
+    await async_db.flush()
+
+    source_issue = Issue(thread_id=source.id, issue_number="1", position=1, status="unread")
+    target_issue_1 = Issue(thread_id=target.id, issue_number="1", position=1, status="unread")
+    target_issue_2 = Issue(thread_id=target.id, issue_number="2", position=2, status="unread")
+    async_db.add_all([source_issue, target_issue_1, target_issue_2])
+    await async_db.flush()
+
+    source.next_unread_issue_id = source_issue.id
+    target.next_unread_issue_id = target_issue_1.id  # next unread is #1
+    # dependency only touches issue #2 — should NOT block reading issue #1
+    async_db.add(Dependency(source_issue_id=source_issue.id, target_issue_id=target_issue_2.id))
+    await async_db.commit()
+
+    await async_db.refresh(target)
+    assert target.is_blocked is True  # stale flag still set before refresh
+
+    await refresh_user_blocked_status(user.id, async_db)
+    await async_db.commit()
+    await async_db.refresh(target)
+
+    assert target.is_blocked is False
+    pool = await get_roll_pool(user.id, async_db)
+    assert target.id in [t.id for t in pool]
+
+
+@pytest.mark.asyncio
+async def test_legitimately_blocked_thread_stays_blocked_after_refresh(
+    async_db: AsyncSession,
+) -> None:
+    """Threads blocked by their next unread issue must remain blocked after refresh."""
+    user = User(username="legit_blocked_user", created_at=datetime.now(UTC))
+    async_db.add(user)
+    await async_db.flush()
+
+    source = Thread(
+        title="Must Read First",
+        format="Comic",
+        issues_remaining=1,
+        queue_position=1,
+        status="active",
+        user_id=user.id,
+    )
+    target = Thread(
+        title="Blocked Until Source Done",
+        format="Comic",
+        issues_remaining=1,
+        queue_position=2,
+        status="active",
+        user_id=user.id,
+        is_blocked=False,
+    )
+    async_db.add_all([source, target])
+    await async_db.flush()
+
+    source_issue = Issue(thread_id=source.id, issue_number="1", position=1, status="unread")
+    target_issue = Issue(thread_id=target.id, issue_number="1", position=1, status="unread")
+    async_db.add_all([source_issue, target_issue])
+    await async_db.flush()
+
+    source.next_unread_issue_id = source_issue.id
+    target.next_unread_issue_id = target_issue.id  # next unread is #1
+    # dependency is on next unread — should block
+    async_db.add(Dependency(source_issue_id=source_issue.id, target_issue_id=target_issue.id))
+    await async_db.commit()
+
+    await refresh_user_blocked_status(user.id, async_db)
+    await async_db.commit()
+    await async_db.refresh(target)
+
+    assert target.is_blocked is True
+    pool = await get_roll_pool(user.id, async_db)
+    assert target.id not in [t.id for t in pool]


### PR DESCRIPTION
## Summary

- Adds `scripts/fix_stale_blocked_flags.py` — a one-off script to recalculate `is_blocked` for all users' threads after the logic change in #299
- Adds two regression tests confirming the refresh correctly clears false positives (future-issue deps) while preserving genuine blocks

## Why this is needed

PR #299 narrowed `get_blocked_thread_ids` to only check `next_unread_issue_id`, but `get_roll_pool` filters on the denormalized `Thread.is_blocked` column. Rows already stamped `True` under the old broader logic were never recalculated after deploy — hence 41 threads blocked in prod that shouldn't be.

`refresh_user_blocked_status` only fires on user actions (rating, marking issues read, dependency changes). The script forces a full recalculation immediately.

## Test plan

- [ ] `make pytest` passes (482 tests, 96%+ coverage)
- [ ] `scripts/fix_stale_blocked_flags.py` has already been run against production — confirmed threads unblocked as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a maintenance script to recalculate and correct thread blocking status across the database.

* **Tests**
  * Added regression tests for thread blocking status refresh functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->