### PR TITLE
fix: address CodeRabbit feedback on theme selector (#537)

### DIFF
--- a/frontend/src/components/ThemeSelector.tsx
+++ b/frontend/src/components/ThemeSelector.tsx
@@ -1,11 +1,18 @@
 import { useEffect, useState } from 'react'
 
 const themes = ['brown', 'blue'] as const
+const DEFAULT_THEME = 'brown'
+
+function loadTheme(): string {
+  const stored = localStorage.getItem('theme')
+  if (stored && (themes as readonly string[]).includes(stored)) {
+    return stored
+  }
+  return DEFAULT_THEME
+}
 
 export default function ThemeSelector() {
-  const [theme, setTheme] = useState(() =>
-    localStorage.getItem('theme') || 'brown'
-  )
+  const [theme, setTheme] = useState(loadTheme)
 
   useEffect(() => {
     document.body.setAttribute('data-theme', theme)
@@ -16,6 +23,7 @@ export default function ThemeSelector() {
     <select
       value={theme}
       onChange={(e) => setTheme(e.target.value)}
+      aria-label="Theme"
       className="bg-white/5 border border-solid border-white/20 rounded-lg px-2 py-1 text-xs text-stone-300 transition-colors"
     >
       {themes.map((t) => (


### PR DESCRIPTION
Addresses CodeRabbit review comments from PR #537:

1. **Validate persisted theme** —  initializer now validates localStorage value against the themes list before accepting it, falling back to 'brown' for stale/unsupported values.
2. **Add aria-label** — Added `aria-label="Theme"` to the select element for accessibility.

Refs #537