### PR TITLE
fix: remove -n 4 from post-merge CI backend tests

### DIFF
--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -127,7 +127,7 @@ jobs:
           exit 1
 
       - name: Run backend tests
-        run: pytest tests/ -n 4 --cov=comic_pile --cov-report=xml
+        run: pytest tests/ --cov=comic_pile --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
## Summary

- Removes `-n 4` from `pytest tests/` in post-merge CI Backend Tests job
- Same root-cause fix as #445 (which removed `-n 4` from E2E tests)

## Why

The 4 parallel pytest-xdist workers share a single PostgreSQL instance and race on session-scoped fixtures (`_create_database_tables`), causing hangs. This manifested as the Backend Tests job consistently timing out at exactly 20 minutes — the last 3 post-merge CI runs all cancelled on this job.

The PR CI (`ci-sharded.yml`) doesn't use `-n 4` for backend tests, which is why it completes in ~2.5 minutes while post-merge CI times out.

## Test plan

- [ ] Backend Tests job completes without timeout on next post-merge CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline test execution configuration, changing from parallelized to non-parallel test execution while maintaining code coverage collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->