### PR TITLE
feat: add theme selector (brown and blue themes) (#487)

### DIFF
--- a/frontend/src/components/ThemeSelector.tsx
+++ b/frontend/src/components/ThemeSelector.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react'
+
+const themes = ['brown', 'blue'] as const
+
+export default function ThemeSelector() {
+  const [theme, setTheme] = useState(() =>
+    localStorage.getItem('theme') || 'brown'
+  )
+
+  useEffect(() => {
+    document.body.setAttribute('data-theme', theme)
+    localStorage.setItem('theme', theme)
+  }, [theme])
+
+  return (
+    <select
+      value={theme}
+      onChange={(e) => setTheme(e.target.value)}
+      className="bg-white/5 border border-solid border-white/20 rounded-lg px-2 py-1 text-xs text-stone-300 transition-colors"
+    >
+      {themes.map((t) => (
+        <option key={t} value={t}>{t.charAt(0).toUpperCase() + t.slice(1)}</option>
+      ))}
+    </select>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,6 +1,20 @@
 @import "tailwindcss";
 @import "./styles.css";
 
+:root {
+  --theme-primary: #d6890e;
+  --theme-primary-light: #f0b429;
+  --theme-bg-dark: #110e0a;
+  --theme-bg-card: rgba(255, 255, 255, 0.05);
+}
+
+[data-theme="blue"] {
+  --theme-primary: #3b82f6;
+  --theme-primary-light: #60a5fa;
+  --theme-bg-dark: #0f172a;
+  --theme-bg-card: rgba(59, 130, 246, 0.1);
+}
+
 /* Strip problematic CSS during screenshot capture for Safari compatibility */
 .screenshot-mode [data-exclude-from-screenshot="true"] {
   display: none !important;

--- a/frontend/src/pages/QueuePage/QueuePage.tsx
+++ b/frontend/src/pages/QueuePage/QueuePage.tsx
@@ -9,6 +9,7 @@ import LoadingSpinner from '../../components/LoadingSpinner'
 import DependencyBuilder from '../../components/DependencyBuilder'
 import MigrationDialog from '../../components/MigrationDialog'
 import CollectionDialog from '../../components/CollectionDialog'
+import ThemeSelector from '../../components/ThemeSelector'
 import CollectionToolbar from '../../components/CollectionToolbar'
 import { useMoveToBack, useMoveToFront, useMoveToPosition, useShuffleQueue } from '../../hooks/useQueue'
 import { useCreateThread, useDeleteThread, useReactivateThread, useThreads, useUpdateThread } from '../../hooks/useThread'
@@ -535,6 +536,7 @@ export default function QueuePage() {
             >
               Add Thread
             </button>
+            <ThemeSelector />
           </div>
         </div>
         {collectionsEnabled && <CollectionToolbar onNewCollection={() => setIsCollectionDialogOpen(true)} />}

--- a/frontend/src/pages/RollPage/index.tsx
+++ b/frontend/src/pages/RollPage/index.tsx
@@ -5,6 +5,7 @@ import Modal from '../../components/Modal'
 import Tooltip from '../../components/Tooltip'
 import MigrationDialog from '../../components/MigrationDialog'
 import SimpleMigrationDialog from '../../components/SimpleMigrationDialog'
+import ThemeSelector from '../../components/ThemeSelector'
 import CollectionDialog from '../../components/CollectionDialog'
 import CollectionToolbar from '../../components/CollectionToolbar'
 import { useNavigate } from 'react-router-dom'
@@ -815,6 +816,7 @@ useEffect(() => {
               Override
             </button>
           </Tooltip>
+          <ThemeSelector />
         </div>
       </header>
       {collectionsEnabled && <CollectionToolbar onNewCollection={() => setIsCollectionDialogOpen(true)} />}


### PR DESCRIPTION
Adds a theme selector component with brown (default) and blue themes. Preference is stored in localStorage. Fixes #487

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a theme switcher in the app header so users can choose between light and blue themes.
  * Theme selection is saved automatically and restored on return.

* **Style**
  * Added theme-aware color styling for the supported visual themes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->