### PR TITLE
fix: stale threads now refresh after reading (#503)

### DIFF
--- a/frontend/src/hooks/useThread.ts
+++ b/frontend/src/hooks/useThread.ts
@@ -171,7 +171,21 @@ export function useStaleThreads(days?: number) {
     };
   }, [days]);
 
-  return { data, isPending, isError };
+  const refetch = useCallback(async () => {
+    setIsPending(true);
+    setIsError(false);
+
+    try {
+      const result = await threadsApi.listStale(days);
+      setData(result);
+    } catch {
+      setIsError(true);
+    } finally {
+      setIsPending(false);
+    }
+  }, [days]);
+
+  return { data, isPending, isError, refetch };
 }
 
 export function useCreateThread() {

--- a/frontend/src/pages/RollPage/index.tsx
+++ b/frontend/src/pages/RollPage/index.tsx
@@ -85,7 +85,7 @@ export default function RollPage() {
   const { activeCollectionId = null } = useCollections()
   const { setRestoreAction, clearRestoreAction } = useBugReportRestore()
   const { data: threads, refetch: refetchThreads } = useThreads('', collectionsEnabled ? activeCollectionId : null)
-  const { data: staleThreads } = useStaleThreads(7)
+  const { data: staleThreads, refetch: refetchStaleThreads } = useStaleThreads(7)
   const navigate = useNavigate()
 
   useEffect(() => {
@@ -223,10 +223,11 @@ export default function RollPage() {
 const handleMigrationComplete = useCallback((migratedThread: Thread) => {
   refetchThreads()
   refetchSession()
+  refetchStaleThreads()
   setShowMigrationDialog(false)
   setThreadToMigrate(null)
   enterRatingView(migratedThread.id, null, migratedThread)
-}, [refetchThreads, refetchSession, enterRatingView, setShowMigrationDialog, setThreadToMigrate])
+}, [refetchThreads, refetchSession, refetchStaleThreads, enterRatingView, setShowMigrationDialog, setThreadToMigrate])
 
 const handleMigrationSkip = useCallback(() => {
   setShowMigrationDialog(false)
@@ -254,11 +255,11 @@ const handleSimpleMigrationComplete = useCallback((issueNumber: string) => {
       setSelectedThreadId(null)
       setActiveRatingThread(null)
       setErrorMessage('')
-      Promise.allSettled([refetchSession(), refetchThreads()])
+      Promise.allSettled([refetchSession(), refetchThreads(), refetchStaleThreads()])
     }).catch((error: unknown) => {
       setErrorMessage(getApiErrorDetail(error) || 'Failed to save rating')
     })
-  }, [activeRatingThread, rating, rateMutation, refetchSession, refetchThreads, setShowSimpleMigration, suppressPendingAutoOpenRef, setIsRolling, setIsRatingView, setRolledResult, setSelectedThreadId, setActiveRatingThread, setErrorMessage])
+  }, [activeRatingThread, rating, rateMutation, refetchSession, refetchThreads, refetchStaleThreads, setShowSimpleMigration, suppressPendingAutoOpenRef, setIsRolling, setIsRatingView, setRolledResult, setSelectedThreadId, setActiveRatingThread, setErrorMessage])
 
   async function handleAction(action: string) {
     if (!selectedThread) return
@@ -511,7 +512,7 @@ useEffect(() => {
           issue_number: activeRatingThread?.issue_number || undefined,
         })
 
-        const refreshResults = await Promise.allSettled([refetchSession(), refetchThreads()])
+        const refreshResults = await Promise.allSettled([refetchSession(), refetchThreads(), refetchStaleThreads()])
         if (refreshResults[0].status === 'rejected' || refreshResults[1].status === 'rejected') {
           setErrorMessage('Rating saved but failed to refresh. Please refresh the page.')
           return
@@ -578,7 +579,7 @@ useEffect(() => {
       }
 
       // Refresh data
-      const refreshResults = await Promise.allSettled([refetchSession(), refetchThreads()])
+      const refreshResults = await Promise.allSettled([refetchSession(), refetchThreads(), refetchStaleThreads()])
       if (refreshResults[0].status === 'rejected' || refreshResults[1].status === 'rejected') {
         setErrorMessage('Rating saved but failed to refresh. Please refresh the page.')
         returnToRollView()


### PR DESCRIPTION
After reading an issue from a stale thread, the stale thread list now properly refreshes. Fixes #503