### PR TITLE
[codex] Fix duplicated build steps in post-merge CI

### DIFF
--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -54,34 +54,6 @@ jobs:
       - name: Set image tag output
         id: set-outputs
         run: echo "image-tag=${{ env.REGISTRY }}/${{ steps.lowercase.outputs.image-name }}:${{ github.sha }}" >> $GITHUB_OUTPUT
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set lowercase image name
-        id: lowercase
-        run: echo "image-name=${IMAGE_NAME,,}" >> $GITHUB_OUTPUT
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build CI Docker image
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile.ci
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ steps.lowercase.outputs.image-name }}:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   frontend-typecheck:
     name: Frontend Lint + Typecheck


### PR DESCRIPTION
## What changed

- Removed the duplicated `steps:` block from the `build` job in `.github/workflows/post-merge-ci.yml`.

## Why

- The post-merge workflow on `main` was invalid and failing immediately with a workflow file issue.
- This was separate from PR #429 itself; the push to `main` exposed an existing workflow syntax problem.

## Validation

- `python3` + `yaml.safe_load` on `.github/workflows/post-merge-ci.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed duplicate steps in the CI/CD pipeline that were causing Docker images to be built twice, improving pipeline efficiency and reducing unnecessary resource consumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->