### PR TITLE
Fix: display next unread issue in rating view instead of last-read issue

### DIFF
--- a/frontend/src/pages/RollPage/components/RatingView.tsx
+++ b/frontend/src/pages/RollPage/components/RatingView.tsx
@@ -45,16 +45,16 @@ export function RatingView({
     <div className="p-4 space-y-8 relative z-10">
       <div id="thread-info" role="status" aria-live="polite">
         <div className="space-y-3 text-center">
-          {activeRatingThread?.issue_number ? (
+          {(activeRatingThread?.next_issue_number || activeRatingThread?.issue_number) ? (
             <>
               <h2 className="text-2xl font-black text-stone-200">{activeRatingThread?.title || 'Loading...'}</h2>
               <div className="flex items-center justify-center gap-3 flex-wrap">
                 <span className="bg-amber-500/20 text-amber-300 px-3 py-1 rounded-lg text-sm font-black uppercase tracking-[0.2em] border border-amber-500/20">
-                  #{activeRatingThread.issue_number}
+                  #{activeRatingThread.next_issue_number ?? activeRatingThread.issue_number}
                 </span>
                 {activeRatingThread.total_issues && (
                   <span className="text-stone-400 text-xs font-bold">
-                    (#{activeRatingThread.issue_number} of {activeRatingThread.total_issues})
+                    (#{activeRatingThread.next_issue_number ?? activeRatingThread.issue_number} of {activeRatingThread.total_issues})
                   </span>
                 )}
                 <span className="bg-amber-600/20 text-amber-400 px-3 py-1 rounded-lg text-[10px] font-black uppercase tracking-[0.2em] border border-amber-600/20">


### PR DESCRIPTION
## Summary
Fixes #322: After reading issue #78 of X-Force and checking it off in the issue list, the rating view still displays "#78" and "(#78 of 106)" instead of advancing to #79. The edit view confirms #78 has a green checkmark, so the two views are out of sync.

## Root Cause
The RatingView component was displaying `activeRatingThread.issue_number` (the current/last-read issue) instead of `next_issue_number` (the upcoming unread issue). When a user rates an issue, they expect to see what issue comes next, not the one they just marked complete.

## Changes
- Updated RatingView to check for `next_issue_number` first, then fall back to `issue_number`
- Changed display from: `#{issue_number} (#{issue_number} of {total_issues})`
- To: `#{next_issue_number ?? issue_number} (#{next_issue_number ?? issue_number} of {total_issues})`
- Maintains backward compatibility with threads that don't have issue metadata

## Testing
- Python linting and type checking pass
- Frontend linting passes (10 pre-existing warnings)
- All existing tests maintain compatibility
- The fix only affects the display logic, not data flow

## Screenshots
N/A - display change only