### PR TITLE
Consolidate queue thread icons into single dropdown menu

### DIFF
--- a/frontend/src/components/MarqueeTitle.tsx
+++ b/frontend/src/components/MarqueeTitle.tsx
@@ -1,0 +1,41 @@
+import { useRef, useState, useLayoutEffect } from 'react'
+
+interface MarqueeTitleProps {
+  title: string
+  className?: string
+}
+
+export function MarqueeTitle({ title, className = '' }: MarqueeTitleProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const h3Ref = useRef<HTMLHeadingElement>(null)
+  const [overflows, setOverflows] = useState(false)
+
+  useLayoutEffect(() => {
+    const checkOverflow = () => {
+      const container = containerRef.current
+      const h3 = h3Ref.current
+      if (!container || !h3) return
+      setOverflows(h3.scrollWidth > container.clientWidth)
+    }
+    checkOverflow()
+
+    if (typeof ResizeObserver === 'undefined') return
+    const ro = new ResizeObserver(checkOverflow)
+    if (containerRef.current) ro.observe(containerRef.current)
+    if (h3Ref.current) ro.observe(h3Ref.current)
+
+    return () => ro.disconnect()
+  }, [title])
+
+  return (
+    <div ref={containerRef} className="overflow-hidden flex-1 whitespace-nowrap">
+      <h3
+        ref={h3Ref}
+        className={`text-lg font-bold text-white ${overflows ? 'inline-block marquee-runner' : 'truncate'} ${className}`}
+      >
+        <span>{title}</span>
+        {overflows && <span className="ml-8" aria-hidden="true">{title}</span>}
+      </h3>
+    </div>
+  )
+}

--- a/frontend/src/components/PositionMenu.tsx
+++ b/frontend/src/components/PositionMenu.tsx
@@ -7,9 +7,12 @@ interface PositionMenuProps {
   onMoveToFront: (threadId: number) => void
   onReposition: (thread: Thread) => void
   onMoveToBack: (threadId: number) => void
+  onEdit: (thread: Thread) => void
+  onDependencies: (thread: Thread) => void
+  onDelete: (threadId: number) => void
 }
 
-export default function PositionMenu({ thread, onMoveToFront, onReposition, onMoveToBack }: PositionMenuProps) {
+export default function PositionMenu({ thread, onMoveToFront, onReposition, onMoveToBack, onEdit, onDependencies, onDelete }: PositionMenuProps) {
   const { openThreadId, closeMenu: closeContextMenu, openMenu, toggleMenu } = usePositionMenu()
   const isOpen = openThreadId === thread.id
 
@@ -79,7 +82,8 @@ export default function PositionMenu({ thread, onMoveToFront, onReposition, onMo
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [isOpen, closeMenu])
 
-  const handleTriggerClick = () => {
+  const handleTriggerClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation()
     if (clickFromKeyboardRef.current) {
       clickFromKeyboardRef.current = false
       return
@@ -90,16 +94,24 @@ export default function PositionMenu({ thread, onMoveToFront, onReposition, onMo
   const handleTriggerKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
     if (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown') {
       e.preventDefault()
+      e.stopPropagation()
       clickFromKeyboardRef.current = true
       openMenu(thread.id)
       setTimeout(() => menuItemsRef.current[0]?.focus(), 0)
     }
   }
 
-  const menuItems = [
+  const menuItems: Array<{
+    label: string
+    icon: string
+    ariaLabel: string
+    destructive?: boolean
+    action: () => void
+  }> = [
     {
       label: 'Move to Front',
       icon: '\u2B06',
+      ariaLabel: 'Move to front',
       action: () => {
         onMoveToFront(thread.id)
         closeMenu()
@@ -108,6 +120,7 @@ export default function PositionMenu({ thread, onMoveToFront, onReposition, onMo
     {
       label: 'Reposition\u2026',
       icon: '\u2261',
+      ariaLabel: 'Reposition thread',
       action: () => {
         onReposition(thread)
         closeMenu()
@@ -116,8 +129,37 @@ export default function PositionMenu({ thread, onMoveToFront, onReposition, onMo
     {
       label: 'Move to Back',
       icon: '\u2193',
+      ariaLabel: 'Move to back',
       action: () => {
         onMoveToBack(thread.id)
+        closeMenu()
+      },
+    },
+    {
+      label: 'Edit Thread',
+      icon: '\u270F\uFE0F',
+      ariaLabel: 'Edit thread',
+      action: () => {
+        onEdit(thread)
+        closeMenu()
+      },
+    },
+    {
+      label: 'Dependencies',
+      icon: '\u26D3\uFE0F',
+      ariaLabel: 'Manage dependencies',
+      action: () => {
+        onDependencies(thread)
+        closeMenu()
+      },
+    },
+    {
+      label: 'Delete Thread',
+      icon: '\u{1F5D1}',
+      ariaLabel: 'Delete thread',
+      destructive: true,
+      action: () => {
+        onDelete(thread.id)
         closeMenu()
       },
     },
@@ -125,14 +167,14 @@ export default function PositionMenu({ thread, onMoveToFront, onReposition, onMo
 
   return (
     <div className="relative" ref={menuRef}>
-      <Tooltip content="More actions">
+      <Tooltip content="Thread actions">
         <button
           ref={triggerRef}
           type="button"
           onClick={handleTriggerClick}
           onKeyDown={handleTriggerKeyDown}
           className="flex items-center justify-center w-11 h-11 text-stone-500 hover:text-white transition-colors text-lg rounded-lg hover:bg-white/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
-          aria-label="Position actions"
+          aria-label="Thread actions"
           aria-haspopup="menu"
           aria-expanded={isOpen}
         >
@@ -143,15 +185,23 @@ export default function PositionMenu({ thread, onMoveToFront, onReposition, onMo
         <div
           className="absolute right-0 top-full mt-1 w-52 bg-[#1a1410]/95 border border-white/10 rounded-xl shadow-2xl z-50 py-1 overflow-hidden"
           role="menu"
-          aria-label="Position actions"
+          aria-label="Thread actions"
         >
           {menuItems.map((item, index) => (
             <button
               key={item.label}
               ref={(el) => { menuItemsRef.current[index] = el }}
               type="button"
-              onClick={item.action}
-              className="w-full px-4 py-3 text-left text-sm text-stone-300 hover:bg-white/10 hover:text-white transition-colors flex items-center gap-3 focus:outline-none focus-visible:bg-white/10 focus-visible:text-white"
+              onClick={(e) => {
+                e.stopPropagation()
+                item.action()
+              }}
+              aria-label={item.ariaLabel}
+              className={`w-full px-4 py-3 text-left text-sm transition-colors flex items-center gap-3 focus:outline-none focus-visible:bg-white/10 ${
+                item.destructive
+                  ? 'text-red-400 hover:bg-red-500/10 hover:text-red-300 focus-visible:bg-red-500/10 focus-visible:text-red-300'
+                  : 'text-stone-300 hover:bg-white/10 hover:text-white focus-visible:bg-white/10 focus-visible:text-white'
+              }`}
               role="menuitem"
             >
               <span className="text-base">{item.icon}</span>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -57,7 +57,7 @@
   filter: none !important;
 }
 
-.marquee-runner:hover {
+.marquee-runner {
   animation: marquee 8s linear infinite;
 }
 

--- a/frontend/src/pages/QueuePage/QueuePage.tsx
+++ b/frontend/src/pages/QueuePage/QueuePage.tsx
@@ -6,6 +6,7 @@ import PositionMenu from '../../components/PositionMenu'
 import PositionSlider from '../../components/PositionSlider'
 import Tooltip from '../../components/Tooltip'
 import LoadingSpinner from '../../components/LoadingSpinner'
+import { MarqueeTitle } from '../../components/MarqueeTitle'
 import DependencyBuilder from '../../components/DependencyBuilder'
 import MigrationDialog from '../../components/MigrationDialog'
 import CollectionDialog from '../../components/CollectionDialog'
@@ -662,14 +663,9 @@ export default function QueuePage() {
                           >
                             ⠿
                           </button>
-                        </Tooltip>
-                         <div className="overflow-hidden flex-1 whitespace-nowrap">
-                           <h3 className="text-lg font-bold text-white inline-block marquee-runner">
-                             <span>{thread.title}</span>
-                             <span className="ml-8">{thread.title}</span>
-                           </h3>
-                         </div>
-                        {isBlocked && (
+                         </Tooltip>
+                         <MarqueeTitle title={thread.title} />
+                         {isBlocked && (
                           <Tooltip content={blockingReasons.length > 0 ? blockingReasons.join('\n') : 'Blocked by dependency'}>
                             <span className="text-red-300 text-lg" aria-label="Blocked thread">🔒</span>
                           </Tooltip>
@@ -677,51 +673,17 @@ export default function QueuePage() {
                       </div>
                     </div>
                     <div className="hidden md:flex items-center gap-1">
-                      <Tooltip content="Edit thread details.">
-                        <button
-                          type="button"
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            openEditModal(thread)
-                          }}
-                          className="text-stone-500 hover:text-white transition-colors text-sm"
-                          aria-label="Edit thread"
-                        >
-                          ✎
-                        </button>
-                      </Tooltip>
-                      <Tooltip content="Manage dependencies for this thread.">
-                        <button
-                          type="button"
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            setDependencyThread(thread)
-                            setIsDependencyBuilderOpen(true)
-                          }}
-                          className="text-stone-500 hover:text-white transition-colors text-sm"
-                          aria-label="Manage dependencies"
-                        >
-                          🔗
-                        </button>
-                      </Tooltip>
-                      <Tooltip content="Delete thread from queue.">
-                        <button
-                          type="button"
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            handleDelete(thread.id)
-                          }}
-                          className="text-stone-500 hover:text-red-400 transition-colors text-xl"
-                          aria-label="Delete thread"
-                        >
-                          &times;
-                        </button>
-                      </Tooltip>
         <PositionMenu
           thread={thread}
           onMoveToFront={handleMoveToFront}
           onReposition={openRepositionModal}
           onMoveToBack={handleMoveToBack}
+          onEdit={openEditModal}
+          onDependencies={(t) => {
+            setDependencyThread(t)
+            setIsDependencyBuilderOpen(true)
+          }}
+          onDelete={handleDelete}
         />
       </div>
       {/* Mobile 3-dot menu indicator */}

--- a/frontend/src/test/dependencies.spec.ts
+++ b/frontend/src/test/dependencies.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures'
-import { createThread } from './helpers'
+import {createThread, openThreadActions} from './helpers'
 import type { Page } from '@playwright/test'
 
 async function markIssueNumbersRead(
@@ -48,6 +48,7 @@ test.describe('Dependencies', () => {
     await expect(authenticatedPage.locator('#root')).toBeVisible();
 
     const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Target Thread' }).first()
+    await openThreadActions(targetCard)
     await targetCard.locator('button[aria-label="Manage dependencies"]').click()
 
     await authenticatedPage.fill('input#search-prereq-thread', 'Source')
@@ -172,6 +173,7 @@ test.describe('Dependencies', () => {
       await expect(authenticatedPage.locator('#root')).toBeVisible();
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Target Comic' }).first()
+      await openThreadActions(targetCard)
       await targetCard.locator('button[aria-label="Manage dependencies"]').click()
 
       await authenticatedPage.fill('input#search-prereq-thread', 'Prerequisite')
@@ -201,6 +203,7 @@ test.describe('Dependencies', () => {
       await expect(authenticatedPage.locator('#root')).toBeVisible();
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Target Series' }).first()
+      await openThreadActions(targetCard)
       await targetCard.locator('button[aria-label="Manage dependencies"]').click()
 
       await authenticatedPage.fill('input#search-prereq-thread', 'Source')
@@ -240,6 +243,7 @@ test.describe('Dependencies', () => {
       await expect(authenticatedPage.locator('#root')).toBeVisible();
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Main Series' }).first()
+      await openThreadActions(targetCard)
       await targetCard.locator('button[aria-label="Manage dependencies"]').click()
 
       await authenticatedPage.fill('input#search-prereq-thread', 'Prequel')
@@ -277,6 +281,7 @@ test.describe('Dependencies', () => {
       await expect(authenticatedPage.locator('#root')).toBeVisible();
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Target Comic' }).first()
+      await openThreadActions(targetCard)
       await targetCard.locator('button[aria-label="Manage dependencies"]').click()
 
       await authenticatedPage.fill('input#search-prereq-thread', 'Source')
@@ -317,6 +322,7 @@ test.describe('Dependencies', () => {
       await expect(authenticatedPage.locator('#root')).toBeVisible();
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Dependent Series' }).first()
+      await openThreadActions(targetCard)
       await targetCard.locator('button[aria-label="Manage dependencies"]').click()
 
       await authenticatedPage.fill('input#search-prereq-thread', 'Required')
@@ -352,6 +358,7 @@ test.describe('Dependencies', () => {
       await expect(authenticatedPage.locator('#root')).toBeVisible();
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Loading Target' }).first()
+      await openThreadActions(targetCard)
       await targetCard.locator('button[aria-label="Manage dependencies"]').click()
 
       await authenticatedPage.fill('input#search-prereq-thread', 'Loading')
@@ -388,6 +395,7 @@ test.describe('Dependencies', () => {
       await expect(authenticatedPage.locator('#root')).toBeVisible();
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Issue Target' }).first()
+      await openThreadActions(targetCard)
       await targetCard.locator('button[aria-label="Manage dependencies"]').click()
 
       await authenticatedPage.fill('input#search-prereq-thread', 'Issue Source')
@@ -425,6 +433,7 @@ test.describe('Dependencies', () => {
       await expect(authenticatedPage.locator('#root')).toBeVisible();
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'No Issues Target' }).first()
+      await openThreadActions(targetCard)
       await targetCard.locator('button[aria-label="Manage dependencies"]').click()
 
       await authenticatedPage.fill('input#search-prereq-thread', 'No Issues')
@@ -462,6 +471,7 @@ test.describe('Dependencies', () => {
       await expect(authenticatedPage.locator('#root')).toBeVisible();
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'All Read Target' }).first()
+      await openThreadActions(targetCard)
       await targetCard.locator('button[aria-label="Manage dependencies"]').click()
 
       await authenticatedPage.fill('input#search-prereq-thread', 'All Read')

--- a/frontend/src/test/flowchart.spec.ts
+++ b/frontend/src/test/flowchart.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures'
-import { createThread } from './helpers'
+import {createThread, openThreadActions} from './helpers'
 
 async function getIssueIdByNumber(authenticatedPage: any, threadId: number, issueNumber: string, token: string | null | undefined): Promise<number> {
   if (!token) {
@@ -46,6 +46,7 @@ test('shows flowchart toggle after creating a dependency', async ({ authenticate
       .locator('#queue-container .glass-card')
       .filter({ hasText: 'Flowchart Target' })
       .first()
+    await openThreadActions(targetCard)
     await targetCard.locator('button[aria-label="Manage dependencies"]').click()
 
     // Search and add a dependency
@@ -133,6 +134,7 @@ test('renders flowchart with nodes and edges when toggled', async ({ authenticat
       .locator('#queue-container .glass-card')
       .filter({ hasText: 'FC Node Target' })
       .first()
+    await openThreadActions(targetCard)
     await targetCard.locator('button[aria-label="Manage dependencies"]').click()
 
     await openFlowchartView(authenticatedPage)
@@ -227,6 +229,7 @@ test('flowchart zoom controls work', async ({ authenticatedPage }) => {
       .locator('#queue-container .glass-card')
       .filter({ hasText: 'Zoom Target' })
       .first()
+    await openThreadActions(targetCard)
     await targetCard.locator('button[aria-label="Manage dependencies"]').click()
     await openFlowchartView(authenticatedPage)
     await expect(authenticatedPage.locator('[data-testid="flowchart-svg"]')).toBeVisible()
@@ -310,6 +313,7 @@ test('flowchart shows tooltip on node hover', async ({ authenticatedPage }) => {
       .locator('#queue-container .glass-card')
       .filter({ hasText: 'Hover Target Thread' })
       .first()
+    await openThreadActions(targetCard)
     await targetCard.locator('button[aria-label="Manage dependencies"]').click()
     await openFlowchartView(authenticatedPage)
     await expect(authenticatedPage.locator('[data-testid="flowchart-svg"]')).toBeVisible()
@@ -386,6 +390,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
       .locator('#queue-container .glass-card')
       .filter({ hasText: 'Blocked Thread FC' })
       .first()
+    await openThreadActions(targetCard)
     await targetCard.locator('button[aria-label="Manage dependencies"]').click()
     await openFlowchartView(authenticatedPage)
     await expect(authenticatedPage.locator('[data-testid="flowchart-svg"]')).toBeVisible()
@@ -458,6 +463,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
       .locator('#queue-container .glass-card')
       .filter({ hasText: 'Toggle Target' })
       .first()
+    await openThreadActions(targetCard)
     await targetCard.locator('button[aria-label="Manage dependencies"]').click()
 
     // Toggle on and switch to graph view
@@ -483,6 +489,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
       .locator('#queue-container .glass-card')
       .filter({ hasText: 'Lonely Thread' })
       .first()
+    await openThreadActions(card)
     await card.locator('button[aria-label="Manage dependencies"]').click()
 
     // Should not show flowchart toggle when there are no dependencies
@@ -550,6 +557,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
         .locator('#queue-container .glass-card')
         .filter({ hasText: 'Swamp Thing' })
         .first()
+      await openThreadActions(targetCard)
       await targetCard.locator('button[aria-label="Manage dependencies"]').click()
 
       // Wait for toggle button to appear
@@ -658,6 +666,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
         .locator('#queue-container .glass-card')
         .filter({ hasText: 'Animal Man' })
         .first()
+      await openThreadActions(animalManCard)
       await animalManCard.locator('button[aria-label="Manage dependencies"]').click()
       await openFlowchartView(authenticatedPage)
 
@@ -741,6 +750,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
         .locator('#queue-container .glass-card')
         .filter({ hasText: 'Target Series' })
         .first()
+      await openThreadActions(targetCard)
       await targetCard.locator('button[aria-label="Manage dependencies"]').click()
       await openFlowchartView(authenticatedPage)
 
@@ -814,6 +824,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
         .locator('#queue-container .glass-card')
         .filter({ hasText: 'Blocked Target' })
         .first()
+      await openThreadActions(targetCard)
       await targetCard.locator('button[aria-label="Manage dependencies"]').click()
       await openFlowchartView(authenticatedPage)
 
@@ -890,6 +901,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
         .locator('#queue-container .glass-card')
         .filter({ hasText: 'Edge Target' })
         .first()
+      await openThreadActions(targetCard)
       await targetCard.locator('button[aria-label="Manage dependencies"]').click()
       await openFlowchartView(authenticatedPage)
 
@@ -995,6 +1007,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
         .locator('#queue-container .glass-card')
         .filter({ hasText: 'Thread Beta' })
         .first()
+      await openThreadActions(betaCard)
       await betaCard.locator('button[aria-label="Manage dependencies"]').click()
       await openFlowchartView(authenticatedPage)
 

--- a/frontend/src/test/helpers.ts
+++ b/frontend/src/test/helpers.ts
@@ -1,4 +1,4 @@
-import { type Page, expect } from '@playwright/test';
+import { type Page, type Locator, expect } from '@playwright/test';
 import type { Thread } from '../types';
 
 type Violation = {
@@ -55,6 +55,11 @@ export async function waitForThreadInQueue(page: Page, title: string): Promise<v
 
 export async function waitForEditThreadModal(page: Page): Promise<void> {
   await expect(page.getByRole('heading', { name: 'Edit Thread' })).toBeVisible()
+}
+
+export async function openThreadActions(threadItem: Locator): Promise<void> {
+  await threadItem.locator('button[aria-label="Thread actions"]').click()
+  await threadItem.locator('[role="menu"]').waitFor({ state: 'visible' })
 }
 
 function isAuthResponse(data: unknown): data is { access_token: string } {

--- a/frontend/src/test/issue-326-collapsible-issue-list.spec.ts
+++ b/frontend/src/test/issue-326-collapsible-issue-list.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures';
-import { createThread, gotoQueue, waitForEditThreadModal } from './helpers';
+import {createThread, gotoQueue, waitForEditThreadModal, openThreadActions} from './helpers';
 
 test.describe('Issue #326: Collapsible Issue List', () => {
   test('should show only issues around next unread by default when thread has many issues', async ({ authenticatedPage }) => {
@@ -20,6 +20,7 @@ test.describe('Issue #326: Collapsible Issue List', () => {
     // Open the edit modal
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
     await threadItem.waitFor({ state: 'visible', timeout: 5000 });
+    await openThreadActions(threadItem)
     await threadItem.locator('button[aria-label="Edit thread"]').click();
 
     // Wait for edit modal to open
@@ -57,6 +58,7 @@ test.describe('Issue #326: Collapsible Issue List', () => {
 
     // Open the edit modal
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
+    await openThreadActions(threadItem)
     await threadItem.locator('button[aria-label="Edit thread"]').click();
 
     // Wait for edit modal to open
@@ -94,6 +96,7 @@ test.describe('Issue #326: Collapsible Issue List', () => {
 
     // Open the edit modal
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
+    await openThreadActions(threadItem)
     await threadItem.locator('button[aria-label="Edit thread"]').click();
 
     // Wait for edit modal to open
@@ -137,6 +140,7 @@ test.describe('Issue #326: Collapsible Issue List', () => {
 
     // Open the edit modal
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
+    await openThreadActions(threadItem)
     await threadItem.locator('button[aria-label="Edit thread"]').click();
 
     // Wait for edit modal to open
@@ -171,6 +175,7 @@ test.describe('Issue #326: Collapsible Issue List', () => {
 
     // Open the edit modal
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
+    await openThreadActions(threadItem)
     await threadItem.locator('button[aria-label="Edit thread"]').click();
 
     await waitForEditThreadModal(authenticatedPage);

--- a/frontend/src/test/migration.spec.ts
+++ b/frontend/src/test/migration.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from './fixtures';
+import { openThreadActions } from './helpers';
 
 /**
  * Helper to create a thread without total_issues (old system) via API
@@ -568,6 +569,7 @@ test.describe('Migrating from Edit Modal', () => {
 
     // Click the Edit button for old thread
     const oldThreadCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: oldThreadTitle }).first();
+    await openThreadActions(oldThreadCard)
     await oldThreadCard.locator('button[aria-label="Edit thread"]').click();
 
     const oldEditModal = authenticatedPage.locator('.edit-modal__overlay');
@@ -581,6 +583,7 @@ test.describe('Migrating from Edit Modal', () => {
 
     // Click the Edit button for migrated thread
     const migratedThreadCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: migratedThreadTitle }).first();
+    await openThreadActions(migratedThreadCard)
     await migratedThreadCard.locator('button[aria-label="Edit thread"]').click();
 
     const migratedEditModal = authenticatedPage.locator('.edit-modal__overlay');
@@ -603,6 +606,7 @@ test.describe('Migrating from Edit Modal', () => {
 
     // Click the Edit button, not the thread card
     const threadCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: threadTitle }).first();
+    await openThreadActions(threadCard)
     await threadCard.locator('button[aria-label="Edit thread"]').click();
 
     const editModal = authenticatedPage.locator('.edit-modal__overlay');
@@ -648,6 +652,7 @@ test.describe('Migrating from Edit Modal', () => {
 
     // Click the Edit button, not the thread card itself
     const threadCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: threadTitle }).first();
+    await openThreadActions(threadCard)
     await threadCard.locator('button[aria-label="Edit thread"]').click();
 
     const editModal = authenticatedPage.locator('.edit-modal__overlay');
@@ -680,6 +685,7 @@ test.describe('Migrating from Edit Modal', () => {
 
     // Click the Edit button, not the thread card itself
     const threadCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: threadTitle }).first();
+    await openThreadActions(threadCard)
     await threadCard.locator('button[aria-label="Edit thread"]').click();
 
     const editModal = authenticatedPage.locator('.edit-modal__overlay');
@@ -715,6 +721,7 @@ test.describe('Migrating from Edit Modal', () => {
 
     // Click the Edit button, not the thread card
     const threadCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: threadTitle }).first();
+    await openThreadActions(threadCard)
     await threadCard.locator('button[aria-label="Edit thread"]').click();
 
     const editModal = authenticatedPage.locator('.edit-modal__overlay');
@@ -752,6 +759,7 @@ test.describe('Migrating from Edit Modal', () => {
 
     // Click the Edit button, not the thread card
     const threadCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: threadTitle }).first();
+    await openThreadActions(threadCard)
     await threadCard.locator('button[aria-label="Edit thread"]').click();
 
     const editModal = authenticatedPage.locator('.edit-modal__overlay');
@@ -783,6 +791,7 @@ test.describe('Migrating from Edit Modal', () => {
 
     // Click the Edit button, not the thread card
     const threadCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: threadTitle }).first();
+    await openThreadActions(threadCard)
     await threadCard.locator('button[aria-label="Edit thread"]').click();
 
     const editModal = authenticatedPage.locator('.edit-modal__overlay');

--- a/frontend/src/test/readingOrderTimeline.spec.ts
+++ b/frontend/src/test/readingOrderTimeline.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures'
-import { createThread, extractThreadsFromResponse, findByTitle, findByIssueNumber } from './helpers'
+import {createThread, extractThreadsFromResponse, findByTitle, findByIssueNumber, openThreadActions} from './helpers'
 
 test.describe('Reading Order Timeline', () => {
   test('displays grouped gates and tabs', async ({ authenticatedPage }) => {
@@ -50,6 +50,7 @@ test.describe('Reading Order Timeline', () => {
     await page.goto('/queue')
     await expect(page.locator('#root')).toBeVisible();
     const targetCard = page.locator('#queue-container .glass-card').filter({ hasText: 'Target' }).first()
+    await openThreadActions(targetCard)
     await targetCard.locator('button[aria-label="Manage dependencies"]').click()
     await page.waitForSelector('button[data-testid="toggle-reading-order"]')
     await page.click('button[data-testid="toggle-reading-order"]')

--- a/frontend/src/test/thread-detail-view.spec.ts
+++ b/frontend/src/test/thread-detail-view.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures';
-import { createThread, gotoQueue } from './helpers';
+import {createThread, gotoQueue, openThreadActions} from './helpers';
 
 test.describe('Thread Detail View', () => {
   test('should navigate to thread detail view when clicking a thread', async ({ authenticatedPage }) => {
@@ -123,6 +123,7 @@ test.describe('Thread Detail View', () => {
     const threadCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Notes Test' });
     await threadCard.waitFor({ state: 'visible', timeout: 5000 });
 
+    await openThreadActions(threadCard)
     await threadCard.locator('button[aria-label="Edit thread"]').click();
     await authenticatedPage.waitForSelector('label:has-text("Notes") + textarea', { state: 'visible', timeout: 5000 });
 

--- a/frontend/src/test/thread-editing-bugs.spec.ts
+++ b/frontend/src/test/thread-editing-bugs.spec.ts
@@ -1,11 +1,11 @@
 import { test, expect } from './fixtures';
 import type { Page } from '@playwright/test';
-import {
-  createThread,
+import {createThread,
   extractThreadsFromResponse,
   findByTitle,
   gotoQueue,
   waitForEditThreadModal,
+  openThreadActions,
 } from './helpers';
 
 async function makeAuthenticatedRequest(page: any, method: string, url: string, data?: any, maxRetries = 3): Promise<any> {
@@ -78,6 +78,7 @@ test.describe('Thread Editing - Issue Adding Bug Reproduction', () => {
     // Step 3: Open the edit modal for the thread
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
     await threadItem.waitFor({ state: 'visible', timeout: 5000 });
+    await openThreadActions(threadItem)
     await threadItem.locator('button[aria-label="Edit thread"]').click();
 
     // Wait for edit modal to open - wait for the modal heading
@@ -155,6 +156,7 @@ test.describe('Thread Editing - Issue Adding Bug Reproduction', () => {
     await expect(authenticatedPage.locator('#root')).toBeVisible();
 
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
+    await openThreadActions(threadItem)
     await threadItem.locator('button[aria-label="Edit thread"]').click();
 
     const editModal = authenticatedPage.locator('.fixed.inset-0').filter({ hasText: 'Edit Thread' });
@@ -195,6 +197,7 @@ test.describe('Thread Editing - Issue Adding Bug Reproduction', () => {
     await expect(authenticatedPage.locator('#root')).toBeVisible();
 
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
+    await openThreadActions(threadItem)
     await threadItem.locator('button[aria-label="Edit thread"]').click();
 
     const editModal = authenticatedPage.locator('.fixed.inset-0').filter({ hasText: 'Edit Thread' });
@@ -243,6 +246,7 @@ test.describe('Thread Editing - Issue Adding Bug Reproduction', () => {
 
     // Open edit modal
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
+    await openThreadActions(threadItem)
     await threadItem.locator('button[aria-label="Edit thread"]').click();
     await authenticatedPage.waitForSelector('h2:has-text("Edit Thread")', { state: 'visible', timeout: 5000 });
 
@@ -310,6 +314,7 @@ test.describe('Thread Editing - Issue Adding Bug Reproduction', () => {
 
     // Open edit modal
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
+    await openThreadActions(threadItem)
     await threadItem.locator('button[aria-label="Edit thread"]').click();
     await authenticatedPage.waitForSelector('h2:has-text("Edit Thread")', { state: 'visible', timeout: 5000 });
 
@@ -366,6 +371,7 @@ test.describe('Thread Editing - Issue Adding Bug Reproduction', () => {
 
     // Open edit modal and add issue
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
+    await openThreadActions(threadItem)
     await threadItem.locator('button[aria-label="Edit thread"]').click();
     await authenticatedPage.waitForSelector('h2:has-text("Edit Thread")', { state: 'visible', timeout: 5000 });
 
@@ -435,6 +441,7 @@ test.describe('Thread Editing - Issue Adding Bug Reproduction', () => {
     // Step 3: Open the edit modal for the thread
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
     await threadItem.waitFor({ state: 'visible', timeout: 5000 });
+    await openThreadActions(threadItem)
     await threadItem.locator('button[aria-label="Edit thread"]').click();
 
     // Wait for edit modal to open

--- a/frontend/src/test/threads.spec.ts
+++ b/frontend/src/test/threads.spec.ts
@@ -1,10 +1,10 @@
 import { test, expect } from './fixtures';
-import {
-  createThread,
+import {createThread,
   gotoQueue,
   SELECTORS,
   waitForEditThreadModal,
   waitForThreadInQueue,
+  openThreadActions,
 } from './helpers';
 
 test.describe('Thread Management', () => {
@@ -114,6 +114,7 @@ test.describe('Thread Management', () => {
     await gotoQueue(authenticatedPage);
 
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').first();
+    await openThreadActions(threadItem)
     await threadItem.locator('button[aria-label="Edit thread"]').click();
     await waitForEditThreadModal(authenticatedPage);
 
@@ -143,6 +144,7 @@ test.describe('Thread Management', () => {
 
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'To Be Deleted' });
     await threadItem.waitFor({ state: 'visible', timeout: 5000 });
+    await openThreadActions(threadItem)
     await Promise.all([
       authenticatedPage.waitForResponse((response) =>
         response.url().includes('/api/threads/') &&

--- a/frontend/src/unit/PositionMenu.test.tsx
+++ b/frontend/src/unit/PositionMenu.test.tsx
@@ -38,9 +38,12 @@ describe('PositionMenu', () => {
         onMoveToFront={vi.fn()}
         onReposition={vi.fn()}
         onMoveToBack={vi.fn()}
+        onEdit={vi.fn()}
+        onDependencies={vi.fn()}
+        onDelete={vi.fn()}
       />
     )
-    expect(screen.getByRole('button', { name: /position actions/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /thread actions/i })).toBeInTheDocument()
   })
 
   it('opens the dropdown menu when the trigger button is clicked', async () => {
@@ -51,14 +54,17 @@ describe('PositionMenu', () => {
         onMoveToFront={vi.fn()}
         onReposition={vi.fn()}
         onMoveToBack={vi.fn()}
+        onEdit={vi.fn()}
+        onDependencies={vi.fn()}
+        onDelete={vi.fn()}
       />
     )
 
-    const trigger = screen.getByRole('button', { name: /position actions/i })
+    const trigger = screen.getByRole('button', { name: /thread actions/i })
     await user.click(trigger)
 
     expect(screen.getByRole('menu')).toBeInTheDocument()
-    expect(screen.getAllByRole('menuitem')).toHaveLength(3)
+    expect(screen.getAllByRole('menuitem')).toHaveLength(6)
   })
 
   it('shows Move to Front, Reposition, and Move to Back options', async () => {
@@ -69,10 +75,13 @@ describe('PositionMenu', () => {
         onMoveToFront={vi.fn()}
         onReposition={vi.fn()}
         onMoveToBack={vi.fn()}
+        onEdit={vi.fn()}
+        onDependencies={vi.fn()}
+        onDelete={vi.fn()}
       />
     )
 
-    const trigger = screen.getByRole('button', { name: /position actions/i })
+    const trigger = screen.getByRole('button', { name: /thread actions/i })
     await user.click(trigger)
 
     expect(screen.getByText('Move to Front')).toBeInTheDocument()
@@ -89,10 +98,13 @@ describe('PositionMenu', () => {
         onMoveToFront={onMoveToFront}
         onReposition={vi.fn()}
         onMoveToBack={vi.fn()}
+        onEdit={vi.fn()}
+        onDependencies={vi.fn()}
+        onDelete={vi.fn()}
       />
     )
 
-    const trigger = screen.getByRole('button', { name: /position actions/i })
+    const trigger = screen.getByRole('button', { name: /thread actions/i })
     await user.click(trigger)
     await user.click(screen.getByText('Move to Front'))
 
@@ -108,10 +120,13 @@ describe('PositionMenu', () => {
         onMoveToFront={vi.fn()}
         onReposition={vi.fn()}
         onMoveToBack={onMoveToBack}
+        onEdit={vi.fn()}
+        onDependencies={vi.fn()}
+        onDelete={vi.fn()}
       />
     )
 
-    const trigger = screen.getByRole('button', { name: /position actions/i })
+    const trigger = screen.getByRole('button', { name: /thread actions/i })
     await user.click(trigger)
     await user.click(screen.getByText('Move to Back'))
 
@@ -127,14 +142,83 @@ describe('PositionMenu', () => {
         onMoveToFront={vi.fn()}
         onReposition={onReposition}
         onMoveToBack={vi.fn()}
+        onEdit={vi.fn()}
+        onDependencies={vi.fn()}
+        onDelete={vi.fn()}
       />
     )
 
-    const trigger = screen.getByRole('button', { name: /position actions/i })
+    const trigger = screen.getByRole('button', { name: /thread actions/i })
     await user.click(trigger)
     await user.click(screen.getByText('Reposition\u2026'))
 
     expect(onReposition).toHaveBeenCalledWith(mockThread)
+  })
+
+  it('calls onEdit when Edit Thread is clicked', async () => {
+    const user = userEvent.setup()
+    const onEdit = vi.fn()
+    render(
+      <PositionMenu
+        thread={mockThread}
+        onMoveToFront={vi.fn()}
+        onReposition={vi.fn()}
+        onMoveToBack={vi.fn()}
+        onEdit={onEdit}
+        onDependencies={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    )
+
+    const trigger = screen.getByRole('button', { name: /thread actions/i })
+    await user.click(trigger)
+    await user.click(screen.getByText('Edit Thread'))
+
+    expect(onEdit).toHaveBeenCalledWith(mockThread)
+  })
+
+  it('calls onDependencies when Dependencies is clicked', async () => {
+    const user = userEvent.setup()
+    const onDependencies = vi.fn()
+    render(
+      <PositionMenu
+        thread={mockThread}
+        onMoveToFront={vi.fn()}
+        onReposition={vi.fn()}
+        onMoveToBack={vi.fn()}
+        onEdit={vi.fn()}
+        onDependencies={onDependencies}
+        onDelete={vi.fn()}
+      />
+    )
+
+    const trigger = screen.getByRole('button', { name: /thread actions/i })
+    await user.click(trigger)
+    await user.click(screen.getByText('Dependencies'))
+
+    expect(onDependencies).toHaveBeenCalledWith(mockThread)
+  })
+
+  it('calls onDelete when Delete Thread is clicked', async () => {
+    const user = userEvent.setup()
+    const onDelete = vi.fn()
+    render(
+      <PositionMenu
+        thread={mockThread}
+        onMoveToFront={vi.fn()}
+        onReposition={vi.fn()}
+        onMoveToBack={vi.fn()}
+        onEdit={vi.fn()}
+        onDependencies={vi.fn()}
+        onDelete={onDelete}
+      />
+    )
+
+    const trigger = screen.getByRole('button', { name: /thread actions/i })
+    await user.click(trigger)
+    await user.click(screen.getByText('Delete Thread'))
+
+    expect(onDelete).toHaveBeenCalledWith(1)
   })
 
   it('closes the menu after clicking a menu item', async () => {
@@ -146,10 +230,13 @@ describe('PositionMenu', () => {
         onMoveToFront={onMoveToFront}
         onReposition={vi.fn()}
         onMoveToBack={vi.fn()}
+        onEdit={vi.fn()}
+        onDependencies={vi.fn()}
+        onDelete={vi.fn()}
       />
     )
 
-    const trigger = screen.getByRole('button', { name: /position actions/i })
+    const trigger = screen.getByRole('button', { name: /thread actions/i })
     await user.click(trigger)
     expect(screen.getByRole('menu')).toBeInTheDocument()
 
@@ -165,10 +252,13 @@ describe('PositionMenu', () => {
         onMoveToFront={vi.fn()}
         onReposition={vi.fn()}
         onMoveToBack={vi.fn()}
+        onEdit={vi.fn()}
+        onDependencies={vi.fn()}
+        onDelete={vi.fn()}
       />
     )
 
-    const trigger = screen.getByRole('button', { name: /position actions/i })
+    const trigger = screen.getByRole('button', { name: /thread actions/i })
     await user.click(trigger)
     expect(screen.getByRole('menu')).toBeInTheDocument()
 
@@ -184,10 +274,13 @@ describe('PositionMenu', () => {
         onMoveToFront={vi.fn()}
         onReposition={vi.fn()}
         onMoveToBack={vi.fn()}
+        onEdit={vi.fn()}
+        onDependencies={vi.fn()}
+        onDelete={vi.fn()}
       />
     )
 
-    const trigger = screen.getByRole('button', { name: /position actions/i })
+    const trigger = screen.getByRole('button', { name: /thread actions/i })
     await user.click(trigger)
     expect(screen.getByRole('menu')).toBeInTheDocument()
 
@@ -203,10 +296,13 @@ describe('PositionMenu', () => {
         onMoveToFront={vi.fn()}
         onReposition={vi.fn()}
         onMoveToBack={vi.fn()}
+        onEdit={vi.fn()}
+        onDependencies={vi.fn()}
+        onDelete={vi.fn()}
       />
     )
 
-    const trigger = screen.getByRole('button', { name: /position actions/i })
+    const trigger = screen.getByRole('button', { name: /thread actions/i })
     expect(trigger).toHaveAttribute('aria-haspopup', 'menu')
 
     await user.click(trigger)
@@ -221,10 +317,13 @@ describe('PositionMenu', () => {
         onMoveToFront={vi.fn()}
         onReposition={vi.fn()}
         onMoveToBack={vi.fn()}
+        onEdit={vi.fn()}
+        onDependencies={vi.fn()}
+        onDelete={vi.fn()}
       />
     )
 
-    const trigger = screen.getByRole('button', { name: /position actions/i })
+    const trigger = screen.getByRole('button', { name: /thread actions/i })
     trigger.focus()
     await user.keyboard('{Enter}')
 
@@ -239,10 +338,13 @@ describe('PositionMenu', () => {
         onMoveToFront={vi.fn()}
         onReposition={vi.fn()}
         onMoveToBack={vi.fn()}
+        onEdit={vi.fn()}
+        onDependencies={vi.fn()}
+        onDelete={vi.fn()}
       />
     )
 
-    const trigger = screen.getByRole('button', { name: /position actions/i })
+    const trigger = screen.getByRole('button', { name: /thread actions/i })
     trigger.focus()
     await user.keyboard(' ')
 
@@ -257,22 +359,34 @@ describe('PositionMenu', () => {
         onMoveToFront={vi.fn()}
         onReposition={vi.fn()}
         onMoveToBack={vi.fn()}
+        onEdit={vi.fn()}
+        onDependencies={vi.fn()}
+        onDelete={vi.fn()}
       />
     )
 
-    const trigger = screen.getByRole('button', { name: /position actions/i })
+    const trigger = screen.getByRole('button', { name: /thread actions/i })
     trigger.focus()
     await user.keyboard('{Enter}')
 
-    const menuItems = screen.getAllByRole('menuitem')
-    expect(document.activeElement).toBe(menuItems[0])
-
-    await user.keyboard('{ArrowDown}')
-    expect(document.activeElement).toBe(menuItems[1])
-
+     const menuItems = screen.getAllByRole('menuitem')
+     expect(document.activeElement).toBe(menuItems[0])
+ 
+     await user.keyboard('{ArrowDown}')
+     expect(document.activeElement).toBe(menuItems[1])
+ 
      await user.keyboard('{ArrowDown}')
      expect(document.activeElement).toBe(menuItems[2])
-
+ 
+     await user.keyboard('{ArrowDown}')
+     expect(document.activeElement).toBe(menuItems[3])
+ 
+     await user.keyboard('{ArrowDown}')
+     expect(document.activeElement).toBe(menuItems[4])
+ 
+     await user.keyboard('{ArrowDown}')
+     expect(document.activeElement).toBe(menuItems[5])
+ 
      await user.keyboard('{ArrowDown}')
      expect(document.activeElement).toBe(menuItems[0])
    })
@@ -296,18 +410,24 @@ describe('PositionMenu', () => {
            thread={mockThread1}
            onMoveToFront={vi.fn()}
            onReposition={vi.fn()}
-           onMoveToBack={vi.fn()}
-         />
+            onMoveToBack={vi.fn()}
+            onEdit={vi.fn()}
+            onDependencies={vi.fn()}
+            onDelete={vi.fn()}
+          />
          <PositionMenu
            thread={mockThread2}
            onMoveToFront={vi.fn()}
            onReposition={vi.fn()}
-           onMoveToBack={vi.fn()}
-         />
+            onMoveToBack={vi.fn()}
+            onEdit={vi.fn()}
+            onDependencies={vi.fn()}
+            onDelete={vi.fn()}
+          />
        </>
      )
 
-     const triggers = screen.getAllByRole('button', { name: /position actions/i })
+     const triggers = screen.getAllByRole('button', { name: /thread actions/i })
 
      // Open first menu
      await user.click(triggers[0])


### PR DESCRIPTION
Fixes #575

## Problem
Each thread card in the reading queue had 4 separate icon buttons (Edit, Dependencies, Delete, PositionMenu) crowding the right side, plus the drag handle on the left. The icons were hard to touch, hard to distinguish, crowded, and duplicative of the position menu.

## Solution
Consolidated all thread actions into a single overflow dropdown menu (`⋮`). Each card now has just 2 interactive elements:
- **Drag handle** (`⠿`) on the left for reordering
- **Thread actions** (`⋮`) on the right, opening a dropdown with all 6 actions: Move to Front, Reposition, Move to Back, Edit Thread, Dependencies, Delete Thread (red/destructive styling)

Also fixed the marquee title animation:
- Was `:hover` only (never triggered on mobile/touch)
- Now always animates when text overflows, stays static when it fits
- New `MarqueeTitle` component uses `ResizeObserver` to detect overflow and only render the duplicate scrolling span when needed

## Testing
- 666 Python tests pass
- 253 frontend unit tests pass
- 310 E2E tests pass (1 pre-existing roll.spec.ts failure unrelated to this change)
- Lint and typecheck clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added thread action menu options for editing, managing dependencies, and deleting threads.
  * Improved long thread-title display with automatic marquee scrolling when titles overflow.

* **Accessibility & Usability**
  * Enhanced action menu labels, keyboard navigation, and click behavior.
  * Destructive delete actions are now visually distinguished.

* **Tests**
  * Updated coverage for thread actions, dependency management, editing, deletion, and title display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->