### PR TITLE
[codex] Default reading order view to timeline

### DIFF
--- a/frontend/src/components/DependencyBuilder.tsx
+++ b/frontend/src/components/DependencyBuilder.tsx
@@ -574,7 +574,7 @@ const [isSavingNote, setIsSavingNote] = useState(false)
     setShowReadingOrder((prev) => {
       const next = !prev
       if (next) {
-        setReadingView('graph')
+        setReadingView('timeline')
       } else {
         setReadingView('timeline')
       }

--- a/frontend/src/test/readingOrderTimeline.spec.ts
+++ b/frontend/src/test/readingOrderTimeline.spec.ts
@@ -55,12 +55,8 @@ test.describe('Reading Order Timeline', () => {
     await page.click('button[data-testid="toggle-reading-order"]')
     await page.waitForSelector('[role="tablist"]')
 
-    // Check that graph view is the default when reading order is toggled open
-    await expect(page.locator('#reading-order-timeline-tab')).toHaveAttribute('aria-selected', 'false')
-    await expect(page.locator('#flowchart-panel')).not.toBeHidden()
-
-    // Switch to timeline tab to inspect timeline content
-    await page.click('#reading-order-timeline-tab')
+    // Check that timeline view is the default when reading order is toggled open
+    await expect(page.locator('#reading-order-timeline-tab')).toHaveAttribute('aria-selected', 'true')
     await expect(page.locator('#timeline-panel')).not.toBeHidden()
     await expect(page.locator('#flowchart-panel')).toBeHidden()
 


### PR DESCRIPTION
## What changed

- Opening the reading order view now defaults to the timeline tab instead of the graph tab.
- Updated the focused Playwright coverage to assert the new default behavior.

## Why

- The timeline is the more useful first view for chronological reading order, and issue #425 documents that the graph-first default was incorrect.

## Validation

- `cd frontend && npm run typecheck`
- `cd frontend && npm run build && npx playwright test src/test/readingOrderTimeline.spec.ts`
