### PR TITLE
Feature-flag review UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,14 @@ ENABLE_DEBUG_ROUTES=false
 # Default: false
 ENABLE_INTERNAL_OPS_ROUTES=false
 
+# -----------------------------------------------------------------------------
+# Frontend Feature Flags
+# -----------------------------------------------------------------------------
+
+# Enable the review UI in Vite builds
+# Default: false
+VITE_ENABLE_REVIEWS=false
+
 # Logging level: debug, info, warning, error
 LOG_LEVEL=info
 

--- a/frontend/src/config/featureFlags.ts
+++ b/frontend/src/config/featureFlags.ts
@@ -1,0 +1,3 @@
+export function isReviewsFeatureEnabled(): boolean {
+  return import.meta.env.VITE_ENABLE_REVIEWS === 'true'
+}

--- a/frontend/src/pages/RollPage/index.tsx
+++ b/frontend/src/pages/RollPage/index.tsx
@@ -22,6 +22,7 @@ import {
 import { useSnooze, useUnsnooze } from '../../hooks/useSnooze'
 import { useMoveToBack, useMoveToFront } from '../../hooks/useQueue'
 import { useRate } from '../../hooks'
+import { isReviewsFeatureEnabled } from '../../config/featureFlags'
 import { threadsApi, dependenciesApi } from '../../services/api'
 import { reviewsApi } from '../../services/api-reviews'
 import { getApiErrorStatus, getApiErrorDetail } from '../../utils/apiError'
@@ -39,6 +40,7 @@ import { ThreadPool } from './components/ThreadPool'
 import ReviewForm from '../../components/ReviewForm'
 
 export default function RollPage() {
+  const reviewsEnabled = isReviewsFeatureEnabled()
   const state = useRollPageState()
   const {
     isRolling, setIsRolling,
@@ -90,15 +92,15 @@ export default function RollPage() {
     }
   }, [isSessionError, sessionError, navigate])
 
-useEffect(() => {
-  const handleTestEditCollection = ((e: CustomEvent<Collection>) => {
-    setEditingCollection(e.detail)
-    setIsCollectionDialogOpen(true)
-  }) as EventListener
+  useEffect(() => {
+    const handleTestEditCollection = ((e: CustomEvent<Collection>) => {
+      setEditingCollection(e.detail)
+      setIsCollectionDialogOpen(true)
+    }) as EventListener
 
-  window.addEventListener('test-edit-collection', handleTestEditCollection)
-  return () => window.removeEventListener('test-edit-collection', handleTestEditCollection)
-}, [setIsCollectionDialogOpen])
+    window.addEventListener('test-edit-collection', handleTestEditCollection)
+    return () => window.removeEventListener('test-edit-collection', handleTestEditCollection)
+  }, [setIsCollectionDialogOpen])
 
   const setDieMutation = useSetDie()
   const clearManualDieMutation = useClearManualDie()
@@ -148,62 +150,61 @@ useEffect(() => {
     setIsActionSheetOpen(true)
   }
 
-const enterRatingView = useCallback(async (threadId: number | null, result: number | null = null, threadMetadata: ThreadMetadata | null = null) => {
-  if (threadId) setSelectedThreadId(threadId)
-  if (result !== null) setRolledResult(result)
+  const enterRatingView = useCallback(async (threadId: number | null, result: number | null = null, threadMetadata: ThreadMetadata | null = null) => {
+    if (threadId) setSelectedThreadId(threadId)
+    if (result !== null) setRolledResult(result)
 
-  const ratingThread = buildRatingThread(threadId, result, threadMetadata, session?.active_thread)
-  if (ratingThread) {
-    setActiveRatingThread(ratingThread)
-  } else if (!threadId && session?.active_thread) {
-    setActiveRatingThread({
-      id: session.active_thread.id, title: session.active_thread.title,
-      format: session.active_thread.format,
-      issues_remaining: session.active_thread.issues_remaining ?? 0,
-      queue_position: session.active_thread.queue_position ?? 0,
-      total_issues: session.active_thread.total_issues ?? null,
-      reading_progress: session.active_thread.reading_progress ?? null,
-      issue_id: session.active_thread.issue_id ?? null,
-      issue_number: session.active_thread.issue_number ?? null,
-      next_issue_id: session.active_thread.next_issue_id ?? null,
-      next_issue_number: session.active_thread.next_issue_number ?? null,
-      last_rolled_result: session.active_thread.last_rolled_result ?? null,
-    })
-  }
+    const ratingThread = buildRatingThread(threadId, result, threadMetadata, session?.active_thread)
+    if (ratingThread) {
+      setActiveRatingThread(ratingThread)
+    } else if (!threadId && session?.active_thread) {
+      setActiveRatingThread({
+        id: session.active_thread.id, title: session.active_thread.title,
+        format: session.active_thread.format,
+        issues_remaining: session.active_thread.issues_remaining ?? 0,
+        queue_position: session.active_thread.queue_position ?? 0,
+        total_issues: session.active_thread.total_issues ?? null,
+        reading_progress: session.active_thread.reading_progress ?? null,
+        issue_id: session.active_thread.issue_id ?? null,
+        issue_number: session.active_thread.issue_number ?? null,
+        next_issue_id: session.active_thread.next_issue_id ?? null,
+        next_issue_number: session.active_thread.next_issue_number ?? null,
+        last_rolled_result: session.active_thread.last_rolled_result ?? null,
+      })
+    }
 
-  setRating(3.0)
-  setErrorMessage('')
-  const die = currentDie || 6
-  const idx = DICE_LADDER.indexOf(die)
-  setPredictedDie(idx > 0 ? DICE_LADDER[idx - 1] : DICE_LADDER[0])
-  setIsRatingView(true)
-  suppressPendingAutoOpenRef.current = false
+    setRating(3.0)
+    setErrorMessage('')
+    const die = currentDie || 6
+    const idx = DICE_LADDER.indexOf(die)
+    setPredictedDie(idx > 0 ? DICE_LADDER[idx - 1] : DICE_LADDER[0])
+    setIsRatingView(true)
+    suppressPendingAutoOpenRef.current = false
 
-  // Fetch existing review if re-rating a thread
-  if (threadId) {
-    try {
-      const token = localStorage.getItem('auth_token') || (window as any).__COMIC_PILE_ACCESS_TOKEN
-      if (token) {
-        const reviewsResponse = await fetch('/api/v1/reviews/', {
-          headers: { 'Authorization': `Bearer ${token}` },
-        })
-        if (reviewsResponse.ok) {
-          const reviewsData = await reviewsResponse.json()
-          const existing = reviewsData.reviews?.find((r: Review) => 
-            r.thread_id === threadId && 
-            (!ratingThread?.issue_number || r.issue_number === ratingThread.issue_number)
-          )
-          setExistingReview(existing || null)
+    if (reviewsEnabled && threadId) {
+      try {
+        const token = localStorage.getItem('auth_token') || (window as any).__COMIC_PILE_ACCESS_TOKEN
+        if (token) {
+          const reviewsResponse = await fetch('/api/v1/reviews/', {
+            headers: { 'Authorization': `Bearer ${token}` },
+          })
+          if (reviewsResponse.ok) {
+            const reviewsData = await reviewsResponse.json()
+            const existing = reviewsData.reviews?.find((r: Review) => 
+              r.thread_id === threadId && 
+              (!ratingThread?.issue_number || r.issue_number === ratingThread.issue_number)
+            )
+            setExistingReview(existing || null)
+          }
         }
+      } catch (error) {
+        console.error('Failed to fetch existing review:', error)
+        setExistingReview(null)
       }
-    } catch (error) {
-      console.error('Failed to fetch existing review:', error)
+    } else {
       setExistingReview(null)
     }
-  } else {
-    setExistingReview(null)
-  }
-}, [session, currentDie, suppressPendingAutoOpenRef, setSelectedThreadId, setRolledResult, setActiveRatingThread, setRating, setErrorMessage, setPredictedDie, setIsRatingView])
+  }, [reviewsEnabled, session, currentDie, suppressPendingAutoOpenRef, setSelectedThreadId, setRolledResult, setActiveRatingThread, setRating, setErrorMessage, setPredictedDie, setIsRatingView])
 
 const handleMigrationComplete = useCallback((migratedThread: Thread) => {
   refetchThreads()
@@ -427,16 +428,47 @@ useEffect(() => {
       setShowSimpleMigration(true)
       return
     }
-    
-    // Show review form instead of immediately submitting rating
+
+    if (!activeRatingThread) return
+
+    if (!reviewsEnabled) {
+      try {
+        await rateMutation.mutate({
+          thread_id: activeRatingThread.id,
+          rating,
+          finish_session: finishSession,
+          issue_number: activeRatingThread?.issue_number || undefined,
+        })
+
+        const refreshResults = await Promise.allSettled([refetchSession(), refetchThreads()])
+        if (refreshResults[0].status === 'rejected' || refreshResults[1].status === 'rejected') {
+          setErrorMessage('Rating saved but failed to refresh. Please refresh the page.')
+          return
+        }
+
+        setShowReviewForm(false)
+        setPendingRatingAction(null)
+        setReviewSaveError(null)
+        setExistingReview(null)
+        setIsRolling(false)
+        setIsRatingView(false)
+        setRolledResult(null)
+        setSelectedThreadId(null)
+        setActiveRatingThread(null)
+        setErrorMessage('')
+      } catch (error: unknown) {
+        setErrorMessage(getApiErrorDetail(error) || 'Failed to save rating')
+      }
+      return
+    }
+
     setPendingRatingAction({ finishSession })
     setShowReviewForm(true)
   }
 
   async function handleReviewSubmit(reviewData: ReviewCreatePayload) {
     if (!activeRatingThread) return
-    
-    // Function to return to roll view - batch all state updates together
+
     const returnToRollView = () => {
       setShowReviewForm(false)
       setIsRatingView(false)
@@ -446,6 +478,8 @@ useEffect(() => {
       setSelectedThreadId(null)
       setActiveRatingThread(null)
       setErrorMessage('')
+      setReviewSaveError(null)
+      setExistingReview(null)
     }
 
     try {
@@ -849,7 +883,7 @@ useEffect(() => {
           </div>
         </Modal>
 
-        {showReviewForm && activeRatingThread && (
+        {reviewsEnabled && showReviewForm && activeRatingThread && (
           <ReviewForm
             isOpen={showReviewForm}
             onClose={() => {

--- a/frontend/src/pages/ThreadDetailView.tsx
+++ b/frontend/src/pages/ThreadDetailView.tsx
@@ -9,6 +9,7 @@ import { CollectionBadge } from '../pages/QueuePage/CollectionBadge'
 import { FormatSelect } from '../pages/QueuePage/FormatSelect'
 import { useUpdateThread } from '../hooks/useThread'
 import { useThreadReviews } from '../hooks/useReview'
+import { isReviewsFeatureEnabled } from '../config/featureFlags'
 import { getApiErrorDetail } from '../utils/apiError'
 import type { ChangeEvent, FormEvent } from 'react'
 import { DEFAULT_CREATE_STATE, type QueueFormState } from '../pages/QueuePage/types'
@@ -19,6 +20,7 @@ export default function ThreadDetailView() {
   const navigate = useNavigate()
   const updateMutation = useUpdateThread()
   const { reviews, getThreadReviews, isPending: reviewsLoading } = useThreadReviews()
+  const reviewsEnabled = isReviewsFeatureEnabled()
 
   const [thread, setThread] = useState<Thread | null>(null)
   const [isLoading, setIsLoading] = useState(true)
@@ -41,12 +43,14 @@ export default function ThreadDetailView() {
           await fetchIssues(Number(id))
         }
 
-        // Fetch reviews for this thread
-        try {
-          await getThreadReviews(Number(id))
-        } catch (reviewError: unknown) {
-          console.error('Failed to fetch reviews:', getApiErrorDetail(reviewError))
-          // Don't let review failures break the entire page
+        if (reviewsEnabled) {
+          // Fetch reviews for this thread
+          try {
+            await getThreadReviews(Number(id))
+          } catch (reviewError: unknown) {
+            console.error('Failed to fetch reviews:', getApiErrorDetail(reviewError))
+            // Don't let review failures break the entire page
+          }
         }
       } catch (err: unknown) {
         setError(getApiErrorDetail(err))
@@ -56,7 +60,7 @@ export default function ThreadDetailView() {
     }
 
     fetchThread()
-  }, [id, getThreadReviews])
+  }, [id, getThreadReviews, reviewsEnabled])
 
   async function fetchIssues(threadId: number) {
     try {
@@ -272,51 +276,52 @@ export default function ThreadDetailView() {
           </div>
         )}
 
-        {/* Reviews Section */}
-        <div className="glass-card p-4 space-y-3">
-          <div className="flex justify-between items-center">
-            <span className="text-xs font-black uppercase tracking-widest text-stone-500">
-              Reviews {reviews.length > 0 && `(${reviews.length})`}
-            </span>
-          </div>
-
-          {reviewsLoading && (
-            <p className="text-xs text-stone-500">Loading reviews...</p>
-          )}
-
-          {!reviewsLoading && reviews.length === 0 && (
-            <p className="text-xs text-stone-500">No reviews yet.</p>
-          )}
-
-          {!reviewsLoading && reviews.length > 0 && (
-            <div className="space-y-3">
-              {reviews.map((review) => (
-                <div key={review.id} className="p-3 bg-white/5 rounded-lg border border-white/10 space-y-2">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                      <span className="text-lg font-black text-amber-400">
-                        {review.rating.toFixed(1)}
-                      </span>
-                      {review.issue_number && (
-                        <span className="text-xs text-stone-400">
-                          #{review.issue_number}
-                        </span>
-                      )}
-                    </div>
-                    <span className="text-xs text-stone-500">
-                      {new Date(review.created_at).toLocaleDateString()}
-                    </span>
-                  </div>
-                  {review.review_text && (
-                    <p className="text-sm text-stone-300 leading-relaxed">
-                      {review.review_text}
-                    </p>
-                  )}
-                </div>
-              ))}
+        {reviewsEnabled && (
+          <div className="glass-card p-4 space-y-3">
+            <div className="flex justify-between items-center">
+              <span className="text-xs font-black uppercase tracking-widest text-stone-500">
+                Reviews {reviews.length > 0 && `(${reviews.length})`}
+              </span>
             </div>
-          )}
-        </div>
+
+            {reviewsLoading && (
+              <p className="text-xs text-stone-500">Loading reviews...</p>
+            )}
+
+            {!reviewsLoading && reviews.length === 0 && (
+              <p className="text-xs text-stone-500">No reviews yet.</p>
+            )}
+
+            {!reviewsLoading && reviews.length > 0 && (
+              <div className="space-y-3">
+                {reviews.map((review) => (
+                  <div key={review.id} className="p-3 bg-white/5 rounded-lg border border-white/10 space-y-2">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <span className="text-lg font-black text-amber-400">
+                          {review.rating.toFixed(1)}
+                        </span>
+                        {review.issue_number && (
+                          <span className="text-xs text-stone-400">
+                            #{review.issue_number}
+                          </span>
+                        )}
+                      </div>
+                      <span className="text-xs text-stone-500">
+                        {new Date(review.created_at).toLocaleDateString()}
+                      </span>
+                    </div>
+                    {review.review_text && (
+                      <p className="text-sm text-stone-300 leading-relaxed">
+                        {review.review_text}
+                      </p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
 
         <div className="glass-card p-4 space-y-2">
           <span className="text-xs font-black uppercase tracking-widest text-stone-500">Queue Position</span>

--- a/frontend/src/test/helpers.ts
+++ b/frontend/src/test/helpers.ts
@@ -118,6 +118,33 @@ export async function getAuthToken(page: Page): Promise<string | null> {
   });
 }
 
+export async function submitRatingAndDismissReviewIfShown(
+  page: Page,
+  submitAction: () => Promise<void>,
+): Promise<void> {
+  const rateResponse = page.waitForResponse(
+    (response) => response.url().includes('/api/rate/') && response.request().method() === 'POST',
+  )
+
+  await submitAction()
+
+  const reviewModal = page.locator('[data-testid="modal"]')
+  const reviewModalShown = await reviewModal
+    .waitFor({ state: 'visible', timeout: 1000 })
+    .then(() => true)
+    .catch(() => false)
+
+  if (reviewModalShown) {
+    await Promise.all([
+      rateResponse,
+      page.click('button:has-text("Skip")'),
+    ])
+    return
+  }
+
+  await rateResponse
+}
+
 export async function createThread(
   page: Page,
   threadData: { title: string; format: string; issues_remaining: number; total_issues?: number; issue_range?: string }

--- a/frontend/src/test/issue-283-phantom-roll-events.spec.ts
+++ b/frontend/src/test/issue-283-phantom-roll-events.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from './fixtures';
-import { createThread, setupAuthenticatedPage, getAuthToken } from './helpers';
+import {
+  createThread,
+  setupAuthenticatedPage,
+  getAuthToken,
+  submitRatingAndDismissReviewIfShown,
+} from './helpers';
 
 test.describe('Issue #283: Phantom Roll Events on Snooze', () => {
   test('should not create roll event when snoozing from rating view', async ({ page }) => {
@@ -45,14 +50,9 @@ test.describe('Issue #283: Phantom Roll Events on Snooze', () => {
 
     // Rate the thread
     await page.fill('#rating-input', '4');
-    await page.click('button:has-text("Save & Continue")');
-
-    // Review form now appears - submit it (empty is fine)
-    await expect(page.locator('[data-testid="modal"]')).toBeVisible({ timeout: 5000 });
-    await Promise.all([
-      page.waitForResponse(r => r.url().includes('/api/rate/')),
-      page.click('button:has-text("Skip")'), // Save Review button
-    ]);
+    await submitRatingAndDismissReviewIfShown(page, () =>
+      page.click('button:has-text("Save & Continue")'),
+    );
 
     // Wait for roll view to return
     await page.waitForSelector('#main-die-3d', { state: 'visible', timeout: 10000 });
@@ -136,14 +136,9 @@ test.describe('Issue #283: Phantom Roll Events on Snooze', () => {
 
     // Rate the thread
     await page.fill('#rating-input', '5');
-    await page.click('button:has-text("Save & Continue")');
-
-    // Review form now appears - submit it (empty is fine)
-    await expect(page.locator('[data-testid="modal"]')).toBeVisible({ timeout: 5000 });
-    await Promise.all([
-      page.waitForResponse(r => r.url().includes('/api/rate/')),
-      page.click('button:has-text("Skip")'), // Save Review button
-    ]);
+    await submitRatingAndDismissReviewIfShown(page, () =>
+      page.click('button:has-text("Save & Continue")'),
+    );
 
     // Wait for roll view to return
     await page.waitForSelector('#main-die-3d', { state: 'visible', timeout: 10000 });
@@ -243,14 +238,9 @@ test.describe('Issue #283: Phantom Roll Events on Snooze', () => {
 
       // Rate
       await page.fill('#rating-input', '3');
-      await page.click('button:has-text("Save & Continue")');
-      
-    // Review form now appears - submit it (empty is fine)
-    await expect(page.locator('[data-testid="modal"]')).toBeVisible({ timeout: 5000 });
-    await Promise.all([
-      page.waitForResponse(r => r.url().includes('/api/rate/')),
-      page.click('button:has-text("Skip")'), // Skip button (doesn't require text)
-    ]);
+      await submitRatingAndDismissReviewIfShown(page, () =>
+        page.click('button:has-text("Save & Continue")'),
+      );
       
       await page.waitForSelector('#main-die-3d', { state: 'visible', timeout: 10000 });
       await page.waitForLoadState('networkidle');

--- a/frontend/src/test/issue-291-finish-session-button.spec.ts
+++ b/frontend/src/test/issue-291-finish-session-button.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures';
-import { SELECTORS, setRangeInput } from './helpers';
+import { SELECTORS, setRangeInput, submitRatingAndDismissReviewIfShown } from './helpers';
 
 test.describe('Issue 291: Finish Session Button', () => {
   test('should have a "Finish Session" button in rating view', async ({ authenticatedWithThreadsPage }) => {
@@ -40,17 +40,9 @@ test.describe('Issue 291: Finish Session Button', () => {
 
     const finishSessionButton = authenticatedWithThreadsPage.locator('button:has-text("Finish Session")');
     
-    await finishSessionButton.click();
-    
-    // Review form now appears - submit it (empty is fine)
-    await expect(authenticatedWithThreadsPage.locator('[data-testid="modal"]')).toBeVisible({ timeout: 5000 });
-    await Promise.all([
-      authenticatedWithThreadsPage.waitForResponse((response) =>
-        response.url().includes('/api/rate/') && 
-        response.request().method() === 'POST'
-      ),
-      authenticatedWithThreadsPage.click('button:has-text("Skip")'), // Skip button (doesn't require text)
-    ]);
+    await submitRatingAndDismissReviewIfShown(authenticatedWithThreadsPage, () =>
+      finishSessionButton.click(),
+    );
 
     await authenticatedWithThreadsPage.waitForLoadState('networkidle');
 
@@ -87,11 +79,9 @@ test.describe('Issue 291: Finish Session Button', () => {
       await route.continue();
     });
 
-    await finishSessionButton.click();
-    
-    // Review form now appears - submit it (empty is fine)
-    await expect(authenticatedWithThreadsPage.locator('[data-testid="modal"]')).toBeVisible({ timeout: 5000 });
-    await authenticatedWithThreadsPage.click('button:has-text("Skip")'); // Skip button (doesn't require text)
+    await submitRatingAndDismissReviewIfShown(authenticatedWithThreadsPage, () =>
+      finishSessionButton.click(),
+    );
     await authenticatedWithThreadsPage.waitForLoadState('networkidle');
 
     expect(requestData).toBeTruthy();

--- a/frontend/src/test/rate.spec.ts
+++ b/frontend/src/test/rate.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures';
-import { SELECTORS, setRangeInput } from './helpers';
+import { SELECTORS, setRangeInput, submitRatingAndDismissReviewIfShown } from './helpers';
 
 async function ensureRatingView(page: import('@playwright/test').Page): Promise<void> {
   await page.goto('/');
@@ -34,14 +34,9 @@ test.describe('Rate Thread Feature', () => {
 
   test('should submit rating and route to roll page after save and continue', async ({ authenticatedWithThreadsPage }) => {
     await setRangeInput(authenticatedWithThreadsPage, SELECTORS.rate.ratingInput, '4.5');
-    await authenticatedWithThreadsPage.click(SELECTORS.rate.submitButton);
-    await expect(authenticatedWithThreadsPage.locator('[data-testid="modal"]')).toBeVisible({ timeout: 5000 });
-    await Promise.all([
-      authenticatedWithThreadsPage.waitForResponse((response) =>
-        response.url().includes('/api/rate/') && response.request().method() === 'POST'
-      ),
-      authenticatedWithThreadsPage.click('button:has-text("Skip")'),
-    ]);
+    await submitRatingAndDismissReviewIfShown(authenticatedWithThreadsPage, () =>
+      authenticatedWithThreadsPage.click(SELECTORS.rate.submitButton),
+    );
     await authenticatedWithThreadsPage.waitForLoadState('networkidle');
     await expect(authenticatedWithThreadsPage.locator(SELECTORS.roll.mainDie)).toBeVisible();
     await expect(authenticatedWithThreadsPage.locator(SELECTORS.rate.ratingInput)).toHaveCount(0);
@@ -49,14 +44,9 @@ test.describe('Rate Thread Feature', () => {
 
   test('should require rolling again before rating again after save and continue', async ({ authenticatedWithThreadsPage }) => {
     await setRangeInput(authenticatedWithThreadsPage, SELECTORS.rate.ratingInput, '4.0');
-    await authenticatedWithThreadsPage.click(SELECTORS.rate.submitButton);
-    await expect(authenticatedWithThreadsPage.locator('[data-testid="modal"]')).toBeVisible({ timeout: 5000 });
-    await Promise.all([
-      authenticatedWithThreadsPage.waitForResponse((response) =>
-        response.url().includes('/api/rate/') && response.request().method() === 'POST'
-      ),
-      authenticatedWithThreadsPage.click('button:has-text("Skip")'),
-    ]);
+    await submitRatingAndDismissReviewIfShown(authenticatedWithThreadsPage, () =>
+      authenticatedWithThreadsPage.click(SELECTORS.rate.submitButton),
+    );
     await authenticatedWithThreadsPage.waitForLoadState('networkidle');
     await expect(authenticatedWithThreadsPage.locator(SELECTORS.roll.mainDie)).toBeVisible();
     await expect(authenticatedWithThreadsPage.locator(SELECTORS.rate.ratingInput)).toHaveCount(0);
@@ -107,14 +97,9 @@ test.describe('Rate Thread Feature', () => {
 
   test('should accept decimal ratings', async ({ authenticatedWithThreadsPage }) => {
     await setRangeInput(authenticatedWithThreadsPage, SELECTORS.rate.ratingInput, '3.5');
-    await authenticatedWithThreadsPage.click(SELECTORS.rate.submitButton);
-    await expect(authenticatedWithThreadsPage.locator('[data-testid="modal"]')).toBeVisible({ timeout: 5000 });
-    await Promise.all([
-      authenticatedWithThreadsPage.waitForResponse((response) =>
-        response.url().includes('/api/rate/') && response.request().method() === 'POST'
-      ),
-      authenticatedWithThreadsPage.click('button:has-text("Skip")'),
-    ]);
+    await submitRatingAndDismissReviewIfShown(authenticatedWithThreadsPage, () =>
+      authenticatedWithThreadsPage.click(SELECTORS.rate.submitButton),
+    );
   });
 
   test('should display snooze button', async ({ authenticatedWithThreadsPage }) => {
@@ -161,14 +146,9 @@ test.describe('Rate Thread Feature', () => {
 
   test('should update thread rating in database', async ({ authenticatedWithThreadsPage }) => {
     await setRangeInput(authenticatedWithThreadsPage, SELECTORS.rate.ratingInput, '4.0');
-    await authenticatedWithThreadsPage.click(SELECTORS.rate.submitButton);
-    await expect(authenticatedWithThreadsPage.locator('[data-testid="modal"]')).toBeVisible({ timeout: 5000 });
-    await Promise.all([
-      authenticatedWithThreadsPage.waitForResponse((response) =>
-        response.url().includes('/api/rate/') && response.request().method() === 'POST'
-      ),
-      authenticatedWithThreadsPage.click('button:has-text("Skip")'),
-    ]);
+    await submitRatingAndDismissReviewIfShown(authenticatedWithThreadsPage, () =>
+      authenticatedWithThreadsPage.click(SELECTORS.rate.submitButton),
+    );
 
     await authenticatedWithThreadsPage.waitForLoadState('networkidle');
     
@@ -191,14 +171,9 @@ test.describe('Rate Thread Feature', () => {
     if (hasFinishOption) {
       await finishCheckbox.check();
       await setRangeInput(authenticatedWithThreadsPage, SELECTORS.rate.ratingInput, '4.0');
-      await authenticatedWithThreadsPage.click(SELECTORS.rate.submitButton);
-      await expect(authenticatedWithThreadsPage.locator('[data-testid="modal"]')).toBeVisible({ timeout: 5000 });
-      await Promise.all([
-        authenticatedWithThreadsPage.waitForResponse((response) =>
-          response.url().includes('/api/rate/') && response.request().method() === 'POST'
-        ),
-        authenticatedWithThreadsPage.click('button:has-text("Skip")'),
-      ]);
+      await submitRatingAndDismissReviewIfShown(authenticatedWithThreadsPage, () =>
+        authenticatedWithThreadsPage.click(SELECTORS.rate.submitButton),
+      );
 
       await authenticatedWithThreadsPage.waitForURL('**/', { timeout: 5000 });
       await authenticatedWithThreadsPage.waitForLoadState('networkidle');

--- a/frontend/src/test/review-create.spec.ts
+++ b/frontend/src/test/review-create.spec.ts
@@ -1,92 +1,39 @@
-import { test, expect } from './fixtures';
-import { SELECTORS, setRangeInput } from './helpers';
+import { test, expect } from './fixtures'
+import { SELECTORS, setRangeInput } from './helpers'
 
-test.describe('Review Creation E2E Tests', () => {
-  test('should complete full review flow', async ({ authenticatedWithThreadsPage }) => {
-    const page = authenticatedWithThreadsPage;
-    
-    await page.goto('/');
-    await page.waitForLoadState('networkidle');
-    
-    const mainDie = page.locator(SELECTORS.roll.mainDie);
-    await expect(mainDie).toBeVisible();
-    await mainDie.click();
-    
-    await page.waitForSelector(SELECTORS.rate.ratingInput, { timeout: 15000 });
-    
-    const rolledTitle = await page.locator('h2, h1').first().textContent();
-    console.log('Rolled:', rolledTitle);
-    
-    await setRangeInput(page, SELECTORS.rate.ratingInput, '4.5');
-    
-    const submitButton = page.locator('button:has-text("Save & Continue"), button:has-text("Save & Complete")');
-    await expect(submitButton).toBeVisible();
-    await submitButton.click({ force: true });
-    
-    const reviewModal = page.locator('[data-testid="modal"]');
-    await expect(reviewModal).toBeVisible({ timeout: 15000 });
-    
-    const textarea = page.locator('textarea[placeholder*="Share your thoughts"]');
-    await textarea.fill('Great review!');
-    
-    const saveButton = page.locator('button:has-text("Save Review")');
-    await Promise.all([
-      page.waitForResponse(r => r.url().includes('/api/rate/')),
-      page.waitForResponse(r => r.url().includes('/v1/reviews/')),
-      saveButton.click(),
-    ]);
-    
-    await expect(reviewModal).not.toBeVisible();
-    
-    const token = await page.evaluate(() => 
-      localStorage.getItem('auth_token') || (window as any).__COMIC_PILE_ACCESS_TOKEN
-    );
-    
-    const reviewsResponse = await page.request.get('/api/v1/reviews/', {
-      headers: { 'Authorization': `Bearer ${token}` },
-    });
-    const reviewsData = await reviewsResponse.json();
-    const latestReview = reviewsData.reviews?.[0];
-    
-    expect(latestReview).toBeDefined();
-    expect(latestReview.review_text).toBe('Great review!');
-    
-    await page.goto(`/thread/${latestReview.thread_id}`);
-    await page.waitForLoadState('networkidle');
-    await expect(page.locator(`text=${latestReview.review_text}`)).toBeVisible();
-  });
+test.describe('Review Feature Flag E2E Tests', () => {
+  test('rating submission completes without opening the review modal', async ({ authenticatedWithThreadsPage }) => {
+    const page = authenticatedWithThreadsPage
+    let reviewRequestSeen = false
 
-  test('should skip review writing', async ({ authenticatedWithThreadsPage }) => {
-    const page = authenticatedWithThreadsPage;
-    
-    await page.goto('/');
-    await page.waitForLoadState('networkidle');
-    
-    const mainDie = page.locator(SELECTORS.roll.mainDie);
-    await expect(mainDie).toBeVisible();
-    await mainDie.click();
-    
-    await page.waitForSelector(SELECTORS.rate.ratingInput, { timeout: 15000 });
-    
-    await setRangeInput(page, SELECTORS.rate.ratingInput, '3.5');
-    
-    const submitButton = page.locator('button:has-text("Save & Continue"), button:has-text("Save & Complete")');
-    await expect(submitButton).toBeVisible();
-    await submitButton.click({ force: true });
-    
-    const reviewModal = page.locator('[data-testid="modal"]');
-    await expect(reviewModal).toBeVisible({ timeout: 15000 });
-    
-    const skipButton = page.locator('button:has-text("Skip")');
-    await expect(skipButton).toBeVisible();
-    
+    await page.route('**/v1/reviews/**', (route) => {
+      reviewRequestSeen = true
+      throw new Error(`Unexpected review request: ${route.request().url()}`)
+    })
+
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    const mainDie = page.locator(SELECTORS.roll.mainDie)
+    await expect(mainDie).toBeVisible()
+    await mainDie.click()
+
+    await page.waitForSelector(SELECTORS.rate.ratingInput, { timeout: 15000 })
+    await setRangeInput(page, SELECTORS.rate.ratingInput, '4.5')
+
+    const submitButton = page.locator('button:has-text("Save & Continue"), button:has-text("Save & Complete")')
+    await expect(submitButton).toBeVisible()
+
     await Promise.all([
-      page.waitForResponse(r => r.url().includes('/api/rate/')),
-      skipButton.click(),
-    ]);
-    
-    await expect(reviewModal).not.toBeVisible();
-    
-    await page.waitForTimeout(2000);
-  });
-});
+      page.waitForResponse((r) => r.url().includes('/api/rate/')),
+      submitButton.click({ force: true }),
+    ])
+
+    await expect(page.getByText('Write a Review?')).toHaveCount(0)
+    await expect(page.locator('textarea[placeholder*="Share your thoughts"]')).toHaveCount(0)
+    await expect(page.getByText('Tap Die to Roll')).toBeVisible()
+    expect(reviewRequestSeen).toBe(false)
+
+    await page.unroute('**/v1/reviews/**')
+  })
+})

--- a/frontend/src/test/review-display.spec.ts
+++ b/frontend/src/test/review-display.spec.ts
@@ -1,64 +1,28 @@
-import { test, expect } from './fixtures';
-import { SELECTORS, setRangeInput } from './helpers';
+import { test, expect } from './fixtures'
 
-test.describe('Review Display E2E Tests', () => {
-  test('should display issue-specific review information', async ({ authenticatedWithThreadsPage }) => {
-    const page = authenticatedWithThreadsPage;
-    
-    await page.goto('/');
-    await page.waitForLoadState('networkidle');
-    
-    const mainDie = page.locator(SELECTORS.roll.mainDie);
-    await expect(mainDie).toBeVisible();
-    await mainDie.click();
-    
-    await page.waitForSelector(SELECTORS.rate.ratingInput, { timeout: 15000 });
-    
-    const rolledTitle = await page.locator('h2, h1').first().textContent();
-    console.log('Rolled:', rolledTitle);
-    
-    await setRangeInput(page, SELECTORS.rate.ratingInput, '5.0');
-    
-    const submitButton = page.locator('button:has-text("Save & Continue"), button:has-text("Save & Complete")');
-    await expect(submitButton).toBeVisible();
-    await submitButton.click({ force: true });
-    
-    const reviewModal = page.locator('[data-testid="modal"]');
-    await expect(reviewModal).toBeVisible({ timeout: 15000 });
-    
-    await expect(page.locator('text=Reviewing')).toBeVisible();
-    await expect(page.locator('text=Rating:')).toBeVisible();
-    await expect(reviewModal.locator('text=5.0')).toBeVisible();
-    
-    const textarea = page.locator('textarea[placeholder*="Share your thoughts"]');
-    await textarea.fill('Great issue!');
-    
-    const saveButton = page.locator('button:has-text("Save Review")');
-    await Promise.all([
-      page.waitForResponse(r => r.url().includes('/api/rate/')),
-      page.waitForResponse(r => r.url().includes('/v1/reviews/')),
-      saveButton.click(),
-    ]);
-    
-    await expect(reviewModal).not.toBeVisible();
-    
-    const token = await page.evaluate(() => 
+test.describe('Review Feature Flag E2E Tests', () => {
+  test('thread details do not render the review section while reviews are disabled', async ({ authenticatedWithThreadsPage }) => {
+    const page = authenticatedWithThreadsPage
+    const token = await page.evaluate(() =>
       localStorage.getItem('auth_token') || (window as any).__COMIC_PILE_ACCESS_TOKEN
-    );
-    
-    const reviewsResponse = await page.request.get('/api/v1/reviews/', {
+    )
+
+    if (!token) {
+      throw new Error('No auth token found')
+    }
+
+    const threadsResponse = await page.request.get('/api/threads/', {
       headers: { 'Authorization': `Bearer ${token}` },
-    });
-    const reviewsData = await reviewsResponse.json();
-    const latestReview = reviewsData.reviews?.[0];
-    
-    expect(latestReview).toBeDefined();
-    expect(latestReview.review_text).toBe('Great issue!');
-    
-    await page.goto(`/thread/${latestReview.thread_id}`);
-    await page.waitForLoadState('networkidle');
-    
-    await expect(page.locator('text=Great issue!')).toBeVisible();
-    await expect(page.locator('[class*="text-amber-400"]').first()).toBeVisible();
-  });
-});
+    })
+    expect(threadsResponse.ok()).toBeTruthy()
+    const threadsData = await threadsResponse.json()
+    const threads = threadsData.threads ?? threadsData
+    expect(threads.length).toBeGreaterThan(0)
+
+    await page.goto(`/thread/${threads[0].id}`)
+    await page.waitForLoadState('networkidle')
+
+    await expect(page.getByText(/Reviews/)).toHaveCount(0)
+    await expect(page.getByText('No reviews yet.')).toHaveCount(0)
+  })
+})

--- a/frontend/src/test/review-edit.spec.ts
+++ b/frontend/src/test/review-edit.spec.ts
@@ -1,132 +1,67 @@
-import { test, expect } from './fixtures';
-import { SELECTORS, setRangeInput } from './helpers';
+import { test, expect } from './fixtures'
+import { SELECTORS, setRangeInput } from './helpers'
 
-test.describe('Review Editing E2E Tests', () => {
-  test('should edit existing review', async ({ authenticatedWithThreadsPage }) => {
-    const page = authenticatedWithThreadsPage;
-    
-    const token = await page.evaluate(() => 
+test.describe('Review Feature Flag E2E Tests', () => {
+  test('existing review data does not reopen the review prompt when reviews are disabled', async ({ authenticatedWithThreadsPage }) => {
+    const page = authenticatedWithThreadsPage
+    const token = await page.evaluate(() =>
       localStorage.getItem('auth_token') || (window as any).__COMIC_PILE_ACCESS_TOKEN
-    );
-    
+    )
+
     if (!token) {
-      throw new Error('No auth token found');
+      throw new Error('No auth token found')
     }
-    
-    // Get list of threads
+
     const threadsResponse = await page.request.get('/api/threads/', {
       headers: { 'Authorization': `Bearer ${token}` },
-    });
-    expect(threadsResponse.ok()).toBeTruthy();
-    const threadsData = await threadsResponse.json();
-    const threads = threadsData.threads ?? threadsData;
-    expect(threads.length).toBeGreaterThan(0);
-    
-    // Use the first thread for testing
-    const threadId = threads[0].id;
-    const threadTitle = threads[0].title;
-    console.log('Testing with thread:', threadTitle, 'ID:', threadId);
-    
-    // First, set the thread as pending and create a review
-    const setPendingResponse = await page.request.post(`/api/threads/${threadId}/set-pending`, {
+    })
+    expect(threadsResponse.ok()).toBeTruthy()
+    const threadsData = await threadsResponse.json()
+    const threads = threadsData.threads ?? threadsData
+    expect(threads.length).toBeGreaterThan(0)
+
+    const thread = threads[0]
+    const reviewResponse = await page.request.post('/api/v1/reviews/', {
       headers: {
-        'Content-Type': 'application/json',
         'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json',
       },
-    });
-    expect(setPendingResponse.status()).toBe(200);
-    
-    // Navigate to home page - rating modal should appear
-    await page.goto('/');
-    await page.waitForLoadState('networkidle');
-    
-    await page.waitForSelector(SELECTORS.rate.ratingInput, { timeout: 15000 });
-    
-    await setRangeInput(page, SELECTORS.rate.ratingInput, '4.0');
-    
-    const submitButton = page.locator('button:has-text("Save & Continue"), button:has-text("Save & Complete")');
-    await expect(submitButton).toBeVisible();
-    await submitButton.click({ force: true });
-    
-    const reviewModal = page.locator('[data-testid="modal"]');
-    await expect(reviewModal).toBeVisible({ timeout: 15000 });
-    
-    const textarea = page.locator('textarea[placeholder*="Share your thoughts"]');
-    await textarea.fill('Original review');
-    
-    const saveButton = page.locator('button:has-text("Save Review")');
+      data: {
+        thread_id: thread.id,
+        rating: 4.0,
+        review_text: 'Seeded review text',
+        ...(thread.issue_number ? { issue_number: thread.issue_number } : {}),
+      },
+    })
+    expect(reviewResponse.ok()).toBeTruthy()
+
+    let reviewRequestSeen = false
+    await page.route('**/v1/reviews/**', () => {
+      reviewRequestSeen = true
+      throw new Error('Unexpected review request while reviews are disabled')
+    })
+
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    const mainDie = page.locator(SELECTORS.roll.mainDie)
+    await expect(mainDie).toBeVisible()
+    await mainDie.click()
+
+    await page.waitForSelector(SELECTORS.rate.ratingInput, { timeout: 15000 })
+    await setRangeInput(page, SELECTORS.rate.ratingInput, '4.0')
+
+    const submitButton = page.locator('button:has-text("Save & Continue"), button:has-text("Save & Complete")')
+    await expect(submitButton).toBeVisible()
+
     await Promise.all([
-      page.waitForResponse(r => r.url().includes('/api/rate/')),
-      page.waitForResponse(r => r.url().includes('/v1/reviews/')),
-      saveButton.click(),
-    ]);
-    
-    await expect(reviewModal).not.toBeVisible();
-    
-    // Verify the review was created
-    const reviewsResponse = await page.request.get('/api/v1/reviews/', {
-      headers: { 'Authorization': `Bearer ${token}` },
-    });
-    const reviewsData = await reviewsResponse.json();
-    const latestReview = reviewsData.reviews?.find((r: any) => r.thread_id === threadId);
-    
-    expect(latestReview).toBeDefined();
-    expect(latestReview.review_text).toBe('Original review');
-    
-    // Now set the same thread as pending again to test editing
-    const setPendingResponse2 = await page.request.post(`/api/threads/${threadId}/set-pending`, {
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`,
-      },
-    });
-    expect(setPendingResponse2.status()).toBe(200);
-    
-    // Navigate to home page - rating modal should appear again
-    await page.goto('/');
-    await page.waitForLoadState('networkidle');
-    
-    await page.waitForSelector(SELECTORS.rate.ratingInput, { timeout: 15000 });
-    
-    await setRangeInput(page, SELECTORS.rate.ratingInput, '4.0');
-    
-    const submitButtonAgain = page.locator('button:has-text("Save & Continue"), button:has-text("Save & Complete")');
-    await expect(submitButtonAgain).toBeVisible();
-    await submitButtonAgain.click({ force: true });
-    
-    await expect(reviewModal).toBeVisible({ timeout: 15000 });
-    
-    await page.waitForTimeout(1000);
-    
-    const textareaValue = await textarea.inputValue();
-    if (textareaValue === 'Original review') {
-      await expect(textarea).toHaveValue('Original review');
-      await textarea.fill('Updated review');
-      
-      const updateButton = page.locator('button:has-text("Save Review"), button:has-text("Update Review")');
-      await Promise.all([
-        page.waitForResponse(r => r.url().includes('/v1/reviews/')),
-        updateButton.click(),
-      ]);
-      
-      await expect(reviewModal).not.toBeVisible();
-      
-      const reviewsResponse2 = await page.request.get('/api/v1/reviews/', {
-        headers: { 'Authorization': `Bearer ${token}` },
-      });
-      const reviewsData2 = await reviewsResponse2.json();
-      const updatedReview = reviewsData2.reviews?.find((r: any) => r.thread_id === latestReview.thread_id);
-      
-      expect(updatedReview).toBeDefined();
-      expect(updatedReview.review_text).toBe('Updated review');
-    } else {
-      const skipButton = page.locator('button:has-text("Skip")');
-      await Promise.all([
-        page.waitForResponse(r => r.url().includes('/api/rate/')),
-        skipButton.click(),
-      ]);
-      
-      await expect(reviewModal).not.toBeVisible();
-    }
-  });
-});
+      page.waitForResponse((r) => r.url().includes('/api/rate/')),
+      submitButton.click({ force: true }),
+    ])
+
+    await expect(page.getByText('Write a Review?')).toHaveCount(0)
+    expect(reviewRequestSeen).toBe(false)
+
+    await page.unroute('**/v1/reviews/**')
+  })
+})

--- a/frontend/src/test/review-errors.spec.ts
+++ b/frontend/src/test/review-errors.spec.ts
@@ -1,51 +1,37 @@
-import { test, expect } from './fixtures';
-import { SELECTORS, setRangeInput } from './helpers';
+import { test, expect } from './fixtures'
+import { SELECTORS, setRangeInput } from './helpers'
 
-test.describe('Review Error Handling E2E Tests', () => {
-  test('should handle network error during review submission', async ({ authenticatedWithThreadsPage }) => {
-    const page = authenticatedWithThreadsPage;
-    
-    await page.goto('/');
-    await page.waitForLoadState('networkidle');
-    
-    const mainDie = page.locator(SELECTORS.roll.mainDie);
-    await expect(mainDie).toBeVisible();
-    await mainDie.click();
-    
-    await page.waitForSelector(SELECTORS.rate.ratingInput, { timeout: 15000 });
-    
-    await setRangeInput(page, SELECTORS.rate.ratingInput, '4.5');
-    
-    const submitButton = page.locator('button:has-text("Save & Continue"), button:has-text("Save & Complete")');
-    await expect(submitButton).toBeVisible();
-    await submitButton.click({ force: true });
-    
-    const reviewModal = page.locator('[data-testid="modal"]');
-    await expect(reviewModal).toBeVisible({ timeout: 15000 });
-    
-    await page.route('**/v1/reviews/', route => route.abort('failed'));
-    
-    const textarea = page.locator('textarea[placeholder*="Share your thoughts"]');
-    await textarea.fill('This review should fail');
-    
-    const saveButton = page.locator('button:has-text("Save Review")');
-    await saveButton.click();
-    
-    await page.waitForResponse(r => r.url().includes('/api/rate/'), { timeout: 10000 });
-    await page.waitForTimeout(3000);
-    
-    const freshReviewModal = page.locator('[data-testid="modal"]');
-    const errorMessage = freshReviewModal.locator('.text-red-400');
-    const errorVisible = await errorMessage.isVisible().catch(() => false);
-    
-    if (errorVisible) {
-      await expect(errorMessage).toBeVisible();
-    } else {
-      await expect(freshReviewModal).toBeVisible();
-    }
-    
-    await expect(saveButton).toHaveText('Save Review');
-    
-    await page.unroute('**/v1/reviews/');
-  });
-});
+test.describe('Review Feature Flag E2E Tests', () => {
+  test('review API failures do not matter when the review flow is disabled', async ({ authenticatedWithThreadsPage }) => {
+    const page = authenticatedWithThreadsPage
+    let reviewRequestSeen = false
+
+    await page.route('**/v1/reviews/**', () => {
+      reviewRequestSeen = true
+      throw new Error('Unexpected review request while reviews are disabled')
+    })
+
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    const mainDie = page.locator(SELECTORS.roll.mainDie)
+    await expect(mainDie).toBeVisible()
+    await mainDie.click()
+
+    await page.waitForSelector(SELECTORS.rate.ratingInput, { timeout: 15000 })
+    await setRangeInput(page, SELECTORS.rate.ratingInput, '4.5')
+
+    const submitButton = page.locator('button:has-text("Save & Continue"), button:has-text("Save & Complete")')
+    await expect(submitButton).toBeVisible()
+
+    await Promise.all([
+      page.waitForResponse((r) => r.url().includes('/api/rate/')),
+      submitButton.click({ force: true }),
+    ])
+
+    await expect(page.getByText('Write a Review?')).toHaveCount(0)
+    expect(reviewRequestSeen).toBe(false)
+
+    await page.unroute('**/v1/reviews/**')
+  })
+})

--- a/frontend/src/test/review-modal.spec.ts
+++ b/frontend/src/test/review-modal.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from './fixtures';
 import { SELECTORS, setRangeInput } from './helpers';
 
 test.describe('Review Modal Behavior E2E Tests', () => {
-  test('should handle review form cancellation', async ({ authenticatedWithThreadsPage }) => {
+  test('does not open the cancellation modal while reviews are disabled', async ({ authenticatedWithThreadsPage }) => {
     const page = authenticatedWithThreadsPage;
     
     await page.goto('/');
@@ -18,30 +18,13 @@ test.describe('Review Modal Behavior E2E Tests', () => {
     
     const submitButton = page.locator('button:has-text("Save & Continue"), button:has-text("Save & Complete")');
     await expect(submitButton).toBeVisible();
-    await submitButton.click({ force: true });
-    
-    const reviewModal = page.locator('[data-testid="modal"]');
-    await expect(reviewModal).toBeVisible({ timeout: 15000 });
-    
-    const textarea = page.locator('textarea[placeholder*="Share your thoughts"]');
-    await textarea.fill('This review will be cancelled');
-    
-    const closeButton = reviewModal.locator('button[aria-label="Close modal"]');
-    const closeButtonVisible = await closeButton.isVisible().catch(() => false);
-    
-    if (closeButtonVisible) {
-      await closeButton.click();
-    } else {
-      const skipButton = page.locator('button:has-text("Skip")');
-      await expect(skipButton).toBeVisible();
-      await Promise.all([
-        page.waitForResponse(r => r.url().includes('/api/rate/')),
-        skipButton.click(),
-      ]);
-    }
-    
-    await expect(reviewModal).not.toBeVisible();
-    
-    await page.waitForTimeout(2000);
+    await Promise.all([
+      page.waitForResponse((response) => response.url().includes('/api/rate/')),
+      submitButton.click({ force: true }),
+    ]);
+
+    await expect(page.locator('[data-testid="modal"]')).toHaveCount(0);
+    await expect(page.locator('textarea[placeholder*="Share your thoughts"]')).toHaveCount(0);
+    await expect(page.locator(SELECTORS.roll.mainDie)).toBeVisible();
   });
 });

--- a/frontend/src/test/review-validation.spec.ts
+++ b/frontend/src/test/review-validation.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from './fixtures';
 import { SELECTORS, setRangeInput } from './helpers';
 
 test.describe('Review Validation E2E Tests', () => {
-  test('should enforce character limit in review textarea', async ({ authenticatedWithThreadsPage }) => {
+  test('does not render the review textarea while reviews are disabled', async ({ authenticatedWithThreadsPage }) => {
     const page = authenticatedWithThreadsPage;
     
     await page.goto('/');
@@ -18,24 +18,13 @@ test.describe('Review Validation E2E Tests', () => {
     
     const submitButton = page.locator('button:has-text("Save & Continue"), button:has-text("Save & Complete")');
     await expect(submitButton).toBeVisible();
-    await submitButton.click({ force: true });
-    
-    const reviewModal = page.locator('[data-testid="modal"]');
-    await expect(reviewModal).toBeVisible({ timeout: 15000 });
-    
-    const textarea = page.locator('textarea[placeholder*="Share your thoughts"]');
-    await expect(textarea).toBeVisible();
-    
-    const longText = 'a'.repeat(2001);
-    await textarea.fill(longText);
-    await page.waitForTimeout(500);
-    
-    const actualValue = await textarea.inputValue();
-    expect(actualValue.length).toBe(2000);
-    
-    const characterCount = page.locator('text=/\\d+\\/2000 characters/');
-    await expect(characterCount).toBeVisible();
-    const countText = await characterCount.textContent();
-    expect(countText).toBe('2000/2000 characters');
+    await Promise.all([
+      page.waitForResponse((response) => response.url().includes('/api/rate/')),
+      submitButton.click({ force: true }),
+    ]);
+
+    await expect(page.locator('[data-testid="modal"]')).toHaveCount(0);
+    await expect(page.locator('textarea[placeholder*="Share your thoughts"]')).toHaveCount(0);
+    await expect(page.locator(SELECTORS.roll.mainDie)).toBeVisible();
   });
 });

--- a/frontend/src/test/roll.spec.ts
+++ b/frontend/src/test/roll.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 import { test, expect } from './fixtures';
-import { SELECTORS } from './helpers';
+import { SELECTORS, submitRatingAndDismissReviewIfShown } from './helpers';
 
 test.describe('Roll Dice Feature', () => {
   test('should display die selector on home page', async ({ authenticatedPage }) => {
@@ -189,14 +189,9 @@ test.describe('Roll Dice Feature', () => {
 
     // Submit rating to return to roll view
     await authenticatedWithThreadsPage.fill(SELECTORS.rate.ratingInput, '5');
-    await authenticatedWithThreadsPage.click(SELECTORS.rate.submitButton);
-
-    // Review form now appears - submit it (empty is fine)
-    await expect(authenticatedWithThreadsPage.locator('[data-testid="modal"]')).toBeVisible({ timeout: 5000 });
-    await Promise.all([
-      authenticatedWithThreadsPage.waitForResponse(r => r.url().includes('/api/rate/')),
-      authenticatedWithThreadsPage.click('button:has-text("Skip")'), // Skip button (doesn't require text)
-    ]);
+    await submitRatingAndDismissReviewIfShown(authenticatedWithThreadsPage, () =>
+      authenticatedWithThreadsPage.click(SELECTORS.rate.submitButton),
+    );
 
     // Wait to return to roll view
     await expect(authenticatedWithThreadsPage.locator(SELECTORS.roll.mainDie)).toBeVisible({ timeout: 5000 });
@@ -725,14 +720,9 @@ test.describe('Roll Dice Feature', () => {
 
         // Submit rating to reset for next roll
         await authenticatedPage.fill(SELECTORS.rate.ratingInput, '4')
-        await authenticatedPage.click(SELECTORS.rate.submitButton)
-        
-        // Review form now appears - submit it (empty is fine)
-        await expect(authenticatedPage.locator('[data-testid="modal"]')).toBeVisible({ timeout: 5000 })
-        await Promise.all([
-          authenticatedPage.waitForResponse(r => r.url().includes('/api/rate/')),
-          authenticatedPage.click('button:has-text("Skip")'), // Skip button (doesn't require text)
-        ])
+        await submitRatingAndDismissReviewIfShown(authenticatedPage, () =>
+          authenticatedPage.click(SELECTORS.rate.submitButton),
+        )
         
         await expect(authenticatedPage.locator(SELECTORS.roll.mainDie)).toBeVisible({ timeout: 5000 })
       }
@@ -1036,14 +1026,9 @@ test.describe('Roll Dice Feature', () => {
       await expect(authenticatedWithThreadsPage.locator(SELECTORS.rate.ratingInput)).toBeVisible({ timeout: 10000 });
 
       await authenticatedWithThreadsPage.fill(SELECTORS.rate.ratingInput, '5');
-      await authenticatedWithThreadsPage.click(SELECTORS.rate.submitButton);
-
-      // Review form now appears - submit it (empty is fine)
-      await expect(authenticatedWithThreadsPage.locator('[data-testid="modal"]')).toBeVisible({ timeout: 5000 });
-      await Promise.all([
-        authenticatedWithThreadsPage.waitForResponse(r => r.url().includes('/api/rate/')),
-        authenticatedWithThreadsPage.click('button:has-text("Skip")'), // Skip button (doesn't require text)
-      ]);
+      await submitRatingAndDismissReviewIfShown(authenticatedWithThreadsPage, () =>
+        authenticatedWithThreadsPage.click(SELECTORS.rate.submitButton),
+      );
 
       await authenticatedWithThreadsPage.waitForSelector(SELECTORS.roll.mainDie, { timeout: 10000 });
       await authenticatedWithThreadsPage.waitForLoadState('networkidle');

--- a/frontend/src/unit/RollPage.reviews-disabled.test.tsx
+++ b/frontend/src/unit/RollPage.reviews-disabled.test.tsx
@@ -1,0 +1,180 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import RollPage from '../pages/RollPage'
+import { useSession } from '../hooks/useSession'
+import { useStaleThreads, useThreads } from '../hooks/useThread'
+import {
+  useClearManualDie,
+  useDismissPending,
+  useOverrideRoll,
+  useRoll,
+  useSetDie,
+} from '../hooks/useRoll'
+import { useSnooze, useUnsnooze } from '../hooks/useSnooze'
+import { useMoveToBack, useMoveToFront } from '../hooks/useQueue'
+import { useRate } from '../hooks'
+import { useCollections } from '../contexts/CollectionContext'
+import { ToastProvider } from '../contexts/ToastContext'
+import { threadsApi } from '../services/api'
+
+const navigateSpy = vi.fn()
+const reviewsApiMock = vi.hoisted(() => ({
+  createOrUpdateReview: vi.fn(),
+}))
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => navigateSpy,
+  }
+})
+
+vi.mock('../components/LazyDice3D', () => ({
+  default: ({ sides, value }: { sides: number; value: number }) => (
+    <div data-testid="lazy-dice" data-sides={String(sides)} data-value={String(value)} />
+  ),
+}))
+
+vi.mock('../config/featureFlags', () => ({
+  isReviewsFeatureEnabled: vi.fn(() => false),
+}))
+
+vi.mock('../hooks/useSession', () => ({ useSession: vi.fn() }))
+vi.mock('../hooks/useThread', () => ({ useThreads: vi.fn(), useStaleThreads: vi.fn() }))
+vi.mock('../hooks/useRoll', () => ({
+  useSetDie: vi.fn(),
+  useClearManualDie: vi.fn(),
+  useRoll: vi.fn(),
+  useOverrideRoll: vi.fn(),
+  useDismissPending: vi.fn(),
+}))
+vi.mock('../hooks/useSnooze', () => ({
+  useSnooze: vi.fn(),
+  useUnsnooze: vi.fn(),
+}))
+vi.mock('../hooks/useQueue', () => ({
+  useMoveToFront: vi.fn(),
+  useMoveToBack: vi.fn(),
+}))
+vi.mock('../hooks', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    useRate: vi.fn(),
+  }
+})
+vi.mock('../contexts/CollectionContext', () => ({ useCollections: vi.fn() }))
+vi.mock('../contexts/ToastContext', () => ({
+  useToast: vi.fn(() => ({ showToast: vi.fn(), removeToast: vi.fn(), toasts: [] })),
+  ToastProvider: ({ children }: { children: React.ReactNode }) => children,
+}))
+vi.mock('../services/api-reviews', () => ({
+  reviewsApi: reviewsApiMock,
+}))
+
+const mockedUseSession = vi.mocked(useSession) as any
+const mockedUseThreads = vi.mocked(useThreads) as any
+const mockedUseStaleThreads = vi.mocked(useStaleThreads) as any
+const mockedUseSetDie = vi.mocked(useSetDie) as any
+const mockedUseClearManualDie = vi.mocked(useClearManualDie) as any
+const mockedUseRoll = vi.mocked(useRoll) as any
+const mockedUseOverrideRoll = vi.mocked(useOverrideRoll) as any
+const mockedUseDismissPending = vi.mocked(useDismissPending) as any
+const mockedUseSnooze = vi.mocked(useSnooze) as any
+const mockedUseUnsnooze = vi.mocked(useUnsnooze) as any
+const mockedUseMoveToFront = vi.mocked(useMoveToFront) as any
+const mockedUseMoveToBack = vi.mocked(useMoveToBack) as any
+const mockedUseRate = vi.mocked(useRate) as any
+const mockedUseCollections = vi.mocked(useCollections) as any
+
+const baseRollResponse = {
+  thread_id: 1,
+  title: 'Saga',
+  format: 'Comics',
+  issues_remaining: 5,
+  queue_position: 1,
+  die_size: 6,
+  result: 3,
+  offset: 0,
+  snoozed_count: 0,
+  issue_id: null,
+  issue_number: null,
+  next_issue_id: null,
+  next_issue_number: null,
+  total_issues: 50,
+  reading_progress: null,
+}
+
+function getPoolItem(title: string): HTMLElement {
+  const element = screen.getByText(title).closest('[role="button"]')
+  if (!(element instanceof HTMLElement)) {
+    throw new Error(`Pool item for ${title} not found`)
+  }
+  return element
+}
+
+beforeEach(() => {
+  navigateSpy.mockReset()
+  reviewsApiMock.createOrUpdateReview.mockReset()
+  vi.spyOn(threadsApi, 'setPending').mockResolvedValue(baseRollResponse)
+  mockedUseSession.mockReturnValue({
+    data: {
+      current_die: 6,
+      last_rolled_result: null,
+      manual_die: null,
+      has_restore_point: false,
+      snoozed_threads: [],
+    },
+    refetch: vi.fn().mockResolvedValue(undefined),
+  })
+  mockedUseThreads.mockReturnValue({
+    data: [
+      { id: 1, title: 'Saga', format: 'Comics', status: 'active' },
+      { id: 2, title: 'X-Men', format: 'Comics', status: 'active' },
+    ],
+    refetch: vi.fn().mockResolvedValue(undefined),
+  })
+  mockedUseStaleThreads.mockReturnValue({ data: [] })
+  mockedUseSetDie.mockReturnValue({ mutate: vi.fn(), isPending: false })
+  mockedUseClearManualDie.mockReturnValue({ mutate: vi.fn(), isPending: false })
+  mockedUseRoll.mockReturnValue({ mutate: vi.fn().mockResolvedValue(baseRollResponse), isPending: false })
+  mockedUseOverrideRoll.mockReturnValue({ mutate: vi.fn(), isPending: false })
+  mockedUseDismissPending.mockReturnValue({ mutate: vi.fn(), isPending: false })
+  mockedUseSnooze.mockReturnValue({ mutate: vi.fn(), isPending: false })
+  mockedUseUnsnooze.mockReturnValue({ mutate: vi.fn(), isPending: false })
+  mockedUseMoveToFront.mockReturnValue({ mutate: vi.fn(), isPending: false })
+  mockedUseMoveToBack.mockReturnValue({ mutate: vi.fn(), isPending: false })
+  mockedUseRate.mockReturnValue({ mutate: vi.fn().mockResolvedValue(undefined), isPending: false })
+  mockedUseCollections.mockReturnValue({
+    collections: [],
+    activeCollectionId: null,
+    setActiveCollectionId: vi.fn(),
+    isLoading: false,
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+it('submits the rating immediately without showing review UI when reviews are disabled', async () => {
+  const user = userEvent.setup()
+  render(
+    <ToastProvider>
+      <RollPage />
+    </ToastProvider>,
+  )
+
+  await user.click(getPoolItem('Saga'))
+  await user.click(screen.getByText('Read Now'))
+  await user.click(screen.getByText('Save & Continue'))
+
+  await waitFor(() => {
+    expect(screen.getByText('Tap Die to Roll')).toBeInTheDocument()
+  })
+
+  expect(screen.queryByText('Write a Review?')).not.toBeInTheDocument()
+  expect(reviewsApiMock.createOrUpdateReview).not.toHaveBeenCalled()
+})

--- a/frontend/src/unit/RollPage.test.tsx
+++ b/frontend/src/unit/RollPage.test.tsx
@@ -51,6 +51,9 @@ vi.mock('../hooks/useQueue', () => ({
   useMoveToFront: vi.fn(),
   useMoveToBack: vi.fn(),
 }))
+vi.mock('../config/featureFlags', () => ({
+  isReviewsFeatureEnabled: vi.fn(() => true),
+}))
 vi.mock('../hooks', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>
   return {

--- a/frontend/src/unit/ThreadDetailView.reviews-disabled.test.tsx
+++ b/frontend/src/unit/ThreadDetailView.reviews-disabled.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, expect, it, vi } from 'vitest'
+import ThreadDetailView from '../pages/ThreadDetailView'
+import { useUpdateThread } from '../hooks/useThread'
+import { useThreadReviews } from '../hooks/useReview'
+import { threadsApi } from '../services/api'
+import { issuesApi } from '../services/api-issues'
+
+const navigateSpy = vi.fn()
+const getThreadReviewsSpy = vi.fn()
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => navigateSpy,
+    useParams: () => ({ id: '1' }),
+  }
+})
+
+vi.mock('../config/featureFlags', () => ({
+  isReviewsFeatureEnabled: vi.fn(() => false),
+}))
+
+vi.mock('../hooks/useThread', () => ({
+  useUpdateThread: vi.fn(),
+}))
+
+vi.mock('../hooks/useReview', () => ({
+  useThreadReviews: vi.fn(),
+}))
+
+vi.mock('../services/api', () => ({
+  threadsApi: {
+    get: vi.fn(),
+  },
+}))
+
+vi.mock('../services/api-issues', () => ({
+  issuesApi: {
+    list: vi.fn(),
+  },
+}))
+
+const mockedUseUpdateThread = vi.mocked(useUpdateThread) as any
+const mockedUseThreadReviews = vi.mocked(useThreadReviews) as any
+const mockedThreadsApiGet = vi.mocked(threadsApi.get) as any
+const mockedIssuesApiList = vi.mocked(issuesApi.list) as any
+
+beforeEach(() => {
+  navigateSpy.mockReset()
+  getThreadReviewsSpy.mockReset()
+  mockedUseUpdateThread.mockReturnValue({ mutate: vi.fn(), isPending: false })
+  mockedUseThreadReviews.mockReturnValue({
+    reviews: [],
+    getThreadReviews: getThreadReviewsSpy,
+    isPending: false,
+    isError: false,
+  })
+  mockedThreadsApiGet.mockResolvedValue({
+    id: 1,
+    title: 'Saga',
+    format: 'Comics',
+    issues_remaining: 5,
+    queue_position: 1,
+    status: 'active',
+    total_issues: null,
+    notes: null,
+    collection_id: null,
+  })
+  mockedIssuesApiList.mockResolvedValue({
+    issues: [],
+    next_page_token: null,
+  })
+})
+
+it('hides review content and skips review loading when the feature is disabled', async () => {
+  render(<ThreadDetailView />)
+
+  await waitFor(() => {
+    expect(screen.getByText('Saga')).toBeInTheDocument()
+  })
+
+  expect(screen.queryByText(/Reviews/)).not.toBeInTheDocument()
+  expect(screen.queryByText('No reviews yet.')).not.toBeInTheDocument()
+  expect(getThreadReviewsSpy).not.toHaveBeenCalled()
+})

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_ENABLE_REVIEWS?: string
+}


### PR DESCRIPTION
Closes #488

Summary:
- Hide review UI behind a Vite feature flag that defaults off
- Keep review API/code paths intact, but skip review fetch/render when disabled
- Update unit and Playwright coverage for the disabled-by-default behavior

Validation:
- `npm run lint`
- `npm run test -- --run src/unit/RollPage.reviews-disabled.test.tsx src/unit/ThreadDetailView.reviews-disabled.test.tsx`
- `npm run build`
- `REUSE_EXISTING_SERVER=true BASE_URL=http://localhost:9000 npx playwright test src/test/review-create.spec.ts src/test/review-display.spec.ts src/test/review-edit.spec.ts src/test/review-errors.spec.ts --project=chromium`