### PR TITLE
fix: paginate get_all_threads and handle dict response format

### DIFF
--- a/scripts/comic_pile_api.py
+++ b/scripts/comic_pile_api.py
@@ -68,13 +68,28 @@ def get_all_threads(token: str) -> dict[str, dict]:
     Returns:
         Dictionary mapping thread titles to thread info dicts
     """
-    response = requests.get(
-        f"{API_BASE}/api/threads/",
-        headers={"Authorization": f"Bearer {token}"},
-        timeout=REQUESTS_TIMEOUT,
-    )
-    response.raise_for_status()
-    return {thread["title"]: thread for thread in response.json()}
+    all_threads: list[dict] = []
+    page_token: str | None = None
+
+    while True:
+        params: dict[str, str | int] = {"page_size": 200}
+        if page_token:
+            params["page_token"] = page_token
+        response = requests.get(
+            f"{API_BASE}/api/threads/",
+            headers={"Authorization": f"Bearer {token}"},
+            params=params,
+            timeout=REQUESTS_TIMEOUT,
+        )
+        response.raise_for_status()
+        data = response.json()
+        threads = data["threads"] if isinstance(data, dict) else data
+        all_threads.extend(threads)
+        page_token = data.get("next_page_token") if isinstance(data, dict) else None
+        if not page_token:
+            break
+
+    return {thread["title"]: thread for thread in all_threads}
 
 
 def create_thread(token: str, title: str, issues_count: int, format: str = "Comics") -> int:


### PR DESCRIPTION
## Summary
- `get_all_threads()` was treating the API response as a bare list, but the endpoint returns `{"threads": [...], "next_page_token": "..."}`
- Only the first ~50 threads were fetched (no pagination), causing threads beyond page 1 to silently appear missing in verification scripts
- Stormwatch Vol. 1 appeared as "not found" in the Wildstorm reading order verification despite existing in production — it was on page 2

## Test plan
- [ ] Run `verify_wildstorm_reading_order.py` against production and confirm all 17 deps show as ✅ Present with 0 missing/unexpected
- [ ] Confirm the function correctly paginates for users with >200 threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)