### PR TITLE
feat: extend dice ladder to support users with 50+ threads (#492)

### DIFF
--- a/app/api/roll.py
+++ b/app/api/roll.py
@@ -295,7 +295,7 @@ async def set_manual_die(
     """Set manual die size for current session.
 
     Args:
-        die: The die size to set (must be 4, 6, 8, 10, 12, or 20).
+        die: The die size to set (must be 4, 6, 8, 10, 12, 20, 30, 50, or 100).
         current_user: The authenticated user making the request.
         db: SQLAlchemy session for database operations.
 
@@ -307,10 +307,10 @@ async def set_manual_die(
     """
     current_session = await get_or_create(db, user_id=current_user.id)
 
-    if die not in [4, 6, 8, 10, 12, 20]:
+    if die not in [4, 6, 8, 10, 12, 20, 30, 50, 100]:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid die size. Must be one of: 4, 6, 8, 10, 12, 20",
+            detail="Invalid die size. Must be one of: 4, 6, 8, 10, 12, 20, 30, 50, 100",
         )
 
     current_session.manual_die = die

--- a/app/config.py
+++ b/app/config.py
@@ -157,9 +157,14 @@ class SessionSettings(BaseSettings):
         description="Hours of inactivity before starting a new session (1-168)",
         json_schema_extra={"env": "SESSION_GAP_HOURS"},
     )
+    session_gap_hours: int = Field(
+        default=6,
+        description="Hours of inactivity before starting a new session (1-168)",
+        json_schema_extra={"env": "SESSION_GAP_HOURS"},
+    )
     start_die: int = Field(
         default=6,
-        description="Starting die size for new sessions (4-20)",
+        description="Starting die size for new sessions (4-100)",
         json_schema_extra={"env": "START_DIE"},
     )
 
@@ -175,8 +180,8 @@ class SessionSettings(BaseSettings):
     @classmethod
     def validate_start_die(cls, v: int) -> int:
         """Ensure start die is within valid range."""
-        if not 4 <= v <= 20:
-            raise ValueError(f"START_DIE must be between 4 and 20, got {v}")
+        if not 4 <= v <= 100:
+            raise ValueError(f"START_DIE must be between 4 and 100, got {v}")
         return v
 
 

--- a/app/constants.py
+++ b/app/constants.py
@@ -22,7 +22,8 @@ class ThreadStatus(StrEnum):
 
 
 # Dice ladder - standard RPG dice progression
-DICE_LADDER = [4, 6, 8, 10, 12, 20]
+# Extended to support large thread pools (50+ threads)
+DICE_LADDER = [4, 6, 8, 10, 12, 20, 30, 50, 100]
 
 # Session configuration
 DEFAULT_SESSION_GAP_HOURS = 6

--- a/comic_pile/dice_ladder.py
+++ b/comic_pile/dice_ladder.py
@@ -4,7 +4,7 @@ The Dice Ladder System
 ======================
 The dice ladder is the core game mechanic that governs how comics are selected
 for reading. It uses standard RPG polyhedral dice (d4, d6, d8, d10, d12, d20)
-to create a dynamic selection pool that responds to reading satisfaction.
+extended with larger sizes (d30, d50, d100) to support very large thread pools.
 
 How It Works:
 -------------
@@ -24,9 +24,9 @@ Design Philosophy:
 
 Ladder Progression:
 -------------------
-    d4 <-> d6 <-> d8 <-> d10 <-> d12 <-> d20
-    ^                                      ^
-    (minimum - tight focus)     (maximum - wide variety)
+    d4 <-> d6 <-> d8 <-> d10 <-> d12 <-> d20 <-> d30 <-> d50 <-> d100
+    ^                                                              ^
+    (minimum - tight focus)                         (maximum - wide variety)
 
 Example Flow:
 -------------
@@ -36,7 +36,7 @@ Example Flow:
 4. Continue rating poorly -> step up to d8, d10, etc.
 """
 
-DICE_LADDER = [4, 6, 8, 10, 12, 20]
+DICE_LADDER = [4, 6, 8, 10, 12, 20, 30, 50, 100]
 
 
 def step_down(die_size: int) -> int:

--- a/frontend/src/components/Dice3D.tsx
+++ b/frontend/src/components/Dice3D.tsx
@@ -643,6 +643,74 @@ function createD20Geometry(atlasInfo: DiceTextureAtlas): THREE.BufferGeometry {
   return geometry;
 }
 
+function createQuadSphereGeometry(
+  sides: number,
+  latBands: number,
+  lonSegs: number,
+  atlasInfo: DiceTextureAtlas,
+): THREE.BufferGeometry {
+  const { cols, rows, uvInset } = atlasInfo;
+  const verts: number[] = []
+  const uvs: number[] = []
+  const inds: number[] = []
+
+  const sphereVerts: Vector3Tuple[] = []
+  for (let latIdx = 0; latIdx <= latBands; latIdx++) {
+    const theta = (latIdx / latBands) * Math.PI
+    const y = Math.cos(theta)
+    const r = Math.sin(theta)
+    for (let lonIdx = 0; lonIdx < lonSegs; lonIdx++) {
+      const phi = (lonIdx / lonSegs) * 2 * Math.PI
+      sphereVerts.push([r * Math.cos(phi), y, r * Math.sin(phi)])
+    }
+  }
+
+  let faceNum = 1
+  for (let latIdx = 0; latIdx < latBands; latIdx++) {
+    for (let lonIdx = 0; lonIdx < lonSegs; lonIdx++) {
+      const nextLon = (lonIdx + 1) % lonSegs
+
+      const a = latIdx * lonSegs + lonIdx
+      const b = latIdx * lonSegs + nextLon
+      const c = (latIdx + 1) * lonSegs + nextLon
+      const d = (latIdx + 1) * lonSegs + lonIdx
+
+      const uv = getUVForNumber(faceNum, cols, rows, uvInset)
+      const idx = verts.length / 3
+
+      verts.push(
+        sphereVerts[a][0], sphereVerts[a][1], sphereVerts[a][2],
+        sphereVerts[b][0], sphereVerts[b][1], sphereVerts[b][2],
+        sphereVerts[c][0], sphereVerts[c][1], sphereVerts[c][2],
+        sphereVerts[d][0], sphereVerts[d][1], sphereVerts[d][2],
+      )
+      uvs.push(uv.u0, uv.v0, uv.u1, uv.v0, uv.u1, uv.v1, uv.u0, uv.v1)
+      inds.push(idx, idx + 1, idx + 2, idx, idx + 2, idx + 3)
+
+      faceNum++
+    }
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(verts), 3));
+  geometry.setAttribute('uv', new THREE.BufferAttribute(new Float32Array(uvs), 2));
+  geometry.setIndex(new THREE.BufferAttribute(new Uint16Array(inds), 1));
+  geometry.computeVertexNormals();
+  return geometry;
+}
+
+function createD30Geometry(atlasInfo: DiceTextureAtlas): THREE.BufferGeometry {
+  return createQuadSphereGeometry(30, 3, 10, atlasInfo)
+}
+
+function createD50Geometry(atlasInfo: DiceTextureAtlas): THREE.BufferGeometry {
+  return createQuadSphereGeometry(50, 5, 10, atlasInfo)
+}
+
+function createD100Geometry(atlasInfo: DiceTextureAtlas): THREE.BufferGeometry {
+  return createQuadSphereGeometry(100, 10, 10, atlasInfo)
+}
+
 function buildGeometry(sides: number, atlasInfo: DiceTextureAtlas): THREE.BufferGeometry {
   switch (sides) {
     case 4:
@@ -657,6 +725,12 @@ function buildGeometry(sides: number, atlasInfo: DiceTextureAtlas): THREE.Buffer
       return createD12Geometry(atlasInfo);
     case 20:
       return createD20Geometry(atlasInfo);
+    case 30:
+      return createD30Geometry(atlasInfo);
+    case 50:
+      return createD50Geometry(atlasInfo);
+    case 100:
+      return createD100Geometry(atlasInfo);
     default:
       return createD6Geometry(atlasInfo);
   }

--- a/frontend/src/components/diceLadder.ts
+++ b/frontend/src/components/diceLadder.ts
@@ -1,1 +1,1 @@
-export const DICE_LADDER = [4, 6, 8, 10, 12, 20]
+export const DICE_LADDER = [4, 6, 8, 10, 12, 20, 30, 50, 100]

--- a/frontend/src/components/diceTypes.ts
+++ b/frontend/src/components/diceTypes.ts
@@ -1,7 +1,7 @@
-export type DiceSide = 4 | 6 | 8 | 10 | 12 | 20
+export type DiceSide = 4 | 6 | 8 | 10 | 12 | 20 | 30 | 50 | 100
 
 export function isDiceSide(value: number): value is DiceSide {
-  return value === 4 || value === 6 || value === 8 || value === 10 || value === 12 || value === 20
+  return value === 4 || value === 6 || value === 8 || value === 10 || value === 12 || value === 20 || value === 30 || value === 50 || value === 100
 }
 
 export interface DiceRenderGlobalConfig {

--- a/frontend/src/pages/RollPage/index.tsx
+++ b/frontend/src/pages/RollPage/index.tsx
@@ -763,12 +763,12 @@ useEffect(() => {
       <header className="flex justify-between items-center px-3 py-2 shrink-0 z-10">
         <div>
           <h1 className="text-2xl font-black tracking-tighter text-glow uppercase">Pile Roller</h1>
-          {((session?.snoozed_threads?.length ?? 0) > 0) && currentDie === 20 && (
+          {((session?.snoozed_threads?.length ?? 0) > 0) && currentDie === 100 && (
             <div className="flex items-center gap-2 mt-1">
-              <span className="text-[9px] text-stone-500 uppercase tracking-wider">pool at max size (d20) - snoozing won't increase it further</span>
+              <span className="text-[9px] text-stone-500 uppercase tracking-wider">pool at max size (d100) - snoozing won't increase it further</span>
             </div>
           )}
-          {((session?.snoozed_threads?.length ?? 0) > 0) && currentDie !== 20 && (
+          {((session?.snoozed_threads?.length ?? 0) > 0) && currentDie !== 100 && (
             <div className="flex items-center gap-2 mt-1">
               <Tooltip content="Snoozed offset"><span className="modifier-badge text-[10px] font-black text-amber-500 cursor-help border-b border-dashed border-stone-600">+{session?.snoozed_threads?.length ?? 0}</span></Tooltip>
               <Tooltip content="Snoozed offset active"><span className="text-[9px] text-stone-500 uppercase tracking-wider cursor-help border-b border-dashed border-stone-600">offset active</span></Tooltip>
@@ -804,7 +804,7 @@ useEffect(() => {
               </div>
             </div>
             <div className="text-right">
-              <Tooltip content="Dice ladder: d4→d6→d8→d10→d12→d20. Promotes automatically based on ratings (5→up, 1-2→down)">
+              <Tooltip content="Dice ladder: d4→d6→d8→d10→d12→d20→d30→d50→d100. Promotes automatically based on ratings (5→up, 1-2→down)">
                 <span className="block text-[8px] font-black text-stone-500 uppercase tracking-wider cursor-help border-b border-dashed border-stone-600">Ladder</span>
               </Tooltip>
               <span id="header-die-label" className="text-[10px] font-black text-amber-500">d{currentDie}</span>

--- a/frontend/src/unit/diceLadder.test.tsx
+++ b/frontend/src/unit/diceLadder.test.tsx
@@ -2,5 +2,5 @@ import { expect, it } from 'vitest'
 import { DICE_LADDER } from '../components/diceLadder'
 
 it('defines the expected dice ladder', () => {
-  expect(DICE_LADDER).toEqual([4, 6, 8, 10, 12, 20])
+  expect(DICE_LADDER).toEqual([4, 6, 8, 10, 12, 20, 30, 50, 100])
 })

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -88,11 +88,11 @@ class TestSessionSettingsValidation:
         assert settings.start_die == 4
 
     def test_start_die_maximum_boundary(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test that start_die=20 (maximum) is accepted."""
-        monkeypatch.setenv("START_DIE", "20")
+        """Test that start_die=100 (maximum) is accepted."""
+        monkeypatch.setenv("START_DIE", "100")
         clear_settings_cache()
         settings = SessionSettings()
-        assert settings.start_die == 20
+        assert settings.start_die == 100
 
     def test_invalid_start_die_too_low(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that start_die < 4 raises ValidationError."""
@@ -103,20 +103,19 @@ class TestSessionSettingsValidation:
         assert "start_die" in str(exc_info.value).lower()
 
     def test_invalid_start_die_too_high(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test that start_die > 20 raises ValidationError."""
-        monkeypatch.setenv("START_DIE", "21")
+        """Test that start_die > 100 raises ValidationError."""
+        monkeypatch.setenv("START_DIE", "101")
         clear_settings_cache()
         with pytest.raises(ValidationError) as exc_info:
             SessionSettings()
         assert "start_die" in str(exc_info.value).lower()
 
-    def test_invalid_start_die_example_from_issue(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test the example from issue #296: START_DIE=100 should fail."""
+    def test_valid_start_die_max(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that start_die=100 is valid (extended ladder)."""
         monkeypatch.setenv("START_DIE", "100")
         clear_settings_cache()
-        with pytest.raises(ValidationError) as exc_info:
-            SessionSettings()
-        assert "start_die" in str(exc_info.value).lower()
+        settings = SessionSettings()
+        assert settings.start_die == 100
 
 
 class TestRatingSettingsValidation:

--- a/tests/test_dice_ladder.py
+++ b/tests/test_dice_ladder.py
@@ -23,21 +23,21 @@ def test_dice_ladder_step_down_bounds() -> None:
 
 
 def test_dice_ladder_step_up_bounds() -> None:
-    """Returns same when at d20 (maximum)."""
-    assert step_up(20) == 20
+    """Returns same when at d100 (maximum)."""
+    assert step_up(100) == 100
 
 
 def test_dice_ladder_full_traversal() -> None:
     """Test step through all dice values."""
     result = step_up(4)
-    for expected in [6, 8, 10, 12, 20]:
+    for expected in [6, 8, 10, 12, 20, 30, 50, 100]:
         assert result == expected
         result = step_up(result)
 
-    assert step_up(20) == 20
+    assert step_up(100) == 100
 
-    result = step_down(20)
-    for expected in [12, 10, 8, 6, 4]:
+    result = step_down(100)
+    for expected in [50, 30, 20, 12, 10, 8, 6, 4]:
         assert result == expected
         result = step_down(result)
 
@@ -50,8 +50,8 @@ def test_dice_ladder_invalid_die_size_step_down() -> None:
 
     with pytest.raises(ValueError, match="Invalid die size: 5"):
         step_down(5)
-    with pytest.raises(ValueError, match="Invalid die size: 100"):
-        step_down(100)
+    with pytest.raises(ValueError, match="Invalid die size: 99"):
+        step_down(99)
     with pytest.raises(ValueError, match="Invalid die size: 3"):
         step_down(3)
 
@@ -62,15 +62,15 @@ def test_dice_ladder_invalid_die_size_step_up() -> None:
 
     with pytest.raises(ValueError, match="Invalid die size: 5"):
         step_up(5)
-    with pytest.raises(ValueError, match="Invalid die size: 100"):
-        step_up(100)
+    with pytest.raises(ValueError, match="Invalid die size: 99"):
+        step_up(99)
     with pytest.raises(ValueError, match="Invalid die size: 3"):
         step_up(3)
 
 
 def test_dice_ladder_constant_values() -> None:
     """Verify DICE_LADDER contains expected values."""
-    assert DICE_LADDER == [4, 6, 8, 10, 12, 20]
-    assert len(DICE_LADDER) == 6
+    assert DICE_LADDER == [4, 6, 8, 10, 12, 20, 30, 50, 100]
+    assert len(DICE_LADDER) == 9
     assert DICE_LADDER[0] == 4
-    assert DICE_LADDER[-1] == 20
+    assert DICE_LADDER[-1] == 100


### PR DESCRIPTION
Extends the dice ladder from d20 max to d100 to support users with large thread pools.

Changes:
- DICE_LADDER: [4, 6, 8, 10, 12, 20, 30, 50, 100]
- New geometry generators for d30, d50, d100
- Updated DiceSide type and validators
- Extended die selector UI

Fixes #492