### PR TITLE
Shuffle stagnant pool

### DIFF
--- a/app/api/queue.py
+++ b/app/api/queue.py
@@ -4,7 +4,7 @@ import logging
 from datetime import UTC, datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -15,7 +15,7 @@ from app.middleware import limiter
 from app.models import Event, Thread, User
 from app.schemas import ThreadResponse
 from app.api.thread import thread_to_response
-from comic_pile.queue import move_to_back, move_to_front, move_to_position
+from comic_pile.queue import move_to_back, move_to_front, move_to_position, shuffle_queue
 
 logger = logging.getLogger(__name__)
 
@@ -210,3 +210,34 @@ async def move_thread_back(
         clear_cache()
 
     return await thread_to_response(thread, db)
+
+
+@router.post("/shuffle/", status_code=status.HTTP_204_NO_CONTENT)
+@limiter.limit("30/minute")
+async def shuffle_threads(
+    request: Request,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> Response:
+    """Randomize all active queue positions for the authenticated user.
+
+    Args:
+        request: FastAPI request object for rate limiting.
+        current_user: The authenticated user making the request.
+        db: SQLAlchemy session for database operations.
+
+    Returns:
+        Empty response with HTTP 204 status.
+    """
+    logger.info(
+        "API shuffle_threads: user_id=%s, request_url=%s",
+        current_user.id,
+        request.url,
+    )
+
+    await shuffle_queue(current_user.id, db)
+
+    if clear_cache:
+        clear_cache()
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/comic_pile/queue.py
+++ b/comic_pile/queue.py
@@ -1,6 +1,7 @@
 """Queue management functions."""
 
 import logging
+import random
 from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import select, update
@@ -218,6 +219,36 @@ async def move_to_position(
         logger.debug(
             f"  Position {thread.queue_position}: Thread {thread.id} ('{thread.title[:50]}...')"
         )
+
+
+async def shuffle_queue(user_id: int, db: AsyncSession) -> int:
+    """Randomize the order of active queue threads for a user.
+
+    Args:
+        user_id: The user whose active queue should be shuffled.
+        db: The async database session.
+
+    Returns:
+        Number of active threads that were shuffled.
+    """
+    result = await db.execute(
+        select(Thread)
+        .where(Thread.user_id == user_id)
+        .where(Thread.status == "active")
+        .where(Thread.queue_position >= 1)
+        .order_by(Thread.queue_position, Thread.id)
+    )
+    threads = list(result.scalars().all())
+
+    if len(threads) < 2:
+        return len(threads)
+
+    random.shuffle(threads)
+    for position, thread in enumerate(threads, start=1):
+        thread.queue_position = position
+
+    await db.commit()
+    return len(threads)
 
 
 async def get_roll_pool(

--- a/frontend/src/hooks/useQueue.ts
+++ b/frontend/src/hooks/useQueue.ts
@@ -65,3 +65,24 @@ export function useMoveToBack() {
 
   return { mutate, isPending, isError }
 }
+
+export function useShuffleQueue() {
+  const [isPending, setIsPending] = useState(false)
+  const [isError, setIsError] = useState(false)
+
+  const mutate = useCallback(async () => {
+    try {
+      setIsPending(true)
+      setIsError(false)
+      await queueApi.shuffle()
+    } catch (error: unknown) {
+      setIsError(true)
+      console.error('Failed to shuffle queue:', getApiErrorDetail(error))
+      throw error
+    } finally {
+      setIsPending(false)
+    }
+  }, [])
+
+  return { mutate, isPending, isError }
+}

--- a/frontend/src/pages/QueuePage/QueuePage.tsx
+++ b/frontend/src/pages/QueuePage/QueuePage.tsx
@@ -10,7 +10,7 @@ import DependencyBuilder from '../../components/DependencyBuilder'
 import MigrationDialog from '../../components/MigrationDialog'
 import CollectionDialog from '../../components/CollectionDialog'
 import CollectionToolbar from '../../components/CollectionToolbar'
-import { useMoveToBack, useMoveToFront, useMoveToPosition } from '../../hooks/useQueue'
+import { useMoveToBack, useMoveToFront, useMoveToPosition, useShuffleQueue } from '../../hooks/useQueue'
 import { useCreateThread, useDeleteThread, useReactivateThread, useThreads, useUpdateThread } from '../../hooks/useThread'
 import { useSession } from '../../hooks/useSession'
 import { useSnooze, useUnsnooze } from '../../hooks/useSnooze'
@@ -38,6 +38,7 @@ export default function QueuePage() {
   const moveToFrontMutation = useMoveToFront()
   const moveToBackMutation = useMoveToBack()
   const moveToPositionMutation = useMoveToPosition()
+  const shuffleQueueMutation = useShuffleQueue()
   const snoozeMutation = useSnooze()
   const unsnoozeMutation = useUnsnooze()
 
@@ -170,6 +171,15 @@ export default function QueuePage() {
     moveToBackMutation.mutate(threadId).then(() => refetch()).catch(() => {
       alert('Failed to move thread to back. Please try again.')
     })
+  }
+
+  const handleShuffleQueue = async () => {
+    try {
+      await shuffleQueueMutation.mutate()
+      await refetch()
+    } catch {
+      alert('Failed to shuffle queue. Please try again.')
+    }
   }
 
   const handleDragStart = (threadId: number) => (event: DragEvent<HTMLElement>) => {
@@ -457,13 +467,23 @@ export default function QueuePage() {
             <h1 className="text-4xl font-black tracking-tighter text-glow mb-1 uppercase">Read Queue</h1>
             <p className="text-[10px] font-bold text-stone-500 uppercase tracking-widest">Your upcoming comics</p>
           </div>
-          <button
-            type="button"
-            onClick={openCreateModal}
-            className="hidden md:flex h-12 px-5 glass-button text-xs font-black uppercase tracking-widest whitespace-nowrap shadow-xl"
-          >
-            Add Thread
-          </button>
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={handleShuffleQueue}
+              disabled={shuffleQueueMutation.isPending || activeThreads.length < 2}
+              className="h-12 px-5 rounded-lg border border-white/10 bg-white/5 text-xs font-black uppercase tracking-widest whitespace-nowrap text-stone-300 hover:bg-white/10 disabled:opacity-50"
+            >
+              Shuffle Queue
+            </button>
+            <button
+              type="button"
+              onClick={openCreateModal}
+              className="hidden md:flex h-12 px-5 glass-button text-xs font-black uppercase tracking-widest whitespace-nowrap shadow-xl"
+            >
+              Add Thread
+            </button>
+          </div>
         </div>
         <CollectionToolbar onNewCollection={() => setIsCollectionDialogOpen(true)} />
       </header>

--- a/frontend/src/pages/RollPage/components/ThreadPool.tsx
+++ b/frontend/src/pages/RollPage/components/ThreadPool.tsx
@@ -20,7 +20,9 @@ interface ThreadPoolProps {
   onReadStale: () => void
   onToggleSnoozed: () => void
   onToggleBlocked: () => void
+  onShuffle: () => void
   unsnoozeIsPending: boolean
+  shuffleIsPending: boolean
 }
 
 export function ThreadPool({
@@ -41,7 +43,9 @@ export function ThreadPool({
   onReadStale,
   onToggleSnoozed,
   onToggleBlocked,
+  onShuffle,
   unsnoozeIsPending,
+  shuffleIsPending,
 }: ThreadPoolProps) {
   const navigate = useNavigate()
   return (
@@ -60,6 +64,14 @@ export function ThreadPool({
         <div className="flex-1">
           <p className="text-[10px] font-black uppercase tracking-wider text-stone-300">Roll Pool</p>
         </div>
+        <button
+          type="button"
+          onClick={onShuffle}
+          disabled={shuffleIsPending || pool.length < 2}
+          className="h-8 px-3 rounded-lg border border-white/10 bg-white/5 text-[10px] font-black uppercase tracking-widest text-stone-300 hover:bg-white/10 disabled:opacity-50"
+        >
+          Shuffle
+        </button>
       </div>
 
       <div className="space-y-2" data-roll-pool aria-label="Roll pool collection">

--- a/frontend/src/pages/RollPage/index.tsx
+++ b/frontend/src/pages/RollPage/index.tsx
@@ -20,7 +20,7 @@ import {
   useSetDie,
 } from '../../hooks/useRoll'
 import { useSnooze, useUnsnooze } from '../../hooks/useSnooze'
-import { useMoveToBack, useMoveToFront } from '../../hooks/useQueue'
+import { useMoveToBack, useMoveToFront, useShuffleQueue } from '../../hooks/useQueue'
 import { useRate } from '../../hooks'
 import { threadsApi, dependenciesApi } from '../../services/api'
 import { reviewsApi } from '../../services/api-reviews'
@@ -109,6 +109,7 @@ useEffect(() => {
   const unsnoozeMutation = useUnsnooze()
   const moveToFrontMutation = useMoveToFront()
   const moveToBackMutation = useMoveToBack()
+  const shuffleQueueMutation = useShuffleQueue()
   const rateMutation = useRate()
 
   async function handleUnsnooze(threadId: number) {
@@ -117,6 +118,16 @@ useEffect(() => {
       await refetchSession()
     } catch (error) {
       console.error('Unsnooze failed:', error)
+    }
+  }
+
+  async function handleShufflePool() {
+    try {
+      await shuffleQueueMutation.mutate()
+      await refetchThreads()
+    } catch (error) {
+      console.error('Shuffle failed:', error)
+      alert(`Failed to shuffle pool: ${getApiErrorDetail(error)}`)
     }
   }
 
@@ -766,7 +777,9 @@ useEffect(() => {
     onReadStale={handleReadStale}
     onToggleSnoozed={() => setSnoozedExpanded(!snoozedExpanded)}
     onToggleBlocked={() => setBlockedExpanded(!blockedExpanded)}
+    onShuffle={handleShufflePool}
     unsnoozeIsPending={unsnoozeMutation.isPending}
+    shuffleIsPending={shuffleQueueMutation.isPending}
   />
           </div>
         </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -263,6 +263,7 @@ export const queueApi = {
     api.put<void, { new_position: number }>(`/queue/threads/${id}/position/`, { new_position: position }),
   moveToFront: (id: number) => api.put<void>(`/queue/threads/${id}/front/`),
   moveToBack: (id: number) => api.put<void>(`/queue/threads/${id}/back/`),
+  shuffle: () => api.post<void>('/queue/shuffle/'),
 }
 
 export const undoApi = {

--- a/frontend/src/unit/QueuePage.test.tsx
+++ b/frontend/src/unit/QueuePage.test.tsx
@@ -13,7 +13,7 @@ import {
  useThreads,
  useUpdateThread,
 } from '../hooks/useThread'
-import { useMoveToBack, useMoveToFront, useMoveToPosition } from '../hooks/useQueue'
+import { useMoveToBack, useMoveToFront, useMoveToPosition, useShuffleQueue } from '../hooks/useQueue'
 import { useSession } from '../hooks/useSession'
 import { useSnooze, useUnsnooze } from '../hooks/useSnooze'
 import { threadsApi } from '../services/api'
@@ -30,6 +30,7 @@ vi.mock('../hooks/useQueue', () => ({
   useMoveToFront: vi.fn(),
   useMoveToBack: vi.fn(),
   useMoveToPosition: vi.fn(),
+  useShuffleQueue: vi.fn(),
 }))
 
 vi.mock('../hooks/useSession', () => ({
@@ -78,6 +79,7 @@ const mockedUseReactivateThread = vi.mocked(useReactivateThread) as any
 const mockedUseMoveToFront = vi.mocked(useMoveToFront) as any
 const mockedUseMoveToBack = vi.mocked(useMoveToBack) as any
 const mockedUseMoveToPosition = vi.mocked(useMoveToPosition) as any
+const mockedUseShuffleQueue = vi.mocked(useShuffleQueue) as any
 const mockedUseSession = vi.mocked(useSession) as any
 const mockedUseUnsnooze = vi.mocked(useUnsnooze) as any
 const mockedUseSnooze = vi.mocked(useSnooze) as any
@@ -100,6 +102,7 @@ beforeEach(() => {
   mockedUseMoveToFront.mockReturnValue({ mutate: vi.fn(), isPending: false })
   mockedUseMoveToBack.mockReturnValue({ mutate: vi.fn(), isPending: false })
   mockedUseMoveToPosition.mockReturnValue({ mutate: vi.fn(), isPending: false })
+  mockedUseShuffleQueue.mockReturnValue({ mutate: vi.fn(), isPending: false })
   mockedUseSession.mockReturnValue({
     data: { snoozed_threads: [] },
     refetch: vi.fn(),
@@ -142,6 +145,35 @@ it('renders queue items and opens create modal', async () => {
   const addButtons = screen.getAllByRole('button', { name: /add thread/i })
   await user.click(addButtons[0])
   expect(screen.getByRole('heading', { name: /create thread/i })).toBeInTheDocument()
+})
+
+it('shuffles the queue from the header control', async () => {
+  const mockRefetch = vi.fn()
+  const mockShuffle = { mutate: vi.fn(), isPending: false }
+  mockedUseThreads.mockReturnValue({
+    data: [
+      { id: 1, title: 'Saga', format: 'Comic', status: 'active', queue_position: 1, issues_remaining: 5 },
+      { id: 3, title: 'Spawn', format: 'Comic', status: 'active', queue_position: 2, issues_remaining: 7 },
+      { id: 2, title: 'Descender', format: 'Comic', status: 'completed', issues_remaining: 0 },
+    ],
+    isLoading: false,
+    refetch: mockRefetch,
+  })
+  mockedUseShuffleQueue.mockReturnValue(mockShuffle)
+
+  const user = userEvent.setup()
+  render(
+    <BrowserRouter>
+      <ToastProvider>
+        <QueuePage />
+      </ToastProvider>
+    </BrowserRouter>
+  )
+
+  await user.click(screen.getByRole('button', { name: /shuffle queue/i }))
+
+  expect(mockShuffle.mutate).toHaveBeenCalled()
+  expect(mockRefetch).toHaveBeenCalled()
 })
 
 describe('Action Sheet Snooze/Unsnooze', () => {

--- a/frontend/src/unit/RollPage.test.tsx
+++ b/frontend/src/unit/RollPage.test.tsx
@@ -12,7 +12,7 @@ import {
   useSetDie,
 } from '../hooks/useRoll'
 import { useSnooze, useUnsnooze } from '../hooks/useSnooze'
-import { useMoveToBack, useMoveToFront } from '../hooks/useQueue'
+import { useMoveToBack, useMoveToFront, useShuffleQueue } from '../hooks/useQueue'
 import { useRate } from '../hooks'
 import { useCollections } from '../contexts/CollectionContext'
 import { ToastProvider } from '../contexts/ToastContext'
@@ -50,6 +50,7 @@ vi.mock('../hooks/useSnooze', () => ({
 vi.mock('../hooks/useQueue', () => ({
   useMoveToFront: vi.fn(),
   useMoveToBack: vi.fn(),
+  useShuffleQueue: vi.fn(),
 }))
 vi.mock('../hooks', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>
@@ -76,6 +77,7 @@ const mockedUseSnooze = vi.mocked(useSnooze) as any
 const mockedUseUnsnooze = vi.mocked(useUnsnooze) as any
 const mockedUseMoveToFront = vi.mocked(useMoveToFront) as any
 const mockedUseMoveToBack = vi.mocked(useMoveToBack) as any
+const mockedUseShuffleQueue = vi.mocked(useShuffleQueue) as any
 const mockedUseRate = vi.mocked(useRate) as any
 const mockedUseCollections = vi.mocked(useCollections) as any
 
@@ -148,6 +150,7 @@ beforeEach(() => {
   mockedUseUnsnooze.mockReturnValue({ mutate: vi.fn(), isPending: false })
   mockedUseMoveToFront.mockReturnValue({ mutate: vi.fn(), isPending: false })
   mockedUseMoveToBack.mockReturnValue({ mutate: vi.fn(), isPending: false })
+  mockedUseShuffleQueue.mockReturnValue({ mutate: vi.fn(), isPending: false })
   mockedUseRate.mockReturnValue({ mutate: vi.fn(), isPending: false })
   mockedUseCollections.mockReturnValue({
     collections: [],
@@ -304,6 +307,29 @@ describe('Action Sheet', () => {
 
     await waitFor(() => {
       expect(mockRefetchSession).toHaveBeenCalled()
+      expect(mockRefetchThreads).toHaveBeenCalled()
+    })
+  })
+
+  it('shuffles the roll pool from the header control', async () => {
+    const mockShuffle = { mutate: vi.fn(), isPending: false }
+    const mockRefetchThreads = vi.fn()
+    mockedUseShuffleQueue.mockReturnValue(mockShuffle)
+    mockedUseThreads.mockReturnValue({
+      data: [
+        { id: 1, title: 'Saga', format: 'Comics', status: 'active' },
+        { id: 2, title: 'X-Men', format: 'Comics', status: 'active' },
+      ],
+      refetch: mockRefetchThreads,
+    })
+
+    const user = userEvent.setup()
+    render(<RollPage />)
+
+    await user.click(screen.getByRole('button', { name: /shuffle/i }))
+
+    await waitFor(() => {
+      expect(mockShuffle.mutate).toHaveBeenCalled()
       expect(mockRefetchThreads).toHaveBeenCalled()
     })
   })

--- a/frontend/src/unit/api.test.ts
+++ b/frontend/src/unit/api.test.ts
@@ -43,10 +43,12 @@ it('calls queue endpoints with expected paths', () => {
   queueApi.moveToPosition(3, 2)
   queueApi.moveToFront(4)
   queueApi.moveToBack(5)
+  queueApi.shuffle()
 
   expect(put).toHaveBeenCalledWith('/queue/threads/3/position/', { new_position: 2 })
   expect(put).toHaveBeenCalledWith('/queue/threads/4/front/')
   expect(put).toHaveBeenCalledWith('/queue/threads/5/back/')
+  expect(post).toHaveBeenCalledWith('/queue/shuffle/')
 })
 
 it('calls dependency endpoints with expected paths', () => {

--- a/frontend/src/unit/useQueue.test.tsx
+++ b/frontend/src/unit/useQueue.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react'
 import { beforeEach, expect, it, vi } from 'vitest'
-import { useMoveToBack, useMoveToFront, useMoveToPosition } from '../hooks/useQueue'
+import { useMoveToBack, useMoveToFront, useMoveToPosition, useShuffleQueue } from '../hooks/useQueue'
 import { queueApi } from '../services/api'
 
 vi.mock('../services/api', () => ({
@@ -8,6 +8,7 @@ vi.mock('../services/api', () => ({
     moveToPosition: vi.fn(),
     moveToFront: vi.fn(),
     moveToBack: vi.fn(),
+    shuffle: vi.fn(),
   },
 }))
 
@@ -17,6 +18,7 @@ beforeEach(() => {
   mockedQueueApi.moveToPosition.mockResolvedValue(undefined as never)
   mockedQueueApi.moveToFront.mockResolvedValue(undefined as never)
   mockedQueueApi.moveToBack.mockResolvedValue(undefined as never)
+  mockedQueueApi.shuffle.mockResolvedValue(undefined as never)
 })
 
 it('moves queue position', async () => {
@@ -42,4 +44,14 @@ it('moves thread to front and back', async () => {
 
   expect(mockedQueueApi.moveToFront).toHaveBeenCalledWith(8)
   expect(mockedQueueApi.moveToBack).toHaveBeenCalledWith(9)
+})
+
+it('shuffles the queue', async () => {
+  const { result } = renderHook(() => useShuffleQueue())
+
+  await act(async () => {
+    await result.current.mutate()
+  })
+
+  expect(mockedQueueApi.shuffle).toHaveBeenCalled()
 })

--- a/tests/test_queue_api.py
+++ b/tests/test_queue_api.py
@@ -8,7 +8,7 @@ from sqlalchemy import select
 
 from sqlalchemy.ext.asyncio import AsyncSession as SQLAlchemyAsyncSession
 
-from app.models import User
+from app.models import Thread, User
 
 
 @pytest.mark.asyncio
@@ -85,3 +85,29 @@ async def test_reposition_thread_with_sequential_positions(
     # The API response already confirms the thread was moved to position 3
     # The logs show the backend logic executed correctly and normalized positions
     print("✅ SUCCESS: Thread repositioned with sequential positions")
+
+
+@pytest.mark.asyncio
+async def test_shuffle_queue_randomizes_active_positions(
+    auth_client: AsyncClient,
+    async_db: SQLAlchemyAsyncSession,
+    sample_data: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test shuffling the queue randomizes active thread positions."""
+    _ = sample_data
+
+    from comic_pile import queue as queue_module
+
+    monkeypatch.setattr(queue_module.random, "shuffle", lambda threads: threads.reverse())
+
+    response = await auth_client.post("/api/queue/shuffle/")
+    assert response.status_code == 204
+
+    result = await async_db.execute(
+        select(Thread).where(Thread.status == "active").order_by(Thread.queue_position)
+    )
+    active_threads = result.scalars().all()
+
+    assert [thread.title for thread in active_threads] == ["Aquaman", "Flash", "Batman", "Superman"]
+    assert [thread.queue_position for thread in active_threads] == [1, 2, 3, 4]


### PR DESCRIPTION
Closes #491\n\nRandomizes the active queue ordering from both the queue and roll pool views, with backend and frontend regression coverage.