### PR TITLE
Untrack dangling node_modules symlink

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/mnt/extra/josh/code/comic-pile/node_modules


### PR DESCRIPTION
Closes #554.

## Summary
Fixes the tracked, dangling `node_modules` symlink that pointed to a nonexistent Linux path (`/mnt/extra/josh/code/comic-pile/node_modules`), breaking the frontend toolchain on macOS/any host without that mount.

## Changes
- `git rm --cached node_modules` (removes the tracked symlink; `120000` mode).
- `node_modules/` remains in `.gitignore`.
- Verified a real `node_modules` materializes via `npm install`.

## Validation
- `git ls-files node_modules` → empty.
- `npm install` succeeds; `node_modules` is now a real directory, not a dangling symlink.
- `ruff check .` clean.
