### PR TITLE
Preserve editable modal state after bug reports

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import type { AuthUser } from './types'
 import { useBugReport } from './hooks/useBugReport'
 import { ToastProvider } from './contexts/ToastContext'
 import { CacheProvider } from './contexts/CacheContext'
+import { BugReportRestoreProvider } from './contexts/BugReportRestoreContext'
 import './index.css'
 
 declare global {
@@ -301,13 +302,15 @@ function AppRoutes() {
 function App() {
   return (
     <BrowserRouter>
-      <ToastProvider>
-        <CacheProvider>
-          <AuthProvider>
-            <AppRoutes />
-          </AuthProvider>
-        </CacheProvider>
-      </ToastProvider>
+      <BugReportRestoreProvider>
+        <ToastProvider>
+          <CacheProvider>
+            <AuthProvider>
+              <AppRoutes />
+            </AuthProvider>
+          </CacheProvider>
+        </ToastProvider>
+      </BugReportRestoreProvider>
     </BrowserRouter>
   )
 }

--- a/frontend/src/components/BugReportButton.tsx
+++ b/frontend/src/components/BugReportButton.tsx
@@ -4,6 +4,7 @@ import { useDiagnostics } from '../hooks/useDiagnostics'
 import type { DiagnosticData } from '../hooks/useDiagnostics'
 import { captureScreenshot } from '../utils/captureScreenshot'
 import type { ScreenshotDiagnostics } from '../utils/captureScreenshot'
+import { useBugReportRestore } from '../contexts/BugReportRestoreContext'
 
 interface BugReportButtonProps {
   onSubmit: (title: string, description: string, screenshotBlob: Blob | null, diagnosticData: DiagnosticData | null, screenshotDiagnostics?: ScreenshotDiagnostics) => Promise<void>
@@ -15,6 +16,7 @@ export default function BugReportButton({ onSubmit }: BugReportButtonProps) {
   const [diagnosticData, setDiagnosticData] = useState<DiagnosticData | null>(null)
   const [screenshotDiagnostics, setScreenshotDiagnostics] = useState<ScreenshotDiagnostics | null>(null)
   const { collectDiagnostics } = useDiagnostics()
+  const { restoreLastView } = useBugReportRestore()
 
   const handleClick = async () => {
     const diagnostics = collectDiagnostics()
@@ -30,7 +32,7 @@ export default function BugReportButton({ onSubmit }: BugReportButtonProps) {
       setScreenshotDiagnostics(null)
     } finally {
       setIsModalOpen(true)
-}
+    }
   }
 
   const handleClose = () => {
@@ -43,6 +45,7 @@ export default function BugReportButton({ onSubmit }: BugReportButtonProps) {
   const handleSubmit = async (title: string, description: string, screenshotBlob: Blob | null) => {
     await onSubmit(title, description, screenshotBlob, diagnosticData, screenshotDiagnostics ?? undefined)
     handleClose()
+    restoreLastView()
   }
 
   return (

--- a/frontend/src/contexts/BugReportRestoreContext.tsx
+++ b/frontend/src/contexts/BugReportRestoreContext.tsx
@@ -1,0 +1,48 @@
+import { createContext, useCallback, useContext, useState } from 'react'
+import type { ReactNode } from 'react'
+
+type RestoreAction = (() => void) | null
+
+interface BugReportRestoreContextValue {
+  setRestoreAction: (action: RestoreAction) => void
+  clearRestoreAction: () => void
+  restoreLastView: () => void
+}
+
+const BugReportRestoreContext = createContext<BugReportRestoreContextValue | undefined>(undefined)
+
+export function BugReportRestoreProvider({ children }: { children: ReactNode }) {
+  const [restoreAction, setRestoreActionState] = useState<RestoreAction>(null)
+
+  const setRestoreAction = useCallback((action: RestoreAction) => {
+    setRestoreActionState(() => action)
+  }, [])
+
+  const clearRestoreAction = useCallback(() => {
+    setRestoreActionState(null)
+  }, [])
+
+  const restoreLastView = useCallback(() => {
+    restoreAction?.()
+  }, [restoreAction])
+
+  return (
+    <BugReportRestoreContext.Provider
+      value={{
+        setRestoreAction,
+        clearRestoreAction,
+        restoreLastView,
+      }}
+    >
+      {children}
+    </BugReportRestoreContext.Provider>
+  )
+}
+
+export function useBugReportRestore() {
+  const context = useContext(BugReportRestoreContext)
+  if (!context) {
+    throw new Error('useBugReportRestore must be used within a BugReportRestoreProvider')
+  }
+  return context
+}

--- a/frontend/src/pages/QueuePage/QueuePage.tsx
+++ b/frontend/src/pages/QueuePage/QueuePage.tsx
@@ -336,21 +336,18 @@ export default function QueuePage() {
     navigate(location.pathname, { replace: true, state: {} })
   }, [location.pathname, navigate])
 
-  const openCreateModal = useCallback(() => {
+  const showCreateModal = useCallback(() => {
     setCreateForm(DEFAULT_CREATE_STATE)
     setIsCreateOpen(true)
     setRestoreAction(() => {
       setCreateForm(DEFAULT_CREATE_STATE)
       setIsCreateOpen(true)
     })
-    navigate(location.pathname, {
-      replace: true,
-      state: {
-        ...(location.state ?? {}),
-        openCreate: true,
-      },
-    })
-  }, [location.pathname, location.state, navigate, setRestoreAction])
+  }, [setRestoreAction])
+
+  const openCreateModal = useCallback(() => {
+    showCreateModal()
+  }, [showCreateModal])
 
   const closeCreateModal = useCallback(() => {
     setIsCreateOpen(false)
@@ -358,7 +355,7 @@ export default function QueuePage() {
     clearQueueModalState()
   }, [clearQueueModalState, clearRestoreAction])
 
-  const openEditModal = useCallback((thread: Thread) => {
+  const showEditModal = useCallback((thread: Thread) => {
     setEditingThread(thread)
     setEditForm({
       title: thread.title,
@@ -381,14 +378,11 @@ export default function QueuePage() {
       })
       setIsEditOpen(true)
     })
-    navigate(location.pathname, {
-      replace: true,
-      state: {
-        ...(location.state ?? {}),
-        editThreadId: thread.id,
-      },
-    })
-  }, [location.pathname, location.state, navigate, setRestoreAction])
+  }, [setRestoreAction])
+
+  const openEditModal = useCallback((thread: Thread) => {
+    showEditModal(thread)
+  }, [showEditModal])
 
   const closeEditModal = useCallback(() => {
     setEditingThread(null)
@@ -402,13 +396,25 @@ export default function QueuePage() {
     if (location.state?.editThreadId && threads) {
       const thread = threads.find((t) => t.id === location.state.editThreadId)
       if (thread && (!isEditOpen || editingThread?.id !== thread.id)) {
-        openEditModal(thread)
+        showEditModal(thread)
       }
+      clearQueueModalState()
+      return
     }
     if (location.state?.openCreate && !isCreateOpen) {
-      openCreateModal()
+      showCreateModal()
+      clearQueueModalState()
     }
-  }, [editingThread?.id, isCreateOpen, isEditOpen, location.pathname, location.state, openCreateModal, openEditModal, threads])
+  }, [
+    clearQueueModalState,
+    editingThread?.id,
+    isCreateOpen,
+    isEditOpen,
+    location.state,
+    showCreateModal,
+    showEditModal,
+    threads,
+  ])
 
   const openRepositionModal = (thread: Thread) => {
     setRepositioningThread(thread)

--- a/frontend/src/pages/QueuePage/QueuePage.tsx
+++ b/frontend/src/pages/QueuePage/QueuePage.tsx
@@ -16,6 +16,7 @@ import { useSession } from '../../hooks/useSession'
 import { useSnooze, useUnsnooze } from '../../hooks/useSnooze'
 import { dependenciesApi, threadsApi } from '../../services/api'
 import { issuesApi } from '../../services/api-issues'
+import { useBugReportRestore } from '../../contexts/BugReportRestoreContext'
 import { useCollections } from '../../contexts/CollectionContext'
 import { PositionMenuProvider } from '../../contexts/PositionMenuContext'
 import type { Thread } from '../../types'
@@ -29,6 +30,7 @@ export default function QueuePage() {
   const navigate = useNavigate()
   const location = useLocation()
   const { activeCollectionId } = useCollections()
+  const { setRestoreAction, clearRestoreAction } = useBugReportRestore()
   const { data: threads, isPending, refetch } = useThreads('', activeCollectionId)
   const { data: session, refetch: refetchSession } = useSession()
   const createMutation = useCreateThread()
@@ -69,21 +71,6 @@ export default function QueuePage() {
   const [isDependencyBuilderOpen, setIsDependencyBuilderOpen] = useState(false)
   const [issuePreview, setIssuePreview] = useState<number | null>(null)
   const [issueParseError, setIssueParseError] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (location.state?.editThreadId && threads) {
-      const thread = threads.find((t) => t.id === location.state.editThreadId)
-      if (thread) {
-        openEditModal(thread)
-        navigate(location.pathname, { replace: true, state: {} })
-      }
-    }
-    // If navigation from RollPage or other page to create a new thread, auto-open create modal
-    if (location.state?.openCreate) {
-      openCreateModal()
-      navigate(location.pathname, { replace: true, state: {} })
-    }
-  }, [location.state, location.pathname, threads, navigate])
 
   async function refreshBlockedState() {
     try {
@@ -264,7 +251,7 @@ export default function QueuePage() {
       }
 
       setCreateForm(DEFAULT_CREATE_STATE)
-      setIsCreateOpen(false)
+      closeCreateModal()
       refetch()
     } catch (error: unknown) {
       console.error('Failed to create thread:', error)
@@ -292,25 +279,10 @@ export default function QueuePage() {
         id: editingThread.id,
         data: updateData,
       })
-      setEditingThread(null)
-      setIsEditOpen(false)
-      refetch()
+      closeEditModal()
     } catch {
       console.error('Failed to update thread')
     }
-  }
-
-  const openEditModal = (thread: Thread) => {
-    setEditingThread(thread)
-    setEditForm({
-      title: thread.title,
-      format: thread.format,
-      issuesRemaining: thread.issues_remaining,
-      notes: thread.notes || '',
-      issues: '',
-      lastIssueRead: 0,
-    })
-    setIsEditOpen(true)
   }
 
   const openReactivateModal = (thread: Thread | null) => {
@@ -360,10 +332,83 @@ export default function QueuePage() {
     setThreadToMigrate(null)
   }, [])
 
-  const openCreateModal = () => {
+  const clearQueueModalState = useCallback(() => {
+    navigate(location.pathname, { replace: true, state: {} })
+  }, [location.pathname, navigate])
+
+  const openCreateModal = useCallback(() => {
     setCreateForm(DEFAULT_CREATE_STATE)
     setIsCreateOpen(true)
-  }
+    setRestoreAction(() => {
+      setCreateForm(DEFAULT_CREATE_STATE)
+      setIsCreateOpen(true)
+    })
+    navigate(location.pathname, {
+      replace: true,
+      state: {
+        ...(location.state ?? {}),
+        openCreate: true,
+      },
+    })
+  }, [location.pathname, location.state, navigate, setRestoreAction])
+
+  const closeCreateModal = useCallback(() => {
+    setIsCreateOpen(false)
+    clearRestoreAction()
+    clearQueueModalState()
+  }, [clearQueueModalState, clearRestoreAction])
+
+  const openEditModal = useCallback((thread: Thread) => {
+    setEditingThread(thread)
+    setEditForm({
+      title: thread.title,
+      format: thread.format,
+      issuesRemaining: thread.issues_remaining,
+      notes: thread.notes || '',
+      issues: '',
+      lastIssueRead: 0,
+    })
+    setIsEditOpen(true)
+    setRestoreAction(() => {
+      setEditingThread(thread)
+      setEditForm({
+        title: thread.title,
+        format: thread.format,
+        issuesRemaining: thread.issues_remaining,
+        notes: thread.notes || '',
+        issues: '',
+        lastIssueRead: 0,
+      })
+      setIsEditOpen(true)
+    })
+    navigate(location.pathname, {
+      replace: true,
+      state: {
+        ...(location.state ?? {}),
+        editThreadId: thread.id,
+      },
+    })
+  }, [location.pathname, location.state, navigate, setRestoreAction])
+
+  const closeEditModal = useCallback(() => {
+    setEditingThread(null)
+    setIsEditOpen(false)
+    clearRestoreAction()
+    clearQueueModalState()
+    refetch()
+  }, [clearQueueModalState, clearRestoreAction, refetch])
+
+  useEffect(() => {
+    if (location.state?.editThreadId && threads) {
+      const thread = threads.find((t) => t.id === location.state.editThreadId)
+      if (thread && (!isEditOpen || editingThread?.id !== thread.id)) {
+        openEditModal(thread)
+      }
+    }
+    if (location.state?.openCreate && !isCreateOpen) {
+      openCreateModal()
+    }
+  }, [editingThread?.id, isCreateOpen, isEditOpen, location.pathname, location.state, openCreateModal, openEditModal, threads])
 
   const openRepositionModal = (thread: Thread) => {
     setRepositioningThread(thread)
@@ -693,7 +738,7 @@ export default function QueuePage() {
       )}
 
   {/* Create Thread Modal */}
-  <Modal isOpen={isCreateOpen} title="Create Thread" onClose={() => setIsCreateOpen(false)}>
+  <Modal isOpen={isCreateOpen} title="Create Thread" onClose={closeCreateModal}>
   <form className="space-y-4" onSubmit={handleCreateSubmit}>
   <div className="space-y-2">
   <label htmlFor="create-thread-title" className="text-[10px] font-bold uppercase tracking-widest text-stone-500">Title</label>
@@ -785,7 +830,7 @@ export default function QueuePage() {
       </Modal>
 
   {/* Edit Thread Modal */}
-  <Modal isOpen={isEditOpen} title="Edit Thread" onClose={() => { setIsEditOpen(false); refetch() }} overlayClassName="edit-modal__overlay">
+  <Modal isOpen={isEditOpen} title="Edit Thread" onClose={closeEditModal} overlayClassName="edit-modal__overlay">
   <div className="space-y-4">
   <form id="edit-thread-form" className="space-y-4" onSubmit={handleEditSubmit}>
   <div className="space-y-2">

--- a/frontend/src/pages/RollPage/index.tsx
+++ b/frontend/src/pages/RollPage/index.tsx
@@ -12,6 +12,7 @@ import { DICE_LADDER } from '../../components/diceLadder'
 import { useSession } from '../../hooks/useSession'
 import { useStaleThreads, useThreads } from '../../hooks/useThread'
 import { useCollections } from '../../contexts/CollectionContext'
+import { useBugReportRestore } from '../../contexts/BugReportRestoreContext'
 import {
   useClearManualDie,
   useDismissPending,
@@ -79,6 +80,7 @@ export default function RollPage() {
 
   const { data: session, refetch: refetchSession, isPending: isSessionLoading, isError: isSessionError, error: sessionError } = useSession()
   const { activeCollectionId = null } = useCollections()
+  const { setRestoreAction, clearRestoreAction } = useBugReportRestore()
   const { data: threads, refetch: refetchThreads } = useThreads('', activeCollectionId)
   const { data: staleThreads } = useStaleThreads(7)
   const navigate = useNavigate()
@@ -303,6 +305,63 @@ case 'read': {
   const activeThreads = useMemo(() => threads?.filter((t) => t.status === 'active' && !t.is_blocked && !snoozedIds.has(t.id)) ?? [], [threads, snoozedIds])
   const blockedThreads = useMemo(() => threads?.filter((t) => t.status === 'active' && t.is_blocked) ?? [], [threads])
   const displayDie = isDiceSide(currentDie) ? currentDie : 6
+
+  useEffect(() => {
+    if (showReviewForm) {
+      setRestoreAction(() => {
+        setShowReviewForm(true)
+      })
+      return
+    }
+    if (showSimpleMigration) {
+      setRestoreAction(() => {
+        setShowSimpleMigration(true)
+      })
+      return
+    }
+    if (showMigrationDialog && threadToMigrate) {
+      setRestoreAction(() => {
+        setShowMigrationDialog(true)
+      })
+      return
+    }
+    if (isCollectionDialogOpen) {
+      setRestoreAction(() => {
+        setIsCollectionDialogOpen(true)
+      })
+      return
+    }
+    if (isOverrideOpen) {
+      setRestoreAction(() => {
+        setIsOverrideOpen(true)
+      })
+      return
+    }
+    if (isActionSheetOpen && selectedThread) {
+      setRestoreAction(() => {
+        setIsActionSheetOpen(true)
+      })
+      return
+    }
+    clearRestoreAction()
+  }, [
+    clearRestoreAction,
+    isActionSheetOpen,
+    isCollectionDialogOpen,
+    isOverrideOpen,
+    selectedThread,
+    setIsActionSheetOpen,
+    setIsCollectionDialogOpen,
+    setIsOverrideOpen,
+    setRestoreAction,
+    setShowMigrationDialog,
+    setShowSimpleMigration,
+    showMigrationDialog,
+    showReviewForm,
+    showSimpleMigration,
+    threadToMigrate,
+  ])
+
 
 useEffect(() => {
   const fetchBlockingReasons = async () => {

--- a/frontend/src/unit/BugReportButton.test.tsx
+++ b/frontend/src/unit/BugReportButton.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import BugReportButton from '../components/BugReportButton'
+
+const captureScreenshotMock = vi.hoisted(() => vi.fn())
+const collectDiagnosticsMock = vi.hoisted(() => vi.fn())
+const restoreLastViewMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../utils/captureScreenshot', () => ({
+  captureScreenshot: captureScreenshotMock,
+}))
+
+vi.mock('../hooks/useDiagnostics', () => ({
+  useDiagnostics: () => ({ collectDiagnostics: collectDiagnosticsMock }),
+}))
+
+vi.mock('../contexts/BugReportRestoreContext', () => ({
+  useBugReportRestore: () => ({
+    setRestoreAction: vi.fn(),
+    clearRestoreAction: vi.fn(),
+    restoreLastView: restoreLastViewMock,
+  }),
+}))
+
+vi.mock('../components/BugReportModal', () => ({
+  default: ({ isOpen, onSubmit }: { isOpen: boolean; onSubmit: (title: string, description: string, screenshotBlob: Blob | null) => Promise<void> }) =>
+    isOpen ? (
+      <div role="dialog" aria-label="Report a Bug">
+        <button type="button" onClick={() => onSubmit('Bug title', 'Bug description', null)}>
+          Submit Report
+        </button>
+      </div>
+    ) : null,
+}))
+
+describe('BugReportButton', () => {
+  beforeEach(() => {
+    captureScreenshotMock.mockResolvedValue({ blob: new Blob(['png'], { type: 'image/png' }), diagnostics: {} })
+    collectDiagnosticsMock.mockReturnValue({ timestamp: '2024-01-01T00:00:00.000Z' })
+    restoreLastViewMock.mockReset()
+  })
+
+  it('restores the prior view after a successful bug submission', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+
+    render(<BugReportButton onSubmit={onSubmit} />)
+
+    await user.click(screen.getByRole('button', { name: /report a bug/i }))
+    await user.click(await screen.findByRole('button', { name: /submit report/i }))
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      'Bug title',
+      'Bug description',
+      null,
+      { timestamp: '2024-01-01T00:00:00.000Z' },
+      {},
+    )
+    expect(restoreLastViewMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/unit/QueuePage.test.tsx
+++ b/frontend/src/unit/QueuePage.test.tsx
@@ -14,6 +14,7 @@ import {
  useUpdateThread,
 } from '../hooks/useThread'
 import { useMoveToBack, useMoveToFront, useMoveToPosition } from '../hooks/useQueue'
+import { useBugReportRestore } from '../contexts/BugReportRestoreContext'
 import { useSession } from '../hooks/useSession'
 import { useSnooze, useUnsnooze } from '../hooks/useSnooze'
 import { threadsApi } from '../services/api'
@@ -50,6 +51,10 @@ vi.mock('../services/api', () => ({
   },
 }))
 
+vi.mock('../contexts/BugReportRestoreContext', () => ({
+  useBugReportRestore: vi.fn(),
+}))
+
 vi.mock('../contexts/CollectionContext', () => ({
   CollectionProvider: ({ children }: { children: ReactNode }) => children,
   useCollections: vi.fn().mockReturnValue({
@@ -79,6 +84,7 @@ const mockedUseMoveToFront = vi.mocked(useMoveToFront) as any
 const mockedUseMoveToBack = vi.mocked(useMoveToBack) as any
 const mockedUseMoveToPosition = vi.mocked(useMoveToPosition) as any
 const mockedUseSession = vi.mocked(useSession) as any
+const mockedUseBugReportRestore = vi.mocked(useBugReportRestore) as any
 const mockedUseUnsnooze = vi.mocked(useUnsnooze) as any
 const mockedUseSnooze = vi.mocked(useSnooze) as any
 const mockedThreadsApi = vi.mocked(threadsApi) as any
@@ -106,6 +112,11 @@ beforeEach(() => {
   })
   mockedUseUnsnooze.mockReturnValue({ mutate: vi.fn(), isPending: false })
   mockedUseSnooze.mockReturnValue({ mutate: vi.fn(), isPending: false })
+  mockedUseBugReportRestore.mockReturnValue({
+    setRestoreAction: vi.fn(),
+    clearRestoreAction: vi.fn(),
+    restoreLastView: vi.fn(),
+  })
   mockedThreadsApi.setPending.mockResolvedValue({
     thread_id: 1,
     title: 'Saga',
@@ -142,6 +153,34 @@ it('renders queue items and opens create modal', async () => {
   const addButtons = screen.getAllByRole('button', { name: /add thread/i })
   await user.click(addButtons[0])
   expect(screen.getByRole('heading', { name: /create thread/i })).toBeInTheDocument()
+})
+
+it('registers a restore target while the create modal is open', async () => {
+  const user = userEvent.setup()
+  const restoreState = {
+    setRestoreAction: vi.fn(),
+    clearRestoreAction: vi.fn(),
+    restoreLastView: vi.fn(),
+  }
+  mockedUseBugReportRestore.mockReturnValue(restoreState)
+
+  render(
+    <BrowserRouter>
+      <ToastProvider>
+        <QueuePage />
+      </ToastProvider>
+    </BrowserRouter>
+  )
+
+  await user.click(screen.getAllByRole('button', { name: /add thread/i })[0])
+
+  expect(restoreState.setRestoreAction).toHaveBeenCalled()
+
+  await user.click(screen.getByLabelText('Close modal'))
+
+  await waitFor(() => {
+    expect(restoreState.clearRestoreAction).toHaveBeenCalled()
+  })
 })
 
 describe('Action Sheet Snooze/Unsnooze', () => {

--- a/frontend/src/unit/RollPage.test.tsx
+++ b/frontend/src/unit/RollPage.test.tsx
@@ -15,6 +15,7 @@ import { useSnooze, useUnsnooze } from '../hooks/useSnooze'
 import { useMoveToBack, useMoveToFront } from '../hooks/useQueue'
 import { useRate } from '../hooks'
 import { useCollections } from '../contexts/CollectionContext'
+import { useBugReportRestore } from '../contexts/BugReportRestoreContext'
 import { ToastProvider } from '../contexts/ToastContext'
 import type { RollResponse } from '../types'
 
@@ -51,6 +52,7 @@ vi.mock('../hooks/useQueue', () => ({
   useMoveToFront: vi.fn(),
   useMoveToBack: vi.fn(),
 }))
+vi.mock('../contexts/BugReportRestoreContext', () => ({ useBugReportRestore: vi.fn() }))
 vi.mock('../hooks', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>
   return {
@@ -78,6 +80,7 @@ const mockedUseMoveToFront = vi.mocked(useMoveToFront) as any
 const mockedUseMoveToBack = vi.mocked(useMoveToBack) as any
 const mockedUseRate = vi.mocked(useRate) as any
 const mockedUseCollections = vi.mocked(useCollections) as any
+const mockedUseBugReportRestore = vi.mocked(useBugReportRestore) as any
 
 type MockThread = {
   id: number
@@ -155,6 +158,11 @@ beforeEach(() => {
     setActiveCollectionId: vi.fn(),
     isLoading: false,
   })
+  mockedUseBugReportRestore.mockReturnValue({
+    setRestoreAction: vi.fn(),
+    clearRestoreAction: vi.fn(),
+    restoreLastView: vi.fn(),
+  })
 })
 
 afterEach(() => {
@@ -171,6 +179,26 @@ it('renders roll page content and opens override modal', async () => {
 
   await user.click(screen.getByRole('button', { name: /override/i }))
   expect(screen.getByRole('heading', { name: /override roll/i })).toBeInTheDocument()
+})
+
+it('registers a restore target while the override modal is open', async () => {
+  const user = userEvent.setup()
+  const restoreState = {
+    setRestoreAction: vi.fn(),
+    clearRestoreAction: vi.fn(),
+    restoreLastView: vi.fn(),
+  }
+  mockedUseBugReportRestore.mockReturnValue(restoreState)
+
+  render(<RollPage />)
+
+  await user.click(screen.getByRole('button', { name: /override/i }))
+
+  expect(restoreState.setRestoreAction).toHaveBeenCalled()
+
+  await user.click(screen.getByLabelText('Close modal'))
+
+  expect(restoreState.clearRestoreAction).toHaveBeenCalled()
 })
 
 describe('Action Sheet', () => {


### PR DESCRIPTION
Closes #493

## Summary
- add a restore context so bug report submission can return to the last editable view/modal
- preserve queue create/edit modal state and restore it after bug report submit
- register restore actions for Roll page editable modals and add focused regression tests

## Validation
- `npm run lint -- src/components/BugReportButton.tsx src/pages/QueuePage/QueuePage.tsx src/pages/RollPage/index.tsx src/contexts/BugReportRestoreContext.tsx src/unit/BugReportButton.test.tsx src/unit/QueuePage.test.tsx src/unit/RollPage.test.tsx`
- `npm test -- --run src/unit/BugReportButton.test.tsx src/unit/QueuePage.test.tsx src/unit/RollPage.test.tsx`
- `npm run build`
- `npm run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When submitting a bug report, your previous app view is now automatically restored after the report is sent, allowing seamless continuation of your work.

* **Tests**
  * Added comprehensive unit tests for bug report functionality and modal behavior across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->