### PR TITLE
[Security] Sanitize validation error messages in production

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -337,14 +337,17 @@ def create_app(*, serve_frontend: bool = True) -> FastAPI:
 
     @app.exception_handler(RequestValidationError)
     async def validation_exception_handler(request: Request, exc: RequestValidationError):
-        """Handle validation errors with detailed logging.
+        """Handle validation errors with environment-aware sanitization.
+
+        In production: Returns generic error messages to prevent information disclosure.
+        In development/test: Returns detailed error messages for debugging.
 
         Args:
             request: FastAPI request object.
             exc: Validation error that was raised.
 
         Returns:
-            JSON response with 422 status code and validation errors.
+            JSON response with 422 status code and sanitized validation errors.
         """
         errors = []
         for error in exc.errors():
@@ -391,6 +394,14 @@ def create_app(*, serve_frontend: bool = True) -> FastAPI:
             f"Validation Error: {errors}",
             extra=error_data,
         )
+
+        if app_settings.environment == "production":
+            return JSONResponse(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                content={
+                    "detail": "Validation failed",
+                },
+            )
 
         # Convert exc.body to a JSON-serializable format
         # FormData objects are not directly JSON serializable

--- a/app/main.py
+++ b/app/main.py
@@ -393,14 +393,17 @@ def create_app(*, serve_frontend: bool = True) -> FastAPI:
 
     @app.exception_handler(RequestValidationError)
     async def validation_exception_handler(request: Request, exc: RequestValidationError):
-        """Handle validation errors with detailed logging.
+        """Handle validation errors with environment-aware sanitization.
+
+        In production: Returns generic error messages to prevent information disclosure.
+        In development/test: Returns detailed error messages for debugging.
 
         Args:
             request: FastAPI request object.
             exc: Validation error that was raised.
 
         Returns:
-            JSON response with 422 status code and validation errors.
+            JSON response with 422 status code and sanitized validation errors.
         """
         errors = []
         for error in exc.errors():
@@ -449,6 +452,14 @@ def create_app(*, serve_frontend: bool = True) -> FastAPI:
             f"Validation Error: {errors}",
             extra=error_data,
         )
+
+        if app_settings.environment == "production":
+            return JSONResponse(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                content={
+                    "detail": "Validation failed",
+                },
+            )
 
         # Convert exc.body to a JSON-serializable format
         # FormData objects are not directly JSON serializable

--- a/tests/test_main_error_handlers.py
+++ b/tests/test_main_error_handlers.py
@@ -1,9 +1,121 @@
 """Tests for error handlers in app/main.py."""
 
+import os
+
 import pytest
 from fastapi import FastAPI
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 from starlette.exceptions import HTTPException as StarletteHTTPException
+
+
+@pytest.mark.asyncio
+async def test_validation_exception_handler_production_sanitization() -> None:
+    """Test validation exception handler returns generic errors in production."""
+    from app.config import clear_settings_cache
+    from app.main import create_app
+
+    original_env = os.getenv("ENVIRONMENT")
+    original_cors = os.getenv("CORS_ORIGINS")
+
+    try:
+        os.environ["ENVIRONMENT"] = "production"
+        os.environ["CORS_ORIGINS"] = "https://example.com"
+        clear_settings_cache()
+
+        test_app = create_app(serve_frontend=False)
+
+        transport = ASGITransport(app=test_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/api/auth/login",
+                json={},
+            )
+            assert response.status_code == 422
+            data = response.json()
+            assert "detail" in data
+            assert data["detail"] == "Validation failed"
+            assert "errors" not in data
+            assert "body" not in data
+    finally:
+        if original_env is None:
+            os.environ.pop("ENVIRONMENT", None)
+        else:
+            os.environ["ENVIRONMENT"] = original_env
+        if original_cors is None:
+            os.environ.pop("CORS_ORIGINS", None)
+        else:
+            os.environ["CORS_ORIGINS"] = original_cors
+        clear_settings_cache()
+
+
+@pytest.mark.asyncio
+async def test_validation_exception_handler_development_detailed() -> None:
+    """Test validation exception handler returns detailed errors in development."""
+    from app.config import clear_settings_cache
+    from app.main import create_app
+
+    original_env = os.getenv("ENVIRONMENT")
+
+    try:
+        os.environ["ENVIRONMENT"] = "development"
+        clear_settings_cache()
+
+        test_app = create_app(serve_frontend=False)
+
+        transport = ASGITransport(app=test_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/api/auth/login",
+                json={},
+            )
+            assert response.status_code == 422
+            data = response.json()
+            assert "detail" in data
+            assert data["detail"] == "Validation failed"
+            assert "errors" in data
+            assert len(data["errors"]) > 0
+            assert "body" in data
+    finally:
+        if original_env is None:
+            os.environ.pop("ENVIRONMENT", None)
+        else:
+            os.environ["ENVIRONMENT"] = original_env
+        clear_settings_cache()
+
+
+@pytest.mark.asyncio
+async def test_validation_exception_handler_test_detailed() -> None:
+    """Test validation exception handler returns detailed errors in test environment."""
+    from app.config import clear_settings_cache
+    from app.main import create_app
+
+    original_env = os.getenv("ENVIRONMENT")
+
+    try:
+        os.environ["ENVIRONMENT"] = "test"
+        clear_settings_cache()
+
+        test_app = create_app(serve_frontend=False)
+
+        transport = ASGITransport(app=test_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/api/auth/login",
+                json={},
+            )
+            assert response.status_code == 422
+            data = response.json()
+            assert "detail" in data
+            assert data["detail"] == "Validation failed"
+            assert "errors" in data
+            assert len(data["errors"]) > 0
+            assert "body" in data
+    finally:
+        if original_env is None:
+            os.environ.pop("ENVIRONMENT", None)
+        else:
+            os.environ["ENVIRONMENT"] = original_env
+        clear_settings_cache()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Implements environment-aware sanitization of FastAPI validation error messages to prevent information disclosure in production.

## Changes
- Modified `app/main.py` validation exception handler (lines 338-424):
  - Added production environment check using `app_settings.environment`
  - In production: Returns generic `{"detail": "Validation failed"}` response without `errors` or `body` fields
  - In development/test: Returns detailed validation errors with field names, messages, and request body (existing behavior)
  - Always logs detailed validation errors server-side for debugging
- Added tests in `tests/test_main_error_handlers.py`:
  - `test_validation_exception_handler_production_sanitization`: Verifies generic response in production
  - `test_validation_exception_handler_development_detailed`: Verifies detailed response in development
  - `test_validation_exception_handler_test_detailed`: Verifies detailed response in test environment

## Security Impact
Prevents attackers from learning about:
- Database schema and field names
- Validation rules and constraints
- Framework and library versions
- Internal application structure

## Testing
All new tests pass. Validation errors in production now return only a generic message while still logging detailed information server-side.

Fixes #510