### PR TITLE
Fix #355: migration dialog appears for already-migrated threads; rejects non-numeric issue numbers

### DIFF
--- a/app/api/rate.py
+++ b/app/api/rate.py
@@ -214,33 +214,72 @@ async def rate_thread(
     current_die = await get_current_die(current_session_id, db)
 
     if not thread.uses_issue_tracking() and rate_data.issue_number is not None:
-        try:
-            issue_num = rate_data.issue_number
+        issue_number = rate_data.issue_number
 
-            if issue_num < 1:
+        result = await db.execute(
+            select(Issue)
+            .where(Issue.thread_id == thread.id)
+            .where(Issue.issue_number == issue_number)
+        )
+        current_issue = result.scalar_one_or_none()
+
+        if not current_issue:
+            try:
+                issue_num_int = int(issue_number)
+                total_issues = issue_num_int + max(thread.issues_remaining - 1, 0)
+                if total_issues > 1000:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=f"Total issues ({total_issues}) exceeds reasonable limit",
+                    )
+                for i in range(1, total_issues + 1):
+                    db.add(
+                        Issue(
+                            thread_id=thread.id,
+                            issue_number=str(i),
+                            status="read" if i < issue_num_int else "unread",
+                            read_at=datetime.now(UTC) if i < issue_num_int else None,
+                            position=i,
+                        )
+                    )
+                await db.flush()
+                result = await db.execute(
+                    select(Issue)
+                    .where(Issue.thread_id == thread.id)
+                    .where(Issue.issue_number == issue_number)
+                )
+                current_issue = result.scalar_one_or_none()
+                if not current_issue:
+                    raise HTTPException(
+                        status_code=400, detail=f"Failed to create issue '{issue_number}'."
+                    )
+            except ValueError:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="issue_number must be at least 1",
-                )
+                    detail=f"Non-numeric issue '{issue_number}' not found in thread. Add it via Edit Thread first.",
+                ) from None
+            except HTTPException:
+                raise
+            except Exception as e:
+                await db.rollback()
+                raise HTTPException(status_code=500, detail="Migration failed.") from e
 
-            total_issues = issue_num + max(thread.issues_remaining - 1, 0)
-
-            if total_issues > 1000:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"Total issues ({total_issues}) exceeds reasonable limit",
-                )
-
-            await thread.migrate_to_issues(issue_num - 1, total_issues, db)
-            await db.flush()
-        except HTTPException:
-            raise
-        except Exception as e:
-            await db.rollback()
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Migration failed. Please try again.",
-            ) from e
+        all_issues_result = await db.execute(
+            select(Issue).where(Issue.thread_id == thread.id).order_by(Issue.position)
+        )
+        all_issues = all_issues_result.scalars().all()
+        for issue in all_issues:
+            if issue.position < current_issue.position:
+                if issue.status != "read":
+                    issue.status = "read"
+                    issue.read_at = datetime.now(UTC)
+            elif issue.position == current_issue.position:
+                issue.status = "unread"
+                issue.read_at = None
+        thread.total_issues = len(all_issues)
+        thread.next_unread_issue_id = current_issue.id
+        thread.reading_progress = "in_progress"
+        await db.flush()
 
     rating_min, rating_max, rating_threshold = _get_rating_limits()
 

--- a/app/api/thread.py
+++ b/app/api/thread.py
@@ -879,15 +879,75 @@ async def migrate_thread_to_issues_simple(
 
     issue_number = request.issue_number
 
-    if issue_number < 1:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="issue_number must be at least 1",
-        )
+    from sqlalchemy import select
+    from app.models import Issue
 
-    total_issues = issue_number + max(thread.issues_remaining - 1, 0)
+    result = await db.execute(
+        select(Issue).where(Issue.thread_id == thread_id).where(Issue.issue_number == issue_number)
+    )
+    current_issue = result.scalar_one_or_none()
 
-    await thread.migrate_to_issues(issue_number - 1, total_issues, db)
+    if not current_issue:
+        try:
+            issue_num_int = int(issue_number)
+            total_issues = issue_num_int + max(thread.issues_remaining - 1, 0)
+
+            for i in range(1, total_issues + 1):
+                if i < issue_num_int:
+                    issue_status = "read"
+                    read_at = datetime.now(UTC)
+                else:
+                    issue_status = "unread"
+                    read_at = None
+
+                issue = Issue(
+                    thread_id=thread.id,
+                    issue_number=str(i),
+                    status=issue_status,
+                    read_at=read_at,
+                    position=i,
+                )
+                db.add(issue)
+
+            await db.flush()
+
+            result = await db.execute(
+                select(Issue)
+                .where(Issue.thread_id == thread_id)
+                .where(Issue.issue_number == issue_number)
+            )
+            current_issue = result.scalar_one_or_none()
+
+            if not current_issue:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Failed to create issue '{issue_number}'. Please add it via Edit Thread first.",
+                )
+        except ValueError:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Non-numeric issue '{issue_number}' not found in thread. Please add it via Edit Thread first.",
+            ) from None
+
+    result = await db.execute(
+        select(Issue).where(Issue.thread_id == thread_id).order_by(Issue.position)
+    )
+    all_issues = result.scalars().all()
+
+    for issue in all_issues:
+        if issue.position < current_issue.position:
+            if issue.status != "read":
+                issue.status = "read"
+                issue.read_at = datetime.now(UTC)
+        elif issue.position == current_issue.position:
+            issue.status = "unread"
+            issue.read_at = None
+
+    thread.total_issues = len(all_issues)
+    thread.next_unread_issue_id = current_issue.id
+    thread.reading_progress = "in_progress"
+
+    await db.flush()
 
     response = await thread_to_response(thread, db)
 

--- a/app/schemas/migration.py
+++ b/app/schemas/migration.py
@@ -17,4 +17,9 @@ class MigrateToIssuesRequest(BaseModel):
 class MigrateToIssuesSimpleRequest(BaseModel):
     """Schema for simplified migration (infers total_issues from current state)."""
 
-    issue_number: int = Field(..., ge=1, description="The issue number user just read (e.g., 5)")
+    issue_number: str = Field(
+        ...,
+        min_length=1,
+        max_length=50,
+        description="The issue number user just read (e.g., '5', 'Annual 1')",
+    )

--- a/app/schemas/rate.py
+++ b/app/schemas/rate.py
@@ -8,6 +8,9 @@ class RateRequest(BaseModel):
 
     rating: float = Field(..., ge=0.5, le=5.0)
     finish_session: bool = Field(default=False)
-    issue_number: int | None = Field(
-        default=None, ge=1, description="Issue number just read (triggers migration if provided)"
+    issue_number: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=50,
+        description="Issue number just read, e.g. '5' or 'Annual 1' (triggers migration if provided)",
     )

--- a/frontend/src/components/SimpleMigrationDialog.tsx
+++ b/frontend/src/components/SimpleMigrationDialog.tsx
@@ -39,17 +39,6 @@ export default function SimpleMigrationDialog({
       return false
     }
 
-    const num = parseInt(issueNumber, 10)
-    if (isNaN(num)) {
-      setError('Please enter a valid number')
-      return false
-    }
-
-    if (num < 1) {
-      setError('Issue number must be at least 1')
-      return false
-    }
-
     return true
   }
 
@@ -100,8 +89,7 @@ export default function SimpleMigrationDialog({
             <input
               ref={inputRef}
               id="issue-number"
-              type="number"
-              min="1"
+              type="text"
               value={issueNumber}
               onChange={(e) => setIssueNumber(e.target.value)}
               placeholder="e.g., 42"

--- a/frontend/src/pages/RollPage/index.tsx
+++ b/frontend/src/pages/RollPage/index.tsx
@@ -117,7 +117,7 @@ export default function RollPage() {
         next_issue_id: response.next_issue_id, next_issue_number: response.next_issue_number,
         last_rolled_result: response.result ?? response.last_rolled_result,
       }
-      if (!response.total_issues) {
+      if (response.total_issues === null) {
         setThreadToMigrate(threadMetadata as RatingThread)
         setShowMigrationDialog(true)
       } else {
@@ -184,13 +184,8 @@ export default function RollPage() {
   }, [])
 
   const handleSimpleMigrationComplete = useCallback((issueNumber: string) => {
-    const num = parseInt(issueNumber, 10)
-    if (isNaN(num) || num < 1) {
-      setErrorMessage('Invalid issue number')
-      return
-    }
     setShowSimpleMigration(false)
-    rateMutation.mutate({ rating, finish_session: false, issue_number: num }).then(() => {
+    rateMutation.mutate({ rating, finish_session: false, issue_number: issueNumber }).then(() => {
       suppressPendingAutoOpenRef.current = true
       setIsRolling(false)
       setIsRatingView(false)
@@ -221,7 +216,7 @@ export default function RollPage() {
             next_issue_id: response.next_issue_id, next_issue_number: response.next_issue_number,
             last_rolled_result: response.result ?? response.last_rolled_result,
           }
-          if (!response.total_issues) {
+          if (response.total_issues === null) {
             setThreadToMigrate(threadMetadata as RatingThread)
             setShowMigrationDialog(true)
           } else {
@@ -373,7 +368,13 @@ export default function RollPage() {
 
   async function handleSubmitRating(finishSession = false) {
     if (rating >= RATING_THRESHOLD) createExplosion()
-    if (activeRatingThread && !activeRatingThread.total_issues) {
+
+    const freshTotalIssues =
+      session?.active_thread?.id === activeRatingThread?.id
+        ? session?.active_thread?.total_issues ?? activeRatingThread?.total_issues
+        : activeRatingThread?.total_issues
+
+    if (activeRatingThread && freshTotalIssues === null) {
       setShowSimpleMigration(true)
       return
     }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -227,8 +227,8 @@ export const rollApi = {
 }
 
 export const rateApi = {
-  rate: (data: { thread_id: number; rating: number; issues_read?: number; finish_session?: boolean; issue_number?: number }) =>
-    api.post<void, { thread_id: number; rating: number; issues_read?: number; finish_session?: boolean; issue_number?: number }>('/rate/', data),
+  rate: (data: { thread_id: number; rating: number; issues_read?: number; finish_session?: boolean; issue_number?: string }) =>
+    api.post<void, { thread_id: number; rating: number; issues_read?: number; finish_session?: boolean; issue_number?: string }>('/rate/', data),
 }
 
 export const sessionApi = {

--- a/tests/test_session_api.py
+++ b/tests/test_session_api.py
@@ -402,7 +402,7 @@ async def test_simplified_migration_endpoint(
     await async_db.refresh(thread)
 
     response = await auth_client.post(
-        f"/api/threads/{thread.id}:migrateToIssuesSimple", json={"issue_number": 5}
+        f"/api/threads/{thread.id}:migrateToIssuesSimple", json={"issue_number": "5"}
     )
     assert response.status_code == 200
 
@@ -471,7 +471,7 @@ async def test_rate_with_issue_number_triggers_migration(
     async_db.add(event)
     await async_db.commit()
 
-    response = await auth_client.post("/api/rate/", json={"rating": 4.0, "issue_number": 6})
+    response = await auth_client.post("/api/rate/", json={"rating": 4.0, "issue_number": "6"})
     assert response.status_code == 200
 
     data = response.json()
@@ -738,7 +738,7 @@ async def test_migration_during_rating_marks_issues_correctly(
     async_db.add(event)
     await async_db.commit()
 
-    response = await auth_client.post("/api/rate/", json={"rating": 4.0, "issue_number": 8})
+    response = await auth_client.post("/api/rate/", json={"rating": 4.0, "issue_number": "8"})
     assert response.status_code == 200
 
     data = response.json()
@@ -790,7 +790,7 @@ async def test_migration_with_issue_number_1_starts_from_beginning(
     await async_db.refresh(thread)
 
     response = await auth_client.post(
-        f"/api/threads/{thread.id}:migrateToIssuesSimple", json={"issue_number": 1}
+        f"/api/threads/{thread.id}:migrateToIssuesSimple", json={"issue_number": "1"}
     )
     assert response.status_code == 200
 
@@ -980,7 +980,7 @@ async def test_migration_with_issue_number_1_starts_fresh(
     async_db.add(event)
     await async_db.commit()
 
-    response = await auth_client.post("/api/rate/", json={"rating": 4.0, "issue_number": 1})
+    response = await auth_client.post("/api/rate/", json={"rating": 4.0, "issue_number": "1"})
 
     assert response.status_code == 200
     data = response.json()
@@ -1043,7 +1043,7 @@ async def test_migration_with_zero_issues_remaining(
     async_db.add(event)
     await async_db.commit()
 
-    response = await auth_client.post("/api/rate/", json={"rating": 4.0, "issue_number": 10})
+    response = await auth_client.post("/api/rate/", json={"rating": 4.0, "issue_number": "10"})
 
     # Cannot migrate a completed thread with no issues remaining
     assert response.status_code == 400
@@ -1112,7 +1112,7 @@ async def test_migration_already_migrated_thread_skips_migration(
     async_db.add(event)
     await async_db.commit()
 
-    response = await auth_client.post("/api/rate/", json={"rating": 4.0, "issue_number": 3})
+    response = await auth_client.post("/api/rate/", json={"rating": 4.0, "issue_number": "3"})
 
     assert response.status_code in [200, 400]
 
@@ -1156,7 +1156,7 @@ async def test_simple_migration_creates_correct_issues(
     await async_db.refresh(thread)
 
     response = await auth_client.post(
-        f"/api/threads/{thread.id}:migrateToIssuesSimple", json={"issue_number": 1}
+        f"/api/threads/{thread.id}:migrateToIssuesSimple", json={"issue_number": "1"}
     )
     assert response.status_code == 200
 


### PR DESCRIPTION
## Summary

Fixes three root causes (A, B, C) identified in issue #355, plus a critical fourth issue (D) discovered during code review:

- **Fix A**: Replace falsy `!total_issues` checks with explicit `=== null` checks in RollPage (3 locations)
- **Fix B**: Add fresh session data reconciliation in `handleSubmitRating` to prevent stale state
- **Fix C**: Change SimpleMigrationDialog and endpoints to accept string issue numbers (e.g., "Annual 1")
- **Fix D (Issue 4)**: Update rate endpoint migration path to handle string issue numbers (mirrors SimpleMigrationDialog logic)

## Changes Made

### Backend (app/api/rate.py, app/api/thread.py)
- Updated migration logic to accept string issue numbers instead of integers
- Added proper error handling for non-numeric issue numbers
- Fixed missing `await db.flush()` before `thread_to_response()` call
- Added exception chaining with `from None` for cleaner error messages

### Backend Schemas (app/schemas/migration.py, app/schemas/rate.py)
- Changed `issue_number` field from `int` to `str` with appropriate validation

### Frontend Components (frontend/src/components/SimpleMigrationDialog.tsx, frontend/src/pages/RollPage/index.tsx)
- Changed input type from "number" to "text" to support non-numeric issue numbers
- Removed `parseInt()` validation that was blocking strings like "Annual 1"
- Fixed null checks to use explicit `=== null` instead of falsy checks
- Added fresh session data reconciliation to prevent stale state

### Frontend API (frontend/src/services/api.ts)
- Updated TypeScript types to use `string` instead of `number` for issue_number

### Tests (tests/test_session_api.py, frontend/src/test/roll.spec.ts)
- Updated 5 backend tests to pass string issue numbers instead of integers
- Fixed E2E test assertion to expect '6' (not '5') after migration and rating

## Test Results

- ✅ 522 backend tests passed (98.97% coverage)
- ✅ All linting passed (ruff, ty, ESLint)
- ✅ All type checking passed
- ✅ E2E tests passed

## Root Cause Analysis

**Issue A**: Falsy checks treated `0` (valid for zero issues remaining) the same as `null`/`undefined`
**Issue B**: Stale session data caused migration dialog to appear for already-migrated threads
**Issue C**: Integer-only schema rejected non-numeric issue numbers like "Annual 1"
**Issue D**: Rate endpoint migration path still used integer-only logic, blocking non-numeric strings at runtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Issue numbers now accept string formats (e.g., "Annual 1", "5"), providing greater flexibility for custom issue naming conventions beyond numeric identifiers.

* **Bug Fixes**
  * Enhanced validation and error handling for issue number migration, with improved error messages for invalid formats.

* **Tests**
  * Updated test suite to reflect string-based issue number handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->