### PR TITLE
fix: disable rate limiting and test-only endpoints in CI E2E shards

### DIFF
--- a/.github/workflows/ci-sharded.yml
+++ b/.github/workflows/ci-sharded.yml
@@ -254,6 +254,7 @@ jobs:
         totalShards: [8]
     env:
       CI: true
+      TEST_ENVIRONMENT: "true"
       SECRET_KEY: test-secret-key-for-testing-only
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@postgres:5432/comic_pile_test
       TEST_DATABASE_URL: postgresql+asyncpg://postgres:postgres@postgres:5432/comic_pile_test

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -226,9 +226,6 @@ export const test = base.extend<TestFixtures>({
     // 3. Wait for the roll page to be ready
     await page.waitForSelector('[aria-label="Roll pool collection"]', { state: 'visible', timeout: 10000 });
 
-    // 4. Wait for network to be idle to ensure all API calls completed
-    await page.waitForLoadState('networkidle');
-
     await use(page);
 
     // Cleanup: clear localStorage and attempt logout

--- a/frontend/src/test/helpers.ts
+++ b/frontend/src/test/helpers.ts
@@ -31,7 +31,7 @@ export function generateTestUser(): TestUser {
 
 export async function registerUser(page: Page, user: TestUser): Promise<void> {
   await page.goto('/register', { waitUntil: 'domcontentloaded' });
-  await page.waitForLoadState('networkidle');
+  await page.waitForSelector('input[name="username"]', { state: 'visible', timeout: 10000 });
   await page.fill('input[name="username"]', user.username);
   await page.fill('input[name="email"]', user.email);
   await page.fill('input[name="password"]', user.password);
@@ -190,7 +190,7 @@ export async function setupAuthenticatedPage(
 
   // Use 'domcontentloaded' instead of 'load' to avoid timeout in SPAs
   await page.goto('/', { waitUntil: 'domcontentloaded' });
-  await page.waitForLoadState('networkidle');
+  await page.waitForSelector('[aria-label="Roll pool collection"]', { state: 'visible', timeout: 10000 }).catch(() => {});
 
   return testUser;
 }


### PR DESCRIPTION
## Summary
- Add `TEST_ENVIRONMENT=true` to CI env block to prevent production rate limiting (was causing 429s with 30/min limits) and 403s on test-only endpoints
- Remove `networkidle` waits from 3 shared fixture locations that were causing flakiness

## Root Cause
Shards 4 and 8 were failing intermittently because:
1. CI workflow lacked `TEST_ENVIRONMENT`, so production rate limiting applied (localhost requests share same IP bucket)
2. `networkidle` waits are unreliable with background requests and slow CI I/O

## Testing
- [ ] Run CI 5-10 times to measure flake rate improvement