### PR TITLE
fix: return HTTP 400 for out-of-range move_to_position (#288)

### DIFF
--- a/app/api/queue.py
+++ b/app/api/queue.py
@@ -78,6 +78,14 @@ async def move_thread_position(
         await move_to_position(thread_id, current_user.id, position_request.new_position, db)
         await db.refresh(thread)
         logger.info(f"Thread {thread_id} refreshed, new position: {thread.queue_position}")
+    except ValueError as e:
+        logger.error(
+            f"Invalid position {position_request.new_position} for thread {thread_id}: {e}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
     except Exception as e:
         logger.error(
             f"Error moving thread {thread_id} to position {position_request.new_position}: {e}"

--- a/comic_pile/queue.py
+++ b/comic_pile/queue.py
@@ -117,10 +117,6 @@ async def move_to_position(
     old_position = target_thread.queue_position
     logger.info(f"Current thread position: {old_position}")
 
-    if new_position < 1:
-        logger.warning(f"new_position {new_position} < 1, setting to 1")
-        new_position = 1
-
     # Get all active threads sorted by current position
     result = await db.execute(
         select(Thread)
@@ -134,14 +130,6 @@ async def move_to_position(
     thread_count = len(all_threads)
     logger.info(f"Active thread count: {thread_count}")
 
-    if new_position > thread_count:
-        logger.warning(
-            f"new_position {new_position} > thread_count {thread_count}, capping to thread_count"
-        )
-        new_position = thread_count
-
-    logger.info(f"Final target position: {new_position} (original: {old_position})")
-
     # Find the current sequential position of our target thread
     current_sequential_pos = next(
         (i + 1 for i, thread in enumerate(all_threads) if thread.id == thread_id), 0
@@ -150,6 +138,17 @@ async def move_to_position(
     if current_sequential_pos == 0:
         logger.error(f"Target thread {thread_id} not found in active threads list")
         return
+
+    # Validate position range only if thread is in active list
+    if new_position < 1:
+        raise ValueError(f"Position must be at least 1, got {new_position}")
+
+    if new_position > thread_count:
+        raise ValueError(
+            f"Position {new_position} is out of range. Maximum position is {thread_count}."
+        )
+
+    logger.info(f"Final target position: {new_position} (original: {old_position})")
 
     if current_sequential_pos == new_position:
         logger.info(

--- a/tests/test_queue_edge_cases.py
+++ b/tests/test_queue_edge_cases.py
@@ -12,7 +12,7 @@ from comic_pile.queue import move_to_back, move_to_front, move_to_position
 async def test_move_to_position_clamps_to_max(
     auth_client: AsyncClient, async_db: AsyncSession, sample_data: dict
 ) -> None:
-    """Moving to position > max_position clamps to max."""
+    """Moving to position > max_position returns HTTP 400 with error message."""
     thread_id = sample_data["threads"][0].id
 
     response = await auth_client.get("/api/threads/")
@@ -23,11 +23,12 @@ async def test_move_to_position_clamps_to_max(
     response = await auth_client.put(
         f"/api/queue/threads/{thread_id}/position/", json={"new_position": max_position + 10}
     )
-    assert response.status_code == 200
-
-    thread = await async_db.get(Thread, thread_id)
-    assert thread is not None
-    assert thread.queue_position == max_position
+    # Should return HTTP 400, not 200 (no silent clamping)
+    assert response.status_code == 400
+    # Should have an error message about position being out of range
+    assert "detail" in response.json()
+    detail = response.json()["detail"]
+    assert "out of range" in detail.lower() or "maximum position" in detail.lower()
 
 
 @pytest.mark.asyncio
@@ -195,18 +196,13 @@ async def test_move_to_position_thread_not_in_active_list(
 
 @pytest.mark.asyncio
 async def test_move_to_position_clamps_negative_position(
-    async_db: AsyncSession, default_user: User, sample_data: dict, caplog: pytest.LogCaptureFixture
+    async_db: AsyncSession, default_user: User, sample_data: dict
 ) -> None:
-    """move_to_position with new_position < 1 clamps to 1."""
+    """move_to_position with new_position < 1 raises ValueError."""
     thread_id = sample_data["threads"][0].id
 
-    with caplog.at_level("WARNING"):
+    with pytest.raises(ValueError, match="Position must be at least 1"):
         await move_to_position(thread_id, default_user.id, 0, async_db)
-
-    thread = await async_db.get(Thread, thread_id)
-    assert thread is not None
-    assert thread.queue_position == 1
-    assert any("new_position 0 < 1, setting to 1" in record.message for record in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1179,18 +1179,14 @@ async def test_get_or_create_returns_existing_within_time_window(
 
 @pytest.mark.asyncio
 async def test_move_to_position_handles_zero(async_db: AsyncSession, sample_data: dict) -> None:
-    """Test that move_to_position handles new_position=0 correctly.
-
-    This covers line 70 where new_position is set to 1 when it's < 1.
-    """
+    """Test that move_to_position raises ValueError for new_position=0."""
     from comic_pile.queue import move_to_position
+    import pytest
 
     thread = sample_data["threads"][0]
 
-    await move_to_position(thread.id, thread.user_id, 0, async_db)
-
-    await async_db.refresh(thread)
-    assert thread.queue_position == 1
+    with pytest.raises(ValueError, match="Position must be at least 1"):
+        await move_to_position(thread.id, thread.user_id, 0, async_db)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Fixed `move_to_position` endpoint to return HTTP 400 with descriptive error message when requested position is out of range (negative or beyond queue length)
- Removed silent clamping behavior that was causing data loss
- Updated existing tests that were incorrectly testing the clamping behavior

## Changes
- **comic_pile/queue.py**: Replaced silent clamping with ValueError for invalid positions
- **app/api/queue.py**: Added ValueError handler to return HTTP 400 with error detail
- **tests/test_queue_edge_cases.py**: Updated tests to expect correct behavior
- **tests/test_session.py**: Updated test to expect ValueError for position 0

Fixes #288