### PR TITLE
fix: foreignObject capability probe + blob validation for Safari screenshots

### DIFF
--- a/frontend/src/utils/captureScreenshot.ts
+++ b/frontend/src/utils/captureScreenshot.ts
@@ -1,13 +1,138 @@
 import { toBlob } from 'html-to-image'
 
 /**
- * Inject a <style> override that replaces CSS custom properties containing
- * oklch() values with their sRGB equivalents. html2canvas cannot parse oklch,
- * but the canvas 2D API always serialises fillStyle as sRGB — so we use that
- * as a cheap colour-conversion step before calling html2canvas.
+ * Probe whether this browser can render SVG <foreignObject> content.
  *
- * Returns the injected <style> element (caller must remove it) or null if no
- * oklch variables were found.
+ * Renders a 16×16 green div via foreignObject to a canvas and samples the
+ * centre pixel. Returns true only when the pixel is actually green — meaning
+ * foreignObject rendering works correctly on this device right now.
+ *
+ * This is the same technique used internally by html2canvas. UA sniffing is
+ * intentionally avoided: Safari behaviour varies across iOS versions,
+ * WKWebView vs Safari, and DOM/CSS complexity.
+ */
+async function supportsForeignObjectRendering(): Promise<boolean> {
+  try {
+    const size = 16
+    const xmlns = 'http://www.w3.org/2000/svg'
+
+    const svg = document.createElementNS(xmlns, 'svg')
+    svg.setAttribute('width', String(size))
+    svg.setAttribute('height', String(size))
+    svg.setAttribute('viewBox', `0 0 ${size} ${size}`)
+
+    const foreignObject = document.createElementNS(xmlns, 'foreignObject')
+    foreignObject.setAttribute('x', '0')
+    foreignObject.setAttribute('y', '0')
+    foreignObject.setAttribute('width', '100%')
+    foreignObject.setAttribute('height', '100%')
+
+    const div = document.createElement('div')
+    div.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml')
+    div.style.width = `${size}px`
+    div.style.height = `${size}px`
+    div.style.background = 'rgb(0, 255, 0)'
+
+    foreignObject.appendChild(div)
+    svg.appendChild(foreignObject)
+
+    const serialized = new XMLSerializer().serializeToString(svg)
+    const dataUrl = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(serialized)
+
+    const img = new Image()
+    img.decoding = 'sync'
+
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => resolve()
+      img.onerror = () => reject(new Error('foreignObject probe image load failed'))
+      img.src = dataUrl
+    })
+
+    const canvas = document.createElement('canvas')
+    canvas.width = size
+    canvas.height = size
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return false
+
+    ctx.drawImage(img, 0, 0)
+
+    const [r, g, b, a] = ctx.getImageData(8, 8, 1, 1).data
+    return r < 10 && g > 245 && b < 10 && a > 245
+  } catch {
+    return false
+  }
+}
+
+let foreignObjectSupportPromise: Promise<boolean> | null = null
+
+/** Returns cached foreignObject support for this page session. */
+function getForeignObjectSupport(): Promise<boolean> {
+  if (!foreignObjectSupportPromise) {
+    foreignObjectSupportPromise = supportsForeignObjectRendering()
+  }
+  return foreignObjectSupportPromise
+}
+
+/**
+ * Returns true if the blob appears to be blank, black, or nearly uniform —
+ * indicating a failed/silent render rather than real content.
+ *
+ * Downsamples to sampleSize×sampleSize before pixel inspection so it runs
+ * quickly regardless of the blob's original dimensions.
+ */
+async function blobLooksBlankOrBlack(
+  blob: Blob,
+  { sampleSize = 8, uniformTolerance = 8 }: { sampleSize?: number; uniformTolerance?: number } = {}
+): Promise<boolean> {
+  try {
+    const bitmap = await createImageBitmap(blob)
+
+    const canvas = document.createElement('canvas')
+    canvas.width = sampleSize
+    canvas.height = sampleSize
+
+    const ctx = canvas.getContext('2d', { willReadFrequently: true })
+    if (!ctx) return true
+
+    ctx.drawImage(bitmap, 0, 0, sampleSize, sampleSize)
+    const data = ctx.getImageData(0, 0, sampleSize, sampleSize).data
+
+    let blackish = 0
+    let transparentish = 0
+    let min = 255
+    let max = 0
+
+    for (let i = 0; i < data.length; i += 4) {
+      const r = data[i]
+      const g = data[i + 1]
+      const b = data[i + 2]
+      const a = data[i + 3]
+      const luminance = (r + g + b) / 3
+
+      if (a < 10) transparentish++
+      if (a > 245 && luminance < 10) blackish++
+
+      min = Math.min(min, r, g, b, a)
+      max = Math.max(max, r, g, b, a)
+    }
+
+    const total = data.length / 4
+    const almostAllBlack = blackish / total > 0.98
+    const almostAllTransparent = transparentish / total > 0.98
+    const nearlyUniform = max - min <= uniformTolerance
+
+    return almostAllBlack || almostAllTransparent || nearlyUniform
+  } catch {
+    return true
+  }
+}
+
+/**
+ * Inject a <style> override that replaces CSS custom properties containing
+ * oklch() values with their sRGB equivalents before calling html2canvas.
+ *
+ * html2canvas renders via Canvas 2D API which cannot parse oklch; the canvas
+ * fillStyle serialisation trick converts them to hex for free.
  */
 function injectOklchFallbacks(): HTMLStyleElement | null {
   const tmp = document.createElement('canvas')
@@ -54,24 +179,29 @@ function injectOklchFallbacks(): HTMLStyleElement | null {
  * Capture the current page as a PNG Blob.
  *
  * Strategy:
- *  1. html-to-image toBlob  — fast, supports oklch, works on Chrome / Firefox.
- *  2. html2canvas fallback  — used when toBlob returns null or throws (Safari /
- *     iOS, where SVG foreignObject is blocked). oklch colours are normalised to
- *     sRGB before calling html2canvas.
+ *  1. Probe whether this browser supports SVG foreignObject rendering (cached).
+ *  2. If yes, try html-to-image toBlob and validate the result isn't blank/black.
+ *  3. Fall back to html2canvas (Canvas 2D, no foreignObject) with oklch CSS
+ *     variable normalisation. This path always runs on Safari/iOS.
  *
- * Returns null only if both approaches fail.
+ * Returns null only if all approaches fail.
  */
 export async function captureScreenshot(): Promise<Blob | null> {
-  // ── Primary: html-to-image ──────────────────────────────────────────────────
-  try {
-    const blob = await toBlob(document.body, { skipFonts: true })
-    if (blob !== null) return blob
-  } catch {
-    // fall through to html2canvas
+  const canUseForeignObject = await getForeignObjectSupport()
+
+  if (canUseForeignObject) {
+    try {
+      const blob = await toBlob(document.body, { skipFonts: true })
+      if (blob !== null && !(await blobLooksBlankOrBlack(blob))) {
+        return blob
+      }
+    } catch {
+      // fall through to html2canvas
+    }
   }
 
-  // ── Fallback: html2canvas + oklch normalisation ────────────────────────────
-  // Dynamically import so it doesn't bloat the main bundle on non-Safari browsers.
+  // html2canvas fallback — Canvas 2D rendering, no foreignObject dependency.
+  // Dynamically imported so it doesn't bloat the main bundle on Chrome/Firefox.
   let html2canvas: typeof import('html2canvas').default
   try {
     html2canvas = (await import('html2canvas')).default


### PR DESCRIPTION
## Root cause

`html-to-image` silently returns a **non-null black blob** on Safari/iOS instead of throwing or returning null — Safari blocks SVG `<foreignObject>` rendering without surfacing an error. The `if (blob !== null) return blob` guard accepted this black blob, and `html2canvas` never ran.

## Fix (two layers, per ChatGPT + html2canvas project recommendation)

**1. Runtime capability probe** (cached per page session)
Renders a 16×16 green `<div>` via `<foreignObject>` to a canvas and samples the centre pixel. Only uses `html-to-image` if the pixel is actually green — i.e., foreignObject works on this specific device right now. Avoids UA sniffing, which breaks across iOS versions, WKWebView vs Safari, and DOM/CSS variations.

**2. Blob sanity check**
Even if the probe passes, downsamples the result to 8×8 and rejects blobs that are >98% black, >98% transparent, or nearly uniform — the failure modes seen on Safari.

UA sniffing removed entirely.

## Test plan
- [ ] Submit a bug report on iPhone — screenshot should be a real capture, not black

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced screenshot capture to detect rendering capabilities and validate captured images, preventing blank or black screenshots from being saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->