### PR TITLE
Remove dead thread block fields

### DIFF
--- a/alembic/versions/a4e6b7c8d9f0_drop_dead_thread_block_fields.py
+++ b/alembic/versions/a4e6b7c8d9f0_drop_dead_thread_block_fields.py
@@ -1,0 +1,33 @@
+"""Drop dead thread block JSON fields.
+
+Revision ID: a4e6b7c8d9f0
+Revises: 64026791e5bf
+Create Date: 2026-04-03 17:45:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a4e6b7c8d9f0"
+down_revision: str | Sequence[str] | None = "64026791e5bf"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table("threads") as batch_op:
+        batch_op.drop_column("blocked_by_thread_ids")
+        batch_op.drop_column("blocked_by_issue_ids")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("threads") as batch_op:
+        batch_op.add_column(sa.Column("blocked_by_issue_ids", sa.JSON(), nullable=True))
+        batch_op.add_column(sa.Column("blocked_by_thread_ids", sa.JSON(), nullable=True))

--- a/app/api/thread.py
+++ b/app/api/thread.py
@@ -84,8 +84,6 @@ async def thread_to_response(
         reading_progress=reading_progress,
         next_unread_issue_id=next_unread_issue_id,
         next_unread_issue_number=next_unread_issue_number,
-        blocked_by_thread_ids=thread.blocked_by_thread_ids or [],
-        blocked_by_issue_ids=thread.blocked_by_issue_ids or [],
         blocking_reasons=[],
     )
 

--- a/app/models/thread.py
+++ b/app/models/thread.py
@@ -10,7 +10,6 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
-    JSON,
     String,
     Text,
 )
@@ -42,9 +41,6 @@ class Thread(Base):
         ForeignKey("issues.id", ondelete="SET NULL"), nullable=True
     )
     reading_progress: Mapped[str | None] = mapped_column(String(20), nullable=True)
-    # Dependency tracking fields (for Phase 3)
-    blocked_by_thread_ids: Mapped[list[int] | None] = mapped_column(JSON, nullable=True)
-    blocked_by_issue_ids: Mapped[list[int] | None] = mapped_column(JSON, nullable=True)
     queue_position: Mapped[int] = mapped_column(Integer, nullable=False)
     status: Mapped[str] = mapped_column(String(20), default="active")
     last_rating: Mapped[float | None] = mapped_column(Float, nullable=True)

--- a/app/schemas/thread.py
+++ b/app/schemas/thread.py
@@ -51,8 +51,6 @@ class ThreadResponse(BaseModel):
     reading_progress: str | None = None
     next_unread_issue_id: int | None = None
     next_unread_issue_number: str | None = None
-    blocked_by_thread_ids: list[int] = []
-    blocked_by_issue_ids: list[int] = []
 
 
 class ReactivateRequest(BaseModel):

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -104,6 +104,8 @@ async def test_get_thread(auth_client: AsyncClient, sample_data: dict) -> None:
     assert thread["issues_remaining"] == 10
     assert thread["queue_position"] == 1
     assert thread["status"] == "active"
+    assert "blocked_by_thread_ids" not in thread
+    assert "blocked_by_issue_ids" not in thread
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- remove the dead `blocked_by_thread_ids` and `blocked_by_issue_ids` fields from the Thread ORM model and thread API schema
- stop serializing those fields from `/api/threads` responses and add a regression assertion that they are absent
- add an Alembic migration to drop the unused columns from `threads`

## Testing
- `.venv/bin/pytest tests/test_api_endpoints.py -k "get_thread or list_threads"`
- `ruff check app/models/thread.py app/schemas/thread.py app/api/thread.py tests/test_api_endpoints.py alembic/versions/a4e6b7c8d9f0_drop_dead_thread_block_fields.py`
- `python3 -m py_compile alembic/versions/a4e6b7c8d9f0_drop_dead_thread_block_fields.py app/models/thread.py app/schemas/thread.py app/api/thread.py tests/test_api_endpoints.py`
- `DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5437/comic_pile_migration_check" alembic upgrade head`
- `docker exec comic-pile-e2e-postgres psql -U postgres -d comic_pile_migration_check -c "select version_num from alembic_version;"`
- `docker exec comic-pile-e2e-postgres psql -U postgres -d comic_pile_migration_check -c "select column_name from information_schema.columns where table_name = 'threads' and column_name in ('blocked_by_thread_ids','blocked_by_issue_ids');"`

## Notes
- The existing Docker test database on `5437` is metadata-created and not Alembic-stamped, so migration validation was done on a fresh scratch DB in the same container: `comic_pile_migration_check`.