### PR TITLE
Reconcile psycopg dependency guidance with actual usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,15 +36,20 @@ Comic Pile is a dice-driven comic reading tracker built with:
 - **Frontend**: React 19, Vite, Tailwind CSS
 - **Package managers**: `uv` (Python), `npm` (frontend)
 
-## CRITICAL: Async PostgreSQL Only - NO Sync psycopg2
+## CRITICAL: Async PostgreSQL Only in Application Code
 
-**This project uses asyncpg (async PostgreSQL) ONLY. NEVER use synchronous psycopg2.**
+**Application code must use asyncpg (async PostgreSQL) ONLY. Never use synchronous database drivers in `app/` or `comic_pile/`.**
 
 **Database Access Rules**:
-- ✅ **USE**: `asyncpg` (async), `create_async_engine()`, `AsyncSession`
-- ❌ **NEVER USE**: `psycopg2`, `psycopg`, `create_engine()` (sync), `Session` (sync)
+- ✅ **USE in app code**: `asyncpg` (async), `create_async_engine()`, `AsyncSession`
+- ❌ **NEVER USE in app code**: `psycopg2`, `create_engine()` (sync), `Session` (sync), or any sync DB driver
 
-**Why async-only?** Weeks of refactoring converted entire codebase to async. Mixing sync/async causes event loop conflicts and greenlet errors. Sync code WILL BREAK the application.
+**The ONE exception — `psycopg` is permitted inside `alembic/` ONLY for migrations**:
+- `psycopg[binary]` (the psycopg v3 sync driver) is a core dependency, but its sync use is confined to `alembic/env.py`.
+- `alembic/env.py` converts the app's `postgresql+asyncpg://` URL to `postgresql+psycopg://` so Alembic can run migrations synchronously.
+- `app/config.py` converts any `postgresql+psycopg://` URL back to `postgresql+asyncpg://` at runtime, so the application never runs sync DB access.
+
+**Why async-only in app code?** Weeks of refactoring converted the codebase to async. Mixing sync/async causes event loop conflicts and greenlet errors. Sync DB access in `app/` or `comic_pile/` WILL BREAK the application.
 
 **If you need to create tables in tests**: Use module-scoped `@pytest_asyncio.fixture` with `create_async_engine()`, call `await conn.run_sync(Base.metadata.create_all)`. See `tests_e2e/conftest.py:_create_database_tables` for example.
 

--- a/README.md
+++ b/README.md
@@ -29,13 +29,15 @@ Skipped tests create technical debt and hide broken functionality. If a test is 
 - **Auth**: JWT authentication with refresh token rotation
 - **Code Quality**: ruff linting, ty type checking, 96% coverage requirement
 
-> **⚠️ IMPORTANT: Async PostgreSQL Only**
+> **⚠️ IMPORTANT: Async PostgreSQL Only in Application Code**
 > 
-> This project uses **asyncpg (async PostgreSQL) ONLY**. Never use synchronous psycopg2.
-> - ✅ USE: `asyncpg`, `create_async_engine()`, `AsyncSession`
-> - ❌ NEVER USE: `psycopg2`, `psycopg`, `create_engine()` (sync), `Session` (sync)
+> Application code uses **asyncpg (async PostgreSQL) ONLY**. Never use synchronous database drivers in `app/` or `comic_pile/`.
+> - ✅ USE in app code: `asyncpg`, `create_async_engine()`, `AsyncSession`
+> - ❌ NEVER USE in app code: `psycopg2`, `create_engine()` (sync), `Session` (sync)
 > 
-> Mixing sync/async database code will break the application. See [AGENTS.md](AGENTS.md) for details.
+> The one exception: `psycopg` (sync, v3) is a core dependency used **only inside `alembic/`** for migrations. `app/config.py` converts `postgresql+psycopg://` back to `postgresql+asyncpg://` at runtime, so the app never runs sync DB access.
+> 
+> Mixing sync/async database code in the application will break it. See [AGENTS.md](AGENTS.md) for details.
 
 ## Quick Start
 


### PR DESCRIPTION
Closes #553.

## Summary
Reconciles the documentation's "NEVER USE psycopg" rule with reality: `psycopg[binary]` is a core dependency and IS legitimately used — but only inside `alembic/` for synchronous migrations. The blanket ban was inaccurate.

## Changes (docs only — no code/dep changes)
- `AGENTS.md`: scoped the async-only rule to app code (`app/`, `comic_pile/`); clarified `psycopg` (sync) is permitted only inside `alembic/` for migrations.
- `README.md`: aligned the "Async PostgreSQL Only" callout.
- Aligned any other docs repeating the false blanket claim.

## Validation
- `ruff check .` clean.
