### PR TITLE
feat: add --verify/--fix flags and YAML spec for reading order (#417)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "filelock>=3.25.2",
     "PyGithub>=2.0.0",
     "pytest-xdist>=3.0.0",
+    "pyyaml>=6.0.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/create_wildstorm_reading_order.py
+++ b/scripts/create_wildstorm_reading_order.py
@@ -100,28 +100,28 @@ def _print_verification_report(result: VerificationResult) -> None:
     not_found = result["not_found"]
 
     if present:
-        print(f"  Present ({len(present)}):")
+        print(f"  ✅ Present ({len(present)}):")
         for edge in present:
             print(
                 f"    {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
             )
 
     if missing:
-        print(f"  Missing ({len(missing)}):")
+        print(f"  ❌ Missing ({len(missing)}):")
         for edge in missing:
             print(
                 f"    {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
             )
 
     if unexpected:
-        print(f"  Unexpected ({len(unexpected)}):")
+        print(f"  ⚠️ Unexpected ({len(unexpected)}):")
         for edge in unexpected:
             print(
                 f"    {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
             )
 
     if not_found:
-        print(f"  Not found in DB ({len(not_found)}):")
+        print(f"  🔍 Not found in DB ({len(not_found)}):")
         for edge in not_found:
             print(
                 f"    {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
@@ -149,7 +149,7 @@ def run_verify(token: str, chains: list[list[tuple[str, str]]]) -> int:
     _print_verification_report(result)
 
     if not result["missing"] and not result["unexpected"] and not result["not_found"]:
-        print("\nAll dependencies verified successfully!")
+        print("\n🎉 All dependencies verified successfully!")
         return 0
     return 1
 
@@ -170,11 +170,11 @@ def run_fix(token: str, chains: list[list[tuple[str, str]]]) -> int:
     if not result["missing"]:
         _print_verification_report(result)
         if not result["unexpected"] and not result["not_found"]:
-            print("\nAll dependencies verified successfully!")
+            print("\n🎉 All dependencies verified successfully!")
         return 0 if not result["unexpected"] and not result["not_found"] else 1
 
-    print(f"  Found {len(result['missing'])} missing dependencies")
-    print("\nFetching issue IDs for fix...")
+    print(f"  ❌ Found {len(result['missing'])} missing dependencies")
+    print("\n🔧 Fetching issue IDs for fix...")
 
     all_threads = get_all_threads(token)
 
@@ -201,18 +201,18 @@ def run_fix(token: str, chains: list[list[tuple[str, str]]]) -> int:
             if create_dependency(token, source_issue_id, target_issue_id):
                 fixed_count += 1
                 print(
-                    f"  Fixed: {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
+                    f"  ✅ Fixed: {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
                 )
             else:
                 print(
-                    f"  Skipped (already exists): {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
+                    f"  ⚠️ Skipped (already exists): {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
                 )
         else:
             print(
-                f"  Cannot fix (issue not in DB): {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
+                f"  🔍 Cannot fix (issue not in DB): {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
             )
 
-    print(f"\nFixed {fixed_count} dependencies")
+    print(f"\n✅ Fixed {fixed_count} dependencies")
     return 0 if fixed_count == len(result["missing"]) else 1
 
 
@@ -226,14 +226,14 @@ def run_create(token: str, chains: list[list[tuple[str, str]]]) -> int:
     Returns:
         Exit code: 0 on success.
     """
-    print("\nChecking existing threads...")
+    print("\n📖 Checking existing threads...")
     existing_threads = get_all_threads(token)
 
     if "Planetary" in existing_threads:
         planetary_thread = existing_threads["Planetary"]
         next_unread = planetary_thread.get("next_unread_issue_number", "1")
         issues_read = int(next_unread) - 1 if next_unread else 0
-        print(f"Planetary exists: next unread is #{next_unread} (read #1-{issues_read})")
+        print(f"📖 Planetary exists: next unread is #{next_unread} (read #1-{issues_read})")
 
     thread_specs = {
         "Stormwatch Vol. 1": ThreadSpec("Stormwatch Vol. 1", 50, []),
@@ -251,16 +251,16 @@ def run_create(token: str, chains: list[list[tuple[str, str]]]) -> int:
         "Planetary/Batman: Night on Earth": ThreadSpec("Planetary/Batman: Night on Earth", 1, []),
     }
 
-    print("\nCreating/migrating threads...")
+    print("\n📝 Creating/migrating threads...")
     print("=" * 70)
 
     thread_ids: dict[str, int] = {}
     for title, spec in thread_specs.items():
         if title in existing_threads:
             thread_id = existing_threads[title]["id"]
-            print(f"  Using existing: {title}")
+            print(f"  ✅ Using existing: {title}")
         else:
-            print(f"  Creating: {title}")
+            print(f"  📚 Creating: {title}")
             thread_id = create_thread(token, title, spec.total_issues)
 
         thread_ids[title] = thread_id
@@ -275,7 +275,7 @@ def run_create(token: str, chains: list[list[tuple[str, str]]]) -> int:
                 else:
                     print(f"  Migration issue for {title}: {e}")
 
-    print("\nFetching issue IDs...")
+    print("\n🔗 Fetching issue IDs...")
     print("=" * 70)
 
     thread_issue_ids: dict[str, dict[str, int]] = {}
@@ -285,7 +285,7 @@ def run_create(token: str, chains: list[list[tuple[str, str]]]) -> int:
         thread_issue_ids[title] = issues
         print(f"  {title}: {len(issues)} issues")
 
-    print("\nCreating dependencies...")
+    print("\n🔗 Creating dependencies...")
     print("=" * 70)
 
     created_count = 0
@@ -302,12 +302,12 @@ def run_create(token: str, chains: list[list[tuple[str, str]]]) -> int:
 
                 if create_dependency(token, source_issue_id, target_issue_id):
                     created_count += 1
-                    print(f"  {source_title} #{source_issue} -> {target_title} #{target_issue}")
+                    print(f"  🔗 {source_title} #{source_issue} -> {target_title} #{target_issue}")
 
     print("\n" + "=" * 70)
-    print("Summary")
+    print("📊 Summary")
     print("=" * 70)
-    print(f"Dependencies created: {created_count}")
+    print(f"🔐 Dependencies created: {created_count}")
 
     chain_names = list(load_chains().keys())
     print("\nReading structure:")
@@ -315,7 +315,7 @@ def run_create(token: str, chains: list[list[tuple[str, str]]]) -> int:
     print(f"  {chain_names[1]}: Interleaved with hard blocks")
     print(f"  {chain_names[2]}: Crossovers + endgame (#24-26)")
     print("=" * 70)
-    print("\nWarren Ellis Wildstorm reading order complete!")
+    print("\n🎉 Warren Ellis Wildstorm reading order complete!")
     print("=" * 70)
 
     return 0

--- a/scripts/create_wildstorm_reading_order.py
+++ b/scripts/create_wildstorm_reading_order.py
@@ -6,6 +6,8 @@ This script creates the proper reading order for:
 - Planetary and The Authority interleaved (1999-2000)
 - Planetary mid-run and DC crossovers (2003-2009)
 
+Chain specifications are loaded from scripts/wildstorm_reading_order.yaml.
+
 Environment Variables:
     COMIC_PILE_USERNAME: Your username
     COMIC_PILE_PASSWORD: Your password
@@ -13,9 +15,12 @@ Environment Variables:
 Usage:
     export COMIC_PILE_USERNAME=Josh_Digital_Comics
     export COMIC_PILE_PASSWORD=your_password
-    python scripts/create_wildstorm_reading_order.py
+    python scripts/create_wildstorm_reading_order.py              # Create all deps
+    python scripts/create_wildstorm_reading_order.py --verify     # Verify only
+    python scripts/create_wildstorm_reading_order.py --fix        # Create only missing deps
 """
 
+import argparse
 import os
 import sys
 
@@ -23,70 +28,212 @@ import requests
 
 from comic_pile_api import (
     ThreadSpec,
+    VerificationResult,
     create_dependency,
     create_thread,
     get_all_threads,
     get_thread_issues,
     login,
     migrate_thread,
+    verify_reading_order,
 )
-
-stormwatch_chain: list[tuple[str, str]] = [
-    ("Stormwatch Vol. 1", "37"),
-    ("Stormwatch Vol. 1", "43"),
-    ("Stormwatch Vol. 1", "48"),
-    ("Stormwatch Vol. 2", "1"),
-    ("Stormwatch Vol. 2", "4"),
-    ("WildC.A.T.s/Aliens", "1"),
-    ("Stormwatch Vol. 2", "10"),
-]
-
-planetary_authority_chain: list[tuple[str, str]] = [
-    ("Planetary", "1"),
-    ("The Authority", "1"),
-    ("Planetary", "6"),
-    ("The Authority", "5"),
-    ("Planetary/The Authority: Ruling the World", "1"),
-    ("Planetary", "10"),
-    ("The Authority", "9"),
-]
-
-planetary_late_chain: list[tuple[str, str]] = [
-    ("Planetary", "13"),
-    ("Planetary", "16"),
-    ("Planetary/JLA: Terra Occulta", "1"),
-    ("Planetary", "17"),
-    ("Planetary/Batman: Night on Earth", "1"),
-    ("Planetary", "21"),
-    ("Planetary", "24"),
-    ("Planetary", "27"),
-]
+from wildstorm_chains import load_chains_as_list, load_chains
 
 
-def main() -> int:
-    """Main entry point."""
-    print("🎯 Creating Warren Ellis Wildstorm Reading Order")
-    print("=" * 70)
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse command-line arguments.
 
+    Args:
+        argv: Command-line argument strings.
+
+    Returns:
+        Parsed namespace with verify and fix boolean flags.
+    """
+    parser = argparse.ArgumentParser(
+        description="Manage Warren Ellis Wildstorm reading order dependencies",
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--verify",
+        action="store_true",
+        help="Verify dependencies only; do not create or modify anything",
+    )
+    group.add_argument(
+        "--fix",
+        action="store_true",
+        help="Verify first, then create only the missing dependencies",
+    )
+    return parser.parse_args(argv)
+
+
+def _authenticate() -> str:
+    """Authenticate with Comic Pile API using environment credentials.
+
+    Returns:
+        Bearer token string.
+
+    Raises:
+        SystemExit: If credentials are not set.
+    """
     username = os.environ.get("COMIC_PILE_USERNAME")
     password = os.environ.get("COMIC_PILE_PASSWORD")
 
     if not username or not password:
-        print("❌ Error: Please set COMIC_PILE_USERNAME and COMIC_PILE_PASSWORD")
-        return 1
+        print("Error: Please set COMIC_PILE_USERNAME and COMIC_PILE_PASSWORD")
+        raise SystemExit(1)
 
-    print("\n🔐 Authenticating...")
+    print("\nAuthenticating...")
     token = login(username, password)
-    print("✅ Authenticated")
+    print("Authenticated")
+    return token
 
-    print("\n📚 Checking existing threads...")
+
+def _print_verification_report(result: VerificationResult) -> None:
+    """Print a human-readable verification report.
+
+    Args:
+        result: Verification result with present, missing, unexpected, not_found lists.
+    """
+    present = result["present"]
+    missing = result["missing"]
+    unexpected = result["unexpected"]
+    not_found = result["not_found"]
+
+    if present:
+        print(f"  Present ({len(present)}):")
+        for edge in present:
+            print(
+                f"    {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
+            )
+
+    if missing:
+        print(f"  Missing ({len(missing)}):")
+        for edge in missing:
+            print(
+                f"    {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
+            )
+
+    if unexpected:
+        print(f"  Unexpected ({len(unexpected)}):")
+        for edge in unexpected:
+            print(
+                f"    {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
+            )
+
+    if not_found:
+        print(f"  Not found in DB ({len(not_found)}):")
+        for edge in not_found:
+            print(
+                f"    {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
+            )
+
+    total = len(present) + len(missing) + len(unexpected) + len(not_found)
+    print(
+        f"  Total: {total} edges | {len(present)} present | {len(missing)} missing"
+        f" | {len(unexpected)} unexpected | {len(not_found)} not found"
+    )
+
+
+def run_verify(token: str, chains: list[list[tuple[str, str]]]) -> int:
+    """Run verification only, without creating or modifying dependencies.
+
+    Args:
+        token: Auth token.
+        chains: List of reading order chains.
+
+    Returns:
+        Exit code: 0 if all present, 1 if any missing/unexpected/not_found.
+    """
+    print("\nVerifying dependencies...")
+    result = verify_reading_order(chains, token)
+    _print_verification_report(result)
+
+    if not result["missing"] and not result["unexpected"] and not result["not_found"]:
+        print("\nAll dependencies verified successfully!")
+        return 0
+    return 1
+
+
+def run_fix(token: str, chains: list[list[tuple[str, str]]]) -> int:
+    """Verify first, then create only missing dependencies.
+
+    Args:
+        token: Auth token.
+        chains: List of reading order chains.
+
+    Returns:
+        Exit code: 0 on success, 1 if issues remain after fix attempt.
+    """
+    print("\nVerifying dependencies...")
+    result = verify_reading_order(chains, token)
+
+    if not result["missing"]:
+        _print_verification_report(result)
+        if not result["unexpected"] and not result["not_found"]:
+            print("\nAll dependencies verified successfully!")
+        return 0 if not result["unexpected"] and not result["not_found"] else 1
+
+    print(f"  Found {len(result['missing'])} missing dependencies")
+    print("\nFetching issue IDs for fix...")
+
+    all_threads = get_all_threads(token)
+
+    thread_issue_ids: dict[str, dict[str, int]] = {}
+    all_titles: set[str] = set()
+    for chain_edges in chains:
+        for title, _ in chain_edges:
+            all_titles.add(title)
+
+    for title in all_titles:
+        if title in all_threads:
+            issues = get_thread_issues(token, all_threads[title]["id"])
+            thread_issue_ids[title] = issues
+
+    fixed_count = 0
+    for edge in result["missing"]:
+        source_issues = thread_issue_ids.get(edge.source_title, {})
+        target_issues = thread_issue_ids.get(edge.target_title, {})
+
+        source_issue_id = source_issues.get(edge.source_issue)
+        target_issue_id = target_issues.get(edge.target_issue)
+
+        if source_issue_id is not None and target_issue_id is not None:
+            if create_dependency(token, source_issue_id, target_issue_id):
+                fixed_count += 1
+                print(
+                    f"  Fixed: {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
+                )
+            else:
+                print(
+                    f"  Skipped (already exists): {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
+                )
+        else:
+            print(
+                f"  Cannot fix (issue not in DB): {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
+            )
+
+    print(f"\nFixed {fixed_count} dependencies")
+    return 0 if fixed_count == len(result["missing"]) else 1
+
+
+def run_create(token: str, chains: list[list[tuple[str, str]]]) -> int:
+    """Create all dependencies (original behaviour).
+
+    Args:
+        token: Auth token.
+        chains: List of reading order chains.
+
+    Returns:
+        Exit code: 0 on success.
+    """
+    print("\nChecking existing threads...")
     existing_threads = get_all_threads(token)
 
     if "Planetary" in existing_threads:
         planetary_thread = existing_threads["Planetary"]
         next_unread = planetary_thread.get("next_unread_issue_number", "1")
         issues_read = int(next_unread) - 1 if next_unread else 0
-        print(f"✅ Planetary exists: next unread is #{next_unread} (read #1-{issues_read})")
+        print(f"Planetary exists: next unread is #{next_unread} (read #1-{issues_read})")
 
     thread_specs = {
         "Stormwatch Vol. 1": ThreadSpec("Stormwatch Vol. 1", 50, []),
@@ -104,14 +251,14 @@ def main() -> int:
         "Planetary/Batman: Night on Earth": ThreadSpec("Planetary/Batman: Night on Earth", 1, []),
     }
 
-    print("\n📝 Creating/migrating threads...")
+    print("\nCreating/migrating threads...")
     print("=" * 70)
 
-    thread_ids = {}
+    thread_ids: dict[str, int] = {}
     for title, spec in thread_specs.items():
         if title in existing_threads:
             thread_id = existing_threads[title]["id"]
-            print(f"  ✅ Using existing: {title}")
+            print(f"  Using existing: {title}")
         else:
             print(f"  Creating: {title}")
             thread_id = create_thread(token, title, spec.total_issues)
@@ -126,81 +273,77 @@ def main() -> int:
                 if e.response is not None and "already uses issue tracking" in e.response.text:
                     pass
                 else:
-                    print(f"  ⚠️  Migration issue for {title}: {e}")
+                    print(f"  Migration issue for {title}: {e}")
 
-    print("\n📖 Fetching issue IDs...")
+    print("\nFetching issue IDs...")
     print("=" * 70)
 
-    thread_issue_ids = {}
-    for title in thread_specs.keys():
+    thread_issue_ids: dict[str, dict[str, int]] = {}
+    for title in thread_specs:
         thread_id = thread_ids[title]
         issues = get_thread_issues(token, thread_id)
         thread_issue_ids[title] = issues
         print(f"  {title}: {len(issues)} issues")
 
-    print("\n🔗 Creating dependencies...")
+    print("\nCreating dependencies...")
     print("=" * 70)
 
     created_count = 0
+    for chain in chains:
+        for i in range(len(chain) - 1):
+            source_title, source_issue = chain[i]
+            target_title, target_issue = chain[i + 1]
 
-    for i in range(len(stormwatch_chain) - 1):
-        source_title, source_issue = stormwatch_chain[i]
-        target_title, target_issue = stormwatch_chain[i + 1]
+            if source_issue in thread_issue_ids.get(
+                source_title, {}
+            ) and target_issue in thread_issue_ids.get(target_title, {}):
+                source_issue_id = thread_issue_ids[source_title][source_issue]
+                target_issue_id = thread_issue_ids[target_title][target_issue]
 
-        if (
-            source_issue in thread_issue_ids[source_title]
-            and target_issue in thread_issue_ids[target_title]
-        ):
-            source_issue_id = thread_issue_ids[source_title][source_issue]
-            target_issue_id = thread_issue_ids[target_title][target_issue]
-
-            if create_dependency(token, source_issue_id, target_issue_id):
-                created_count += 1
-                print(f"  ✅ {source_title} #{source_issue} → {target_title} #{target_issue}")
-
-    for i in range(len(planetary_authority_chain) - 1):
-        source_title, source_issue = planetary_authority_chain[i]
-        target_title, target_issue = planetary_authority_chain[i + 1]
-
-        if (
-            source_issue in thread_issue_ids[source_title]
-            and target_issue in thread_issue_ids[target_title]
-        ):
-            source_issue_id = thread_issue_ids[source_title][source_issue]
-            target_issue_id = thread_issue_ids[target_title][target_issue]
-
-            if create_dependency(token, source_issue_id, target_issue_id):
-                created_count += 1
-                print(f"  ✅ {source_title} #{source_issue} → {target_title} #{target_issue}")
-
-    for i in range(len(planetary_late_chain) - 1):
-        source_title, source_issue = planetary_late_chain[i]
-        target_title, target_issue = planetary_late_chain[i + 1]
-
-        if (
-            source_issue in thread_issue_ids[source_title]
-            and target_issue in thread_issue_ids[target_title]
-        ):
-            source_issue_id = thread_issue_ids[source_title][source_issue]
-            target_issue_id = thread_issue_ids[target_title][target_issue]
-
-            if create_dependency(token, source_issue_id, target_issue_id):
-                created_count += 1
-                print(f"  ✅ {source_title} #{source_issue} → {target_title} #{target_issue}")
+                if create_dependency(token, source_issue_id, target_issue_id):
+                    created_count += 1
+                    print(f"  {source_title} #{source_issue} -> {target_title} #{target_issue}")
 
     print("\n" + "=" * 70)
-    print("📊 Summary")
+    print("Summary")
     print("=" * 70)
-    print(f"✅ Dependencies created: {created_count}")
-    print("\n📖 Reading structure:")
-    print("  🔵 Stormwatch chain: STRICT ORDER (with WildC.A.T.s/Aliens block)")
-    print("  🟢 Planetary/Authority: Interleaved with hard blocks")
-    print("  🟡 Planetary late: Crossovers + endgame (#24-26)")
+    print(f"Dependencies created: {created_count}")
+
+    chain_names = list(load_chains().keys())
+    print("\nReading structure:")
+    print(f"  {chain_names[0]}: STRICT ORDER (with WildC.A.T.s/Aliens block)")
+    print(f"  {chain_names[1]}: Interleaved with hard blocks")
+    print(f"  {chain_names[2]}: Crossovers + endgame (#24-26)")
     print("=" * 70)
-    print("\n🎉 Warren Ellis Wildstorm reading order complete!")
+    print("\nWarren Ellis Wildstorm reading order complete!")
     print("=" * 70)
 
     return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entry point.
+
+    Args:
+        argv: Command-line arguments. Defaults to sys.argv[1:].
+
+    Returns:
+        Exit code.
+    """
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    chains = load_chains_as_list()
+
+    print("Warren Ellis Wildstorm Reading Order")
+    print("=" * 70)
+
+    token = _authenticate()
+
+    if args.verify:
+        return run_verify(token, chains)
+    elif args.fix:
+        return run_fix(token, chains)
+    else:
+        return run_create(token, chains)
 
 
 if __name__ == "__main__":

--- a/scripts/verify_wildstorm_reading_order.py
+++ b/scripts/verify_wildstorm_reading_order.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Verify Warren Ellis Wildstorm reading order dependencies.
 
-Compares the expected reading order chains against the actual dependencies
+Compares the expected reading order chains (loaded from
+scripts/wildstorm_reading_order.yaml) against the actual dependencies
 stored in the Comic Pile API and prints a human-readable report.
 
 Environment Variables:
@@ -18,11 +19,7 @@ import os
 import sys
 
 from comic_pile_api import VerificationResult, login, verify_reading_order
-from create_wildstorm_reading_order import (
-    planetary_authority_chain,
-    planetary_late_chain,
-    stormwatch_chain,
-)
+from wildstorm_chains import load_chains_as_list
 
 
 def print_report(result: VerificationResult) -> None:
@@ -41,64 +38,64 @@ def print_report(result: VerificationResult) -> None:
     print("=" * 70)
 
     if present:
-        print(f"\n✅ Present ({len(present)}):")
+        print(f"\n  Present ({len(present)}):")
         for edge in present:
             print(
-                f"   {edge.source_title} #{edge.source_issue} → {edge.target_title} #{edge.target_issue}"
+                f"   {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
             )
 
     if missing:
-        print(f"\n❌ Missing ({len(missing)}):")
+        print(f"\n  Missing ({len(missing)}):")
         for edge in missing:
             print(
-                f"   {edge.source_title} #{edge.source_issue} → {edge.target_title} #{edge.target_issue}"
+                f"   {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
             )
 
     if unexpected:
-        print(f"\n⚠️  Unexpected ({len(unexpected)}):")
+        print(f"\n  Unexpected ({len(unexpected)}):")
         for edge in unexpected:
             print(
-                f"   {edge.source_title} #{edge.source_issue} → {edge.target_title} #{edge.target_issue}"
+                f"   {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
             )
 
     if not_found:
-        print(f"\n🔍 Not found in DB ({len(not_found)}):")
+        print(f"\n  Not found in DB ({len(not_found)}):")
         for edge in not_found:
             print(
-                f"   {edge.source_title} #{edge.source_issue} → {edge.target_title} #{edge.target_issue}"
+                f"   {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
             )
 
     print("\n" + "=" * 70)
     total = len(present) + len(missing) + len(unexpected) + len(not_found)
     print(
-        f"Total: {total} edges | ✅ {len(present)} present | ❌ {len(missing)} missing"
-        f" | ⚠️  {len(unexpected)} unexpected | 🔍 {len(not_found)} not found"
+        f"Total: {total} edges | {len(present)} present | {len(missing)} missing"
+        f" | {len(unexpected)} unexpected | {len(not_found)} not found"
     )
 
     if not missing and not unexpected and not not_found:
-        print("🎉 All dependencies verified successfully!")
+        print("All dependencies verified successfully!")
     print("=" * 70)
 
 
 def main() -> int:
     """Main entry point."""
-    print("🔍 Verifying Warren Ellis Wildstorm Reading Order")
+    print("Verifying Warren Ellis Wildstorm Reading Order")
     print("=" * 70)
 
     username = os.environ.get("COMIC_PILE_USERNAME")
     password = os.environ.get("COMIC_PILE_PASSWORD")
 
     if not username or not password:
-        print("❌ Error: Please set COMIC_PILE_USERNAME and COMIC_PILE_PASSWORD")
+        print("Error: Please set COMIC_PILE_USERNAME and COMIC_PILE_PASSWORD")
         return 1
 
-    print("\n🔐 Authenticating...")
+    print("\nAuthenticating...")
     token = login(username, password)
-    print("✅ Authenticated")
+    print("Authenticated")
 
-    chains = [stormwatch_chain, planetary_authority_chain, planetary_late_chain]
+    chains = load_chains_as_list()
 
-    print("\n🔎 Verifying dependencies...")
+    print("\nVerifying dependencies...")
     result = verify_reading_order(chains, token)
     print_report(result)
 

--- a/scripts/verify_wildstorm_reading_order.py
+++ b/scripts/verify_wildstorm_reading_order.py
@@ -38,28 +38,28 @@ def print_report(result: VerificationResult) -> None:
     print("=" * 70)
 
     if present:
-        print(f"\n  Present ({len(present)}):")
+        print(f"\n  ✅ Present ({len(present)}):")
         for edge in present:
             print(
                 f"   {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
             )
 
     if missing:
-        print(f"\n  Missing ({len(missing)}):")
+        print(f"\n  ❌ Missing ({len(missing)}):")
         for edge in missing:
             print(
                 f"   {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
             )
 
     if unexpected:
-        print(f"\n  Unexpected ({len(unexpected)}):")
+        print(f"\n  ⚠️ Unexpected ({len(unexpected)}):")
         for edge in unexpected:
             print(
                 f"   {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
             )
 
     if not_found:
-        print(f"\n  Not found in DB ({len(not_found)}):")
+        print(f"\n  🔍 Not found in DB ({len(not_found)}):")
         for edge in not_found:
             print(
                 f"   {edge.source_title} #{edge.source_issue} -> {edge.target_title} #{edge.target_issue}"
@@ -73,13 +73,13 @@ def print_report(result: VerificationResult) -> None:
     )
 
     if not missing and not unexpected and not not_found:
-        print("All dependencies verified successfully!")
+        print("🎉 All dependencies verified successfully!")
     print("=" * 70)
 
 
 def main() -> int:
     """Main entry point."""
-    print("Verifying Warren Ellis Wildstorm Reading Order")
+    print("🔍 Verifying Warren Ellis Wildstorm Reading Order")
     print("=" * 70)
 
     username = os.environ.get("COMIC_PILE_USERNAME")

--- a/scripts/wildstorm_chains.py
+++ b/scripts/wildstorm_chains.py
@@ -1,0 +1,52 @@
+"""Shared YAML loading utilities for Wildstorm reading order scripts.
+
+Provides a single source of truth for loading chain specifications from
+scripts/wildstorm_reading_order.yaml.
+"""
+
+from pathlib import Path
+
+import yaml
+
+YAML_PATH = Path(__file__).parent / "wildstorm_reading_order.yaml"
+
+
+def load_chains() -> dict[str, list[tuple[str, str]]]:
+    """Load reading order chains from the YAML spec file.
+
+    Returns:
+        Dictionary mapping chain names to lists of (title, issue_number) tuples.
+
+    Raises:
+        FileNotFoundError: If the YAML spec file does not exist.
+        ValueError: If any chain has fewer than 2 edges (cannot form dependencies).
+    """
+    if not YAML_PATH.exists():
+        raise FileNotFoundError(f"YAML spec not found: {YAML_PATH}")
+
+    with YAML_PATH.open("r") as f:
+        data = yaml.safe_load(f)
+
+    chains: dict[str, list[tuple[str, str]]] = {}
+    for chain_def in data["chains"]:
+        name = chain_def["name"]
+        edges = [(edge[0], edge[1]) for edge in chain_def["edges"]]
+        if len(edges) < 2:
+            raise ValueError(f"Chain '{name}' must have at least 2 edges, got {len(edges)}")
+        chains[name] = edges
+
+    return chains
+
+
+def load_chains_as_list() -> list[list[tuple[str, str]]]:
+    """Load reading order chains as an ordered list.
+
+    Returns:
+        List of chains in YAML definition order, each a list of
+        (title, issue_number) tuples.
+    """
+    chain_dict = load_chains()
+    with YAML_PATH.open("r") as f:
+        data = yaml.safe_load(f)
+    ordered_names = [chain_def["name"] for chain_def in data["chains"]]
+    return [chain_dict[name] for name in ordered_names]

--- a/scripts/wildstorm_chains.py
+++ b/scripts/wildstorm_chains.py
@@ -45,8 +45,4 @@ def load_chains_as_list() -> list[list[tuple[str, str]]]:
         List of chains in YAML definition order, each a list of
         (title, issue_number) tuples.
     """
-    chain_dict = load_chains()
-    with YAML_PATH.open("r") as f:
-        data = yaml.safe_load(f)
-    ordered_names = [chain_def["name"] for chain_def in data["chains"]]
-    return [chain_dict[name] for name in ordered_names]
+    return list(load_chains().values())

--- a/scripts/wildstorm_reading_order.yaml
+++ b/scripts/wildstorm_reading_order.yaml
@@ -1,0 +1,34 @@
+chains:
+  - name: stormwatch
+    description: "Stormwatch (1996-1998) with WildC.A.T.s/Aliens crossover"
+    edges:
+      - ["Stormwatch Vol. 1", "37"]
+      - ["Stormwatch Vol. 1", "43"]
+      - ["Stormwatch Vol. 1", "48"]
+      - ["Stormwatch Vol. 2", "1"]
+      - ["Stormwatch Vol. 2", "4"]
+      - ["WildC.A.T.s/Aliens", "1"]
+      - ["Stormwatch Vol. 2", "10"]
+
+  - name: planetary_authority
+    description: "Planetary and The Authority interleaved (1999-2000)"
+    edges:
+      - ["Planetary", "1"]
+      - ["The Authority", "1"]
+      - ["Planetary", "6"]
+      - ["The Authority", "5"]
+      - ["Planetary/The Authority: Ruling the World", "1"]
+      - ["Planetary", "10"]
+      - ["The Authority", "9"]
+
+  - name: planetary_late
+    description: "Planetary mid-run and DC crossovers (2003-2009)"
+    edges:
+      - ["Planetary", "13"]
+      - ["Planetary", "16"]
+      - ["Planetary/JLA: Terra Occulta", "1"]
+      - ["Planetary", "17"]
+      - ["Planetary/Batman: Night on Earth", "1"]
+      - ["Planetary", "21"]
+      - ["Planetary", "24"]
+      - ["Planetary", "27"]

--- a/tests/test_scripts_verify_reading_order.py
+++ b/tests/test_scripts_verify_reading_order.py
@@ -1,4 +1,4 @@
-"""Tests for scripts/comic_pile_api.py verify_reading_order()."""
+"""Tests for scripts/comic_pile_api.py verify_reading_order() and create_wildstorm_reading_order.py flags."""
 
 import importlib.util
 import sys
@@ -25,6 +25,14 @@ _comic_pile_api = _load_script_module("comic_pile_api")
 sys.modules["comic_pile_api"] = _comic_pile_api
 DepEdge = _comic_pile_api.DepEdge
 verify_reading_order = _comic_pile_api.verify_reading_order
+
+_wildstorm_chains = _load_script_module("wildstorm_chains")
+sys.modules["wildstorm_chains"] = _wildstorm_chains
+
+_create_module = _load_script_module("create_wildstorm_reading_order")
+run_verify = _create_module.run_verify
+run_fix = _create_module.run_fix
+_parse_args = _create_module._parse_args
 
 
 def _mock_response(json_data: dict | list, status_code: int = 200) -> MagicMock:
@@ -389,3 +397,163 @@ class TestVerifyReadingOrderIssueNotFound:
         assert len(result["not_found"]) == 2
         assert DepEdge("Stormwatch Vol. 1", "43", "Stormwatch Vol. 1", "99") in result["not_found"]
         assert DepEdge("Stormwatch Vol. 1", "99", "Stormwatch Vol. 2", "1") in result["not_found"]
+
+
+MINI_CHAINS: list[list[tuple[str, str]]] = [
+    [
+        ("Stormwatch Vol. 1", "37"),
+        ("Stormwatch Vol. 1", "43"),
+        ("Stormwatch Vol. 1", "48"),
+    ],
+]
+
+
+class TestArgParsing:
+    """Tests for command-line argument parsing."""
+
+    def test_no_flags_defaults(self) -> None:
+        """Verify no flags means neither verify nor fix."""
+        args = _parse_args([])
+        assert args.verify is False
+        assert args.fix is False
+
+    def test_verify_flag(self) -> None:
+        """Verify --verify flag sets verify=True."""
+        args = _parse_args(["--verify"])
+        assert args.verify is True
+        assert args.fix is False
+
+    def test_fix_flag(self) -> None:
+        """Verify --fix flag sets fix=True."""
+        args = _parse_args(["--fix"])
+        assert args.verify is False
+        assert args.fix is True
+
+    def test_verify_and_fix_mutually_exclusive(self) -> None:
+        """Verify --verify and --fix cannot be used together."""
+        with pytest.raises(SystemExit):
+            _parse_args(["--verify", "--fix"])
+
+
+class TestRunVerify:
+    """Tests for the --verify flag behaviour."""
+
+    @patch("comic_pile_api.requests.post")
+    @patch("comic_pile_api.requests.get")
+    def test_verify_returns_zero_when_all_present(
+        self, mock_get: MagicMock, mock_post: MagicMock
+    ) -> None:
+        """Verify --verify returns 0 when all deps are present."""
+        mock_get.side_effect = _make_get_handler(THREADS, ISSUES, FULL_DEPS)
+        mock_post.return_value = MagicMock()
+
+        exit_code = run_verify("fake-token", MINI_CHAINS)
+
+        assert exit_code == 0
+        mock_post.assert_not_called()
+
+    @patch("comic_pile_api.requests.post")
+    @patch("comic_pile_api.requests.get")
+    def test_verify_returns_one_when_missing(
+        self, mock_get: MagicMock, mock_post: MagicMock
+    ) -> None:
+        """Verify --verify returns 1 when deps are missing."""
+        partial_deps = {
+            1: {
+                "blocking": [
+                    {"source_issue_id": 101, "target_issue_id": 102},
+                ],
+                "blocked_by": [],
+            },
+            2: {"blocking": [], "blocked_by": []},
+            3: {"blocking": [], "blocked_by": []},
+        }
+        mock_get.side_effect = _make_get_handler(THREADS, ISSUES, partial_deps)
+        mock_post.return_value = MagicMock()
+
+        exit_code = run_verify("fake-token", MINI_CHAINS)
+
+        assert exit_code == 1
+        mock_post.assert_not_called()
+
+    @patch("comic_pile_api.requests.post")
+    @patch("comic_pile_api.requests.get")
+    def test_verify_does_not_create_deps(self, mock_get: MagicMock, mock_post: MagicMock) -> None:
+        """Verify --verify never calls create_dependency (no POST to dependencies endpoint)."""
+        mock_get.side_effect = _make_get_handler(THREADS, ISSUES, FULL_DEPS)
+        mock_post.return_value = MagicMock()
+
+        run_verify("fake-token", MINI_CHAINS)
+
+        mock_post.assert_not_called()
+
+
+class TestRunFix:
+    """Tests for the --fix flag behaviour."""
+
+    @patch("comic_pile_api.requests.post")
+    @patch("comic_pile_api.requests.get")
+    def test_fix_creates_only_missing_deps(self, mock_get: MagicMock, mock_post: MagicMock) -> None:
+        """Verify --fix creates only the missing dependencies, not present ones."""
+        partial_deps = {
+            1: {
+                "blocking": [
+                    {"source_issue_id": 101, "target_issue_id": 102},
+                ],
+                "blocked_by": [],
+            },
+            2: {"blocking": [], "blocked_by": []},
+            3: {"blocking": [], "blocked_by": []},
+        }
+        mock_get.side_effect = _make_get_handler(THREADS, ISSUES, partial_deps)
+        dep_response = MagicMock()
+        dep_response.status_code = 201
+        mock_post.return_value = dep_response
+
+        exit_code = run_fix("fake-token", MINI_CHAINS)
+
+        assert exit_code == 0
+        dep_calls = [call for call in mock_post.call_args_list if "/dependencies/" in str(call)]
+        assert len(dep_calls) == 1
+
+    @patch("comic_pile_api.requests.post")
+    @patch("comic_pile_api.requests.get")
+    def test_fix_noop_when_all_present(self, mock_get: MagicMock, mock_post: MagicMock) -> None:
+        """Verify --fix does nothing when all deps are already present."""
+        mock_get.side_effect = _make_get_handler(THREADS, ISSUES, FULL_DEPS)
+        dep_response = MagicMock()
+        dep_response.status_code = 201
+        mock_post.return_value = dep_response
+
+        exit_code = run_fix("fake-token", MINI_CHAINS)
+
+        assert exit_code == 0
+        dep_calls = [call for call in mock_post.call_args_list if "/dependencies/" in str(call)]
+        assert len(dep_calls) == 0
+
+    @patch("comic_pile_api.requests.post")
+    @patch("comic_pile_api.requests.get")
+    def test_fix_does_not_recreate_present_deps(
+        self, mock_get: MagicMock, mock_post: MagicMock
+    ) -> None:
+        """Verify --fix only creates the missing edges, not the already-present one."""
+        partial_deps = {
+            1: {
+                "blocking": [
+                    {"source_issue_id": 101, "target_issue_id": 103},
+                ],
+                "blocked_by": [],
+            },
+            2: {"blocking": [], "blocked_by": []},
+            3: {"blocking": [], "blocked_by": []},
+        }
+        mock_get.side_effect = _make_get_handler(THREADS, ISSUES, partial_deps)
+        dep_response = MagicMock()
+        dep_response.status_code = 201
+        mock_post.return_value = dep_response
+
+        exit_code = run_fix("fake-token", MINI_CHAINS)
+
+        assert exit_code == 0
+        dep_calls = [call for call in mock_post.call_args_list if "/dependencies/" in str(call)]
+        assert len(dep_calls) == 2


### PR DESCRIPTION
## Summary

- Externalize the three Wildstorm reading order chains into `scripts/wildstorm_reading_order.yaml` with a structured format (name, description, edges)
- Add `scripts/wildstorm_chains.py` shared YAML loader module used by both create and verify scripts
- Add `--verify` flag to `create_wildstorm_reading_order.py` that authenticates, runs verification only, and exits 0/1 without creating or modifying any dependencies
- Add `--fix` flag to `create_wildstorm_reading_order.py` that verifies first, then creates only the missing dependencies (does not re-create already-present deps)
- Update `verify_wildstorm_reading_order.py` to load chains from YAML via `wildstorm_chains` instead of importing from the create script
- Add 7 new tests: arg parsing (4), `--verify` behaviour (3), `--fix` behaviour (3)
- Default behaviour (no flags) remains unchanged — creates all dependencies

Closes #417 (Stage 2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added verification mode to check reading order completeness without making changes.
  * Added fix mode to automatically resolve missing dependencies.
  * Improved error reporting distinguishing between missing, present, and unexpected dependencies.

* **Refactor**
  * Reading order chains are now loaded from external configuration instead of hardcoded values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->