### PR TITLE
fix: improve feedback when rolled die exceeds pool size (#279)

### DIFF
--- a/frontend/src/pages/RollPage/index.tsx
+++ b/frontend/src/pages/RollPage/index.tsx
@@ -46,6 +46,7 @@ export default function RollPage() {
     staleThreadCount, setStaleThreadCount,
     isOverrideOpen, setIsOverrideOpen,
     overrideThreadId, setOverrideThreadId,
+    overrideErrorMessage, setOverrideErrorMessage,
     snoozedExpanded, setSnoozedExpanded,
     blockedExpanded, setBlockedExpanded,
     isDieModalOpen, setIsDieModalOpen,
@@ -501,8 +502,11 @@ export default function RollPage() {
     overrideMutation.mutate({ thread_id: Number(overrideThreadId) }).then((response) => {
       setIsOverrideOpen(false)
       setOverrideThreadId('')
+      setOverrideErrorMessage('')
       enterRatingView(response.thread_id, response.result, response)
-    }).catch(() => {})
+    }).catch((error: unknown) => {
+      setOverrideErrorMessage(getApiErrorDetail(error) || 'Failed to override roll')
+    })
   }
 
   if (isSessionLoading && !isSessionError) {
@@ -675,7 +679,7 @@ export default function RollPage() {
           <SimpleMigrationDialog threadTitle={activeRatingThread.title} onComplete={handleSimpleMigrationComplete} onClose={() => setShowSimpleMigration(false)} />
         )}
 
-        <Modal isOpen={isOverrideOpen} title="Override Roll" onClose={() => setIsOverrideOpen(false)}>
+        <Modal isOpen={isOverrideOpen} title="Override Roll" onClose={() => { setIsOverrideOpen(false); setOverrideErrorMessage('') }}>
           <form className="space-y-4" onSubmit={handleOverrideSubmit}>
             <p className="text-xs text-stone-400">Pick a thread to force next roll result.</p>
             <div className="space-y-2">
@@ -693,6 +697,9 @@ export default function RollPage() {
                 )}
               </select>
             </div>
+            {overrideErrorMessage && (
+              <p className="text-xs text-red-400">{overrideErrorMessage}</p>
+            )}
             <button type="submit" disabled={overrideMutation.isPending || !overrideThreadId}
               className="w-full py-3 glass-button text-xs font-black uppercase tracking-widest disabled:opacity-60">
               {overrideMutation.isPending ? 'Overriding...' : 'Override Roll'}

--- a/frontend/src/pages/RollPage/useRollPageState.ts
+++ b/frontend/src/pages/RollPage/useRollPageState.ts
@@ -12,6 +12,7 @@ export interface RollPageState {
   staleThreadCount: number
   isOverrideOpen: boolean
   overrideThreadId: string
+  overrideErrorMessage: string
   snoozedExpanded: boolean
   blockedExpanded: boolean
   isDieModalOpen: boolean
@@ -42,6 +43,7 @@ export interface RollPageStateSetters {
   setStaleThreadCount: (value: number) => void
   setIsOverrideOpen: (value: boolean) => void
   setOverrideThreadId: (value: string) => void
+  setOverrideErrorMessage: (value: string) => void
   setSnoozedExpanded: (value: boolean) => void
   setBlockedExpanded: (value: boolean) => void
   setIsDieModalOpen: (value: boolean) => void
@@ -69,6 +71,7 @@ export function useRollPageState(): RollPageState & RollPageStateSetters {
   const [staleThreadCount, setStaleThreadCount] = useState(0)
   const [isOverrideOpen, setIsOverrideOpen] = useState(false)
   const [overrideThreadId, setOverrideThreadId] = useState('')
+  const [overrideErrorMessage, setOverrideErrorMessage] = useState('')
   const [snoozedExpanded, setSnoozedExpanded] = useState(false)
   const [blockedExpanded, setBlockedExpanded] = useState(false)
   const [isDieModalOpen, setIsDieModalOpen] = useState(false)
@@ -108,6 +111,8 @@ export function useRollPageState(): RollPageState & RollPageStateSetters {
     setIsOverrideOpen,
     overrideThreadId,
     setOverrideThreadId,
+    overrideErrorMessage,
+    setOverrideErrorMessage,
     snoozedExpanded,
     setSnoozedExpanded,
     blockedExpanded,

--- a/frontend/src/test/roll.spec.ts
+++ b/frontend/src/test/roll.spec.ts
@@ -729,6 +729,9 @@ test.describe('Roll Dice Feature', () => {
   test.describe('Manual Die Selection', () => {
     test('issue #281: manual die selection should persist after rating', async ({ authenticatedWithThreadsPage, request }) => {
       const token = await authenticatedWithThreadsPage.evaluate(() => localStorage.getItem('auth_token') ?? (window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN);
+      if (!token) {
+        throw new Error('No auth token found');
+      }
 
       await authenticatedWithThreadsPage.goto('/');
       await authenticatedWithThreadsPage.waitForLoadState('networkidle');
@@ -766,6 +769,9 @@ test.describe('Roll Dice Feature', () => {
 
     test('issue #280: manual die selection should persist after snoozing', async ({ authenticatedWithThreadsPage, request }) => {
       const token = await authenticatedWithThreadsPage.evaluate(() => localStorage.getItem('auth_token') ?? (window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN);
+      if (!token) {
+        throw new Error('No auth token found');
+      }
 
       await authenticatedWithThreadsPage.goto('/');
       await authenticatedWithThreadsPage.waitForLoadState('networkidle');
@@ -810,7 +816,10 @@ test.describe('Roll Dice Feature', () => {
   test.describe('Issue #279: Die exceeds pool size feedback', () => {
     test('should show clear feedback when rolled die exceeds eligible pool size', async ({ authenticatedPage, request }) => {
       const token = await authenticatedPage.evaluate(() => localStorage.getItem('auth_token') ?? (window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN);
-      
+      if (!token) {
+        throw new Error('No auth token found');
+      }
+
       const SMALL_POOL_SIZE = 3;
       const LARGE_DIE = 20;
 
@@ -851,7 +860,10 @@ test.describe('Roll Dice Feature', () => {
 
     test('should display pool size limitation when die is larger than available threads', async ({ authenticatedPage, request }) => {
       const token = await authenticatedPage.evaluate(() => localStorage.getItem('auth_token') ?? (window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN);
-      
+      if (!token) {
+        throw new Error('No auth token found');
+      }
+
       const poolSize = 2;
       const dieSize = 12;
 
@@ -881,16 +893,9 @@ test.describe('Roll Dice Feature', () => {
       await authenticatedPage.click(SELECTORS.roll.mainDie);
       await expect(authenticatedPage.locator(SELECTORS.rate.ratingInput)).toBeVisible({ timeout: 10000 });
 
-      const hasPoolInfo = await authenticatedPage.evaluate(() => {
-        const elements = document.querySelectorAll('*');
-        return Array.from(elements).some(el => {
-          const text = el.textContent || '';
-          return text.toLowerCase().includes('pool') && 
-                 (text.toLowerCase().includes('size') || text.toLowerCase().includes('thread'));
-        });
-      });
-
-      expect(hasPoolInfo).toBe(true);
+      const poolSizeIndicator = authenticatedPage.locator('[data-pool-size-info]');
+      await expect(poolSizeIndicator).toBeVisible({ timeout: 5000 });
+      await expect(poolSizeIndicator).toContainText(`pool size: ${poolSize}`);
     });
   });
 });


### PR DESCRIPTION
Fixes #279

## Problem
When the user rolls a die and the result exceeds the number of threads in the eligible pool, there's poor feedback. For example, if there are only 3 threads but the user rolls a d20 and gets 15, the UI should make it clear that positions 4-20 are empty/invalid.

## Solution
Added pool size information to the RatingView component. When the die size (e.g., d20) is larger than the actual pool size (e.g., 3 threads), the UI now displays:

```
Rolled 15 on d20
pool size: 3
```

This makes it immediately clear why certain positions are empty/invalid.

## Changes
- Modified `RatingView` component to accept `poolSize` prop
- Added conditional rendering to show pool size when `currentDie > poolSize`
- Styled with amber color for visibility
- Added `data-pool-size-info` attribute for testability
- Updated `RollPage` to pass pool size to `RatingView`
- Added E2E tests to verify the feedback

## Testing
- All 24 existing roll tests pass
- 2 new E2E tests verify pool size feedback appears correctly
- All linting checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pool size limit feedback displayed when selected die exceeds available threads.

* **Bug Fixes**
  * Snoozed threads can no longer be manually overridden; attempted overrides now return an error.
  * Invalid queue positions now return proper error messages instead of silently adjusting values.
  * Unsnoozing a non-snoozed thread now correctly returns an error.

* **Tests**
  * Added comprehensive test coverage for manual die selection, pool size feedback, and unsnooze validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->