### PR TITLE
[codex] Gate prod deploys on frontend typecheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,6 +293,8 @@ deploy-prod:  ## Deploy to Railway production
 		echo "Rebase/merge and push before deploy to ensure deterministic release."; \
 		exit 1; \
 	fi
+	@echo "Running frontend TypeScript typecheck..."
+	@cd frontend && npm run typecheck
 	@echo "Deploying to Railway..."
 	@railway up --detach
 	@sleep 60


### PR DESCRIPTION
## What changed

- Added a frontend TypeScript typecheck step to `make deploy-prod` before `railway up` runs.

## Why

- Production deploys could ship broken frontend TypeScript without any pre-deploy type validation.
- This closes the gap that allowed the `TOAST_DURATION` frontend failure to reach production.

## Impact

- `make deploy-prod` now fails fast on frontend type errors.
- Deploys stop before Railway upload when `npm run typecheck` is non-zero.

## Validation

- `cd frontend && npm run typecheck`
- `make -n deploy-prod`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved production deployment reliability by adding mandatory TypeScript type validation that runs before deployment, preventing type errors from reaching production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->