### PR TITLE
Generate random SECRET_KEY in non-production environments

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -8,9 +8,6 @@ ENVIRONMENT=test
 DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5437/comic_pile_test
 TEST_DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5437/comic_pile_test
 
-# Application secrets
-SECRET_KEY=test-secret-key-for-testing-only
-
 # Disable auto-backup in tests
 AUTO_BACKUP_ENABLED=false
 

--- a/app/config.py
+++ b/app/config.py
@@ -5,6 +5,7 @@ Configuration is validated at startup and provides type-safe access to settings.
 """
 
 import os
+import secrets
 from functools import lru_cache
 from typing import Literal
 
@@ -72,7 +73,7 @@ class AuthSettings(BaseSettings):
     model_config = SettingsConfigDict(env_file=[".env.test", ".env", ".envrc"], extra="ignore")
 
     secret_key: str = Field(
-        default_factory=lambda: os.environ.get("SECRET_KEY") or "test-secret-key-for-testing-only",
+        default="",
         description="Secret key for JWT token signing (required)",
         json_schema_extra={"env": "SECRET_KEY"},
     )
@@ -90,6 +91,18 @@ class AuthSettings(BaseSettings):
         description="Refresh token expiration time in days",
         json_schema_extra={"env": "REFRESH_TOKEN_EXPIRE_DAYS"},
     )
+
+    @field_validator("secret_key", mode="before")
+    @classmethod
+    def validate_secret_key(cls, v: str | None) -> str:
+        """Require explicit secret key in production, randomize in non-production."""
+        environment = os.environ.get("ENVIRONMENT", "development")
+        if environment == "production":
+            if v and v.strip():
+                return v
+            raise ValueError("SECRET_KEY must be set in production mode")
+
+        return secrets.token_urlsafe(48)
 
 
 class AppSettings(BaseSettings):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,9 +31,6 @@ from app.models import Session as SessionModel
 
 load_dotenv(".env.test")
 
-if not os.getenv("SECRET_KEY"):
-    os.environ["SECRET_KEY"] = "test-secret-key-for-testing-only"
-
 
 TRUNCATE_TEST_DATA_SQL = text(
     "TRUNCATE TABLE sessions, events, threads, issues, snapshots, dependencies, "

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -10,8 +10,9 @@ import pytest
 from pydantic import ValidationError
 
 from app.config import (
-    SessionSettings,
+    AuthSettings,
     RatingSettings,
+    SessionSettings,
     clear_settings_cache,
 )
 
@@ -231,3 +232,60 @@ class TestRatingSettingsValidation:
         with pytest.raises(ValidationError) as exc_info:
             RatingSettings()
         assert "rating_threshold" in str(exc_info.value).lower()
+
+
+class TestAuthSettingsValidation:
+    """Test AuthSettings environment-aware secret key behavior."""
+
+    def test_generates_random_secret_key_in_test(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test test environment generates random secret key when missing."""
+        monkeypatch.setenv("ENVIRONMENT", "test")
+        monkeypatch.setenv("SECRET_KEY", "")
+        clear_settings_cache()
+        first_settings = AuthSettings()
+        clear_settings_cache()
+        second_settings = AuthSettings()
+
+        assert first_settings.secret_key
+        assert second_settings.secret_key
+        assert first_settings.secret_key != second_settings.secret_key
+
+    def test_ignores_configured_secret_key_in_test(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test test environment still uses randomized secret key when configured."""
+        monkeypatch.setenv("ENVIRONMENT", "test")
+        monkeypatch.setenv("SECRET_KEY", "configured-key")
+        clear_settings_cache()
+        settings = AuthSettings()
+
+        assert settings.secret_key != "configured-key"
+
+    def test_generates_random_secret_key_in_development(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test development environment generates random secret key when missing."""
+        monkeypatch.setenv("ENVIRONMENT", "development")
+        monkeypatch.setenv("SECRET_KEY", "")
+        clear_settings_cache()
+        settings = AuthSettings()
+
+        assert settings.secret_key
+
+    def test_requires_secret_key_in_production(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test production environment rejects missing secret key."""
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.setenv("SECRET_KEY", "")
+        clear_settings_cache()
+
+        with pytest.raises(ValidationError) as exc_info:
+            AuthSettings()
+
+        assert "secret_key" in str(exc_info.value).lower()
+
+    def test_uses_explicit_secret_key_in_production(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test production environment uses configured secret key."""
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.setenv("SECRET_KEY", "prod-secret-key")
+        clear_settings_cache()
+        settings = AuthSettings()
+
+        assert settings.secret_key == "prod-secret-key"

--- a/tests_e2e/conftest.py
+++ b/tests_e2e/conftest.py
@@ -27,9 +27,6 @@ from app.models import User
 
 load_dotenv()
 
-if not os.getenv("SECRET_KEY"):
-    os.environ["SECRET_KEY"] = "test-secret-key-for-testing-only"
-
 
 @pytest_asyncio.fixture(scope="session", autouse=True)
 async def _create_database_tables():


### PR DESCRIPTION
## Summary
- make auth secret key environment-aware: production now requires `SECRET_KEY`, while development/test generate a random key at startup
- remove hardcoded test secret defaults from test env bootstrap (`.env.test`, backend pytest conftest, and e2e conftest)
- add config validation tests covering random key behavior in test/dev and required explicit key in production

## Validation
- `make lint`
- `make pytest`