### PR TITLE
fix: recurse into @layer blocks when normalising oklch CSS variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,5 @@ scripts/clone_prod_users.sh
 
 # Dogfood/test output
 dogfood-output/
+.opencode_handoff/
+.playwright-mcp/

--- a/frontend/src/utils/captureScreenshot.ts
+++ b/frontend/src/utils/captureScreenshot.ts
@@ -128,11 +128,27 @@ async function blobLooksBlankOrBlack(
 }
 
 /**
+ * Walk all CSS rules recursively, yielding every CSSRule including those
+ * nested inside @layer, @media, @supports, etc.
+ */
+function* iterateCSSRules(rules: CSSRuleList): Generator<CSSRule> {
+  for (const rule of Array.from(rules)) {
+    yield rule
+    if ('cssRules' in rule && rule.cssRules) {
+      yield* iterateCSSRules(rule.cssRules as CSSRuleList)
+    }
+  }
+}
+
+/**
  * Inject a <style> override that replaces CSS custom properties containing
  * oklch() values with their sRGB equivalents before calling html2canvas.
  *
  * html2canvas renders via Canvas 2D API which cannot parse oklch; the canvas
  * fillStyle serialisation trick converts them to hex for free.
+ *
+ * Recurses into @layer/@media/@supports blocks because Tailwind v4 defines
+ * its :root variables inside `@layer theme { :root, :host { ... } }`.
  */
 function injectOklchFallbacks(): HTMLStyleElement | null {
   const tmp = document.createElement('canvas')
@@ -145,7 +161,7 @@ function injectOklchFallbacks(): HTMLStyleElement | null {
 
   for (const sheet of Array.from(document.styleSheets)) {
     try {
-      for (const rule of Array.from(sheet.cssRules)) {
+      for (const rule of iterateCSSRules(sheet.cssRules)) {
         if (
           rule instanceof CSSStyleRule &&
           (rule.selectorText === ':root' ||


### PR DESCRIPTION
## Root cause

All screenshots from iOS/Safari were the dark stone background with invisible content. html2canvas was rendering the background color correctly but all text and UI elements appeared transparent.

**Why:** Tailwind v4 defines all colour variables inside `@layer theme { :root, :host { ... } }`. The oklch normalisation code only walked top-level `cssRules`, so it never found these variables, injected no overrides, and html2canvas received raw `oklch()` values it cannot parse — rendering all colours as invalid/transparent.

## Fix

Add `iterateCSSRules()` which recursively yields rules nested inside `@layer`, `@media`, `@supports`, and any other grouping rule that exposes a `cssRules` property. The normalisation now correctly finds and overrides the Tailwind oklch variables.

## Verification

The production CSS contains: `@layer theme{:root,:host{--color-red-100:oklch(93.6% .032 17.717);...}}` — confirmed the variables are inside `@layer theme`, confirming the fix is targeted correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Screenshot capture now correctly detects and preserves color values defined inside nested CSS constructs (media queries, layers, supports, etc.), improving color fidelity in captured images.

* **Chores**
  * Updated repository ignore rules to exclude new local/tooling output directories from commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->