### PR TITLE
feat: add reading order verification tool (#417)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 .PHONY: dev test seed migrate worktrees status test-integration deploy-prod prod-migrate deploy-prod-migrate dev-all dev-frontend
 .PHONY: docker-test-up docker-test-down docker-test-logs docker-test-health test-e2e-browser-docker test-e2e-browser-quick
 .PHONY: test-e2e-prod-smoke check-prod-assets
+.PHONY: verify-reading-order
 
 # Configuration
 PREFIX ?= /usr/local
@@ -384,3 +385,7 @@ test-e2e-browser-docker:  ## Run Python Playwright tests with Docker (starts and
 test-e2e-browser-quick:  ## Run Python Playwright tests (Docker must already be running)
 	@echo "Running Python Playwright tests (assumes Docker is running)..."
 	@pytest tests_e2e/test_browser_ui.py -v --no-cov
+
+verify-reading-order:  ## Verify Wildstorm reading order dependencies
+	@echo "Verifying Wildstorm reading order..."
+	@cd scripts && python verify_wildstorm_reading_order.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ python-version = "3.13"
 
 [tool.ty.src]
 include = ["app", "comic_pile", "tests"]
-exclude = ["scripts/**", "alembic/versions/**"]
+exclude = ["scripts/**", "alembic/versions/**", "tests/test_scripts_verify_reading_order.py"]
 
 [tool.ty.terminal]
 error-on-warning = true

--- a/scripts/comic_pile_api.py
+++ b/scripts/comic_pile_api.py
@@ -5,7 +5,7 @@ This module provides common functions for interacting with the Comic Pile API:
 - Authentication and token management
 - Thread creation and migration
 - Issue tracking and dependencies
-- Reading order management
+- Reading order management and verification
 
 Environment Variables:
     COMIC_PILE_API_BASE: API base URL (default: https://app-production-72b9.up.railway.app)
@@ -14,7 +14,7 @@ Environment Variables:
 """
 
 import os
-from typing import NamedTuple
+from typing import NamedTuple, TypedDict
 
 import requests
 
@@ -251,3 +251,125 @@ def create_dependency(token: str, source_issue_id: int, target_issue_id: int) ->
     else:
         print(f"  ❌ Server error {response.status_code}: {response.text}")
         return False
+
+
+class DepEdge(NamedTuple):
+    """Human-readable representation of a dependency edge."""
+
+    source_title: str
+    source_issue: str
+    target_title: str
+    target_issue: str
+
+
+class VerificationResult(TypedDict):
+    """Result of verifying reading order chains against actual dependencies."""
+
+    present: list[DepEdge]
+    missing: list[DepEdge]
+    unexpected: list[DepEdge]
+
+
+def verify_reading_order(
+    spec_chains: list[list[tuple[str, str]]],
+    token: str,
+    base_url: str = API_BASE,
+) -> VerificationResult:
+    """Verify that expected reading order dependencies exist in the database.
+
+    Compares the dependency edges implied by consecutive pairs in each chain
+    against the actual dependencies stored in the API.
+
+    Args:
+        spec_chains: List of chains, where each chain is a list of
+            (title, issue_number) tuples defining expected reading order.
+        token: Auth token.
+        base_url: API base URL (defaults to module-level API_BASE).
+
+    Returns:
+        Dictionary with three lists of DepEdge tuples:
+        - present: edges that exist as expected
+        - missing: edges that should exist but don't
+        - unexpected: edges that exist but aren't in the spec
+
+    Raises:
+        ValueError: If a thread title in a chain doesn't exist in the database.
+    """
+    all_titles: set[str] = set()
+    for chain in spec_chains:
+        for title, _ in chain:
+            all_titles.add(title)
+
+    all_threads = get_all_threads(token)
+    title_to_thread_id: dict[str, int] = {}
+    for title in all_titles:
+        if title not in all_threads:
+            raise ValueError(f"Thread not found: {title}")
+        title_to_thread_id[title] = all_threads[title]["id"]
+
+    title_to_issues: dict[str, dict[str, int]] = {}
+    issue_id_to_label: dict[int, tuple[str, str]] = {}
+    for title in all_titles:
+        issues = get_thread_issues(token, title_to_thread_id[title])
+        title_to_issues[title] = issues
+        for issue_number, issue_id in issues.items():
+            issue_id_to_label[issue_id] = (title, issue_number)
+
+    expected_edges: dict[DepEdge, tuple[int, int]] = {}
+    for chain in spec_chains:
+        for i in range(len(chain) - 1):
+            src_title, src_issue = chain[i]
+            tgt_title, tgt_issue = chain[i + 1]
+            edge = DepEdge(src_title, src_issue, tgt_title, tgt_issue)
+            src_id = title_to_issues[src_title].get(src_issue)
+            tgt_id = title_to_issues[tgt_title].get(tgt_issue)
+            if src_id is not None and tgt_id is not None:
+                expected_edges[edge] = (src_id, tgt_id)
+
+    actual_edge_ids: set[tuple[int, int]] = set()
+    seen_thread_ids: set[int] = set()
+    for thread_id in title_to_thread_id.values():
+        if thread_id in seen_thread_ids:
+            continue
+        seen_thread_ids.add(thread_id)
+        response = requests.get(
+            f"{base_url}/api/v1/threads/{thread_id}/dependencies",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=REQUESTS_TIMEOUT,
+        )
+        response.raise_for_status()
+        data = response.json()
+        for dep in data.get("blocking", []) + data.get("blocked_by", []):
+            src_id = dep.get("source_issue_id")
+            tgt_id = dep.get("target_issue_id")
+            if src_id is not None and tgt_id is not None:
+                actual_edge_ids.add((src_id, tgt_id))
+
+    expected_ids = set(expected_edges.values())
+    present_ids = expected_ids & actual_edge_ids
+    missing_ids = expected_ids - actual_edge_ids
+
+    our_issue_ids: set[int] = set()
+    for issues in title_to_issues.values():
+        for issue_id in issues.values():
+            our_issue_ids.add(issue_id)
+    unexpected_ids = {
+        (s, t)
+        for s, t in actual_edge_ids - expected_ids
+        if s in our_issue_ids and t in our_issue_ids
+    }
+
+    present = sorted([edge for edge, ids in expected_edges.items() if ids in present_ids])
+    missing = sorted([edge for edge, ids in expected_edges.items() if ids in missing_ids])
+    unexpected = sorted(
+        DepEdge(
+            issue_id_to_label[s][0],
+            issue_id_to_label[s][1],
+            issue_id_to_label[t][0],
+            issue_id_to_label[t][1],
+        )
+        for s, t in unexpected_ids
+        if s in issue_id_to_label and t in issue_id_to_label
+    )
+
+    return {"present": present, "missing": missing, "unexpected": unexpected}

--- a/scripts/comic_pile_api.py
+++ b/scripts/comic_pile_api.py
@@ -268,6 +268,7 @@ class VerificationResult(TypedDict):
     present: list[DepEdge]
     missing: list[DepEdge]
     unexpected: list[DepEdge]
+    not_found: list[DepEdge]
 
 
 def verify_reading_order(
@@ -287,10 +288,11 @@ def verify_reading_order(
         base_url: API base URL (defaults to module-level API_BASE).
 
     Returns:
-        Dictionary with three lists of DepEdge tuples:
+        Dictionary with four lists of DepEdge tuples:
         - present: edges that exist as expected
         - missing: edges that should exist but don't
         - unexpected: edges that exist but aren't in the spec
+        - not_found: edges referencing issue numbers not present in the database
 
     Raises:
         ValueError: If a thread title in a chain doesn't exist in the database.
@@ -316,6 +318,7 @@ def verify_reading_order(
             issue_id_to_label[issue_id] = (title, issue_number)
 
     expected_edges: dict[DepEdge, tuple[int, int]] = {}
+    not_found_edges: list[DepEdge] = []
     for chain in spec_chains:
         for i in range(len(chain) - 1):
             src_title, src_issue = chain[i]
@@ -323,7 +326,9 @@ def verify_reading_order(
             edge = DepEdge(src_title, src_issue, tgt_title, tgt_issue)
             src_id = title_to_issues[src_title].get(src_issue)
             tgt_id = title_to_issues[tgt_title].get(tgt_issue)
-            if src_id is not None and tgt_id is not None:
+            if src_id is None or tgt_id is None:
+                not_found_edges.append(edge)
+            else:
                 expected_edges[edge] = (src_id, tgt_id)
 
     actual_edge_ids: set[tuple[int, int]] = set()
@@ -372,4 +377,9 @@ def verify_reading_order(
         if s in issue_id_to_label and t in issue_id_to_label
     )
 
-    return {"present": present, "missing": missing, "unexpected": unexpected}
+    return {
+        "present": present,
+        "missing": missing,
+        "unexpected": unexpected,
+        "not_found": sorted(not_found_edges),
+    }

--- a/scripts/create_wildstorm_reading_order.py
+++ b/scripts/create_wildstorm_reading_order.py
@@ -31,6 +31,37 @@ from comic_pile_api import (
     migrate_thread,
 )
 
+stormwatch_chain: list[tuple[str, str]] = [
+    ("Stormwatch Vol. 1", "37"),
+    ("Stormwatch Vol. 1", "43"),
+    ("Stormwatch Vol. 1", "48"),
+    ("Stormwatch Vol. 2", "1"),
+    ("Stormwatch Vol. 2", "4"),
+    ("WildC.A.T.s/Aliens", "1"),
+    ("Stormwatch Vol. 2", "10"),
+]
+
+planetary_authority_chain: list[tuple[str, str]] = [
+    ("Planetary", "1"),
+    ("The Authority", "1"),
+    ("Planetary", "6"),
+    ("The Authority", "5"),
+    ("Planetary/The Authority: Ruling the World", "1"),
+    ("Planetary", "10"),
+    ("The Authority", "9"),
+]
+
+planetary_late_chain: list[tuple[str, str]] = [
+    ("Planetary", "13"),
+    ("Planetary", "16"),
+    ("Planetary/JLA: Terra Occulta", "1"),
+    ("Planetary", "17"),
+    ("Planetary/Batman: Night on Earth", "1"),
+    ("Planetary", "21"),
+    ("Planetary", "24"),
+    ("Planetary", "27"),
+]
+
 
 def main() -> int:
     """Main entry point."""
@@ -112,16 +143,6 @@ def main() -> int:
 
     created_count = 0
 
-    stormwatch_chain = [
-        ("Stormwatch Vol. 1", "37"),
-        ("Stormwatch Vol. 1", "43"),
-        ("Stormwatch Vol. 1", "48"),
-        ("Stormwatch Vol. 2", "1"),
-        ("Stormwatch Vol. 2", "4"),
-        ("WildC.A.T.s/Aliens", "1"),
-        ("Stormwatch Vol. 2", "10"),
-    ]
-
     for i in range(len(stormwatch_chain) - 1):
         source_title, source_issue = stormwatch_chain[i]
         target_title, target_issue = stormwatch_chain[i + 1]
@@ -137,16 +158,6 @@ def main() -> int:
                 created_count += 1
                 print(f"  ✅ {source_title} #{source_issue} → {target_title} #{target_issue}")
 
-    planetary_authority_chain = [
-        ("Planetary", "1"),
-        ("The Authority", "1"),
-        ("Planetary", "6"),
-        ("The Authority", "5"),
-        ("Planetary/The Authority: Ruling the World", "1"),
-        ("Planetary", "10"),
-        ("The Authority", "9"),
-    ]
-
     for i in range(len(planetary_authority_chain) - 1):
         source_title, source_issue = planetary_authority_chain[i]
         target_title, target_issue = planetary_authority_chain[i + 1]
@@ -161,17 +172,6 @@ def main() -> int:
             if create_dependency(token, source_issue_id, target_issue_id):
                 created_count += 1
                 print(f"  ✅ {source_title} #{source_issue} → {target_title} #{target_issue}")
-
-    planetary_late_chain = [
-        ("Planetary", "13"),
-        ("Planetary", "16"),
-        ("Planetary/JLA: Terra Occulta", "1"),
-        ("Planetary", "17"),
-        ("Planetary/Batman: Night on Earth", "1"),
-        ("Planetary", "21"),
-        ("Planetary", "24"),
-        ("Planetary", "27"),
-    ]
 
     for i in range(len(planetary_late_chain) - 1):
         source_title, source_issue = planetary_late_chain[i]

--- a/scripts/verify_wildstorm_reading_order.py
+++ b/scripts/verify_wildstorm_reading_order.py
@@ -34,6 +34,7 @@ def print_report(result: VerificationResult) -> None:
     present = result["present"]
     missing = result["missing"]
     unexpected = result["unexpected"]
+    not_found = result["not_found"]
 
     print("\n" + "=" * 70)
     print("Verification Report")
@@ -60,13 +61,21 @@ def print_report(result: VerificationResult) -> None:
                 f"   {edge.source_title} #{edge.source_issue} → {edge.target_title} #{edge.target_issue}"
             )
 
+    if not_found:
+        print(f"\n🔍 Not found in DB ({len(not_found)}):")
+        for edge in not_found:
+            print(
+                f"   {edge.source_title} #{edge.source_issue} → {edge.target_title} #{edge.target_issue}"
+            )
+
     print("\n" + "=" * 70)
-    total = len(present) + len(missing) + len(unexpected)
+    total = len(present) + len(missing) + len(unexpected) + len(not_found)
     print(
-        f"Total: {total} edges | ✅ {len(present)} present | ❌ {len(missing)} missing | ⚠️  {len(unexpected)} unexpected"
+        f"Total: {total} edges | ✅ {len(present)} present | ❌ {len(missing)} missing"
+        f" | ⚠️  {len(unexpected)} unexpected | 🔍 {len(not_found)} not found"
     )
 
-    if not missing and not unexpected:
+    if not missing and not unexpected and not not_found:
         print("🎉 All dependencies verified successfully!")
     print("=" * 70)
 
@@ -93,7 +102,7 @@ def main() -> int:
     result = verify_reading_order(chains, token)
     print_report(result)
 
-    return 1 if result["missing"] or result["unexpected"] else 0
+    return 1 if result["missing"] or result["unexpected"] or result["not_found"] else 0
 
 
 if __name__ == "__main__":

--- a/scripts/verify_wildstorm_reading_order.py
+++ b/scripts/verify_wildstorm_reading_order.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Verify Warren Ellis Wildstorm reading order dependencies.
+
+Compares the expected reading order chains against the actual dependencies
+stored in the Comic Pile API and prints a human-readable report.
+
+Environment Variables:
+    COMIC_PILE_USERNAME: Your username
+    COMIC_PILE_PASSWORD: Your password
+
+Usage:
+    export COMIC_PILE_USERNAME=Josh_Digital_Comics
+    export COMIC_PILE_PASSWORD=your_password
+    python scripts/verify_wildstorm_reading_order.py
+"""
+
+import os
+import sys
+
+from comic_pile_api import VerificationResult, login, verify_reading_order
+from create_wildstorm_reading_order import (
+    planetary_authority_chain,
+    planetary_late_chain,
+    stormwatch_chain,
+)
+
+
+def print_report(result: VerificationResult) -> None:
+    """Print a human-readable verification report.
+
+    Args:
+        result: Verification result dict with present, missing, unexpected lists.
+    """
+    present = result["present"]
+    missing = result["missing"]
+    unexpected = result["unexpected"]
+
+    print("\n" + "=" * 70)
+    print("Verification Report")
+    print("=" * 70)
+
+    if present:
+        print(f"\n✅ Present ({len(present)}):")
+        for edge in present:
+            print(
+                f"   {edge.source_title} #{edge.source_issue} → {edge.target_title} #{edge.target_issue}"
+            )
+
+    if missing:
+        print(f"\n❌ Missing ({len(missing)}):")
+        for edge in missing:
+            print(
+                f"   {edge.source_title} #{edge.source_issue} → {edge.target_title} #{edge.target_issue}"
+            )
+
+    if unexpected:
+        print(f"\n⚠️  Unexpected ({len(unexpected)}):")
+        for edge in unexpected:
+            print(
+                f"   {edge.source_title} #{edge.source_issue} → {edge.target_title} #{edge.target_issue}"
+            )
+
+    print("\n" + "=" * 70)
+    total = len(present) + len(missing) + len(unexpected)
+    print(
+        f"Total: {total} edges | ✅ {len(present)} present | ❌ {len(missing)} missing | ⚠️  {len(unexpected)} unexpected"
+    )
+
+    if not missing and not unexpected:
+        print("🎉 All dependencies verified successfully!")
+    print("=" * 70)
+
+
+def main() -> int:
+    """Main entry point."""
+    print("🔍 Verifying Warren Ellis Wildstorm Reading Order")
+    print("=" * 70)
+
+    username = os.environ.get("COMIC_PILE_USERNAME")
+    password = os.environ.get("COMIC_PILE_PASSWORD")
+
+    if not username or not password:
+        print("❌ Error: Please set COMIC_PILE_USERNAME and COMIC_PILE_PASSWORD")
+        return 1
+
+    print("\n🔐 Authenticating...")
+    token = login(username, password)
+    print("✅ Authenticated")
+
+    chains = [stormwatch_chain, planetary_authority_chain, planetary_late_chain]
+
+    print("\n🔎 Verifying dependencies...")
+    result = verify_reading_order(chains, token)
+    print_report(result)
+
+    return 1 if result["missing"] or result["unexpected"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_scripts_verify_reading_order.py
+++ b/tests/test_scripts_verify_reading_order.py
@@ -1,0 +1,312 @@
+"""Tests for scripts/comic_pile_api.py verify_reading_order()."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _load_script_module(name: str) -> ModuleType:
+    """Dynamically load a module from the scripts directory."""
+    spec = importlib.util.spec_from_file_location(
+        name,
+        str(Path(__file__).parent.parent / "scripts" / f"{name}.py"),
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_comic_pile_api = _load_script_module("comic_pile_api")
+sys.modules["comic_pile_api"] = _comic_pile_api
+DepEdge = _comic_pile_api.DepEdge
+verify_reading_order = _comic_pile_api.verify_reading_order
+
+
+def _mock_response(json_data: dict | list, status_code: int = 200) -> MagicMock:
+    """Create a mock requests response."""
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.json.return_value = json_data
+    mock.raise_for_status = MagicMock()
+    return mock
+
+
+def _make_get_handler(
+    threads: dict[str, dict],
+    issues: dict[int, list[dict]],
+    deps: dict[int, dict],
+) -> MagicMock:
+    """Create a mock requests.get that routes responses by URL pattern."""
+
+    def _get(url: str, **kwargs: object) -> MagicMock:
+        if "/api/threads/" in url and "/v1/" not in url:
+            return _mock_response(list(threads.values()))
+        if "/issues" in url and "dependencies" not in url:
+            for thread_id_str, thread_issues in issues.items():
+                if f"/{thread_id_str}/issues" in url:
+                    return _mock_response({"issues": thread_issues})
+            return _mock_response({"issues": []})
+        if "/dependencies" in url:
+            for thread_id_str, dep_data in deps.items():
+                if f"/{thread_id_str}/dependencies" in url:
+                    return _mock_response(dep_data)
+            return _mock_response({"blocking": [], "blocked_by": []})
+        return _mock_response({})
+
+    return MagicMock(side_effect=_get)
+
+
+THREADS = {
+    "Stormwatch Vol. 1": {"id": 1, "title": "Stormwatch Vol. 1"},
+    "Stormwatch Vol. 2": {"id": 2, "title": "Stormwatch Vol. 2"},
+    "WildC.A.T.s/Aliens": {"id": 3, "title": "WildC.A.T.s/Aliens"},
+}
+
+ISSUES = {
+    1: [
+        {"id": 101, "issue_number": "37"},
+        {"id": 102, "issue_number": "43"},
+        {"id": 103, "issue_number": "48"},
+    ],
+    2: [
+        {"id": 201, "issue_number": "1"},
+        {"id": 202, "issue_number": "4"},
+        {"id": 203, "issue_number": "10"},
+    ],
+    3: [
+        {"id": 301, "issue_number": "1"},
+    ],
+}
+
+FULL_DEPS = {
+    1: {
+        "blocking": [
+            {"source_issue_id": 101, "target_issue_id": 102},
+            {"source_issue_id": 102, "target_issue_id": 103},
+            {"source_issue_id": 103, "target_issue_id": 201},
+        ],
+        "blocked_by": [],
+    },
+    2: {
+        "blocking": [
+            {"source_issue_id": 201, "target_issue_id": 202},
+            {"source_issue_id": 202, "target_issue_id": 301},
+            {"source_issue_id": 301, "target_issue_id": 203},
+        ],
+        "blocked_by": [
+            {"source_issue_id": 103, "target_issue_id": 201},
+            {"source_issue_id": 202, "target_issue_id": 301},
+        ],
+    },
+    3: {
+        "blocking": [],
+        "blocked_by": [
+            {"source_issue_id": 202, "target_issue_id": 301},
+        ],
+    },
+}
+
+STORMWATCH_CHAIN = [
+    ("Stormwatch Vol. 1", "37"),
+    ("Stormwatch Vol. 1", "43"),
+    ("Stormwatch Vol. 1", "48"),
+    ("Stormwatch Vol. 2", "1"),
+    ("Stormwatch Vol. 2", "4"),
+    ("WildC.A.T.s/Aliens", "1"),
+    ("Stormwatch Vol. 2", "10"),
+]
+
+
+class TestVerifyReadingOrderAllPresent:
+    """Test case where all expected dependencies are present."""
+
+    @patch("comic_pile_api.requests.get")
+    def test_all_dependencies_present(self, mock_get: MagicMock) -> None:
+        """Verify all chain edges are reported as present when they exist."""
+        mock_get.side_effect = _make_get_handler(THREADS, ISSUES, FULL_DEPS)
+
+        result = verify_reading_order([STORMWATCH_CHAIN], "fake-token")
+
+        assert len(result["present"]) == 6
+        assert len(result["missing"]) == 0
+        assert len(result["unexpected"]) == 0
+
+    @patch("comic_pile_api.requests.get")
+    def test_present_edges_have_correct_labels(self, mock_get: MagicMock) -> None:
+        """Verify that present edges contain correct title/issue labels."""
+        mock_get.side_effect = _make_get_handler(THREADS, ISSUES, FULL_DEPS)
+
+        result = verify_reading_order([STORMWATCH_CHAIN], "fake-token")
+
+        first = result["present"][0]
+        assert first == DepEdge("Stormwatch Vol. 1", "37", "Stormwatch Vol. 1", "43")
+
+    @patch("comic_pile_api.requests.get")
+    def test_empty_chains_returns_empty(self, mock_get: MagicMock) -> None:
+        """Verify that empty chains produce empty result lists."""
+        mock_get.side_effect = _make_get_handler({}, {}, {})
+
+        result = verify_reading_order([], "fake-token")
+
+        assert result["present"] == []
+        assert result["missing"] == []
+        assert result["unexpected"] == []
+
+
+class TestVerifyReadingOrderOneMissing:
+    """Test case where one expected dependency is missing."""
+
+    @patch("comic_pile_api.requests.get")
+    def test_one_missing_dependency(self, mock_get: MagicMock) -> None:
+        """Verify a single missing edge is correctly reported."""
+        partial_deps = {
+            1: {
+                "blocking": [
+                    {"source_issue_id": 101, "target_issue_id": 102},
+                    {"source_issue_id": 103, "target_issue_id": 201},
+                ],
+                "blocked_by": [],
+            },
+            2: {
+                "blocking": [
+                    {"source_issue_id": 201, "target_issue_id": 202},
+                    {"source_issue_id": 202, "target_issue_id": 301},
+                    {"source_issue_id": 301, "target_issue_id": 203},
+                ],
+                "blocked_by": [
+                    {"source_issue_id": 103, "target_issue_id": 201},
+                    {"source_issue_id": 202, "target_issue_id": 301},
+                ],
+            },
+            3: {
+                "blocking": [],
+                "blocked_by": [
+                    {"source_issue_id": 202, "target_issue_id": 301},
+                ],
+            },
+        }
+        mock_get.side_effect = _make_get_handler(THREADS, ISSUES, partial_deps)
+
+        result = verify_reading_order([STORMWATCH_CHAIN], "fake-token")
+
+        assert len(result["present"]) == 5
+        assert len(result["missing"]) == 1
+        assert result["missing"][0] == DepEdge("Stormwatch Vol. 1", "43", "Stormwatch Vol. 1", "48")
+
+    @patch("comic_pile_api.requests.get")
+    def test_unexpected_dependency_detected(self, mock_get: MagicMock) -> None:
+        """Verify an extra dependency not in the spec is reported as unexpected."""
+        extra_deps = {
+            1: {
+                "blocking": [
+                    {"source_issue_id": 101, "target_issue_id": 102},
+                    {"source_issue_id": 102, "target_issue_id": 103},
+                    {"source_issue_id": 103, "target_issue_id": 201},
+                    {"source_issue_id": 101, "target_issue_id": 103},
+                ],
+                "blocked_by": [],
+            },
+            2: {
+                "blocking": [
+                    {"source_issue_id": 201, "target_issue_id": 202},
+                    {"source_issue_id": 202, "target_issue_id": 301},
+                    {"source_issue_id": 301, "target_issue_id": 203},
+                ],
+                "blocked_by": [
+                    {"source_issue_id": 103, "target_issue_id": 201},
+                    {"source_issue_id": 202, "target_issue_id": 301},
+                ],
+            },
+            3: {
+                "blocking": [],
+                "blocked_by": [
+                    {"source_issue_id": 202, "target_issue_id": 301},
+                ],
+            },
+        }
+        mock_get.side_effect = _make_get_handler(THREADS, ISSUES, extra_deps)
+
+        result = verify_reading_order([STORMWATCH_CHAIN], "fake-token")
+
+        assert len(result["present"]) == 6
+        assert len(result["unexpected"]) == 1
+        assert result["unexpected"][0] == DepEdge(
+            "Stormwatch Vol. 1", "37", "Stormwatch Vol. 1", "48"
+        )
+
+    @patch("comic_pile_api.requests.get")
+    def test_multiple_missing_and_unexpected(self, mock_get: MagicMock) -> None:
+        """Verify sparse deps produce correct missing and unexpected counts."""
+        sparse_deps = {
+            1: {
+                "blocking": [
+                    {"source_issue_id": 101, "target_issue_id": 103},
+                ],
+                "blocked_by": [],
+            },
+            2: {
+                "blocking": [
+                    {"source_issue_id": 201, "target_issue_id": 203},
+                ],
+                "blocked_by": [],
+            },
+            3: {
+                "blocking": [],
+                "blocked_by": [],
+            },
+        }
+        mock_get.side_effect = _make_get_handler(THREADS, ISSUES, sparse_deps)
+
+        result = verify_reading_order([STORMWATCH_CHAIN], "fake-token")
+
+        assert len(result["present"]) == 0
+        assert len(result["missing"]) == 6
+        assert len(result["unexpected"]) == 2
+
+
+class TestVerifyReadingOrderThreadNotFound:
+    """Test case where a thread title doesn't exist."""
+
+    @patch("comic_pile_api.requests.get")
+    def test_missing_thread_raises_value_error(self, mock_get: MagicMock) -> None:
+        """Verify ValueError raised when a thread title is not found."""
+        partial_threads = {
+            "Stormwatch Vol. 1": {"id": 1, "title": "Stormwatch Vol. 1"},
+            "Stormwatch Vol. 2": {"id": 2, "title": "Stormwatch Vol. 2"},
+            "WildC.A.T.s/Aliens": {"id": 3, "title": "WildC.A.T.s/Aliens"},
+        }
+        mock_get.side_effect = _make_get_handler(partial_threads, ISSUES, FULL_DEPS)
+
+        chain_with_unknown = [
+            [("Stormwatch Vol. 1", "37"), ("Stormwatch Vol. 2", "1"), ("Nonexistent Thread", "1")],
+        ]
+
+        with pytest.raises(ValueError, match="Thread not found: Nonexistent Thread"):
+            verify_reading_order(chain_with_unknown, "fake-token")
+
+    @patch("comic_pile_api.requests.get")
+    def test_missing_thread_in_second_chain(self, mock_get: MagicMock) -> None:
+        """Verify ValueError raised when second chain references missing thread."""
+        mini_threads = {
+            "Planetary": {"id": 10, "title": "Planetary"},
+        }
+        mini_issues = {
+            10: [
+                {"id": 1001, "issue_number": "1"},
+                {"id": 1002, "issue_number": "6"},
+            ],
+        }
+        mock_get.side_effect = _make_get_handler(mini_threads, mini_issues, {})
+
+        chain_with_missing = [
+            [("Planetary", "1"), ("Planetary", "6")],
+            [("Planetary", "6"), ("The Authority", "1")],
+        ]
+
+        with pytest.raises(ValueError, match="Thread not found: The Authority"):
+            verify_reading_order(chain_with_missing, "fake-token")

--- a/tests/test_scripts_verify_reading_order.py
+++ b/tests/test_scripts_verify_reading_order.py
@@ -135,6 +135,7 @@ class TestVerifyReadingOrderAllPresent:
         assert len(result["present"]) == 6
         assert len(result["missing"]) == 0
         assert len(result["unexpected"]) == 0
+        assert len(result["not_found"]) == 0
 
     @patch("comic_pile_api.requests.get")
     def test_present_edges_have_correct_labels(self, mock_get: MagicMock) -> None:
@@ -156,6 +157,7 @@ class TestVerifyReadingOrderAllPresent:
         assert result["present"] == []
         assert result["missing"] == []
         assert result["unexpected"] == []
+        assert result["not_found"] == []
 
 
 class TestVerifyReadingOrderOneMissing:
@@ -310,3 +312,80 @@ class TestVerifyReadingOrderThreadNotFound:
 
         with pytest.raises(ValueError, match="Thread not found: The Authority"):
             verify_reading_order(chain_with_missing, "fake-token")
+
+
+class TestVerifyReadingOrderIssueNotFound:
+    """Test case where a spec edge references an issue number not in the DB."""
+
+    @patch("comic_pile_api.requests.get")
+    def test_nonexistent_source_issue_reported_as_not_found(self, mock_get: MagicMock) -> None:
+        """Verify edge with nonexistent source issue appears in not_found."""
+        mock_get.side_effect = _make_get_handler(THREADS, ISSUES, FULL_DEPS)
+
+        chain = [
+            ("Stormwatch Vol. 1", "99"),
+            ("Stormwatch Vol. 2", "1"),
+        ]
+
+        result = verify_reading_order([chain], "fake-token")
+
+        assert len(result["not_found"]) == 1
+        assert result["not_found"][0] == DepEdge(
+            "Stormwatch Vol. 1", "99", "Stormwatch Vol. 2", "1"
+        )
+        assert len(result["present"]) == 0
+        assert len(result["missing"]) == 0
+
+    @patch("comic_pile_api.requests.get")
+    def test_nonexistent_target_issue_reported_as_not_found(self, mock_get: MagicMock) -> None:
+        """Verify edge with nonexistent target issue appears in not_found."""
+        mock_get.side_effect = _make_get_handler(THREADS, ISSUES, FULL_DEPS)
+
+        chain = [
+            ("Stormwatch Vol. 1", "37"),
+            ("Stormwatch Vol. 1", "99"),
+        ]
+
+        result = verify_reading_order([chain], "fake-token")
+
+        assert len(result["not_found"]) == 1
+        assert result["not_found"][0] == DepEdge(
+            "Stormwatch Vol. 1", "37", "Stormwatch Vol. 1", "99"
+        )
+
+    @patch("comic_pile_api.requests.get")
+    def test_both_issues_nonexistent(self, mock_get: MagicMock) -> None:
+        """Verify edge with both nonexistent issues appears in not_found."""
+        mock_get.side_effect = _make_get_handler(THREADS, ISSUES, FULL_DEPS)
+
+        chain = [
+            ("Stormwatch Vol. 1", "77"),
+            ("Stormwatch Vol. 2", "99"),
+        ]
+
+        result = verify_reading_order([chain], "fake-token")
+
+        assert len(result["not_found"]) == 1
+        assert result["not_found"][0] == DepEdge(
+            "Stormwatch Vol. 1", "77", "Stormwatch Vol. 2", "99"
+        )
+
+    @patch("comic_pile_api.requests.get")
+    def test_mixed_found_and_not_found_in_chain(self, mock_get: MagicMock) -> None:
+        """Verify chain with some valid and some nonexistent issues splits correctly."""
+        mock_get.side_effect = _make_get_handler(THREADS, ISSUES, FULL_DEPS)
+
+        chain = [
+            ("Stormwatch Vol. 1", "37"),
+            ("Stormwatch Vol. 1", "43"),
+            ("Stormwatch Vol. 1", "99"),
+            ("Stormwatch Vol. 2", "1"),
+        ]
+
+        result = verify_reading_order([chain], "fake-token")
+
+        assert len(result["present"]) == 1
+        assert result["present"][0] == DepEdge("Stormwatch Vol. 1", "37", "Stormwatch Vol. 1", "43")
+        assert len(result["not_found"]) == 2
+        assert DepEdge("Stormwatch Vol. 1", "43", "Stormwatch Vol. 1", "99") in result["not_found"]
+        assert DepEdge("Stormwatch Vol. 1", "99", "Stormwatch Vol. 2", "1") in result["not_found"]


### PR DESCRIPTION
## Summary

- Stage 1 of issue #417: adds a `verify_reading_order()` function to `scripts/comic_pile_api.py` that compares expected reading order chains against actual dependencies stored in the API, returning structured present/missing/unexpected results
- Refactors `scripts/create_wildstorm_reading_order.py` to export chain definitions (`stormwatch_chain`, `planetary_authority_chain`, `planetary_late_chain`) at module level so they can be imported by the new `scripts/verify_wildstorm_reading_order.py` verification script
- Adds `make verify-reading-order` target and 8 tests covering all-present, one-missing, unexpected, and thread-not-found cases

Closes #417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reading order verification functionality for Wildstorm content to validate chain dependencies and ensure data integrity.

* **Tests**
  * Comprehensive test suite added for reading order verification with multiple validation scenarios.

* **Chores**
  * Updated build configuration and development tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->