### PR TITLE
fix: show count indicator for stale thread nudge (#295)

### DIFF
--- a/frontend/src/test/roll.spec.ts
+++ b/frontend/src/test/roll.spec.ts
@@ -729,6 +729,9 @@ test.describe('Roll Dice Feature', () => {
   test.describe('Manual Die Selection', () => {
     test('issue #281: manual die selection should persist after rating', async ({ authenticatedWithThreadsPage, request }) => {
       const token = await authenticatedWithThreadsPage.evaluate(() => localStorage.getItem('auth_token') ?? (window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN);
+      if (!token) {
+        throw new Error('No auth token found');
+      }
 
       await authenticatedWithThreadsPage.goto('/');
       await authenticatedWithThreadsPage.waitForLoadState('networkidle');
@@ -738,6 +741,7 @@ test.describe('Roll Dice Feature', () => {
 
       const dieButton = authenticatedWithThreadsPage.locator(`button:has-text("d${MANUAL_DIE}")`).first();
       await dieButton.click();
+      await authenticatedWithThreadsPage.waitForLoadState('networkidle');
 
       const sessionBefore = await request.get('/api/sessions/current/', {
         headers: { 'Authorization': `Bearer ${token}` },
@@ -766,6 +770,9 @@ test.describe('Roll Dice Feature', () => {
 
     test('issue #280: manual die selection should persist after snoozing', async ({ authenticatedWithThreadsPage, request }) => {
       const token = await authenticatedWithThreadsPage.evaluate(() => localStorage.getItem('auth_token') ?? (window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN);
+      if (!token) {
+        throw new Error('No auth token found');
+      }
 
       await authenticatedWithThreadsPage.goto('/');
       await authenticatedWithThreadsPage.waitForLoadState('networkidle');
@@ -775,6 +782,7 @@ test.describe('Roll Dice Feature', () => {
 
       const dieButton = authenticatedWithThreadsPage.locator(`button:has-text("d${MANUAL_DIE}")`).first();
       await dieButton.click();
+      await authenticatedWithThreadsPage.waitForLoadState('networkidle');
 
       const sessionBeforeRoll = await request.get('/api/sessions/current/', {
         headers: { 'Authorization': `Bearer ${token}` },
@@ -810,7 +818,10 @@ test.describe('Roll Dice Feature', () => {
   test.describe('Issue #279: Die exceeds pool size feedback', () => {
     test('should show clear feedback when rolled die exceeds eligible pool size', async ({ authenticatedPage, request }) => {
       const token = await authenticatedPage.evaluate(() => localStorage.getItem('auth_token') ?? (window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN);
-      
+      if (!token) {
+        throw new Error('No auth token found');
+      }
+
       const SMALL_POOL_SIZE = 3;
       const LARGE_DIE = 20;
 
@@ -851,7 +862,10 @@ test.describe('Roll Dice Feature', () => {
 
     test('should display pool size limitation when die is larger than available threads', async ({ authenticatedPage, request }) => {
       const token = await authenticatedPage.evaluate(() => localStorage.getItem('auth_token') ?? (window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN);
-      
+      if (!token) {
+        throw new Error('No auth token found');
+      }
+
       const poolSize = 2;
       const dieSize = 12;
 
@@ -881,16 +895,9 @@ test.describe('Roll Dice Feature', () => {
       await authenticatedPage.click(SELECTORS.roll.mainDie);
       await expect(authenticatedPage.locator(SELECTORS.rate.ratingInput)).toBeVisible({ timeout: 10000 });
 
-      const hasPoolInfo = await authenticatedPage.evaluate(() => {
-        const elements = document.querySelectorAll('*');
-        return Array.from(elements).some(el => {
-          const text = el.textContent || '';
-          return text.toLowerCase().includes('pool') && 
-                 (text.toLowerCase().includes('size') || text.toLowerCase().includes('thread'));
-        });
-      });
-
-      expect(hasPoolInfo).toBe(true);
+      const poolSizeIndicator = authenticatedPage.locator('[data-pool-size-info]');
+      await expect(poolSizeIndicator).toBeVisible({ timeout: 5000 });
+      await expect(poolSizeIndicator).toContainText(`pool size: ${poolSize}`);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Added count indicator to stale thread nudge showing total number of stale threads (e.g., "3 stale threads")
- Fixed backend/frontend cutoff logic mismatch (backend uses `< cutoff_date`, frontend was using `>= days`)
- Changed frontend cutoff from 7 to 8 days to match backend behavior
- Added test-only API endpoint `/api/threads/{id}/test-backdate` for E2E testing of time-based scenarios

## Changes
- **Frontend**: Added `staleThreadCount` state to track number of stale threads
- **Frontend**: Updated stale thread nudge UI to display count with proper singular/plural forms
- **Frontend**: Fixed stale thread detection cutoff to match backend (8+ days)
- **Backend**: Added test-only endpoint for backdating threads (only works when `TEST_ENVIRONMENT=true`)
- **Tests**: Added E2E tests for single and multiple stale thread scenarios

Fixes #295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added stale thread count display with adjusted threshold (8 days).
  * Added pool size indicator when selected die exceeds available threads.
  * Added "Save & Complete" button label when rating the last issue.
  * Enhanced manual die selection persistence across actions.

* **Bug Fixes**
  * Invalid queue positions now return proper error responses instead of silently adjusting.
  * Cannot override snoozed threads; returns error with explanation.
  * Completed threads removed from active session view after rating.
  * Session state now correctly reflects database changes immediately.

* **Tests**
  * Added comprehensive test coverage for stale thread nudges, completed thread handling, button labels, and die selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->