### PR TITLE
fix: open bug report modal immediately before screenshot capture

### DIFF
--- a/frontend/src/components/BugReportButton.tsx
+++ b/frontend/src/components/BugReportButton.tsx
@@ -17,14 +17,13 @@ export default function BugReportButton({ onSubmit }: BugReportButtonProps) {
   const handleClick = async () => {
     const diagnostics = collectDiagnostics()
     setDiagnosticData(diagnostics)
+    setIsModalOpen(true)
     try {
       const blob = await captureScreenshot()
       setScreenshotBlob(blob)
     } catch (error) {
       console.error('Failed to capture screenshot:', error)
       setScreenshotBlob(null)
-    } finally {
-      setIsModalOpen(true)
     }
   }
 


### PR DESCRIPTION
## Summary

- Move `setIsModalOpen(true)` before `captureScreenshot()` so the modal opens on tap instead of after the screenshot finishes

## Root cause

On iOS/Safari, `html2canvas` renders the entire DOM to canvas synchronously (no `foreignObject` shortcut), which takes several seconds. The modal was in a `finally` block that only ran after `captureScreenshot()` resolved — so the "Report Bug" button appeared frozen/greyed for the duration.

## Fix

Open the modal immediately on tap. The screenshot capture continues in the background and populates when ready. If the user submits before the screenshot arrives, it submits without one — which is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bug report modal initialization timing to open immediately when the button is clicked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->