### PR TITLE
fix: reduce bug report button visual footprint

### DIFF
--- a/frontend/src/components/BugReportButton.tsx
+++ b/frontend/src/components/BugReportButton.tsx
@@ -49,18 +49,18 @@ export default function BugReportButton({ onSubmit }: BugReportButtonProps) {
     <>
       <button
         onClick={handleClick}
-        className="fixed bottom-6 right-6 z-50 flex items-center gap-2 px-4 py-2 bg-amber-500 hover:bg-amber-400 text-stone-900 rounded-lg shadow-lg transition-all hover:scale-105"
+        className="fixed bottom-4 right-4 z-50 flex items-center justify-center w-8 h-8 bg-stone-800/60 hover:bg-amber-500/80 text-stone-400 hover:text-stone-900 rounded-full shadow-sm transition-all backdrop-blur-sm"
         aria-label="Report a bug"
+        title="Report a bug"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
+          viewBox="0 0 20 20"
           fill="currentColor"
-          className="w-5 h-5"
+          className="w-4 h-4"
         >
-          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z" />
+          <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
         </svg>
-        <span className="text-sm font-semibold">🎯 NEW</span>
       </button>
 
       <BugReportModal


### PR DESCRIPTION
## Summary

Closes #474

- Replaces the prominent amber pill button ("🎯 NEW") with a small 32×32px semi-transparent icon-only circle in the bottom-right corner
- Uses subdued stone-800/60 background with backdrop blur, only highlighting with amber on hover
- Removes the text label and scale-on-hover animation that drew unnecessary attention
- Adds a `title` tooltip for discoverability ("Report a bug")

### Before
`fixed bottom-6 right-6`, `px-4 py-2`, amber background, bold text "🎯 NEW", `shadow-lg`, `hover:scale-105`

### After
`fixed bottom-4 right-4`, `w-8 h-8`, stone-800/60 with backdrop blur, icon-only, `shadow-sm`, rounded-full

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Repositioned and redesigned the bug report button with a new compact circular appearance
  * Enhanced visual design with semi-transparent background styling, improved hover effects, and refined color schemes
  * Added accessibility tooltip for better user guidance and discoverability
  * Streamlined the interface by removing label text for a cleaner design

<!-- end of auto-generated comment: release notes by coderabbit.ai -->