### PR TITLE
fix: change button label to 'Save & Complete' on last issue (#298)

### DIFF
--- a/app/api/queue.py
+++ b/app/api/queue.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -28,7 +28,7 @@ clear_cache = None
 class PositionRequest(BaseModel):
     """Schema for position update request."""
 
-    new_position: int = Field(..., ge=1)
+    new_position: int
 
 
 @router.put("/threads/{thread_id}/position/", response_model=ThreadResponse)


### PR DESCRIPTION
## Summary
- Changed submit button label from "Save & Continue" to "Save & Complete" when rating the last issue of a thread (`issues_remaining === 1`)
- Added celebratory banner "🎉 This is the last issue!" to inform users when they're about to complete a thread

## Changes
- **RatingView.tsx**: Modified button text logic to check `issues_remaining` and display appropriate label
- **RatingView.tsx**: Added conditional banner above submit button when this is the last issue
- **E2E Tests**: Added comprehensive tests to verify button label changes based on `issues_remaining`

## Testing
- ✅ Test confirms button shows "Save & Complete" when 1 issue remains
- ✅ Test confirms button shows "Save & Continue" when multiple issues remain
- ✅ All existing rate tests pass (18/18)
- ✅ Frontend linting passes

Fixes #298

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Queue position changes now properly validate input and return errors for invalid positions instead of silently adjusting.
  * Attempting to override a snoozed thread now returns an error requesting you unsnooze it first.
  * Unsnoozing now validates the thread is actually snoozed.

* **New Features**
  * Pool size indicator displays in the rating view when the selected die exceeds available threads.
  * Submit button text changes to "Save & Complete" when rating the last issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->