### PR TITLE
feat: warn on stale dependency target (#414)

### DIFF
--- a/app/api/dependency.py
+++ b/app/api/dependency.py
@@ -334,6 +334,29 @@ async def create_dependency(
                 detail="Cannot create dependency: would create circular dependency",
             )
 
+        warning: str | None = None
+        if target_thread.next_unread_issue_id is not None:
+            next_unread_issue = await db.get(Issue, target_thread.next_unread_issue_id)
+            if next_unread_issue is not None and target_issue.position < next_unread_issue.position:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        f"Target issue #{target_issue.issue_number} has already been read"
+                        f" in {target_thread.title} (current next unread:"
+                        f" #{next_unread_issue.issue_number}). This dependency would"
+                        f" never activate. Did you mean to target issue"
+                        f" #{next_unread_issue.issue_number}?"
+                    ),
+                )
+            if next_unread_issue is not None and target_issue.position > next_unread_issue.position:
+                issues_ahead = target_issue.position - next_unread_issue.position
+                issue_word = "issue" if issues_ahead == 1 else "issues"
+                warning = (
+                    f"Target issue #{target_issue.issue_number} is not yet the next"
+                    f" unread (current next unread: #{next_unread_issue.issue_number})."
+                    f" This dependency will activate in {issues_ahead} {issue_word}."
+                )
+
         dependency = Dependency(
             source_issue_id=dependency_data.source_id,
             target_issue_id=dependency_data.target_id,
@@ -365,7 +388,9 @@ async def create_dependency(
     await db.commit()
     await db.refresh(dependency)
 
-    return (await enrich_dependencies([dependency], db))[0]
+    response = (await enrich_dependencies([dependency], db))[0]
+    response.warning = warning
+    return response
 
 
 @router.get("/dependencies/{dependency_id}", response_model=DependencyResponse)

--- a/app/schemas/dependency.py
+++ b/app/schemas/dependency.py
@@ -30,6 +30,7 @@ class DependencyResponse(BaseModel):
     target_label: str | None = None
     source_issue_thread_id: int | None = None
     target_issue_thread_id: int | None = None
+    warning: str | None = None
 
 
 class DependencyNoteUpdate(BaseModel):

--- a/frontend/src/components/DependencyBuilder.tsx
+++ b/frontend/src/components/DependencyBuilder.tsx
@@ -427,12 +427,15 @@ const [isSavingNote, setIsSavingNote] = useState(false)
     setError('')
     try {
       if (dependencyMode === 'issue') {
-        await dependenciesApi.createDependency({
+        const result = await dependenciesApi.createDependency({
           sourceType: 'issue',
           sourceId: sourceIssueId!,
           targetType: 'issue',
           targetId: targetIssueId!,
         })
+        if (result.warning) {
+          toast.showToast(result.warning, 'warning')
+        }
       } else {
         await dependenciesApi.createDependency({
           sourceType: 'thread',
@@ -1023,6 +1026,17 @@ function DependencyRow({
             className="text-stone-500 hover:text-stone-300 text-[10px] font-black uppercase tracking-widest"
           >
             Edit note
+          </button>
+        </div>
+      ) : dependency.warning ? (
+        <div className="flex items-center gap-2">
+          <p className="text-xs text-amber-400 italic flex-1">{dependency.warning}</p>
+          <button
+            type="button"
+            onClick={() => onEditNote(dependency)}
+            className="text-stone-600 hover:text-stone-400 text-[10px] font-black uppercase tracking-widest"
+          >
+            + Add note
           </button>
         </div>
       ) : (

--- a/frontend/src/components/DependencyBuilder.tsx
+++ b/frontend/src/components/DependencyBuilder.tsx
@@ -1028,17 +1028,6 @@ function DependencyRow({
             Edit note
           </button>
         </div>
-      ) : dependency.warning ? (
-        <div className="flex items-center gap-2">
-          <p className="text-xs text-amber-400 italic flex-1">{dependency.warning}</p>
-          <button
-            type="button"
-            onClick={() => onEditNote(dependency)}
-            className="text-stone-600 hover:text-stone-400 text-[10px] font-black uppercase tracking-widest"
-          >
-            + Add note
-          </button>
-        </div>
       ) : (
         <button
           type="button"

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -323,6 +323,8 @@ export interface Dependency {
   target_issue_thread_id?: number | null;
   /** Optional note explaining why this dependency exists */
   note?: string | null;
+  /** Warning message when target issue is ahead of next-unread position */
+  warning?: string | null;
 }
 
 /**

--- a/tests/test_dependency_api.py
+++ b/tests/test_dependency_api.py
@@ -1103,3 +1103,210 @@ async def test_dependency_note_in_list_endpoint(auth_client, async_db, test_user
     data = list_resp.json()
     assert len(data["blocked_by"]) == 1
     assert data["blocked_by"][0]["note"] == "Note visible in list"
+
+
+@pytest.mark.asyncio
+async def test_dependency_rejects_already_read_target(auth_client, async_db, test_username):
+    """POST /api/v1/dependencies/ returns 400 when target issue is behind next-unread."""
+    user_result = await async_db.execute(select(User).where(User.username == test_username))
+    user = user_result.scalar_one()
+
+    source_thread = Thread(
+        title="Prereq Series",
+        format="Comic",
+        issues_remaining=1,
+        queue_position=1,
+        status="active",
+        user_id=user.id,
+        total_issues=1,
+    )
+    target_thread = Thread(
+        title="Planetary",
+        format="Comic",
+        issues_remaining=3,
+        queue_position=2,
+        status="active",
+        user_id=user.id,
+        total_issues=3,
+    )
+    async_db.add_all([source_thread, target_thread])
+    await async_db.flush()
+
+    source_issue = Issue(
+        thread_id=source_thread.id,
+        issue_number="1",
+        position=1,
+        status="unread",
+    )
+    target_issue_1 = Issue(
+        thread_id=target_thread.id,
+        issue_number="8",
+        position=1,
+        status="read",
+        read_at=datetime.now(UTC),
+    )
+    target_issue_2 = Issue(
+        thread_id=target_thread.id,
+        issue_number="9",
+        position=2,
+        status="unread",
+    )
+    async_db.add_all([source_issue, target_issue_1, target_issue_2])
+    await async_db.flush()
+
+    target_thread.next_unread_issue_id = target_issue_2.id
+    await async_db.commit()
+    await async_db.refresh(source_issue)
+    await async_db.refresh(target_issue_1)
+
+    resp = await auth_client.post(
+        "/api/v1/dependencies/",
+        json={
+            "source_type": "issue",
+            "source_id": source_issue.id,
+            "target_type": "issue",
+            "target_id": target_issue_1.id,
+        },
+    )
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert "already been read" in detail
+    assert "#8" in detail
+    assert "#9" in detail
+
+
+@pytest.mark.asyncio
+async def test_dependency_exact_next_unread_no_warning(auth_client, async_db, test_username):
+    """POST /api/v1/dependencies/ returns 201 with no warning for exact next-unread target."""
+    user_result = await async_db.execute(select(User).where(User.username == test_username))
+    user = user_result.scalar_one()
+
+    source_thread = Thread(
+        title="Exact Source",
+        format="Comic",
+        issues_remaining=1,
+        queue_position=1,
+        status="active",
+        user_id=user.id,
+        total_issues=1,
+    )
+    target_thread = Thread(
+        title="Exact Target",
+        format="Comic",
+        issues_remaining=1,
+        queue_position=2,
+        status="active",
+        user_id=user.id,
+        total_issues=1,
+    )
+    async_db.add_all([source_thread, target_thread])
+    await async_db.flush()
+
+    source_issue = Issue(
+        thread_id=source_thread.id,
+        issue_number="1",
+        position=1,
+        status="unread",
+    )
+    target_issue = Issue(
+        thread_id=target_thread.id,
+        issue_number="1",
+        position=1,
+        status="unread",
+    )
+    async_db.add_all([source_issue, target_issue])
+    await async_db.flush()
+
+    target_thread.next_unread_issue_id = target_issue.id
+    await async_db.commit()
+    await async_db.refresh(source_issue)
+    await async_db.refresh(target_issue)
+
+    resp = await auth_client.post(
+        "/api/v1/dependencies/",
+        json={
+            "source_type": "issue",
+            "source_id": source_issue.id,
+            "target_type": "issue",
+            "target_id": target_issue.id,
+        },
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data.get("warning") is None
+
+
+@pytest.mark.asyncio
+async def test_dependency_future_target_returns_warning(auth_client, async_db, test_username):
+    """POST /api/v1/dependencies/ returns 201 with warning when target is ahead of next-unread."""
+    user_result = await async_db.execute(select(User).where(User.username == test_username))
+    user = user_result.scalar_one()
+
+    source_thread = Thread(
+        title="Stormwatch Vol. 2",
+        format="Comic",
+        issues_remaining=1,
+        queue_position=1,
+        status="active",
+        user_id=user.id,
+        total_issues=1,
+    )
+    target_thread = Thread(
+        title="Planetary",
+        format="Comic",
+        issues_remaining=3,
+        queue_position=2,
+        status="active",
+        user_id=user.id,
+        total_issues=3,
+    )
+    async_db.add_all([source_thread, target_thread])
+    await async_db.flush()
+
+    source_issue = Issue(
+        thread_id=source_thread.id,
+        issue_number="11",
+        position=1,
+        status="unread",
+    )
+    target_issue_1 = Issue(
+        thread_id=target_thread.id,
+        issue_number="8",
+        position=1,
+        status="unread",
+    )
+    target_issue_2 = Issue(
+        thread_id=target_thread.id,
+        issue_number="9",
+        position=2,
+        status="unread",
+    )
+    target_issue_3 = Issue(
+        thread_id=target_thread.id,
+        issue_number="10",
+        position=3,
+        status="unread",
+    )
+    async_db.add_all([source_issue, target_issue_1, target_issue_2, target_issue_3])
+    await async_db.flush()
+
+    target_thread.next_unread_issue_id = target_issue_1.id
+    await async_db.commit()
+    await async_db.refresh(source_issue)
+    await async_db.refresh(target_issue_3)
+
+    resp = await auth_client.post(
+        "/api/v1/dependencies/",
+        json={
+            "source_type": "issue",
+            "source_id": source_issue.id,
+            "target_type": "issue",
+            "target_id": target_issue_3.id,
+        },
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["warning"] is not None
+    assert "#10" in data["warning"]
+    assert "#8" in data["warning"]
+    assert "2 issues" in data["warning"]


### PR DESCRIPTION
## Summary

- Add pre-flight validation to `POST /api/v1/dependencies/` that compares the target issue's position against the target thread's `next_unread_issue_id` position
- Returns HTTP 400 with a helpful error message when the target issue has already been read (position < next-unread)
- Returns HTTP 201 with a `warning` field in the response body when the target issue is ahead of next-unread (future dependency)
- No behavior change when target issue is exactly the next-unread (HTTP 201, no warning)
- Adds `warning: str | None = None` field to `DependencyResponse` schema
- Surfaces the warning in the frontend DependencyBuilder UI via toast notification and inline display on dependency rows
- Adds 3 test cases covering all three scenarios (already-read, exact match, future target)

Closes #414

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dependency creation now validates target issues against your reading progress and displays guidance when issues arise (e.g., target already read or ahead of next unread).
  * Warning notifications appear when creating a dependency targeting an issue further ahead than the next unread position.

* **Tests**
  * Added validation test coverage for dependency creation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->