### PR TITLE
fix: capture screenshot before modal opens (dark backdrop was causing blank images)

### DIFF
--- a/frontend/src/components/BugReportButton.tsx
+++ b/frontend/src/components/BugReportButton.tsx
@@ -8,11 +8,8 @@ interface BugReportButtonProps {
   onSubmit: (title: string, description: string, screenshotBlob: Blob | null, diagnosticData: DiagnosticData | null) => Promise<void>
 }
 
-const SCREENSHOT_TIMEOUT_MS = 8000
-
 export default function BugReportButton({ onSubmit }: BugReportButtonProps) {
   const [isModalOpen, setIsModalOpen] = useState(false)
-  const [isCapturing, setIsCapturing] = useState(false)
   const [screenshotBlob, setScreenshotBlob] = useState<Blob | null>(null)
   const [diagnosticData, setDiagnosticData] = useState<DiagnosticData | null>(null)
   const { collectDiagnostics } = useDiagnostics()
@@ -20,21 +17,16 @@ export default function BugReportButton({ onSubmit }: BugReportButtonProps) {
   const handleClick = async () => {
     const diagnostics = collectDiagnostics()
     setDiagnosticData(diagnostics)
-    setIsCapturing(true)
-    // Capture screenshot BEFORE opening modal — the modal's dark backdrop
-    // covers the viewport and would make every screenshot appear blank.
+    // Open modal immediately for responsive UX. The modal is marked with
+    // data-exclude-from-screenshot so it's filtered out of the capture
+    // regardless of when React commits the render.
+    setIsModalOpen(true)
     try {
-      const blob = await Promise.race([
-        captureScreenshot(),
-        new Promise<null>(resolve => setTimeout(() => resolve(null), SCREENSHOT_TIMEOUT_MS)),
-      ])
+      const blob = await captureScreenshot()
       setScreenshotBlob(blob)
     } catch (error) {
       console.error('Failed to capture screenshot:', error)
       setScreenshotBlob(null)
-    } finally {
-      setIsCapturing(false)
-      setIsModalOpen(true)
     }
   }
 
@@ -53,33 +45,18 @@ export default function BugReportButton({ onSubmit }: BugReportButtonProps) {
     <>
       <button
         onClick={handleClick}
-        disabled={isCapturing}
-        className="fixed bottom-6 right-6 z-50 flex items-center gap-2 px-4 py-2 bg-amber-500 hover:bg-amber-400 text-stone-900 rounded-lg shadow-lg transition-all hover:scale-105 disabled:opacity-70 disabled:cursor-wait disabled:hover:scale-100"
-        aria-label={isCapturing ? 'Capturing screenshot…' : 'Report a bug'}
+        className="fixed bottom-6 right-6 z-50 flex items-center gap-2 px-4 py-2 bg-amber-500 hover:bg-amber-400 text-stone-900 rounded-lg shadow-lg transition-all hover:scale-105"
+        aria-label="Report a bug"
       >
-        {isCapturing ? (
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            className="w-5 h-5 animate-spin"
-          >
-            <circle cx="12" cy="12" r="10" strokeOpacity="0.25" />
-            <path d="M12 2a10 10 0 0 1 10 10" />
-          </svg>
-        ) : (
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="currentColor"
-            className="w-5 h-5"
-          >
-            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z" />
-          </svg>
-        )}
-        <span className="text-sm font-semibold">{isCapturing ? 'Capturing…' : 'Report Bug'}</span>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          className="w-5 h-5"
+        >
+          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z" />
+        </svg>
+        <span className="text-sm font-semibold">Report Bug</span>
       </button>
 
       <BugReportModal

--- a/frontend/src/components/BugReportButton.tsx
+++ b/frontend/src/components/BugReportButton.tsx
@@ -8,8 +8,11 @@ interface BugReportButtonProps {
   onSubmit: (title: string, description: string, screenshotBlob: Blob | null, diagnosticData: DiagnosticData | null) => Promise<void>
 }
 
+const SCREENSHOT_TIMEOUT_MS = 8000
+
 export default function BugReportButton({ onSubmit }: BugReportButtonProps) {
   const [isModalOpen, setIsModalOpen] = useState(false)
+  const [isCapturing, setIsCapturing] = useState(false)
   const [screenshotBlob, setScreenshotBlob] = useState<Blob | null>(null)
   const [diagnosticData, setDiagnosticData] = useState<DiagnosticData | null>(null)
   const { collectDiagnostics } = useDiagnostics()
@@ -17,13 +20,21 @@ export default function BugReportButton({ onSubmit }: BugReportButtonProps) {
   const handleClick = async () => {
     const diagnostics = collectDiagnostics()
     setDiagnosticData(diagnostics)
-    setIsModalOpen(true)
+    setIsCapturing(true)
+    // Capture screenshot BEFORE opening modal — the modal's dark backdrop
+    // covers the viewport and would make every screenshot appear blank.
     try {
-      const blob = await captureScreenshot()
+      const blob = await Promise.race([
+        captureScreenshot(),
+        new Promise<null>(resolve => setTimeout(() => resolve(null), SCREENSHOT_TIMEOUT_MS)),
+      ])
       setScreenshotBlob(blob)
     } catch (error) {
       console.error('Failed to capture screenshot:', error)
       setScreenshotBlob(null)
+    } finally {
+      setIsCapturing(false)
+      setIsModalOpen(true)
     }
   }
 
@@ -42,18 +53,33 @@ export default function BugReportButton({ onSubmit }: BugReportButtonProps) {
     <>
       <button
         onClick={handleClick}
-        className="fixed bottom-6 right-6 z-50 flex items-center gap-2 px-4 py-2 bg-amber-500 hover:bg-amber-400 text-stone-900 rounded-lg shadow-lg transition-all hover:scale-105"
-        aria-label="Report a bug"
+        disabled={isCapturing}
+        className="fixed bottom-6 right-6 z-50 flex items-center gap-2 px-4 py-2 bg-amber-500 hover:bg-amber-400 text-stone-900 rounded-lg shadow-lg transition-all hover:scale-105 disabled:opacity-70 disabled:cursor-wait disabled:hover:scale-100"
+        aria-label={isCapturing ? 'Capturing screenshot…' : 'Report a bug'}
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="currentColor"
-          className="w-5 h-5"
-        >
-          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z" />
-        </svg>
-        <span className="text-sm font-semibold">Report Bug</span>
+        {isCapturing ? (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            className="w-5 h-5 animate-spin"
+          >
+            <circle cx="12" cy="12" r="10" strokeOpacity="0.25" />
+            <path d="M12 2a10 10 0 0 1 10 10" />
+          </svg>
+        ) : (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            className="w-5 h-5"
+          >
+            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z" />
+          </svg>
+        )}
+        <span className="text-sm font-semibold">{isCapturing ? 'Capturing…' : 'Report Bug'}</span>
       </button>
 
       <BugReportModal

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -80,7 +80,7 @@ export default function Modal({
   if (!isOpen) return null
 
   return (
-    <div className={`fixed inset-0 z-50 flex items-center justify-center px-4 ${overlayClassName || ''}`}>
+    <div data-exclude-from-screenshot="true" className={`fixed inset-0 z-50 flex items-center justify-center px-4 ${overlayClassName || ''}`}>
       <div className="absolute inset-0 bg-[#110e0a]/80" onClick={onClose} aria-hidden="true"></div>
       <div
         ref={modalRef}

--- a/frontend/src/utils/captureScreenshot.ts
+++ b/frontend/src/utils/captureScreenshot.ts
@@ -176,7 +176,23 @@ function injectOklchFallbacks(): HTMLStyleElement | null {
 }
 
 /**
+ * Returns true for any node (or descendant of a node) that should be excluded
+ * from screenshots. Using closest() ensures children of excluded containers
+ * are filtered even when the capture library visits them individually.
+ */
+function shouldExclude(node: Node): boolean {
+  return (
+    node instanceof HTMLElement &&
+    node.closest('[data-exclude-from-screenshot="true"]') !== null
+  )
+}
+
+/**
  * Capture the current page as a PNG Blob.
+ *
+ * Both capture paths filter out elements marked with
+ * data-exclude-from-screenshot="true" (e.g. modal overlays) so the screenshot
+ * always shows the underlying page regardless of UI state at capture time.
  *
  * Strategy:
  *  1. Probe whether this browser supports SVG foreignObject rendering (cached).
@@ -191,7 +207,10 @@ export async function captureScreenshot(): Promise<Blob | null> {
 
   if (canUseForeignObject) {
     try {
-      const blob = await toBlob(document.body, { skipFonts: true })
+      const blob = await toBlob(document.body, {
+        skipFonts: true,
+        filter: (node) => !shouldExclude(node),
+      })
       if (blob !== null && !(await blobLooksBlankOrBlack(blob))) {
         return blob
       }
@@ -216,6 +235,7 @@ export async function captureScreenshot(): Promise<Blob | null> {
       allowTaint: false,
       scale: Math.min(window.devicePixelRatio ?? 1, 2),
       logging: false,
+      ignoreElements: shouldExclude,
     })
     return new Promise<Blob | null>(resolve => {
       try {

--- a/frontend/src/utils/captureScreenshot.ts
+++ b/frontend/src/utils/captureScreenshot.ts
@@ -182,7 +182,7 @@ function injectOklchFallbacks(): HTMLStyleElement | null {
  */
 function shouldExclude(node: Node): boolean {
   return (
-    node instanceof HTMLElement &&
+    node instanceof Element &&
     node.closest('[data-exclude-from-screenshot="true"]') !== null
   )
 }


### PR DESCRIPTION
## Root cause

The Modal component has a `bg-[#110e0a]/80` backdrop — 80% opaque dark overlay covering the entire viewport. We were calling `setIsModalOpen(true)` **before** `captureScreenshot()`, so every screenshot captured the page behind that nearly-black overlay, producing a blank/black image.

This is why all iOS screenshots looked blank despite html2canvas working correctly.

## Fix

- Capture screenshot **before** opening the modal (clean page state, no overlay)
- Add `isCapturing` state: button shows a spinner and "Capturing…" label while screenshot runs
- 8-second timeout: if capture takes too long, open modal anyway without a screenshot
- Button is disabled during capture to prevent double-tap

## UX

| Before | After |
|--------|-------|
| Button appeared frozen (old) or opened modal over dark backdrop | Spinner shows briefly, then modal opens with real screenshot |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bug report button now automatically captures diagnostics and screenshots before opening the report modal.
  * Visual loading state displays during the capture process.
  * Automatic timeout protection ensures the capture process completes within 8 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->