### PR TITLE
fix: use html2canvas fallback on Safari for real screenshots

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^1.13.6",
         "html-to-image": "^1.11.11",
+        "html2canvas": "^1.4.1",
         "jiti": "^2.6.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -3079,6 +3080,15 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.11",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.11.tgz",
@@ -3335,6 +3345,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -4298,6 +4317,19 @@
       "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
       "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
       "license": "MIT"
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -5810,6 +5842,15 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/three": {
       "version": "0.183.2",
       "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
@@ -6038,6 +6079,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "axios": "^1.13.6",
     "html-to-image": "^1.11.11",
+    "html2canvas": "^1.4.1",
     "jiti": "^2.6.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/frontend/src/components/BugReportButton.tsx
+++ b/frontend/src/components/BugReportButton.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react'
-import { toBlob } from 'html-to-image'
 import BugReportModal from './BugReportModal'
 import { useDiagnostics } from '../hooks/useDiagnostics'
 import type { DiagnosticData } from '../hooks/useDiagnostics'
+import { captureScreenshot } from '../utils/captureScreenshot'
 
 interface BugReportButtonProps {
   onSubmit: (title: string, description: string, screenshotBlob: Blob | null, diagnosticData: DiagnosticData | null) => Promise<void>
@@ -17,17 +17,8 @@ export default function BugReportButton({ onSubmit }: BugReportButtonProps) {
   const handleClick = async () => {
     const diagnostics = collectDiagnostics()
     setDiagnosticData(diagnostics)
-
-    // Safari/iOS cannot render DOM to canvas via SVG foreignObject (html-to-image's
-    // technique), producing a black image. Skip capture and open modal without screenshot.
-    const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
-    if (isSafari) {
-      setScreenshotBlob(null)
-      setIsModalOpen(true)
-      return
-    }
     try {
-      const blob = await toBlob(document.body, { skipFonts: true })
+      const blob = await captureScreenshot()
       setScreenshotBlob(blob)
     } catch (error) {
       console.error('Failed to capture screenshot:', error)

--- a/frontend/src/utils/captureScreenshot.ts
+++ b/frontend/src/utils/captureScreenshot.ts
@@ -1,0 +1,100 @@
+import { toBlob } from 'html-to-image'
+
+/**
+ * Inject a <style> override that replaces CSS custom properties containing
+ * oklch() values with their sRGB equivalents. html2canvas cannot parse oklch,
+ * but the canvas 2D API always serialises fillStyle as sRGB — so we use that
+ * as a cheap colour-conversion step before calling html2canvas.
+ *
+ * Returns the injected <style> element (caller must remove it) or null if no
+ * oklch variables were found.
+ */
+function injectOklchFallbacks(): HTMLStyleElement | null {
+  const tmp = document.createElement('canvas')
+  tmp.width = 1
+  tmp.height = 1
+  const ctx = tmp.getContext('2d')
+  if (!ctx) return null
+
+  const overrides: Array<[string, string]> = []
+
+  for (const sheet of Array.from(document.styleSheets)) {
+    try {
+      for (const rule of Array.from(sheet.cssRules)) {
+        if (
+          rule instanceof CSSStyleRule &&
+          (rule.selectorText === ':root' ||
+            rule.selectorText === ':root, :host' ||
+            rule.selectorText === '*')
+        ) {
+          for (const prop of Array.from(rule.style)) {
+            const val = rule.style.getPropertyValue(prop).trim()
+            if (val.includes('oklch')) {
+              ctx.fillStyle = val
+              overrides.push([prop, ctx.fillStyle])
+            }
+          }
+        }
+      }
+    } catch {
+      // cross-origin stylesheet — skip
+    }
+  }
+
+  if (overrides.length === 0) return null
+
+  const style = document.createElement('style')
+  style.setAttribute('data-screenshot-override', '1')
+  style.textContent = `:root { ${overrides.map(([k, v]) => `${k}: ${v}`).join('; ')} }`
+  document.head.appendChild(style)
+  return style
+}
+
+/**
+ * Capture the current page as a PNG Blob.
+ *
+ * Strategy:
+ *  1. html-to-image toBlob  — fast, supports oklch, works on Chrome / Firefox.
+ *  2. html2canvas fallback  — used when toBlob returns null or throws (Safari /
+ *     iOS, where SVG foreignObject is blocked). oklch colours are normalised to
+ *     sRGB before calling html2canvas.
+ *
+ * Returns null only if both approaches fail.
+ */
+export async function captureScreenshot(): Promise<Blob | null> {
+  // ── Primary: html-to-image ──────────────────────────────────────────────────
+  try {
+    const blob = await toBlob(document.body, { skipFonts: true })
+    if (blob !== null) return blob
+  } catch {
+    // fall through to html2canvas
+  }
+
+  // ── Fallback: html2canvas + oklch normalisation ────────────────────────────
+  // Dynamically import so it doesn't bloat the main bundle on non-Safari browsers.
+  let html2canvas: typeof import('html2canvas').default
+  try {
+    html2canvas = (await import('html2canvas')).default
+  } catch {
+    return null
+  }
+
+  const overrideStyle = injectOklchFallbacks()
+  try {
+    const canvas = await html2canvas(document.body, {
+      useCORS: true,
+      allowTaint: true,
+      scale: Math.min(window.devicePixelRatio ?? 1, 2),
+      logging: false,
+    })
+    return new Promise<Blob | null>(resolve => {
+      canvas.toBlob(blob => resolve(blob), 'image/png')
+    })
+  } catch {
+    return null
+  } finally {
+    if (overrideStyle) {
+      document.head.removeChild(overrideStyle)
+    }
+  }
+}

--- a/frontend/src/utils/captureScreenshot.ts
+++ b/frontend/src/utils/captureScreenshot.ts
@@ -83,12 +83,16 @@ export async function captureScreenshot(): Promise<Blob | null> {
   try {
     const canvas = await html2canvas(document.body, {
       useCORS: true,
-      allowTaint: true,
+      allowTaint: false,
       scale: Math.min(window.devicePixelRatio ?? 1, 2),
       logging: false,
     })
     return new Promise<Blob | null>(resolve => {
-      canvas.toBlob(blob => resolve(blob), 'image/png')
+      try {
+        canvas.toBlob(blob => resolve(blob), 'image/png')
+      } catch {
+        resolve(null)
+      }
     })
   } catch {
     return null


### PR DESCRIPTION
## Problem
`html-to-image` uses SVG `foreignObject` to render the DOM, which Safari blocks — returning null or a black canvas. Previous fix skipped capture on Safari entirely (my bad decision, not requested).

## Solution
Fall back to `html2canvas` when `html-to-image` returns null or throws. `html2canvas` renders via Canvas 2D API (no `foreignObject`) so it works on Safari.

**`html2canvas` + oklch**: Tailwind v4 uses oklch CSS custom properties which html2canvas can't parse. Before calling it, we inject a `<style>` override that resolves all `:root` oklch variables to sRGB using the canvas `fillStyle` serialisation trick (`ctx.fillStyle = oklchVal; return ctx.fillStyle` always yields sRGB).

## Capture strategy in `captureScreenshot.ts`
1. `html-to-image` `toBlob` — primary (fast, oklch-native, Chrome/Firefox)  
2. `html2canvas` + oklch normalisation — fallback (Safari/iOS)

`html2canvas` is dynamically imported so it doesn't bloat the main bundle on non-Safari browsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screenshot capture reliability in bug reports with enhanced browser support and robust fallback handling.
  * Enhanced color handling for better visual fidelity in captured screenshots across devices.

* **Refactor**
  * Consolidated screenshot capture into a dedicated utility to simplify the reporting flow.

* **Chores**
  * Added a runtime dependency to support the new screenshot fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->