### PR TITLE
Document API route versioning convention

### DIFF
--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -174,16 +174,17 @@
 
 ## Low Priority (Nice-to-Have Improvements)
 
-### 9. No API Versioning Strategy
-**Location:** All routes at `/api/` level (no version prefix)
-**Description:** No versioning (e.g., `/api/v1/`) on API routes
+### 9. Partial API Versioning (Documented Convention)
+**Location:** `app/main.py` router includes; `docs/API.md` (API Versioning)
+**Description:** Versioning is partially applied: newer resources (dependencies, collections, reviews, issues, reading-orders) are served under `/api/v1/*`, while legacy resources (threads, roll, queue, rate, snooze, undo, auth, admin, analytics, bug-reports, sessions) remain under `/api/*`. `/api/v1/sessions/*` is an explicit, tested backwards-compat alias of `/api/sessions/*` (issue #376, `tests/test_route_versioning.py`).
+**Status:** The convention is now **documented** (`docs/API.md` + a comment in `app/main.py`): new resources go under `/api/v1/*`; no new bare `/api/*` routes.
 **Why It's Debt:**
-- Breaking changes affect all clients
-- Can't maintain multiple API versions
-**Suggested Approach:**
-- Add version prefix to all API routes: `/api/v1/threads/`
-- Document versioning strategy
-**Estimated Effort:** 3-4 hours
+- Two surfaces remain; a single-version migration is not yet complete
+- Breaking changes to legacy resources still affect all clients on `/api/*`
+**Suggested Approach (deferred):**
+- Migrate remaining legacy resources onto `/api/v1/*` behind a coordinated frontend update
+- Keep `/api/*` as a deprecated alias during transition, then remove
+**Estimated Effort:** 6-10 hours (frontend + backend coordinated migration)
 
 ### 10. No Pagination on Most List Endpoints
 **Location:** Only `/sessions/` has pagination

--- a/app/main.py
+++ b/app/main.py
@@ -151,6 +151,18 @@ def create_app(*, serve_frontend: bool = True) -> FastAPI:
     # Global, HTTP, and validation exception handlers (environment-aware logging).
     register_exception_handlers(app, app_settings)
 
+    # API route prefix convention:
+    # - Legacy resources are served under /api/* (threads, roll, queue,
+    #   rate, snooze, undo, auth, admin, analytics, bug-reports, sessions).
+    # - Newer resources are served under the versioned /api/v1/* surface
+    #   (dependencies, collections, reviews, issues, reading-orders).
+    # - /api/v1/sessions/* is an explicit, tested backwards-compat alias of
+    #   /api/sessions/* (see tests/test_route_versioning.py, issue #376).
+    # - Non-production tooling routes (debug, test) are also mounted under
+    #   bare /api/* but only in non-production/test environments — they are
+    #   intentional exceptions to the versioning rule, not client APIs.
+    # Add new client resources under /api/v1/*; do not introduce new bare
+    # /api/* routes.
     app.include_router(roll.router, prefix="/api/roll", tags=["roll"])
     app.include_router(router, prefix="/api/v1/reviews", tags=["reviews"])
     app.include_router(admin.router, prefix="/api", tags=["admin"])

--- a/docs/API.md
+++ b/docs/API.md
@@ -16,6 +16,30 @@ FastAPI automatically generates interactive API documentation:
 
 ---
 
+## API Versioning
+
+The API uses a **partial versioning** strategy with two surfaces:
+
+- **`/api/*`** — the legacy surface, used by the original resources: threads,
+  roll, queue, rate, snooze, undo, auth, admin, analytics, bug-reports, and
+  sessions.
+- **`/api/v1/*`** — the versioned surface, used by newer resources:
+  dependencies, collections, reviews, issues, and reading-orders.
+
+`/api/v1/sessions/*` is an explicit, tested backwards-compatibility alias of
+`/api/sessions/*` (see `tests/test_route_versioning.py`, originally issue #376)
+so session consumers can transition onto the versioned surface without breaking
+existing clients.
+
+**Convention for new endpoints:** add new client resources under `/api/v1/*`;
+do not introduce new bare `/api/*` routes. Non-production tooling routes
+(`debug`, `test`) are mounted under bare `/api/*` but only in non-production or
+test environments — they are intentional exceptions, not client APIs.
+Migrating the remaining legacy resources onto `/api/v1/*` is tracked as
+deferred work (see `TECH_DEBT.md`).
+
+---
+
 ## Threads
 
 Thread CRUD operations and queue management.

--- a/tests/test_route_versioning.py
+++ b/tests/test_route_versioning.py
@@ -1,6 +1,14 @@
-"""Tests for API route versioning aliases (issue #376).
+"""Tests for the API route prefix convention and the sessions alias (issue #376).
 
-Ensures /api/v1/sessions/* endpoints behave identically to /api/sessions/*.
+The API exposes a legacy surface (/api/*) and a versioned surface (/api/v1/*).
+/api/v1/sessions/current/ is an explicit backwards-compat alias of
+/api/sessions/current/ so session consumers can use the versioned surface
+without behavior changes. See docs/API.md (API Versioning) and the convention
+comment in app/main.py.
+
+This test verifies the alias does not drift for the /sessions/current/
+endpoint: /api/v1/sessions/current/ must behave identically to
+/api/sessions/current/. Other session sub-paths are not yet parametrized here.
 """
 
 import pytest


### PR DESCRIPTION
Closes #558.

## Summary
Documents the API route prefix convention so the prefix is predictable (the actual least-concern issue), and corrects the misleading TECH_DEBT.md "No versioning" claim.

## Context
The frontend uses `/api/*` for legacy resources and `/api/v1/*` for newer ones (dependencies, collections, reviews, issues, reading-orders); `/api/v1/sessions/*` is an intentional, tested backwards-compat alias of `/api/sessions/*` (issue #376, `tests/test_route_versioning.py`). A full single-prefix migration is a large, coordinated frontend+backend effort and the alias is tested — so the responsible fix here is to document the convention rather than risk a blind migration.

## Changes
- `app/main.py`: convention comment above the router includes.
- `docs/API.md`: new "API Versioning" section.
- `TECH_DEBT.md`: corrected item #9 ("No API Versioning" → "Partial API Versioning (Documented Convention)").
- `tests/test_route_versioning.py`: expanded docstring referencing the documented convention.

## Validation
- `python -c "import app.main"` → ok.
- `tests/test_route_versioning.py`, `tests/test_session_api.py` → 19 passed.
- `ruff check .` clean.
