### PR TITLE
fix: block dependencies only at next unread issue

### DIFF
--- a/COMIC_DEPENDENCIES_GUIDE.md
+++ b/COMIC_DEPENDENCIES_GUIDE.md
@@ -665,10 +665,16 @@ Current state:
 
 Result: X-Men is NOT blocked yet
 
-After reading UX-M #361:
-  - UX-M next_unread = #362 (now matches the dependency source)
+After reading X-Men #81:
+  - X-Men next_unread = #82 (now matches the dependency target)
+  - UX-M #362 is still unread
 
 Result: X-Men is now BLOCKED (can't roll #82 until #362 is read)
+
+After reading UX-M #362:
+  - UX-M #362 status = read
+
+Result: X-Men is unblocked
 ```
 
 ### Roll Pool Filtering (`comic_pile/queue.py`)
@@ -953,7 +959,7 @@ POST /api/v1/dependencies/
 
 **Step 2: Select Issue-Level Dependencies**
 1. Click "Issue Level" button (highlights amber)
-2. See helper text: "Uses each thread's next unread issue"
+2. See helper text: "Blocks only when the target issue becomes next unread"
 
 **Step 3: Find Source Thread**
 1. Type "uncanny" in search box

--- a/app/api/dependency.py
+++ b/app/api/dependency.py
@@ -354,7 +354,8 @@ async def create_dependency(
                 warning = (
                     f"Target issue #{target_issue.issue_number} is not yet the next"
                     f" unread (current next unread: #{next_unread_issue.issue_number})."
-                    f" This dependency will activate in {issues_ahead} {issue_word}."
+                    f" This dependency will block when the target thread reaches it in"
+                    f" {issues_ahead} {issue_word}."
                 )
 
         dependency = Dependency(

--- a/comic_pile/dependencies.py
+++ b/comic_pile/dependencies.py
@@ -13,23 +13,17 @@ from app.models.thread import Thread
 async def get_blocked_thread_ids(user_id: int, db: AsyncSession) -> set[int]:
     """Return thread IDs blocked by unsatisfied issue-level dependencies for a user."""
     source_issue = Issue.__table__.alias("source_issue")
-    dep_target_issue = Issue.__table__.alias("dep_target_issue")
-    target_next_unread = Issue.__table__.alias("target_next_unread")
+    next_unread_issue = Issue.__table__.alias("next_unread_issue")
     target_thread = Thread.__table__.alias("target_thread")
     source = Thread.__table__.alias("source_thread")
 
     issue_result = await db.execute(
         select(target_thread.c.id)
         .join(
-            target_next_unread,
-            target_next_unread.c.id == target_thread.c.next_unread_issue_id,
+            next_unread_issue,
+            next_unread_issue.c.id == target_thread.c.next_unread_issue_id,
         )
-        .join(
-            dep_target_issue,
-            (dep_target_issue.c.thread_id == target_thread.c.id)
-            & (dep_target_issue.c.position >= target_next_unread.c.position),
-        )
-        .join(Dependency, Dependency.target_issue_id == dep_target_issue.c.id)
+        .join(Dependency, Dependency.target_issue_id == next_unread_issue.c.id)
         .join(source_issue, Dependency.source_issue_id == source_issue.c.id)
         .join(source, source_issue.c.thread_id == source.c.id)
         .where(target_thread.c.user_id == user_id)
@@ -44,8 +38,7 @@ async def get_blocked_thread_ids(user_id: int, db: AsyncSession) -> set[int]:
 async def get_blocking_explanations(thread_id: int, user_id: int, db: AsyncSession) -> list[str]:
     """Human-readable reasons a thread is blocked."""
     source_issue = Issue.__table__.alias("source_issue")
-    dep_target_issue = Issue.__table__.alias("dep_target_issue")
-    target_next_unread = Issue.__table__.alias("target_next_unread")
+    next_unread_issue = Issue.__table__.alias("next_unread_issue")
     source_thread = Thread.__table__.alias("source_thread")
     target_thread = Thread.__table__.alias("target_thread")
 
@@ -58,15 +51,10 @@ async def get_blocking_explanations(thread_id: int, user_id: int, db: AsyncSessi
         )
         .select_from(target_thread)
         .join(
-            target_next_unread,
-            target_next_unread.c.id == target_thread.c.next_unread_issue_id,
+            next_unread_issue,
+            next_unread_issue.c.id == target_thread.c.next_unread_issue_id,
         )
-        .join(
-            dep_target_issue,
-            (dep_target_issue.c.thread_id == target_thread.c.id)
-            & (dep_target_issue.c.position >= target_next_unread.c.position),
-        )
-        .join(Dependency, Dependency.target_issue_id == dep_target_issue.c.id)
+        .join(Dependency, Dependency.target_issue_id == next_unread_issue.c.id)
         .join(source_issue, Dependency.source_issue_id == source_issue.c.id)
         .join(source_thread, source_issue.c.thread_id == source_thread.c.id)
         .where(target_thread.c.id == thread_id)

--- a/docs/blocking-ux-polish-plan.md
+++ b/docs/blocking-ux-polish-plan.md
@@ -77,7 +77,7 @@ Roll Pool (d4)
 | "No prerequisites yet." | "No reading prerequisites." |
 | "No dependent threads yet." | "Doesn't unlock anything yet." |
 | "Adding dependency…" | "Saving…" |
-| "Uses each thread's next unread issue." | "Block a specific issue behind another issue." |
+| "Uses each thread's next unread issue." | "Blocks only when the target issue becomes next unread." |
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-04-26
+
+**Dependency Blocking**
+- Fixed issue-level dependencies so future gated issues no longer hide a thread from the roll pool early.
+- Threads now become blocked only when their next unread issue has an unread prerequisite.
+- Updated dependency creation copy to clarify that future issue gates activate when the target issue is reached.
+
 ## 2026-03-27
 
 **Pagination for thread list and session list endpoints (#378)**
@@ -182,6 +189,7 @@
 - Fixed dependency blocking to only block when next unread issue has unread prerequisite
 - Improved `is_blocked` flag recalculation after dependency changes
 - Dependency blocking now works correctly regardless of `next_unread_issue`
+  - Superseded on 2026-04-26: issue dependencies now block only when the target issue is next unread.
 
 **Data Migration**
 - Fixed off-by-one error in auto-migration that created phantom issues
@@ -204,6 +212,7 @@
 
 **Dependencies**
 - Fixed issue dependencies to block threads regardless of `next_unread_issue` state
+  - Superseded on 2026-04-26: issue dependencies now block only when the target issue is next unread.
 
 ## 2026-03-09
 

--- a/frontend/src/components/DependencyBuilder.tsx
+++ b/frontend/src/components/DependencyBuilder.tsx
@@ -7,7 +7,7 @@ import { dependenciesApi, threadsApi } from '../services/api'
 import { issuesApi } from '../services/api-issues'
 import type { Dependency, FlowchartDependency, FlowchartNode, Issue, Thread, ThreadDependenciesResponse } from '../types'
 import { getApiErrorDetail } from '../utils/apiError'
-import { useToast } from '../contexts/ToastContext'
+import { useToast } from '../contexts/useToast'
 
 function getDefaultDependencyMode(_thread: Thread | null): 'thread' | 'issue' {
   return 'issue'
@@ -728,7 +728,7 @@ const [isSavingNote, setIsSavingNote] = useState(false)
             Dependency type
           </p>
           <p className="text-xs text-stone-500">
-            Issue-level: uses each thread&apos;s next unread issue.
+            Issue-level: blocks only when the target issue becomes next unread.
           </p>
         </div>
 

--- a/frontend/src/test/dependencies.spec.ts
+++ b/frontend/src/test/dependencies.spec.ts
@@ -1,5 +1,32 @@
 import { test, expect } from './fixtures'
 import { createThread } from './helpers'
+import type { Page } from '@playwright/test'
+
+async function markIssueNumbersRead(
+  page: Page,
+  token: string | null,
+  threadId: number,
+  issueNumbers: string[]
+): Promise<void> {
+  const issuesResponse = await page.request.get(`/api/v1/threads/${threadId}/issues`, {
+    headers: {
+      ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
+    },
+  })
+  expect(issuesResponse.ok()).toBeTruthy()
+  const issuesData = await issuesResponse.json() as { issues: Array<{ id: number; issue_number: string }> }
+
+  for (const issueNumber of issueNumbers) {
+    const issue = issuesData.issues.find((candidate) => candidate.issue_number === issueNumber)
+    expect(issue, `Expected issue #${issueNumber} in thread ${threadId}`).toBeDefined()
+    const markReadResponse = await page.request.post(`/api/v1/issues/${issue!.id}:markRead`, {
+      headers: {
+        ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
+      },
+    })
+    expect(markReadResponse.ok()).toBeTruthy()
+  }
+}
 
 test.describe('Dependencies', () => {
   test('creates dependency from queue UI and shows blocked indicator', async ({ authenticatedPage }) => {
@@ -211,31 +238,9 @@ test.describe('Dependencies', () => {
         total_issues: 10,
       })
 
-      const token = await authenticatedPage.evaluate(() => localStorage.getItem('auth_token') ?? (window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN)
+      const token = await authenticatedPage.evaluate(() => localStorage.getItem('auth_token') ?? (window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN ?? null)
 
-      await authenticatedPage.request.post(`/api/v1/threads/${sourceThread.id}/issues`, {
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
-        data: { issue_range: '1-10' },
-      })
-
-      await authenticatedPage.request.patch(`/api/v1/threads/${sourceThread.id}/issues/1`, {
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
-        data: { read: true },
-      })
-
-      await authenticatedPage.request.patch(`/api/v1/threads/${sourceThread.id}/issues/2`, {
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
-        data: { read: true },
-      })
+      await markIssueNumbersRead(authenticatedPage, token, sourceThread.id, ['1', '2'])
 
       await authenticatedPage.goto('/queue')
       await authenticatedPage.waitForLoadState('networkidle')
@@ -453,40 +458,10 @@ test.describe('Dependencies', () => {
         total_issues: 5,
       })
 
-      const token = await authenticatedPage.evaluate(() => localStorage.getItem('auth_token') ?? (window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN)
+      const token = await authenticatedPage.evaluate(() => localStorage.getItem('auth_token') ?? (window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN ?? null)
 
-      // Mark all but the last issue as read
-      await authenticatedPage.request.patch(`/api/v1/threads/${sourceThread.id}/issues/1`, {
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
-        data: { read: true },
-      })
-
-      await authenticatedPage.request.patch(`/api/v1/threads/${sourceThread.id}/issues/2`, {
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
-        data: { read: true },
-      })
-
-      await authenticatedPage.request.patch(`/api/v1/threads/${sourceThread.id}/issues/3`, {
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
-        data: { read: true },
-      })
-
-      await authenticatedPage.request.patch(`/api/v1/threads/${sourceThread.id}/issues/4`, {
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
-        },
-        data: { read: true },
-      })
+      // Mark all but the last issue as read.
+      await markIssueNumbersRead(authenticatedPage, token, sourceThread.id, ['1', '2', '3', '4'])
 
       await authenticatedPage.goto('/queue')
       await authenticatedPage.waitForLoadState('networkidle')

--- a/frontend/src/unit/DependencyBuilder.test.tsx
+++ b/frontend/src/unit/DependencyBuilder.test.tsx
@@ -124,6 +124,16 @@ beforeEach(() => {
 })
 
 describe('DependencyBuilder issue selection', () => {
+  it('explains that issue dependencies block only when the target issue is next unread', async () => {
+    mockedIssuesApi.list.mockResolvedValue(buildListResponse([]))
+
+    renderBuilder()
+
+    expect(
+      await screen.findByText(/blocks only when the target issue becomes next unread/i)
+    ).toBeInTheDocument()
+  })
+
   it('fetches source and target issues with status=unread filter', async () => {
     mockedIssuesApi.list.mockResolvedValue(buildListResponse([]))
     renderBuilder()

--- a/frontend/src/unit/QueuePage.test.tsx
+++ b/frontend/src/unit/QueuePage.test.tsx
@@ -76,6 +76,10 @@ vi.mock('../contexts/ToastContext', () => ({
   ToastProvider: ({ children }: { children: ReactNode }) => children,
 }))
 
+vi.mock('../contexts/useToast', () => ({
+  useToast: vi.fn(() => ({ showToast: vi.fn(), removeToast: vi.fn(), toasts: [] })),
+}))
+
 const mockedUseThreads = vi.mocked(useThreads) as any
 const mockedUseCreateThread = vi.mocked(useCreateThread) as any
 const mockedUseUpdateThread = vi.mocked(useUpdateThread) as any

--- a/frontend/src/unit/readingOrderTimeline.test.ts
+++ b/frontend/src/unit/readingOrderTimeline.test.ts
@@ -52,6 +52,10 @@ describe('buildReadingOrderTimelineEntries', () => {
     expect(entries[0].kind).toBe('span')
     expect(entries[1].kind).toBe('gate')
     expect(entries[1].kind === 'gate' && entries[1].gate.status).toBe('blocked')
+    expect(entries[1].kind === 'gate' && entries[1].gate.isCurrent).toBe(true)
+    expect(entries[2].kind).toBe('gate')
+    expect(entries[2].kind === 'gate' && entries[2].gate.status).toBe('dormant')
+    expect(entries[2].kind === 'gate' && entries[2].gate.isCurrent).toBe(false)
     expect(entries[3].kind === 'span' && entries[3].span.label).toBe('Issues 17–30')
   })
 

--- a/prompts/issue-413-dependency-range-fix.md
+++ b/prompts/issue-413-dependency-range-fix.md
@@ -1,5 +1,10 @@
 # Prompt: Fix issue-level dependency blocking to use position-based range
 
+> Superseded by GitHub issue #528. This prompt documents the older anticipatory-blocking
+> behavior that caused false thread deadlocks in interleaved reading orders. Current desired
+> behavior is next-unread-only blocking: a dependency blocks only when its target issue is the
+> target thread's immediate next unread issue.
+
 ## Context
 
 You are working on `comic-pile`, a FastAPI + React comic reading queue app.

--- a/tests/test_admin_refresh_blocked.py
+++ b/tests/test_admin_refresh_blocked.py
@@ -1,9 +1,9 @@
 """Regression tests for fix_stale_blocked_flags script.
 
 Verifies that refresh_user_blocked_status (the core of the script) correctly
-recalculates stale is_blocked flags after the position-based blocking logic:
-- Threads stamped is_blocked=True by the old exact-match logic must be cleared when
-  the dependency's target issue is before next_unread_issue (i.e., already past).
+recalculates stale is_blocked flags after the next-unread-only blocking logic:
+- Threads stamped is_blocked=True by old range-based logic must be cleared when
+  the dependency's target issue is not the next unread issue.
 - Threads that are genuinely blocked must remain blocked after recalculation.
 """
 
@@ -21,10 +21,9 @@ from comic_pile.queue import get_roll_pool
 async def test_stale_blocked_flag_cleared_after_refresh(async_db: AsyncSession) -> None:
     """Stale is_blocked=True flags must be cleared when next_unread is past the dep target.
 
-    Regression: old exact-match logic only blocked when dep target was exactly
-    next_unread_issue_id. Position-based logic blocks when dep target position
-    >= next_unread position. When next_unread has moved past the dep target,
-    the block should be cleared.
+    Regression: range-based logic blocked whenever a dependency target was at or
+    after next_unread. Next-unread-only logic must clear stale flags unless the
+    dependency target is exactly the next unread issue.
     """
     user = User(username="stale_flag_user", created_at=datetime.now(UTC))
     async_db.add(user)

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -395,8 +395,8 @@ async def test_issue_dependency_blocks_by_next_unread_issue(async_db):
 
 
 @pytest.mark.asyncio
-async def test_dep_on_future_issue_blocks_thread_before_reaching_it(async_db):
-    """Dependency on a future issue should block the thread even when next-unread is before it."""
+async def test_dep_on_future_issue_does_not_block_before_reaching_it(async_db):
+    """Dependency on a future issue should not block before next-unread reaches it."""
     user = User(username="future_dep_user", created_at=datetime.now(UTC))
     async_db.add(user)
     await async_db.flush()
@@ -463,7 +463,7 @@ async def test_dep_on_future_issue_blocks_thread_before_reaching_it(async_db):
     await async_db.commit()
 
     blocked = await get_blocked_thread_ids(user.id, async_db)
-    assert target_thread.id in blocked
+    assert target_thread.id not in blocked
 
     target_issue_1.status = "read"
     target_issue_1.read_at = datetime.now(UTC)
@@ -534,9 +534,9 @@ async def test_validate_position_dependency_consistency_warns_on_conflict(async_
 
 
 @pytest.mark.asyncio
-async def test_dep_blocks_anticipatorily_before_dep_target(async_db):
-    """Dep on issue #3 should block thread when next_unread is issue #1."""
-    user = User(username="anticipatory_dep_user", created_at=datetime.now(UTC))
+async def test_dep_does_not_block_until_next_unread_reaches_dep_target(async_db):
+    """Dep on issue #3 should not block thread when next_unread is issue #1."""
+    user = User(username="future_dep_user", created_at=datetime.now(UTC))
     async_db.add(user)
     await async_db.flush()
 
@@ -605,7 +605,17 @@ async def test_dep_blocks_anticipatorily_before_dep_target(async_db):
     await async_db.commit()
 
     blocked = await get_blocked_thread_ids(user.id, async_db)
-    assert target_thread.id in blocked
+    assert target_thread.id not in blocked
+
+    target_issue_1.status = "read"
+    target_issue_1.read_at = datetime.now(UTC)
+    target_issue_2.status = "read"
+    target_issue_2.read_at = datetime.now(UTC)
+    target_thread.next_unread_issue_id = target_issue_3.id
+    await async_db.commit()
+
+    blocked_at_target = await get_blocked_thread_ids(user.id, async_db)
+    assert target_thread.id in blocked_at_target
 
     source_issue_3.status = "read"
     source_issue_3.read_at = datetime.now(UTC)

--- a/tests/test_dependency_api.py
+++ b/tests/test_dependency_api.py
@@ -249,7 +249,10 @@ async def test_issue_dependency_api_lifecycle(auth_client, async_db, test_userna
 
     info_resp = await auth_client.post(f"/api/v1/threads/{target_thread.id}:getBlockingInfo")
     assert info_resp.status_code == 200
-    assert info_resp.json()["is_blocked"] is True
+    info = info_resp.json()
+    assert info["is_blocked"] is True
+    assert info["blocking_reasons"]
+    assert "issue #1" in info["blocking_reasons"][0].lower()
     target_thread = Thread(
         title="Negative Target Thread",
         format="Comic",
@@ -379,10 +382,10 @@ async def test_duplicate_dependency_returns_400(auth_client, async_db, test_user
 
 
 @pytest.mark.asyncio
-async def test_issue_dependency_blocks_when_target_not_next_unread(
+async def test_issue_dependency_does_not_block_until_target_is_next_unread(
     auth_client, async_db, test_username
 ):
-    """Issue dependency on a future issue should block thread anticipatorily (issue #270)."""
+    """Future issue dependency should block only when target becomes next unread."""
     user_result = await async_db.execute(select(User).where(User.username == test_username))
     user = user_result.scalar_one()
 
@@ -451,9 +454,13 @@ async def test_issue_dependency_blocks_when_target_not_next_unread(
 
     blocked_resp = await auth_client.get("/api/v1/dependencies/blocked")
     assert blocked_resp.status_code == 200
-    assert target_thread.id in blocked_resp.json(), (
-        "Thread should be blocked when dependency target position >= next_unread position"
+    assert target_thread.id not in blocked_resp.json(), (
+        "Thread should remain roll-eligible until the dependency target is next unread"
     )
+
+    info_before_target = await auth_client.post(f"/api/v1/threads/{target_thread.id}:getBlockingInfo")
+    assert info_before_target.status_code == 200
+    assert info_before_target.json()["is_blocked"] is False
 
     target_issue_1.status = "read"
     target_issue_1.read_at = datetime.now(UTC)
@@ -475,10 +482,10 @@ async def test_issue_dependency_blocks_when_target_not_next_unread(
 
 
 @pytest.mark.asyncio
-async def test_issue_dependency_blocking_multiple_issues_same_thread(
+async def test_issue_dependency_waits_for_first_matching_target_in_same_thread(
     auth_client, async_db, test_username
 ):
-    """Multiple dependencies on different issues in same thread should all block."""
+    """Multiple future dependencies should block only when one target is next unread."""
     user_result = await async_db.execute(select(User).where(User.username == test_username))
     user = user_result.scalar_one()
 
@@ -565,11 +572,11 @@ async def test_issue_dependency_blocking_multiple_issues_same_thread(
 
     blocked_resp = await auth_client.get("/api/v1/dependencies/blocked")
     assert blocked_resp.status_code == 200
-    assert target_thread.id in blocked_resp.json(), (
-        "Thread should be blocked when dependency target positions >= next_unread position"
+    assert target_thread.id not in blocked_resp.json(), (
+        "Thread should remain roll-eligible before the first dependency target"
     )
 
-    # Now read issue 1, making next unread issue 2
+    # Now read issue 1, making the first dependency target the next unread issue.
     target_issue_1.status = "read"
     target_issue_1.read_at = datetime.now(UTC)
     target_thread.next_unread_issue_id = target_issue_3.id
@@ -1310,3 +1317,4 @@ async def test_dependency_future_target_returns_warning(auth_client, async_db, t
     assert "#10" in data["warning"]
     assert "#8" in data["warning"]
     assert "2 issues" in data["warning"]
+    assert "will block when the target thread reaches it" in data["warning"]

--- a/tests/test_issue_api.py
+++ b/tests/test_issue_api.py
@@ -1376,7 +1376,7 @@ async def test_move_issue_refreshes_blocked_status_from_new_next_unread_issue(
 
     await async_db.refresh(target_thread)
     assert target_thread.next_unread_issue_id == target_issues[2].id
-    assert target_thread.is_blocked is True
+    assert target_thread.is_blocked is False
 
     source_issues[0].status = "read"
     source_issues[0].read_at = datetime.now(UTC)
@@ -1455,7 +1455,7 @@ async def test_reorder_issues_refreshes_blocked_status_from_new_next_unread_issu
 
     await async_db.refresh(target_thread)
     assert target_thread.next_unread_issue_id == target_issues[1].id
-    assert target_thread.is_blocked is True
+    assert target_thread.is_blocked is False
 
     source_issues[0].status = "read"
     source_issues[0].read_at = datetime.now(UTC)


### PR DESCRIPTION
## Summary

Fixes #528.

This changes issue-level dependency blocking from anticipatory/range-based blocking to next-unread-only blocking. A thread now leaves the roll pool only when its immediate next unread issue has an unread prerequisite, rather than when any future issue in that thread has an unread prerequisite.

## What changed

- Updated `get_blocked_thread_ids()` and `get_blocking_explanations()` to match dependencies only against `Thread.next_unread_issue_id`.
- Kept future-target dependency creation allowed, but clarified the warning copy so users know the dependency will block when the target issue is reached.
- Updated backend tests for dependency blocking, dependency API behavior, issue move/reorder refresh behavior, and stale blocked-flag refresh wording.
- Updated dependency UI helper text and timeline unit coverage so future gates remain dormant until current.
- Updated docs/changelog and marked the old anticipatory-blocking prompt as superseded.
- Removed a Vite circular chunk warning by importing `useToast` directly from the hook module in `DependencyBuilder`.

## Validation

- `uv run pytest tests/test_dependencies.py tests/test_dependency_api.py tests/test_admin_refresh_blocked.py tests/test_issue_api.py -q`
- `make test`
- `make lint`
- `cd frontend && npm test -- --run`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run build`

## Notes

`threads.is_blocked` is denormalized, so production accounts affected by the old range-based calculation should have blocked flags refreshed after deploy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined issue-level dependency blocking to activate only when the target issue becomes your next unread item, providing more precise control over reading order.

* **Documentation**
  * Updated guides and in-app help text to clarify the exact conditions for when dependencies block your reading progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->