### PR TITLE
feat(security): add login rate limiting and account lockout

### DIFF
--- a/alembic/versions/a7b8c9d0e1f2_add_failed_login_attempts_table.py
+++ b/alembic/versions/a7b8c9d0e1f2_add_failed_login_attempts_table.py
@@ -1,0 +1,52 @@
+"""Add failed_login_attempts table for account lockout.
+
+Revision ID: a7b8c9d0e1f2
+Revises: b9ec6f922a61
+Create Date: 2026-04-19 16:30:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+revision: str = "a7b8c9d0e1f2"
+down_revision: str | Sequence[str] | None = "b9ec6f922a61"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "failed_login_attempts",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("username", sa.String(50), nullable=False),
+        sa.Column("ip_address", sa.String(45), nullable=False),
+        sa.Column(
+            "attempted_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_failed_login_username_time",
+        "failed_login_attempts",
+        ["username", "attempted_at"],
+    )
+    op.create_index(
+        "ix_failed_login_ip_time",
+        "failed_login_attempts",
+        ["ip_address", "attempted_at"],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_failed_login_ip_time", table_name="failed_login_attempts")
+    op.drop_index("ix_failed_login_username_time", table_name="failed_login_attempts")
+    op.drop_table("failed_login_attempts")

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -18,6 +18,7 @@ from app.auth import (
     JWTError,
 )
 from app.database import get_db
+from app.middleware import limiter
 from app.models.user import User
 from app.schemas.auth import (
     RefreshTokenRequest,
@@ -25,6 +26,12 @@ from app.schemas.auth import (
     UserLoginRequest,
     UserRegisterRequest,
     UserResponse,
+)
+from app.security import (
+    check_login_lockout,
+    clear_failed_logins,
+    get_client_ip,
+    record_failed_login,
 )
 
 router = APIRouter(tags=["auth"])
@@ -129,6 +136,7 @@ async def register_user(
 
 
 @router.post("/login", response_model=TokenResponse)
+@limiter.limit("5/minute")
 async def login_user(
     login_data: UserLoginRequest,
     request: Request,
@@ -139,7 +147,7 @@ async def login_user(
 
     Args:
         login_data: User login data (username, password).
-        request: Incoming request used for cookie security policy.
+        request: Incoming request used for cookie security policy and IP extraction.
         response: Outgoing response used to set auth cookies.
         db: SQLAlchemy session for database operations.
 
@@ -147,23 +155,33 @@ async def login_user(
         TokenResponse with access and refresh tokens.
 
     Raises:
-        HTTPException: If credentials are invalid.
+        HTTPException: If credentials are invalid or account is locked out.
     """
+    client_ip = get_client_ip(
+        dict(request.headers),
+        request.client.host if request.client else None,
+    )
+
+    await check_login_lockout(db, username=login_data.username, ip_address=client_ip)
+
     result = await db.execute(select(User).where(User.username == login_data.username).limit(1))
     user = result.scalar_one_or_none()
     if not user or not user.password_hash:
+        await record_failed_login(db, username=login_data.username, ip_address=client_ip)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect username or password",
         )
 
     if not verify_password(login_data.password, user.password_hash):
+        await record_failed_login(db, username=login_data.username, ip_address=client_ip)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect username or password",
         )
 
-    # Create tokens with JTI for revocation
+    await clear_failed_logins(db, username=login_data.username)
+
     jti = secrets.token_urlsafe(32)
     access_token = create_access_token(data={"sub": user.username, "jti": jti})
     refresh_token = create_refresh_token(data={"sub": user.username, "jti": jti})
@@ -197,7 +215,9 @@ async def refresh_access_token(
         HTTPException: If refresh token is invalid or revoked.
     """
     try:
-        refresh_token = refresh_data.refresh_token if refresh_data else request.cookies.get(REFRESH_COOKIE_NAME)
+        refresh_token = (
+            refresh_data.refresh_token if refresh_data else request.cookies.get(REFRESH_COOKIE_NAME)
+        )
         if not refresh_token:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,

--- a/app/middleware/rate_limit.py
+++ b/app/middleware/rate_limit.py
@@ -11,116 +11,128 @@ from slowapi import Limiter
 from slowapi.util import get_remote_address
 from starlette.requests import Request
 
-TEST_MODE = os.getenv("TEST_ENVIRONMENT") == "true"
 RateLimitValue = str | Callable[..., str]
+_current_request: contextvars.ContextVar[Request | None] = contextvars.ContextVar(
+    "rate_limit_request",
+    default=None,
+)
+
+
+def _is_test_mode() -> bool:
+    """Return whether the current process is running under tests."""
+    return os.getenv("TEST_ENVIRONMENT") == "true"
 
 
 def _should_enable_rate_limiting() -> bool:
     """Check if rate limiting should be enabled."""
-    if not TEST_MODE:
+    if not _is_test_mode():
         return True
     return os.getenv("ENABLE_RATE_LIMITING_IN_TESTS") == "true"
 
 
-if TEST_MODE:
-    _current_request: contextvars.ContextVar[Request | None] = contextvars.ContextVar(
-        "rate_limit_request",
-        default=None,
-    )
-
-    def _test_rate_limit_key(request: Request) -> str:
-        """Derive test-mode rate limit key from auth context, falling back to client address."""
+def _rate_limit_key(request: Request) -> str:
+    """Use auth-aware keys in tests and client IPs elsewhere."""
+    if _is_test_mode():
         auth_header = request.headers.get("authorization")
         if auth_header:
             return auth_header
-        return get_remote_address(request)
+    return get_remote_address(request)
 
-    class TestLimiter(Limiter):
-        """Limiter that can dynamically exempt requests while tests are running."""
 
-        def limit(
-            self,
-            limit_value: RateLimitValue,
-            key_func: Callable[..., str] | None = None,
-            per_method: bool = False,
-            methods: list[str] | None = None,
-            error_message: RateLimitValue | None = None,
-            exempt_when: Callable[..., bool] | None = None,
-            cost: int | Callable[..., int] = 1,
-            override_defaults: bool = True,
-        ) -> Callable:
-            """Return a decorator that exempts requests unless rate limiting is enabled."""
-            expects_request = False
-            if exempt_when is not None:
-                signature = inspect.signature(exempt_when)
-                expects_request = len(signature.parameters) == 1
+class DynamicTestLimiter(Limiter):
+    """Limiter that defers test-mode exemptions until each request."""
 
-            def _test_exempt_when() -> bool:
-                if not _should_enable_rate_limiting():
-                    return True
-                if exempt_when is None:
+    def limit(
+        self,
+        limit_value: RateLimitValue,
+        key_func: Callable[..., str] | None = None,
+        per_method: bool = False,
+        methods: list[str] | None = None,
+        error_message: RateLimitValue | None = None,
+        exempt_when: Callable[..., bool] | None = None,
+        cost: int | Callable[..., int] = 1,
+        override_defaults: bool = True,
+    ) -> Callable:
+        """Return a decorator that can disable limits during most tests."""
+        expects_request = False
+        if exempt_when is not None:
+            signature = inspect.signature(exempt_when)
+            expects_request = len(signature.parameters) == 1
+
+        def _test_exempt_when() -> bool:
+            if _is_test_mode() and not _should_enable_rate_limiting():
+                return True
+            if exempt_when is None:
+                return False
+            if expects_request:
+                request = _current_request.get()
+                if request is None:
                     return False
-                if expects_request:
-                    request = _current_request.get()
-                    if request is None:
-                        return False
-                    return exempt_when(request)
-                return exempt_when()
+                return exempt_when(request)
+            return exempt_when()
 
-            limit_decorator = super().limit(
-                limit_value,
-                key_func=key_func,
-                per_method=per_method,
-                methods=methods,
-                error_message=error_message,
-                exempt_when=_test_exempt_when,
-                cost=cost,
-                override_defaults=override_defaults,
+        limit_decorator = super().limit(
+            limit_value,
+            key_func=key_func,
+            per_method=per_method,
+            methods=methods,
+            error_message=error_message,
+            exempt_when=_test_exempt_when,
+            cost=cost,
+            override_defaults=override_defaults,
+        )
+
+        def decorator(func: Callable) -> Callable:
+            limited_func = limit_decorator(func)
+            if not expects_request:
+                return limited_func
+
+            request_parameter_index = next(
+                (
+                    index
+                    for index, parameter in enumerate(inspect.signature(func).parameters.values())
+                    if parameter.name == "request"
+                ),
+                -1,
             )
 
-            def decorator(func: Callable) -> Callable:
-                limited_func = limit_decorator(func)
-                if not expects_request:
-                    return limited_func
-
-                request_parameter_index = next(
-                    (
-                        index
-                        for index, parameter in enumerate(inspect.signature(func).parameters.values())
-                        if parameter.name == "request"
-                    ),
-                    -1,
-                )
-
-                if asyncio.iscoroutinefunction(limited_func):
-                    @functools.wraps(limited_func)
-                    async def async_with_request(*args, **kwargs):
-                        request = kwargs.get("request")
-                        if request is None and request_parameter_index >= 0 and len(args) > request_parameter_index:
-                            request = args[request_parameter_index]
-                        token = _current_request.set(request if isinstance(request, Request) else None)
-                        try:
-                            return await limited_func(*args, **kwargs)
-                        finally:
-                            _current_request.reset(token)
-
-                    return async_with_request
+            if asyncio.iscoroutinefunction(limited_func):
 
                 @functools.wraps(limited_func)
-                def sync_with_request(*args, **kwargs):
+                async def async_with_request(*args, **kwargs):
                     request = kwargs.get("request")
-                    if request is None and request_parameter_index >= 0 and len(args) > request_parameter_index:
+                    if (
+                        request is None
+                        and request_parameter_index >= 0
+                        and len(args) > request_parameter_index
+                    ):
                         request = args[request_parameter_index]
                     token = _current_request.set(request if isinstance(request, Request) else None)
                     try:
-                        return limited_func(*args, **kwargs)
+                        return await limited_func(*args, **kwargs)
                     finally:
                         _current_request.reset(token)
 
-                return sync_with_request
+                return async_with_request
 
-            return decorator
+            @functools.wraps(limited_func)
+            def sync_with_request(*args, **kwargs):
+                request = kwargs.get("request")
+                if (
+                    request is None
+                    and request_parameter_index >= 0
+                    and len(args) > request_parameter_index
+                ):
+                    request = args[request_parameter_index]
+                token = _current_request.set(request if isinstance(request, Request) else None)
+                try:
+                    return limited_func(*args, **kwargs)
+                finally:
+                    _current_request.reset(token)
 
-    limiter = TestLimiter(key_func=_test_rate_limit_key, default_limits=["1000000/second"])
-else:
-    limiter = Limiter(key_func=get_remote_address)
+            return sync_with_request
+
+        return decorator
+
+
+limiter = DynamicTestLimiter(key_func=_rate_limit_key)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -3,6 +3,7 @@
 from app.models.collection import Collection
 from app.models.dependency import Dependency
 from app.models.event import Event
+from app.models.failed_login_attempt import FailedLoginAttempt
 from app.models.issue import Issue
 from app.models.revoked_token import RevokedToken
 from app.models.review import Review
@@ -15,6 +16,7 @@ __all__ = [
     "Collection",
     "Dependency",
     "Event",
+    "FailedLoginAttempt",
     "Issue",
     "RevokedToken",
     "Review",

--- a/app/models/failed_login_attempt.py
+++ b/app/models/failed_login_attempt.py
@@ -1,0 +1,25 @@
+"""FailedLoginAttempt model for database."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import DateTime, Index, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class FailedLoginAttempt(Base):
+    """Record of a failed login attempt for lockout tracking."""
+
+    __tablename__ = "failed_login_attempts"
+    __table_args__ = (
+        Index("ix_failed_login_username_time", "username", "attempted_at"),
+        Index("ix_failed_login_ip_time", "ip_address", "attempted_at"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    username: Mapped[str] = mapped_column(String(50), nullable=False)
+    ip_address: Mapped[str] = mapped_column(String(45), nullable=False)
+    attempted_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )

--- a/app/security.py
+++ b/app/security.py
@@ -1,0 +1,134 @@
+"""Login security: failed-attempt tracking and account lockout."""
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+from fastapi import HTTPException, status
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.failed_login_attempt import FailedLoginAttempt
+
+logger = logging.getLogger(__name__)
+
+MAX_USERNAME_FAILURES = 5
+USERNAME_LOCKOUT_MINUTES = 15
+MAX_IP_FAILURES = 10
+IP_LOCKOUT_MINUTES = 30
+
+LOCKOUT_ERROR_MESSAGE = "Incorrect username or password"
+
+
+def get_client_ip(request_headers: dict, client_host: str | None) -> str:
+    """Extract client IP from request, respecting X-Forwarded-For.
+
+    Args:
+        request_headers: Dict-like request headers.
+        client_host: The direct client host from ``request.client.host``.
+
+    Returns:
+        Client IP address string.
+    """
+    forwarded = request_headers.get("x-forwarded-for", "").split(",")[0].strip()
+    if forwarded:
+        return forwarded
+    return client_host or "unknown"
+
+
+async def _count_recent_attempts(
+    db: AsyncSession,
+    username: str | None = None,
+    ip_address: str | None = None,
+    window_minutes: int = 15,
+) -> int:
+    """Count failed login attempts within a time window.
+
+    Args:
+        db: SQLAlchemy async session.
+        username: Filter by username (optional).
+        ip_address: Filter by IP address (optional).
+        window_minutes: Look-back window in minutes.
+
+    Returns:
+        Number of matching attempts.
+    """
+    cutoff = datetime.now(UTC) - timedelta(minutes=window_minutes)
+    conditions = [FailedLoginAttempt.attempted_at >= cutoff]
+    if username is not None:
+        conditions.append(FailedLoginAttempt.username == username)
+    if ip_address is not None:
+        conditions.append(FailedLoginAttempt.ip_address == ip_address)
+
+    result = await db.execute(
+        select(func.count()).select_from(FailedLoginAttempt).where(*conditions)
+    )
+    return result.scalar_one()
+
+
+async def check_login_lockout(db: AsyncSession, username: str, ip_address: str) -> None:
+    """Raise HTTP 401 if the username or IP is locked out.
+
+    Args:
+        db: SQLAlchemy async session.
+        username: Login username to check.
+        ip_address: Client IP address to check.
+
+    Raises:
+        HTTPException: 401 with generic message when locked out.
+    """
+    username_failures = await _count_recent_attempts(
+        db, username=username, window_minutes=USERNAME_LOCKOUT_MINUTES
+    )
+    if username_failures >= MAX_USERNAME_FAILURES:
+        logger.warning(
+            "Login locked out for username '%s' (%d failures in %d min)",
+            username,
+            username_failures,
+            USERNAME_LOCKOUT_MINUTES,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=LOCKOUT_ERROR_MESSAGE,
+        )
+
+    ip_failures = await _count_recent_attempts(
+        db, ip_address=ip_address, window_minutes=IP_LOCKOUT_MINUTES
+    )
+    if ip_failures >= MAX_IP_FAILURES:
+        logger.warning(
+            "Login locked out for IP '%s' (%d failures in %d min)",
+            ip_address,
+            ip_failures,
+            IP_LOCKOUT_MINUTES,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=LOCKOUT_ERROR_MESSAGE,
+        )
+
+
+async def record_failed_login(db: AsyncSession, username: str, ip_address: str) -> None:
+    """Persist a failed-login attempt record.
+
+    Args:
+        db: SQLAlchemy async session.
+        username: The attempted username.
+        ip_address: The client IP address.
+    """
+    attempt = FailedLoginAttempt(
+        username=username,
+        ip_address=ip_address,
+    )
+    db.add(attempt)
+    await db.commit()
+
+
+async def clear_failed_logins(db: AsyncSession, username: str) -> None:
+    """Remove all failed-login records for a username after successful login.
+
+    Args:
+        db: SQLAlchemy async session.
+        username: The username whose attempts to clear.
+    """
+    await db.execute(delete(FailedLoginAttempt).where(FailedLoginAttempt.username == username))
+    await db.commit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,13 @@ TRUNCATE_TEST_DATA_SQL = text(
 _SHARED_TEST_ENGINE: AsyncEngine | None = None
 
 
+def _get_xdist_sync_dir(tmp_path_factory: pytest.TempPathFactory | None) -> Path:
+    """Return a worker-shared temp directory for xdist coordination files."""
+    if tmp_path_factory is None:
+        return Path("/tmp")
+    return tmp_path_factory.getbasetemp().parent
+
+
 @pytest.fixture(autouse=True, scope="session")
 def set_test_environment() -> Iterator[None]:
     """Set TEST_ENVIRONMENT for all tests to disable rate limiting."""
@@ -171,12 +178,13 @@ async def db_engine(
     is_xdist = worker_id.startswith("gw")
 
     if is_xdist:
-        root_tmp_dir = tmp_path_factory.getbasetemp() if tmp_path_factory else Path("/tmp")
+        root_tmp_dir = _get_xdist_sync_dir(tmp_path_factory)
         lock_file = root_tmp_dir / "db_init.lock"
         marker_file = root_tmp_dir / "db_init.done"
 
         if should_init:
-            with FileLock(lock_file):
+            with FileLock(str(lock_file)):
+                marker_file.unlink(missing_ok=True)
                 async with engine.begin() as conn:
 
                     def _check_and_drop(sync_conn: Connection) -> None:
@@ -200,6 +208,10 @@ async def db_engine(
                 if marker_file.exists():
                     break
                 time.sleep(0.1)
+            else:
+                raise RuntimeError(
+                    f"Timed out waiting for test database initialization marker: {marker_file}"
+                )
     else:
         async with engine.begin() as conn:
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ if not os.getenv("SECRET_KEY"):
 
 TRUNCATE_TEST_DATA_SQL = text(
     "TRUNCATE TABLE sessions, events, threads, issues, snapshots, dependencies, "
-    "revoked_tokens, users RESTART IDENTITY CASCADE;"
+    "revoked_tokens, failed_login_attempts, users RESTART IDENTITY CASCADE;"
 )
 _SHARED_TEST_ENGINE: AsyncEngine | None = None
 
@@ -100,6 +100,7 @@ def _has_schema_drift(conn: Connection) -> bool:
         "events",
         "snapshots",
         "revoked_tokens",
+        "failed_login_attempts",
     }
 
     for table_name in required_table_names:
@@ -328,6 +329,7 @@ async def async_db(db_engine: AsyncEngine) -> AsyncIterator[SQLAlchemyAsyncSessi
     async with db_engine.connect() as connection:
         # Ensure a clean state for tables that may have been left with committed data from async_db_committed tests
         transaction = await connection.begin()
+        await connection.execute(text("TRUNCATE TABLE failed_login_attempts CASCADE"))
         await connection.execute(text("TRUNCATE TABLE users CASCADE"))
         session = SQLAlchemyAsyncSession(
             bind=connection,
@@ -374,6 +376,7 @@ async def async_db_committed(db_engine: AsyncEngine) -> AsyncIterator[SQLAlchemy
         await session.execute(text("DELETE FROM snapshots"))
         await session.execute(text("DELETE FROM dependencies"))
         await session.execute(text("DELETE FROM revoked_tokens"))
+        await session.execute(text("DELETE FROM failed_login_attempts"))
         await session.execute(text("DELETE FROM users"))
         await session.execute(text("DROP INDEX IF EXISTS ix_issue_thread_id"))
         await session.execute(text("DROP INDEX IF EXISTS ix_issue_thread_is_read"))
@@ -389,6 +392,7 @@ async def async_db_committed(db_engine: AsyncEngine) -> AsyncIterator[SQLAlchemy
         await cleanup_session.execute(text("DELETE FROM snapshots"))
         await cleanup_session.execute(text("DELETE FROM dependencies"))
         await cleanup_session.execute(text("DELETE FROM revoked_tokens"))
+        await cleanup_session.execute(text("DELETE FROM failed_login_attempts"))
         await cleanup_session.execute(text("DELETE FROM users"))
         await cleanup_session.commit()
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,10 +1,12 @@
 """Tests for authentication endpoints."""
 
 import pytest
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.database import get_db
+from app.main import app
 from app.models.user import User
 
 
@@ -51,7 +53,6 @@ class TestAuth:
         self, client: AsyncClient, async_db: AsyncSession
     ) -> None:
         """Test registration with duplicate username fails."""
-        # Create first user
         user_data = {
             "username": "testuser",
             "email": "test@example.com",
@@ -60,7 +61,6 @@ class TestAuth:
         response = await client.post("/api/auth/register", json=user_data)
         assert response.status_code == 200
 
-        # Try to create user with same username
         duplicate_data = {
             "username": "testuser",
             "email": "different@example.com",
@@ -75,7 +75,6 @@ class TestAuth:
         self, client: AsyncClient, async_db: AsyncSession
     ) -> None:
         """Test registration with duplicate email fails."""
-        # Create first user
         user_data = {
             "username": "user1",
             "email": "same@example.com",
@@ -84,7 +83,6 @@ class TestAuth:
         response = await client.post("/api/auth/register", json=user_data)
         assert response.status_code == 200
 
-        # Try to create user with same email
         duplicate_data = {
             "username": "user2",
             "email": "same@example.com",
@@ -97,7 +95,6 @@ class TestAuth:
     @pytest.mark.asyncio
     async def test_login_success(self, client: AsyncClient, async_db: AsyncSession) -> None:
         """Test successful user login."""
-        # Register user first
         user_data = {
             "username": "loginuser",
             "email": "login@example.com",
@@ -106,7 +103,6 @@ class TestAuth:
         response = await client.post("/api/auth/register", json=user_data)
         assert response.status_code == 200
 
-        # Login
         login_data = {
             "username": "loginuser",
             "password": "mypassword123",
@@ -133,7 +129,6 @@ class TestAuth:
     @pytest.mark.asyncio
     async def test_refresh_token_success(self, client: AsyncClient, async_db: AsyncSession) -> None:
         """Test successful token refresh."""
-        # Register and login user
         user_data = {
             "username": "refreshuser",
             "email": "refresh@example.com",
@@ -150,7 +145,6 @@ class TestAuth:
         assert response.status_code == 200
         tokens = response.json()
 
-        # Refresh token
         refresh_data = {"refresh_token": tokens["refresh_token"]}
         response = await client.post("/api/auth/refresh", json=refresh_data)
         assert response.status_code == 200
@@ -160,12 +154,13 @@ class TestAuth:
         assert "refresh_token" in new_tokens
         assert new_tokens["token_type"] == "bearer"
 
-        # New tokens should be different
         assert new_tokens["access_token"] != tokens["access_token"]
         assert new_tokens["refresh_token"] != tokens["refresh_token"]
 
     @pytest.mark.asyncio
-    async def test_login_sets_refresh_cookie(self, client: AsyncClient, async_db: AsyncSession) -> None:
+    async def test_login_sets_refresh_cookie(
+        self, client: AsyncClient, async_db: AsyncSession
+    ) -> None:
         """Login sets refresh token in HttpOnly cookie."""
         user_data = {
             "username": "cookieuser",
@@ -184,7 +179,9 @@ class TestAuth:
         assert "HttpOnly" in set_cookie
 
     @pytest.mark.asyncio
-    async def test_refresh_token_success_with_cookie(self, client: AsyncClient, async_db: AsyncSession) -> None:
+    async def test_refresh_token_success_with_cookie(
+        self, client: AsyncClient, async_db: AsyncSession
+    ) -> None:
         """Refresh endpoint accepts refresh token from HttpOnly cookie."""
         user_data = {
             "username": "cookie_refresh_user",
@@ -225,7 +222,6 @@ class TestAuth:
         self, client: AsyncClient, async_db: AsyncSession
     ) -> None:
         """Test getting current user info when authenticated."""
-        # Register and login user
         user_data = {
             "username": "meuser",
             "email": "me@example.com",
@@ -242,7 +238,6 @@ class TestAuth:
         assert response.status_code == 200
         tokens = response.json()
 
-        # Get current user info
         headers = {"Authorization": f"Bearer {tokens['access_token']}"}
         response = await client.get("/api/auth/me", headers=headers)
         assert response.status_code == 200
@@ -262,7 +257,6 @@ class TestAuth:
     @pytest.mark.asyncio
     async def test_logout(self, client: AsyncClient, async_db: AsyncSession) -> None:
         """Test user logout."""
-        # Register and login user
         user_data = {
             "username": "logoutuser",
             "email": "logout@example.com",
@@ -279,7 +273,6 @@ class TestAuth:
         assert response.status_code == 200
         tokens = response.json()
 
-        # Logout
         headers = {"Authorization": f"Bearer {tokens['access_token']}"}
         response = await client.post("/api/auth/logout", headers=headers)
         assert response.status_code == 200
@@ -314,3 +307,150 @@ class TestAuth:
         access_token = tokens["access_token"]
         await revoke_token(async_db, access_token, user.id)
         await revoke_token(async_db, access_token, user.id)
+
+
+async def _create_committed_client(session: AsyncSession):
+    """Build an AsyncClient whose get_db override uses a committed session."""
+
+    async def override():
+        yield session
+
+    app.dependency_overrides[get_db] = override
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test")
+
+
+class TestAccountLockout:
+    """Test account lockout after failed login attempts."""
+
+    @pytest.mark.asyncio
+    async def test_username_lockout_after_five_failures(
+        self, async_db_committed: AsyncSession
+    ) -> None:
+        """Five wrong-password attempts lock the username; 6th fails even with correct pw."""
+        async with await _create_committed_client(async_db_committed) as client:
+            user_data = {
+                "username": "lockoutuser",
+                "email": "lockout@example.com",
+                "password": "password123",
+            }
+            reg = await client.post("/api/auth/register", json=user_data)
+            assert reg.status_code == 200
+
+            wrong = {"username": "lockoutuser", "password": "wrongpw"}
+            for i in range(5):
+                resp = await client.post("/api/auth/login", json=wrong)
+                assert resp.status_code == 401, f"Attempt {i + 1} should be 401"
+
+            correct = {"username": "lockoutuser", "password": "password123"}
+            locked = await client.post("/api/auth/login", json=correct)
+            assert locked.status_code == 401
+            assert "Incorrect username or password" in locked.json()["detail"]
+
+        app.dependency_overrides.pop(get_db, None)
+
+    @pytest.mark.asyncio
+    async def test_success_clears_counter(self, async_db_committed: AsyncSession) -> None:
+        """A successful login resets the failure counter for that username."""
+        async with await _create_committed_client(async_db_committed) as client:
+            user_data = {
+                "username": "resetworks",
+                "email": "reset@example.com",
+                "password": "password123",
+            }
+            reg = await client.post("/api/auth/register", json=user_data)
+            assert reg.status_code == 200
+
+            wrong = {"username": "resetworks", "password": "wrong"}
+            for _ in range(4):
+                resp = await client.post("/api/auth/login", json=wrong)
+                assert resp.status_code == 401
+
+            correct = {"username": "resetworks", "password": "password123"}
+            ok = await client.post("/api/auth/login", json=correct)
+            assert ok.status_code == 200
+
+            for _ in range(4):
+                resp = await client.post("/api/auth/login", json=wrong)
+                assert resp.status_code == 401
+
+            ok2 = await client.post("/api/auth/login", json=correct)
+            assert ok2.status_code == 200
+
+        app.dependency_overrides.pop(get_db, None)
+
+    @pytest.mark.asyncio
+    async def test_lockout_is_per_username(self, async_db_committed: AsyncSession) -> None:
+        """Locking one username does not affect a different username."""
+        async with await _create_committed_client(async_db_committed) as client:
+            user_a = {"username": "user_a", "email": "a@example.com", "password": "pw123"}
+            user_b = {"username": "user_b", "email": "b@example.com", "password": "pw456"}
+            reg_a = await client.post("/api/auth/register", json=user_a)
+            assert reg_a.status_code == 200, f"user_a register: {reg_a.text}"
+            reg_b = await client.post("/api/auth/register", json=user_b)
+            assert reg_b.status_code == 200, f"user_b register: {reg_b.text}"
+
+            wrong_a = {"username": "user_a", "password": "wrong"}
+            for _ in range(5):
+                resp = await client.post("/api/auth/login", json=wrong_a)
+                assert resp.status_code == 401
+
+            locked = await client.post("/api/auth/login", json=wrong_a)
+            assert locked.status_code == 401
+
+            correct_b = {"username": "user_b", "password": "pw456"}
+            ok = await client.post("/api/auth/login", json=correct_b)
+            assert ok.status_code == 200
+
+        app.dependency_overrides.pop(get_db, None)
+
+    @pytest.mark.asyncio
+    async def test_lockout_returns_generic_error(self, async_db_committed: AsyncSession) -> None:
+        """Lockout response does not reveal whether the username exists."""
+        async with await _create_committed_client(async_db_committed) as client:
+            user_data = {
+                "username": "genericerr",
+                "email": "generic@example.com",
+                "password": "password123",
+            }
+            await client.post("/api/auth/register", json=user_data)
+
+            wrong = {"username": "genericerr", "password": "wrong"}
+            for _ in range(5):
+                await client.post("/api/auth/login", json=wrong)
+
+            locked = await client.post("/api/auth/login", json=wrong)
+            assert locked.status_code == 401
+            assert locked.json()["detail"] == "Incorrect username or password"
+
+        app.dependency_overrides.pop(get_db, None)
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_user_records_failure(self, async_db_committed: AsyncSession) -> None:
+        """Attempts against a non-existent username still count toward IP lockout."""
+        async with await _create_committed_client(async_db_committed) as client:
+            for _ in range(9):
+                resp = await client.post(
+                    "/api/auth/login",
+                    json={"username": f"noexist_{_}", "password": "wrong"},
+                )
+                assert resp.status_code == 401
+
+            user_data = {
+                "username": "lateuser",
+                "email": "late@example.com",
+                "password": "password123",
+            }
+            await client.post("/api/auth/register", json=user_data)
+
+            resp = await client.post(
+                "/api/auth/login",
+                json={"username": "lateuser", "password": "wrong"},
+            )
+            assert resp.status_code == 401
+
+            correct = {"username": "lateuser", "password": "password123"}
+            locked = await client.post("/api/auth/login", json=correct)
+            assert locked.status_code == 401
+
+        app.dependency_overrides.pop(get_db, None)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,13 +1,17 @@
 """Tests for authentication endpoints."""
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
 import pytest
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from app.database import get_db
 from app.main import app
 from app.models.user import User
+from tests.conftest import TRUNCATE_TEST_DATA_SQL
 
 
 class TestAuth:
@@ -309,26 +313,39 @@ class TestAuth:
         await revoke_token(async_db, access_token, user.id)
 
 
-async def _create_committed_client(session: AsyncSession):
-    """Build an AsyncClient whose get_db override uses a committed session."""
+@asynccontextmanager
+async def _create_committed_client(db_engine: AsyncEngine) -> AsyncIterator[AsyncClient]:
+    """Build an AsyncClient backed by fresh committed DB sessions per request."""
+    session_maker = async_sessionmaker(bind=db_engine, expire_on_commit=False, class_=AsyncSession)
+
+    async with session_maker() as setup_session:
+        await setup_session.execute(TRUNCATE_TEST_DATA_SQL)
+        await setup_session.commit()
 
     async def override():
-        yield session
+        async with session_maker() as request_session:
+            yield request_session
 
     app.dependency_overrides[get_db] = override
     transport = ASGITransport(app=app)
-    return AsyncClient(transport=transport, base_url="http://test")
+
+    try:
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            yield client
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+        async with session_maker() as cleanup_session:
+            await cleanup_session.execute(TRUNCATE_TEST_DATA_SQL)
+            await cleanup_session.commit()
 
 
 class TestAccountLockout:
     """Test account lockout after failed login attempts."""
 
     @pytest.mark.asyncio
-    async def test_username_lockout_after_five_failures(
-        self, async_db_committed: AsyncSession
-    ) -> None:
+    async def test_username_lockout_after_five_failures(self, db_engine: AsyncEngine) -> None:
         """Five wrong-password attempts lock the username; 6th fails even with correct pw."""
-        async with await _create_committed_client(async_db_committed) as client:
+        async with _create_committed_client(db_engine) as client:
             user_data = {
                 "username": "lockoutuser",
                 "email": "lockout@example.com",
@@ -347,12 +364,10 @@ class TestAccountLockout:
             assert locked.status_code == 401
             assert "Incorrect username or password" in locked.json()["detail"]
 
-        app.dependency_overrides.pop(get_db, None)
-
     @pytest.mark.asyncio
-    async def test_success_clears_counter(self, async_db_committed: AsyncSession) -> None:
+    async def test_success_clears_counter(self, db_engine: AsyncEngine) -> None:
         """A successful login resets the failure counter for that username."""
-        async with await _create_committed_client(async_db_committed) as client:
+        async with _create_committed_client(db_engine) as client:
             user_data = {
                 "username": "resetworks",
                 "email": "reset@example.com",
@@ -377,12 +392,10 @@ class TestAccountLockout:
             ok2 = await client.post("/api/auth/login", json=correct)
             assert ok2.status_code == 200
 
-        app.dependency_overrides.pop(get_db, None)
-
     @pytest.mark.asyncio
-    async def test_lockout_is_per_username(self, async_db_committed: AsyncSession) -> None:
+    async def test_lockout_is_per_username(self, db_engine: AsyncEngine) -> None:
         """Locking one username does not affect a different username."""
-        async with await _create_committed_client(async_db_committed) as client:
+        async with _create_committed_client(db_engine) as client:
             user_a = {"username": "user_a", "email": "a@example.com", "password": "pw123"}
             user_b = {"username": "user_b", "email": "b@example.com", "password": "pw456"}
             reg_a = await client.post("/api/auth/register", json=user_a)
@@ -402,12 +415,10 @@ class TestAccountLockout:
             ok = await client.post("/api/auth/login", json=correct_b)
             assert ok.status_code == 200
 
-        app.dependency_overrides.pop(get_db, None)
-
     @pytest.mark.asyncio
-    async def test_lockout_returns_generic_error(self, async_db_committed: AsyncSession) -> None:
+    async def test_lockout_returns_generic_error(self, db_engine: AsyncEngine) -> None:
         """Lockout response does not reveal whether the username exists."""
-        async with await _create_committed_client(async_db_committed) as client:
+        async with _create_committed_client(db_engine) as client:
             user_data = {
                 "username": "genericerr",
                 "email": "generic@example.com",
@@ -423,12 +434,10 @@ class TestAccountLockout:
             assert locked.status_code == 401
             assert locked.json()["detail"] == "Incorrect username or password"
 
-        app.dependency_overrides.pop(get_db, None)
-
     @pytest.mark.asyncio
-    async def test_nonexistent_user_records_failure(self, async_db_committed: AsyncSession) -> None:
+    async def test_nonexistent_user_records_failure(self, db_engine: AsyncEngine) -> None:
         """Attempts against a non-existent username still count toward IP lockout."""
-        async with await _create_committed_client(async_db_committed) as client:
+        async with _create_committed_client(db_engine) as client:
             for _ in range(9):
                 resp = await client.post(
                     "/api/auth/login",
@@ -452,5 +461,3 @@ class TestAccountLockout:
             correct = {"username": "lateuser", "password": "password123"}
             locked = await client.post("/api/auth/login", json=correct)
             assert locked.status_code == 401
-
-        app.dependency_overrides.pop(get_db, None)

--- a/tests/test_rate_limit_request_exempt.py
+++ b/tests/test_rate_limit_request_exempt.py
@@ -51,3 +51,40 @@ async def test_request_aware_exempt_when_receives_request() -> None:
     limiter.reset()
     monkeypatch.undo()
     importlib.reload(rate_limit_module)
+
+
+@pytest.mark.asyncio
+async def test_rate_limiting_can_be_disabled_after_module_import() -> None:
+    """Test-mode exemption must work even if the limiter was imported before env vars were set."""
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.delenv("TEST_ENVIRONMENT", raising=False)
+    monkeypatch.delenv("ENABLE_RATE_LIMITING_IN_TESTS", raising=False)
+    reloaded_rate_limit_module = importlib.reload(rate_limit_module)
+    limiter = reloaded_rate_limit_module.limiter
+    limiter.reset()
+
+    path = "/api/test-rate-limit/post-import-toggle"
+    temp_app = FastAPI()
+    temp_app.state.limiter = limiter
+    temp_app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+    async def endpoint(request: Request) -> dict[str, bool]:
+        del request
+        return {"ok": True}
+
+    decorated_endpoint = limiter.limit("1/minute")(endpoint)
+    temp_app.add_api_route(path, decorated_endpoint, methods=["GET"])
+
+    monkeypatch.setenv("TEST_ENVIRONMENT", "true")
+
+    transport = ASGITransport(app=temp_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        first = await client.get(path)
+        second = await client.get(path)
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+
+    limiter.reset()
+    monkeypatch.undo()
+    importlib.reload(rate_limit_module)


### PR DESCRIPTION
## Summary

Closes #512

- **Per-username lockout**: After 5 failed login attempts for the same username within 15 minutes, the account is temporarily locked. The lockout applies even with correct credentials.
- **Per-IP lockout**: After 10 failed login attempts from the same IP address within 30 minutes, all login attempts from that IP are blocked.
- **Rate limiting**: Login endpoint limited to 5 requests per minute via `@limiter.limit("5/minute")`.
- **Generic error messages**: Lockout responses use the same "Incorrect username or password" message to prevent username enumeration.
- **Auto-clear on success**: A successful login clears all failure records for that username.

## Implementation details

- New `FailedLoginAttempt` model tracks `(username, ip_address, attempted_at)` for every failed login.
- New `app/security.py` module encapsulates lockout check, failure recording, and counter clearing.
- Alembic migration `a7b8c9d0e1f2` creates the `failed_login_attempts` table with composite indexes for efficient lookups.
- `X-Forwarded-For` header respected for IP extraction behind reverse proxies.
- Server-side logging of all lockout events via standard Python logger.

## Testing

5 new tests in `TestAccountLockout`:
- `test_username_lockout_after_five_failures` — 5 wrong passwords → 6th fails even with correct password
- `test_success_clears_counter` — successful login resets the failure counter
- `test_lockout_is_per_username` — locking one username does not affect another
- `test_lockout_returns_generic_error` — lockout response matches normal auth error
- `test_nonexistent_user_records_failure` — attempts against non-existent usernames count toward IP lockout