### PR TITLE
fix: prevent style leak when reporting bugs (#505)

### DIFF
--- a/frontend/src/components/BugReportButton.tsx
+++ b/frontend/src/components/BugReportButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import BugReportModal from './BugReportModal'
 import { useDiagnostics } from '../hooks/useDiagnostics'
 import type { DiagnosticData } from '../hooks/useDiagnostics'
@@ -18,8 +18,11 @@ export default function BugReportButton({ onSubmit, variant = 'floating' }: BugR
   const [screenshotDiagnostics, setScreenshotDiagnostics] = useState<ScreenshotDiagnostics | null>(null)
   const { collectDiagnostics } = useDiagnostics()
   const { restoreLastView } = useBugReportRestore()
+  const isCapturingRef = useRef(false)
 
   const handleClick = async () => {
+    if (isCapturingRef.current) return
+    isCapturingRef.current = true
     const diagnostics = collectDiagnostics()
     setDiagnosticData(diagnostics)
 
@@ -33,6 +36,7 @@ export default function BugReportButton({ onSubmit, variant = 'floating' }: BugR
       setScreenshotDiagnostics(null)
     } finally {
       setIsModalOpen(true)
+      isCapturingRef.current = false
     }
   }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -35,3 +35,11 @@
   from { transform: translateX(0); }
   to { transform: translateX(-50%); }
 }
+
+/* Force solid background on #root during screenshot to prevent transparency issues.
+   Must use CSS (not inline style) so that concurrent captureScreenshot calls don't
+   create a race condition where one call's prevBackground captures another call's
+   #111827 and restores to the wrong value. */
+.screenshot-mode #root {
+  background-color: #111827 !important;
+}

--- a/frontend/src/utils/captureScreenshot.ts
+++ b/frontend/src/utils/captureScreenshot.ts
@@ -253,12 +253,8 @@ export async function captureScreenshot(): Promise<{ blob: Blob | null; diagnost
   debugLog('Target', diagnostics.target)
   debugLog('Environment', diagnostics.environment)
 
-  // Add screenshot-mode class to strip problematic CSS
+  // Add screenshot-mode class to strip problematic CSS and set solid background
   document.documentElement.classList.add('screenshot-mode')
-
-  // Force solid background to prevent transparency issues
-  const prevBackground = target.style.backgroundColor
-  target.style.backgroundColor = '#111827'
 
   let overrideStyle: HTMLStyleElement | null = null
 
@@ -388,7 +384,6 @@ export async function captureScreenshot(): Promise<{ blob: Blob | null; diagnost
     return { blob: null, diagnostics }
   } finally {
     document.documentElement.classList.remove('screenshot-mode')
-    target.style.backgroundColor = prevBackground
     overrideStyle?.remove()
     debugLog('Cleaned up screenshot mode')
   }


### PR DESCRIPTION
Fixes style switch from brown to blue when reporting a bug. Uses CSS-based background instead of inline JS to prevent race conditions. Fixes #505