### PR TITLE
fix: show feedback when snoozing at d20 max pool size (#286)

### DIFF
--- a/frontend/src/pages/RollPage/index.tsx
+++ b/frontend/src/pages/RollPage/index.tsx
@@ -537,6 +537,11 @@ export default function RollPage() {
       <header className="flex justify-between items-center px-3 py-2 shrink-0 z-10">
         <div>
           <h1 className="text-2xl font-black tracking-tighter text-glow uppercase">Pile Roller</h1>
+          {session?.snoozed_threads?.length > 0 && currentDie === 20 && (
+            <div className="flex items-center gap-2 mt-1">
+              <span className="text-[9px] text-stone-500 uppercase tracking-wider">pool at max size (d20) - snoozing won't increase it further</span>
+            </div>
+          )}
           {session?.snoozed_threads?.length > 0 && currentDie !== 20 && (
             <div className="flex items-center gap-2 mt-1">
               <span className="modifier-badge text-[10px] font-black text-amber-500">+{session.snoozed_threads.length}</span>

--- a/frontend/src/test/issue-286-snooze-d20-feedback.spec.ts
+++ b/frontend/src/test/issue-286-snooze-d20-feedback.spec.ts
@@ -53,7 +53,8 @@ test.describe('Issue #286: Snooze feedback at d20', () => {
 
     // Verify feedback message is shown about being at max pool size
     // The feedback should indicate that snoozing at d20 has no effect
-    const feedbackMessage = page.locator('text=/max|pool|size|already at d20/i');
+    const header = page.locator('header');
+    const feedbackMessage = header.getByText(/pool at max size.*snoozing won't increase/i);
     await expect(feedbackMessage).toBeVisible();
   });
 });


### PR DESCRIPTION
Fixes #286

When a user is at d20 (the maximum die size) and snoozes a thread, it has no effect on the pool size since it can't go higher than d20. This change adds feedback to inform the user that they're already at the maximum pool size and snoozing won't increase it further.

### Changes
- Added feedback message in the roll page header when snoozing at d20
- Message reads: "pool at max size (d20) - snoozing won't increase it further"
- Only shown when there are snoozed threads AND current die is d20

### Testing
- Added E2E test to verify feedback is shown when snoozing at d20
- Test creates 21 threads, sets die to d20, snoozes a thread, and verifies feedback message appears
- All related snooze tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Toast notifications for session expiry and important events
  * "Finish Session" button in rating view
  * Enhanced stale thread messaging with count indicators
  * Test environment endpoints for quality assurance

* **Bug Fixes**
  * Fixed snooze behavior to prevent overriding snoozed threads until unsnoozed
  * Fixed queue position validation to reject out-of-bounds moves with clear error messages
  * Improved completed thread handling in active session slot
  * Fixed stale thread detection threshold and counting logic

* **UI/UX Improvements**
  * Changed default rating to neutral (3.0)
  * Dynamic submit button labels ("Save & Complete" vs "Save & Continue")
  * Added pool size feedback at maximum die level
  * Improved error handling with user-friendly messages

* **Tests**
  * Comprehensive end-to-end test coverage for new features and fixes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->