### PR TITLE
feat(security): enforce resource ownership on API endpoints

### DIFF
--- a/app/api/collection.py
+++ b/app/api/collection.py
@@ -17,6 +17,7 @@ from app.schemas.collection import (
     CollectionResponse,
     CollectionUpdate,
 )
+from app.services.ownership import get_owned_collection_or_404
 
 router = APIRouter(tags=["collections"])
 
@@ -166,12 +167,7 @@ async def get_collection(
     Raises:
         HTTPException: If collection not found.
     """
-    collection = await db.get(Collection, collection_id)
-    if not collection or collection.user_id != current_user.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Collection {collection_id} not found",
-        )
+    collection = await get_owned_collection_or_404(db, current_user.id, collection_id)
 
     return CollectionResponse(
         id=collection.id,
@@ -204,12 +200,7 @@ async def update_collection(
     Raises:
         HTTPException: If collection not found.
     """
-    collection = await db.get(Collection, collection_id)
-    if not collection or collection.user_id != current_user.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Collection {collection_id} not found",
-        )
+    collection = await get_owned_collection_or_404(db, current_user.id, collection_id)
 
     if collection_data.name is not None:
         collection.name = collection_data.name
@@ -259,12 +250,7 @@ async def patch_collection(
     Raises:
         HTTPException: If collection not found.
     """
-    collection = await db.get(Collection, collection_id)
-    if not collection or collection.user_id != current_user.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Collection {collection_id} not found",
-        )
+    collection = await get_owned_collection_or_404(db, current_user.id, collection_id)
 
     if collection_data.name is not None:
         collection.name = collection_data.name
@@ -311,12 +297,7 @@ async def delete_collection(
     """
     from sqlalchemy import update as sa_update
 
-    collection = await db.get(Collection, collection_id)
-    if not collection or collection.user_id != current_user.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Collection {collection_id} not found",
-        )
+    collection = await get_owned_collection_or_404(db, current_user.id, collection_id)
 
     if collection.is_default:
         raise HTTPException(

--- a/app/api/issue.py
+++ b/app/api/issue.py
@@ -22,6 +22,7 @@ from app.schemas import (
     IssueResponse,
 )
 from app.utils.issue_parser import parse_issue_ranges
+from app.services.ownership import get_owned_issue_or_404, get_owned_thread_or_404
 from comic_pile.dependencies import (
     refresh_user_blocked_status,
     validate_position_dependency_consistency,
@@ -76,13 +77,7 @@ async def _get_locked_thread_with_issues(
     db: AsyncSession,
 ) -> tuple[Thread, list[Issue]]:
     """Lock a thread and all of its issues, validating ownership."""
-    thread_result = await db.execute(select(Thread).where(Thread.id == thread_id).with_for_update())
-    thread = thread_result.scalar_one_or_none()
-    if not thread or thread.user_id != current_user.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Thread {thread_id} not found",
-        )
+    thread = await get_owned_thread_or_404(db, current_user.id, thread_id, for_update=True)
 
     issues_result = await db.execute(
         select(Issue)
@@ -177,12 +172,7 @@ async def list_issues(
     Raises:
         HTTPException: If thread not found.
     """
-    thread = await db.get(Thread, thread_id)
-    if not thread or thread.user_id != current_user.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Thread {thread_id} not found",
-        )
+    await get_owned_thread_or_404(db, current_user.id, thread_id)
 
     query = select(Issue).where(Issue.thread_id == thread_id)
 
@@ -261,12 +251,7 @@ async def validate_issue_order(
     Raises:
         HTTPException: If the thread does not exist or is not owned by the user.
     """
-    thread = await db.get(Thread, thread_id)
-    if not thread or thread.user_id != current_user.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Thread {thread_id} not found",
-        )
+    await get_owned_thread_or_404(db, current_user.id, thread_id)
 
     warnings = await validate_position_dependency_consistency(thread_id, current_user.id, db)
     return IssueOrderValidationResponse(warnings=warnings)
@@ -302,13 +287,7 @@ async def create_issues(
         HTTPException: If thread not found, all issues already exist,
                       position collision detected, or issue range is invalid.
     """
-    thread_result = await db.execute(select(Thread).where(Thread.id == thread_id).with_for_update())
-    thread = thread_result.scalar_one_or_none()
-    if not thread or thread.user_id != current_user.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Thread {thread_id} not found",
-        )
+    thread = await get_owned_thread_or_404(db, current_user.id, thread_id, for_update=True)
 
     try:
         issue_numbers = parse_issue_ranges(request.issue_range)
@@ -552,19 +531,7 @@ async def get_issue(
     Raises:
         HTTPException: If issue not found.
     """
-    issue = await db.get(Issue, issue_id)
-    if not issue:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Issue {issue_id} not found",
-        )
-
-    thread = await db.get(Thread, issue.thread_id)
-    if not thread or thread.user_id != current_user.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Issue {issue_id} not found",
-        )
+    issue = await get_owned_issue_or_404(db, current_user.id, issue_id)
 
     return issue_to_response(issue)
 
@@ -755,19 +722,8 @@ async def mark_issue_read(
     Raises:
         HTTPException: If issue not found, thread not found, or issue already read.
     """
-    issue = await db.get(Issue, issue_id)
-    if not issue:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Issue {issue_id} not found",
-        )
-
-    thread = await db.get(Thread, issue.thread_id)
-    if not thread or thread.user_id != current_user.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Issue {issue_id} not found",
-        )
+    issue = await get_owned_issue_or_404(db, current_user.id, issue_id)
+    thread = await get_owned_thread_or_404(db, current_user.id, issue.thread_id)
 
     if issue.status == "read":
         raise HTTPException(
@@ -832,19 +788,8 @@ async def mark_issue_unread(
     Raises:
         HTTPException: If issue not found, thread not found, or issue already unread.
     """
-    issue = await db.get(Issue, issue_id)
-    if not issue:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Issue {issue_id} not found",
-        )
-
-    thread = await db.get(Thread, issue.thread_id)
-    if not thread or thread.user_id != current_user.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Issue {issue_id} not found",
-        )
+    issue = await get_owned_issue_or_404(db, current_user.id, issue_id)
+    thread = await get_owned_thread_or_404(db, current_user.id, issue.thread_id)
 
     if issue.status == "unread":
         raise HTTPException(

--- a/app/api/review.py
+++ b/app/api/review.py
@@ -14,9 +14,10 @@ from sqlalchemy.orm import selectinload
 
 from app.auth import get_current_user
 from app.database import get_db
-from app.models import Issue, Review, Thread
+from app.models import Issue, Review
 from app.models.user import User
 from app.schemas.review import ReviewCreate, ReviewListResponse, ReviewResponse, ReviewUpdate
+from app.services.ownership import get_owned_review_or_404, get_owned_thread_or_404
 
 router = APIRouter(tags=["reviews"])
 
@@ -120,15 +121,7 @@ async def create_review(
     thread_id = review_data.thread_id
 
     # Verify thread exists and belongs to user
-    result = await db.execute(
-        select(Thread).where(and_(Thread.id == thread_id, Thread.user_id == user_id))
-    )
-    thread = result.scalar_one_or_none()
-    if not thread:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Thread {thread_id} not found or does not belong to user",
-        )
+    await get_owned_thread_or_404(db, user_id, thread_id)
 
     # Get issue ID if issue number provided
     issue_id = await _get_issue_id(db, thread_id, review_data.issue_number)
@@ -281,17 +274,12 @@ async def get_review(
     Raises:
         HTTPException: If review not found or not owned by user
     """
-    result = await db.execute(
-        select(Review)
-        .where(and_(Review.id == review_id, Review.user_id == current_user.id))
-        .options(selectinload(Review.thread), selectinload(Review.issue))
+    review = await get_owned_review_or_404(
+        db,
+        current_user.id,
+        review_id,
+        include_relations=True,
     )
-    review = result.scalar_one_or_none()
-    if not review:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Review {review_id} not found or not owned by user",
-        )
 
     return await _create_or_update_review_response(review, db)
 
@@ -317,17 +305,12 @@ async def update_review(
     Raises:
         HTTPException: If review not found or not owned by user
     """
-    result = await db.execute(
-        select(Review)
-        .where(and_(Review.id == review_id, Review.user_id == current_user.id))
-        .options(selectinload(Review.thread), selectinload(Review.issue))
+    review = await get_owned_review_or_404(
+        db,
+        current_user.id,
+        review_id,
+        include_relations=True,
     )
-    review = result.scalar_one_or_none()
-    if not review:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Review {review_id} not found or not owned by user",
-        )
 
     # Update fields if provided
     data = update_data.model_dump(exclude_unset=True)
@@ -354,15 +337,7 @@ async def delete_review(
     Raises:
         HTTPException: If review not found or not owned by user
     """
-    result = await db.execute(
-        select(Review).where(and_(Review.id == review_id, Review.user_id == current_user.id))
-    )
-    review = result.scalar_one_or_none()
-    if not review:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Review {review_id} not found or not owned by user",
-        )
+    review = await get_owned_review_or_404(db, current_user.id, review_id)
 
     await db.delete(review)
     await db.commit()

--- a/app/api/session.py
+++ b/app/api/session.py
@@ -22,6 +22,7 @@ from app.schemas import (
     SnapshotsListResponse,
 )
 from app.schemas.session import SnoozedThreadInfo
+from app.services.ownership import get_owned_session_or_404
 from comic_pile.dependencies import refresh_user_blocked_status
 from comic_pile.session import get_current_die, get_or_create, is_active
 
@@ -605,12 +606,7 @@ async def get_session(
     Raises:
         HTTPException: If session not found.
     """
-    session = await db.get(SessionModel, session_id)
-    if not session:
-        raise HTTPException(status_code=404, detail="Session not found")
-
-    if session.user_id != current_user.id:
-        raise HTTPException(status_code=404, detail="Session not found")
+    session = await get_owned_session_or_404(db, current_user.id, session_id)
 
     _, active_thread = await get_session_with_thread_safe(session_id, db)
 
@@ -657,12 +653,7 @@ async def get_session_details(
     Raises:
         HTTPException: If session not found.
     """
-    session_obj = await db.get(SessionModel, session_id)
-    if not session_obj:
-        raise HTTPException(status_code=404, detail="Session not found")
-
-    if session_obj.user_id != current_user.id:
-        raise HTTPException(status_code=404, detail="Session not found")
+    session_obj = await get_owned_session_or_404(db, current_user.id, session_id)
 
     events_result = await db.execute(
         select(Event).where(Event.session_id == session_id).order_by(Event.timestamp)
@@ -746,12 +737,7 @@ async def get_session_snapshots(
     Raises:
         HTTPException: If session not found.
     """
-    session = await db.get(SessionModel, session_id)
-    if not session:
-        raise HTTPException(status_code=404, detail="Session not found")
-
-    if session.user_id != current_user.id:
-        raise HTTPException(status_code=404, detail="Session not found")
+    await get_owned_session_or_404(db, current_user.id, session_id)
 
     snapshots_result = await db.execute(
         select(Snapshot)
@@ -802,18 +788,7 @@ async def restore_session_start(
 
     while retries < max_retries:
         try:
-            session = await db.get(SessionModel, session_id)
-            if not session:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=f"Session {session_id} not found",
-                )
-
-            if session.user_id != current_user.id:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail="Access denied",
-                )
+            session = await get_owned_session_or_404(db, current_user.id, session_id)
 
             snapshot_result = await db.execute(
                 select(Snapshot)

--- a/app/api/thread.py
+++ b/app/api/thread.py
@@ -31,6 +31,7 @@ from app.schemas import (
 )
 from app.schemas.review import ReviewResponse
 from app.schemas.migration import MigrateToIssuesSimpleRequest
+from app.services.ownership import get_owned_collection_or_404, get_owned_thread_or_404
 from comic_pile.session import get_current_die, get_or_create
 
 router = APIRouter(tags=["threads"])
@@ -316,14 +317,7 @@ async def create_thread(
     """
     # If collection_id is provided, verify it belongs to the user
     if thread_data.collection_id is not None:
-        from app.models import Collection
-
-        collection = await db.get(Collection, thread_data.collection_id)
-        if not collection or collection.user_id != current_user.id:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Collection {thread_data.collection_id} not found",
-            )
+        await get_owned_collection_or_404(db, current_user.id, thread_data.collection_id)
 
     max_retries = 3
     initial_delay = 0.1
@@ -386,12 +380,7 @@ async def get_thread(
     Raises:
         HTTPException: If thread not found.
     """
-    thread = await db.get(Thread, thread_id)
-    if not thread or thread.user_id != current_user.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Thread {thread_id} not found",
-        )
+    thread = await get_owned_thread_or_404(db, current_user.id, thread_id)
     return await thread_to_response(thread, db)
 
 
@@ -416,12 +405,7 @@ async def update_thread(
     Raises:
         HTTPException: If thread not found.
     """
-    thread = await db.get(Thread, thread_id)
-    if not thread or thread.user_id != current_user.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Thread {thread_id} not found",
-        )
+    thread = await get_owned_thread_or_404(db, current_user.id, thread_id)
     if thread_data.title is not None:
         thread.title = thread_data.title
     if thread_data.format is not None:
@@ -441,14 +425,7 @@ async def update_thread(
     if "collection_id" in thread_data.model_fields_set:
         # If collection_id is provided (can be None to clear), verify ownership
         if thread_data.collection_id is not None:
-            from app.models import Collection
-
-            collection = await db.get(Collection, thread_data.collection_id)
-            if not collection or collection.user_id != current_user.id:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=f"Collection {thread_data.collection_id} not found",
-                )
+            await get_owned_collection_or_404(db, current_user.id, thread_data.collection_id)
         thread.collection_id = thread_data.collection_id
     await db.commit()
     await db.refresh(thread)
@@ -472,12 +449,7 @@ async def delete_thread(
     Raises:
         HTTPException: If thread not found.
     """
-    thread = await db.get(Thread, thread_id)
-    if not thread or thread.user_id != current_user.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Thread {thread_id} not found",
-        )
+    thread = await get_owned_thread_or_404(db, current_user.id, thread_id)
 
     from app.models import Session as SessionModel
 
@@ -530,12 +502,7 @@ async def reactivate_thread(
     Raises:
         HTTPException: If thread not found, not completed, or issues_to_add invalid.
     """
-    thread = await db.get(Thread, request.thread_id)
-    if not thread or thread.user_id != current_user.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Thread {request.thread_id} not found",
-        )
+    thread = await get_owned_thread_or_404(db, current_user.id, request.thread_id)
     if thread.status != "completed":
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -625,13 +592,7 @@ async def set_pending_thread(
     Raises:
         HTTPException: If thread not found.
     """
-    thread = await db.get(Thread, thread_id)
-
-    if not thread or thread.user_id != current_user.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Thread {thread_id} not found",
-        )
+    thread = await get_owned_thread_or_404(db, current_user.id, thread_id)
 
     if thread.status != "active":
         raise HTTPException(
@@ -740,23 +701,11 @@ async def move_thread_to_collection(
     Raises:
         HTTPException: If thread not found or collection doesn't belong to user.
     """
-    thread = await db.get(Thread, thread_id)
-    if not thread or thread.user_id != current_user.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Thread {thread_id} not found",
-        )
+    thread = await get_owned_thread_or_404(db, current_user.id, thread_id)
 
     # If collection_id is provided, verify it belongs to the user
     if collection_id is not None:
-        from app.models import Collection
-
-        collection = await db.get(Collection, collection_id)
-        if not collection or collection.user_id != current_user.id:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Collection {collection_id} not found",
-            )
+        await get_owned_collection_or_404(db, current_user.id, collection_id)
 
     thread.collection_id = collection_id
     response = await thread_to_response(thread, db)
@@ -785,12 +734,7 @@ async def get_thread_reviews(
     Raises:
         HTTPException: If thread not found or not owned by user
     """
-    thread = await db.get(Thread, thread_id)
-    if not thread or thread.user_id != current_user.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Thread {thread_id} not found",
-        )
+    await get_owned_thread_or_404(db, current_user.id, thread_id)
 
     result = await db.execute(
         select(Review)
@@ -832,12 +776,7 @@ async def backdate_thread_for_testing(
             detail="This endpoint is only available in test environment",
         )
 
-    thread = await db.get(Thread, thread_id)
-    if not thread or thread.user_id != current_user.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Thread {thread_id} not found",
-        )
+    thread = await get_owned_thread_or_404(db, current_user.id, thread_id)
 
     thread.last_activity_at = datetime.now(UTC) - timedelta(days=days_ago)
     await db.commit()
@@ -870,12 +809,7 @@ async def migrate_thread_to_issues(
     Raises:
         HTTPException: 404 if thread not found, 400 if validation fails
     """
-    thread = await db.get(Thread, thread_id)
-    if not thread or thread.user_id != current_user.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Thread {thread_id} not found",
-        )
+    thread = await get_owned_thread_or_404(db, current_user.id, thread_id)
 
     if thread.total_issues is not None:
         raise HTTPException(
@@ -927,12 +861,7 @@ async def migrate_thread_to_issues_simple(
     Raises:
         HTTPException: 404 if thread not found, 400 if validation fails
     """
-    thread = await db.get(Thread, thread_id)
-    if not thread or thread.user_id != current_user.id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Thread {thread_id} not found",
-        )
+    thread = await get_owned_thread_or_404(db, current_user.id, thread_id)
 
     if thread.total_issues is not None:
         raise HTTPException(

--- a/app/services/ownership.py
+++ b/app/services/ownership.py
@@ -1,0 +1,104 @@
+"""Ownership-scoped data access helpers."""
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models import Collection, Issue, Review, Session as SessionModel, Thread
+
+
+async def get_owned_thread_or_404(
+    db: AsyncSession,
+    user_id: int,
+    thread_id: int,
+    *,
+    for_update: bool = False,
+) -> Thread:
+    """Fetch a thread by ID only if it belongs to the user."""
+    query = select(Thread).where(Thread.id == thread_id, Thread.user_id == user_id)
+    if for_update:
+        query = query.with_for_update()
+    result = await db.execute(query)
+    thread = result.scalar_one_or_none()
+    if thread is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Thread {thread_id} not found",
+        )
+    return thread
+
+
+async def get_owned_collection_or_404(
+    db: AsyncSession,
+    user_id: int,
+    collection_id: int,
+) -> Collection:
+    """Fetch a collection by ID only if it belongs to the user."""
+    result = await db.execute(
+        select(Collection).where(
+            Collection.id == collection_id,
+            Collection.user_id == user_id,
+        )
+    )
+    collection = result.scalar_one_or_none()
+    if collection is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Collection {collection_id} not found",
+        )
+    return collection
+
+
+async def get_owned_issue_or_404(db: AsyncSession, user_id: int, issue_id: int) -> Issue:
+    """Fetch an issue by ID only if its thread belongs to the user."""
+    result = await db.execute(
+        select(Issue)
+        .join(Thread, Thread.id == Issue.thread_id)
+        .where(Issue.id == issue_id, Thread.user_id == user_id)
+    )
+    issue = result.scalar_one_or_none()
+    if issue is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Issue {issue_id} not found",
+        )
+    return issue
+
+
+async def get_owned_review_or_404(
+    db: AsyncSession,
+    user_id: int,
+    review_id: int,
+    *,
+    include_relations: bool = False,
+) -> Review:
+    """Fetch a review by ID only if it belongs to the user."""
+    query = select(Review).where(Review.id == review_id, Review.user_id == user_id)
+    if include_relations:
+        query = query.options(selectinload(Review.thread), selectinload(Review.issue))
+    result = await db.execute(query)
+    review = result.scalar_one_or_none()
+    if review is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Review {review_id} not found",
+        )
+    return review
+
+
+async def get_owned_session_or_404(db: AsyncSession, user_id: int, session_id: int) -> SessionModel:
+    """Fetch a session by ID only if it belongs to the user."""
+    result = await db.execute(
+        select(SessionModel).where(
+            SessionModel.id == session_id,
+            SessionModel.user_id == user_id,
+        )
+    )
+    session = result.scalar_one_or_none()
+    if session is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Session not found",
+        )
+    return session

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/mnt/extra/josh/code/comic-pile/node_modules

--- a/tests/test_collection_api.py
+++ b/tests/test_collection_api.py
@@ -3,9 +3,11 @@
 import pytest
 import pytest_asyncio
 from httpx import AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import Collection, Thread
+from app.auth import create_access_token
+from app.models import Collection, Thread, User
 
 
 @pytest_asyncio.fixture
@@ -118,3 +120,52 @@ async def test_filter_threads_by_collection(
     threads = data["threads"]
     assert len(threads) == 1
     assert threads[0]["id"] == sample_thread.id
+
+
+@pytest.mark.asyncio
+async def test_collection_endpoints_return_404_for_non_owner(
+    auth_client: AsyncClient,
+    async_db: AsyncSession,
+    sample_collection: Collection,
+) -> None:
+    """Collection read/update/delete endpoints return 404 for non-owners."""
+    intruder = User(username="collection_intruder", created_at=None)
+    async_db.add(intruder)
+    await async_db.commit()
+    await async_db.refresh(intruder)
+
+    intruder_token = create_access_token(
+        data={"sub": intruder.username, "jti": "collection-intruder"}
+    )
+    intruder_headers = {"Authorization": f"Bearer {intruder_token}"}
+
+    get_response = await auth_client.get(
+        f"/api/v1/collections/{sample_collection.id}",
+        headers=intruder_headers,
+    )
+    assert get_response.status_code == 404
+
+    put_response = await auth_client.put(
+        f"/api/v1/collections/{sample_collection.id}",
+        json={"name": "Hijacked"},
+        headers=intruder_headers,
+    )
+    assert put_response.status_code == 404
+
+    patch_response = await auth_client.patch(
+        f"/api/v1/collections/{sample_collection.id}",
+        json={"position": 99},
+        headers=intruder_headers,
+    )
+    assert patch_response.status_code == 404
+
+    delete_response = await auth_client.delete(
+        f"/api/v1/collections/{sample_collection.id}",
+        headers=intruder_headers,
+    )
+    assert delete_response.status_code == 404
+
+    collection_result = await async_db.execute(
+        select(Collection).where(Collection.id == sample_collection.id)
+    )
+    assert collection_result.scalar_one_or_none() is not None

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -9,6 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.session import get_active_thread
+from app.auth import create_access_token
 from app.config import clear_settings_cache
 from app.models import Event, Issue, Session, Snapshot, Thread, User
 from app.models import Session as SessionModel
@@ -823,6 +824,55 @@ async def test_restore_session_start_no_snapshot(
     response = await auth_client.post(f"/api/sessions/{session.id}/restore-session-start")
     assert response.status_code == 404
     assert "No session start snapshot found" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_session_endpoints_return_404_for_non_owner(
+    auth_client: AsyncClient,
+    async_db: AsyncSession,
+    default_user: User,
+) -> None:
+    """Session resource endpoints return 404 for non-owners."""
+    owner_session = SessionModel(start_die=6, user_id=default_user.id)
+    async_db.add(owner_session)
+    await async_db.commit()
+    await async_db.refresh(owner_session)
+
+    intruder = User(username="session_intruder", created_at=None)
+    async_db.add(intruder)
+    await async_db.commit()
+    await async_db.refresh(intruder)
+
+    intruder_token = create_access_token(data={"sub": intruder.username, "jti": "session-intruder"})
+    intruder_headers = {"Authorization": f"Bearer {intruder_token}"}
+
+    get_response = await auth_client.get(
+        f"/api/sessions/{owner_session.id}",
+        headers=intruder_headers,
+    )
+    assert get_response.status_code == 404
+    assert get_response.json()["detail"] == "Session not found"
+
+    details_response = await auth_client.get(
+        f"/api/sessions/{owner_session.id}/details",
+        headers=intruder_headers,
+    )
+    assert details_response.status_code == 404
+    assert details_response.json()["detail"] == "Session not found"
+
+    snapshots_response = await auth_client.get(
+        f"/api/sessions/{owner_session.id}/snapshots",
+        headers=intruder_headers,
+    )
+    assert snapshots_response.status_code == 404
+    assert snapshots_response.json()["detail"] == "Session not found"
+
+    restore_response = await auth_client.post(
+        f"/api/sessions/{owner_session.id}/restore-session-start",
+        headers=intruder_headers,
+    )
+    assert restore_response.status_code == 404
+    assert restore_response.json()["detail"] == "Session not found"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #509. Add resource ownership verification to all endpoints; return 404 on mismatch.