### PR TITLE
Smart penalty placement + dependency connection indicator

### DIFF
--- a/app/api/dependency.py
+++ b/app/api/dependency.py
@@ -1,6 +1,6 @@
 """Dependency API endpoints (/api/v1)."""
 
-from typing import Annotated
+from typing import Annotated, TypedDict
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
@@ -32,6 +32,16 @@ from comic_pile.dependencies import (
     get_dependency_order_conflicts,
     refresh_user_blocked_status,
 )
+
+
+class _ConnectedThreadEntry(TypedDict):
+    """Internal structure for tracking connected threads during deduplication."""
+
+    thread_id: int
+    title: str
+    types: set[str]
+    dependency_ids: set[int]
+
 
 router = APIRouter(tags=["dependencies"])
 
@@ -576,7 +586,7 @@ async def get_thread_connected_threads(
             thread_map[thread_obj.id] = thread_obj
 
     # Track unique connected threads by thread_id, aggregating connection types.
-    connected_by_thread: dict[int, dict[str, str | int]] = {}
+    connected_by_thread: dict[int, _ConnectedThreadEntry] = {}
 
     blocking_result2 = await db.execute(
         select(Dependency)

--- a/app/api/dependency.py
+++ b/app/api/dependency.py
@@ -556,7 +556,9 @@ async def get_thread_connected_threads(
         .where(target_issue.c.thread_id == thread_id)
     )
 
-    all_deps = list(blocking_result.scalars().all()) + list(blocked_by_result.scalars().all())
+    blocking_deps = list(blocking_result.scalars().all())
+    blocked_by_deps = list(blocked_by_result.scalars().all())
+    all_deps = blocking_deps + blocked_by_deps
     if not all_deps:
         return ThreadConnectedResponse(thread_id=thread_id, connected_threads=[])
 
@@ -588,12 +590,7 @@ async def get_thread_connected_threads(
     # Track unique connected threads by thread_id, aggregating connection types.
     connected_by_thread: dict[int, _ConnectedThreadEntry] = {}
 
-    blocking_result2 = await db.execute(
-        select(Dependency)
-        .join(source_issue, Dependency.source_issue_id == source_issue.c.id)
-        .where(source_issue.c.thread_id == thread_id)
-    )
-    for dep in blocking_result2.scalars().all():
+    for dep in blocking_deps:
         if dep.target_issue_id is not None:
             target_issue_obj = issue_map.get(dep.target_issue_id)
             if target_issue_obj:
@@ -611,12 +608,7 @@ async def get_thread_connected_threads(
                         connected_by_thread[tid]["types"].add("blocks")
                         connected_by_thread[tid]["dependency_ids"].add(dep.id)
 
-    blocked_by_result2 = await db.execute(
-        select(Dependency)
-        .join(target_issue, Dependency.target_issue_id == target_issue.c.id)
-        .where(target_issue.c.thread_id == thread_id)
-    )
-    for dep in blocked_by_result2.scalars().all():
+    for dep in blocked_by_deps:
         if dep.source_issue_id is not None:
             source_issue_obj = issue_map.get(dep.source_issue_id)
             if source_issue_obj:

--- a/app/api/dependency.py
+++ b/app/api/dependency.py
@@ -575,7 +575,8 @@ async def get_thread_connected_threads(
         for thread_obj in result.scalars():
             thread_map[thread_obj.id] = thread_obj
 
-    connected: list[ConnectedThreadInfo] = []
+    # Track unique connected threads by thread_id, aggregating connection types.
+    connected_by_thread: dict[int, dict[str, str | int]] = {}
 
     blocking_result2 = await db.execute(
         select(Dependency)
@@ -588,12 +589,17 @@ async def get_thread_connected_threads(
             if target_issue_obj:
                 target_thread_obj = thread_map.get(target_issue_obj.thread_id)
                 if target_thread_obj and target_issue_obj.thread_id != thread_id:
-                    connected.append(ConnectedThreadInfo(
-                        thread_id=target_thread_obj.id,
-                        title=target_thread_obj.title,
-                        connection_type="blocks",
-                        dependency_id=dep.id,
-                    ))
+                    tid = target_thread_obj.id
+                    if tid not in connected_by_thread:
+                        connected_by_thread[tid] = {
+                            "thread_id": tid,
+                            "title": target_thread_obj.title,
+                            "types": {"blocks"},
+                            "dependency_ids": {dep.id},
+                        }
+                    else:
+                        connected_by_thread[tid]["types"].add("blocks")
+                        connected_by_thread[tid]["dependency_ids"].add(dep.id)
 
     blocked_by_result2 = await db.execute(
         select(Dependency)
@@ -606,12 +612,33 @@ async def get_thread_connected_threads(
             if source_issue_obj:
                 source_thread_obj = thread_map.get(source_issue_obj.thread_id)
                 if source_thread_obj and source_issue_obj.thread_id != thread_id:
-                    connected.append(ConnectedThreadInfo(
-                        thread_id=source_thread_obj.id,
-                        title=source_thread_obj.title,
-                        connection_type="blocked_by",
-                        dependency_id=dep.id,
-                    ))
+                    tid = source_thread_obj.id
+                    if tid not in connected_by_thread:
+                        connected_by_thread[tid] = {
+                            "thread_id": tid,
+                            "title": source_thread_obj.title,
+                            "types": {"blocked_by"},
+                            "dependency_ids": {dep.id},
+                        }
+                    else:
+                        connected_by_thread[tid]["types"].add("blocked_by")
+                        connected_by_thread[tid]["dependency_ids"].add(dep.id)
+
+    connected: list[ConnectedThreadInfo] = []
+    for entry in connected_by_thread.values():
+        types = entry["types"]
+        if types == {"blocks"}:
+            connection_type = "blocks"
+        elif types == {"blocked_by"}:
+            connection_type = "blocked_by"
+        else:
+            connection_type = "blocks & blocked_by"
+        connected.append(ConnectedThreadInfo(
+            thread_id=entry["thread_id"],
+            title=entry["title"],
+            connection_type=connection_type,
+            dependency_id=min(entry["dependency_ids"]),
+        ))
 
     return ThreadConnectedResponse(thread_id=thread_id, connected_threads=connected)
 

--- a/app/api/dependency.py
+++ b/app/api/dependency.py
@@ -13,6 +13,7 @@ from app.models import Dependency, Issue, Thread
 from app.models.user import User
 from app.schemas.dependency import (
     BlockingExplanation,
+    ConnectedThreadInfo,
     DependencyCreate,
     DependencyNoteUpdate,
     DependencyOrderConflict,
@@ -20,6 +21,7 @@ from app.schemas.dependency import (
     DependencyResponse,
     IssueDependenciesResponse,
     IssueDependencyEdge,
+    ThreadConnectedResponse,
     ThreadDependenciesResponse,
     ThreadDependencyOrderCheckResponse,
 )
@@ -507,6 +509,111 @@ async def check_thread_dependency_order(
         conflicts.append(conflict_obj)
 
     return ThreadDependencyOrderCheckResponse(thread_id=thread_id, conflicts=conflicts)
+
+
+@router.get(
+    "/threads/{thread_id}/connected",
+    response_model=ThreadConnectedResponse,
+)
+async def get_thread_connected_threads(
+    thread_id: int,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: AsyncSession = Depends(get_db),
+) -> ThreadConnectedResponse:
+    """Return threads connected to this one via dependencies.
+
+    When you are reading a thread, this tells you which other threads
+    are part of the same dependency web so you know there's a relationship.
+    """
+    thread = await db.get(Thread, thread_id)
+    if not thread or thread.user_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Thread {thread_id} not found",
+        )
+
+    source_issue = Issue.__table__.alias("source_issue")
+    target_issue = Issue.__table__.alias("target_issue")
+
+    blocking_result = await db.execute(
+        select(Dependency)
+        .join(source_issue, Dependency.source_issue_id == source_issue.c.id)
+        .where(source_issue.c.thread_id == thread_id)
+    )
+    blocked_by_result = await db.execute(
+        select(Dependency)
+        .join(target_issue, Dependency.target_issue_id == target_issue.c.id)
+        .where(target_issue.c.thread_id == thread_id)
+    )
+
+    all_deps = list(blocking_result.scalars().all()) + list(blocked_by_result.scalars().all())
+    if not all_deps:
+        return ThreadConnectedResponse(thread_id=thread_id, connected_threads=[])
+
+    issue_ids = set()
+    for dep in all_deps:
+        if dep.source_issue_id is not None:
+            issue_ids.add(dep.source_issue_id)
+        if dep.target_issue_id is not None:
+            issue_ids.add(dep.target_issue_id)
+
+    issue_map: dict[int, Issue] = {}
+    thread_ids: set[int] = set()
+    if issue_ids:
+        result = await db.execute(
+            select(Issue).where(Issue.id.in_(issue_ids))
+        )
+        for issue_obj in result.scalars():
+            issue_map[issue_obj.id] = issue_obj
+            thread_ids.add(issue_obj.thread_id)
+
+    thread_map: dict[int, Thread] = {}
+    if thread_ids:
+        result = await db.execute(
+            select(Thread).where(Thread.id.in_(thread_ids)).where(Thread.user_id == current_user.id)
+        )
+        for thread_obj in result.scalars():
+            thread_map[thread_obj.id] = thread_obj
+
+    connected: list[ConnectedThreadInfo] = []
+
+    blocking_result2 = await db.execute(
+        select(Dependency)
+        .join(source_issue, Dependency.source_issue_id == source_issue.c.id)
+        .where(source_issue.c.thread_id == thread_id)
+    )
+    for dep in blocking_result2.scalars().all():
+        if dep.target_issue_id is not None:
+            target_issue_obj = issue_map.get(dep.target_issue_id)
+            if target_issue_obj:
+                target_thread_obj = thread_map.get(target_issue_obj.thread_id)
+                if target_thread_obj and target_issue_obj.thread_id != thread_id:
+                    connected.append(ConnectedThreadInfo(
+                        thread_id=target_thread_obj.id,
+                        title=target_thread_obj.title,
+                        connection_type="blocks",
+                        dependency_id=dep.id,
+                    ))
+
+    blocked_by_result2 = await db.execute(
+        select(Dependency)
+        .join(target_issue, Dependency.target_issue_id == target_issue.c.id)
+        .where(target_issue.c.thread_id == thread_id)
+    )
+    for dep in blocked_by_result2.scalars().all():
+        if dep.source_issue_id is not None:
+            source_issue_obj = issue_map.get(dep.source_issue_id)
+            if source_issue_obj:
+                source_thread_obj = thread_map.get(source_issue_obj.thread_id)
+                if source_thread_obj and source_issue_obj.thread_id != thread_id:
+                    connected.append(ConnectedThreadInfo(
+                        thread_id=source_thread_obj.id,
+                        title=source_thread_obj.title,
+                        connection_type="blocked_by",
+                        dependency_id=dep.id,
+                    ))
+
+    return ThreadConnectedResponse(thread_id=thread_id, connected_threads=connected)
 
 
 async def _is_dependency_owned_by_user(

--- a/app/api/rate.py
+++ b/app/api/rate.py
@@ -18,7 +18,7 @@ from app.schemas import RateRequest, ThreadResponse
 from app.api.thread import thread_to_response
 from comic_pile.dependencies import refresh_user_blocked_status
 from comic_pile.dice_ladder import step_down, step_up
-from comic_pile.queue import move_to_back, move_to_front
+from comic_pile.queue import move_to_back, move_to_front, move_to_safe_position
 from comic_pile.session import get_current_die
 
 router = APIRouter()
@@ -370,7 +370,7 @@ async def rate_thread(
     elif rate_data.rating >= rating_threshold:
         await move_to_front(thread_id, user_id, db, commit=False)
     else:
-        await move_to_back(thread_id, user_id, db, commit=False)
+        await move_to_safe_position(thread_id, user_id, new_die, db)
 
     if rate_data.finish_session:
         current_session.ended_at = datetime.now(UTC)

--- a/app/schemas/dependency.py
+++ b/app/schemas/dependency.py
@@ -94,3 +94,19 @@ class ThreadDependencyOrderCheckResponse(BaseModel):
 
     thread_id: int
     conflicts: list[DependencyOrderConflict]
+
+
+class ConnectedThreadInfo(BaseModel):
+    """Lightweight info about a thread connected via dependencies."""
+
+    thread_id: int
+    title: str
+    connection_type: str  # "blocks" or "blocked_by"
+    dependency_id: int
+
+
+class ThreadConnectedResponse(BaseModel):
+    """Schema for thread dependency connectivity info."""
+
+    thread_id: int
+    connected_threads: list[ConnectedThreadInfo]

--- a/app/schemas/dependency.py
+++ b/app/schemas/dependency.py
@@ -101,7 +101,7 @@ class ConnectedThreadInfo(BaseModel):
 
     thread_id: int
     title: str
-    connection_type: str  # "blocks" or "blocked_by"
+    connection_type: str  # "blocks" | "blocked_by" | "blocks & blocked_by"
     dependency_id: int
 
 

--- a/comic_pile/queue.py
+++ b/comic_pile/queue.py
@@ -94,9 +94,18 @@ async def move_to_back(thread_id: int, user_id: int, db: AsyncSession, commit: b
 
 
 async def move_to_position(
-    thread_id: int, user_id: int, new_position: int, db: AsyncSession
+    thread_id: int, user_id: int, new_position: int, db: AsyncSession,
+    do_commit: bool = True,
 ) -> None:
-    """Move thread to specific position."""
+    """Move thread to specific position.
+
+    Args:
+        thread_id: Thread to move.
+        user_id: Thread owner.
+        new_position: Target sequential position (1-indexed).
+        db: Async database session.
+        do_commit: Whether to commit inside this helper.
+    """
     logger.info(
         f"move_to_position ENTRY: thread_id={thread_id}, user_id={user_id}, new_position={new_position}"
     )
@@ -201,7 +210,8 @@ async def move_to_position(
         logger.info(f"Set target thread {thread_id} position to {new_position}")
 
     logger.debug("Committing database transaction")
-    await db.commit()
+    if do_commit:
+        await db.commit()
 
     logger.info(f"move_to_position SUCCESS: thread {thread_id} moved to position {new_position}")
 
@@ -219,6 +229,71 @@ async def move_to_position(
         logger.debug(
             f"  Position {thread.queue_position}: Thread {thread.id} ('{thread.title[:50]}...')"
         )
+
+
+async def move_to_safe_position(
+    thread_id: int,
+    user_id: int,
+    die_size: int,
+    db: AsyncSession,
+) -> None:
+    """Move thread to a position just beyond the current die range.
+
+    Instead of sending a low-rated thread to the very back (which can bury it
+    for months), place it at position ``die_size + 1`` in sequential order,
+    adjusted for blocked threads that occupy positions within the die range
+    but are not rollable.  This guarantees the thread won't reappear in the
+    next roll pool while keeping it realistically reachable.
+
+    Example (die=d6, no blocked threads):
+        Position 1-6: rollable pool
+        Rated thread -> position 7
+
+    Example (die=d6, 2 blocked threads in top 8):
+        Position 1-6: rollable pool (but 2 are blocked, so only 4 real options)
+        Rated thread -> position 9  (6 + 2 blocked = 8, +1 = 9)
+
+    Args:
+        thread_id: Thread to reposition.
+        user_id: Thread owner.
+        die_size: Current die size from the dice ladder.
+        db: Async database session (caller handles commit/rollback).
+    """
+    result = await db.execute(
+        select(Thread)
+        .where(Thread.user_id == user_id)
+        .where(Thread.status == "active")
+        .where(Thread.queue_position >= 1)
+        .order_by(Thread.queue_position)
+    )
+    all_active = list(result.scalars().all())
+
+    target_index = next(
+        (i for i, t in enumerate(all_active) if t.id == thread_id), -1
+    )
+    if target_index == -1:
+        return
+
+    if target_index == 0 and len(all_active) == 1:
+        return
+
+    # Count blocked threads among the first (die_size + target's position) slots.
+    # We want to place the thread far enough out that it won't be in the die
+    # range the next time the user rolls.
+    blocked_in_range = sum(
+        1 for i, t in enumerate(all_active)
+        if i != target_index
+        and t.is_blocked
+        and i < (die_size + target_index)
+    )
+
+    raw_target = die_size + 1 + blocked_in_range
+    target_seq = min(raw_target, len(all_active))
+
+    if target_seq == target_index + 1:
+        return
+
+    await move_to_position(thread_id, user_id, target_seq, db, do_commit=False)
 
 
 async def shuffle_queue(user_id: int, db: AsyncSession) -> int:

--- a/frontend/src/pages/RollPage/components/RatingView.tsx
+++ b/frontend/src/pages/RollPage/components/RatingView.tsx
@@ -7,6 +7,7 @@ import IssueCorrectionDialog from '../../../components/IssueCorrectionDialog'
 import { RATING_THRESHOLD, getProgressPercentage } from '../utils'
 import type { RatingThread } from '../types'
 import type { ReadingOrder } from '../../../services/api-reading-orders'
+import type { ConnectedThreadInfo } from '../../../types'
 
 interface RatingViewProps {
   activeRatingThread: RatingThread | null
@@ -21,6 +22,7 @@ interface RatingViewProps {
   snoozeIsPending: boolean
   dismissIsPending: boolean
   readingOrders: ReadingOrder[]
+  connectedThreads: ConnectedThreadInfo[]
   onUpdateRating: (value: string) => void
   onSubmitRating: (finishSession: boolean) => void
   onSnooze: () => void
@@ -41,6 +43,7 @@ export function RatingView({
   snoozeIsPending,
   dismissIsPending,
   readingOrders,
+  connectedThreads,
   onUpdateRating,
   onSubmitRating,
   onSnooze,
@@ -119,6 +122,24 @@ export function RatingView({
           )}
         </div>
       </div>
+
+      {connectedThreads.length > 0 && (
+        <div className="text-center">
+          <div className="inline-flex items-center gap-2 px-3 py-1.5 bg-blue-900/20 border border-blue-700/30 rounded-lg">
+            <span className="text-[10px] font-black uppercase tracking-wider text-blue-400">Connected</span>
+            <Tooltip content={`This thread is linked to ${connectedThreads.length} other thread${connectedThreads.length !== 1 ? 's' : ''} via dependencies.`}>
+              <span className="text-[9px] text-blue-500 cursor-help border-b border-dashed border-blue-800">
+                {connectedThreads.map((ct, i) => (
+                  <span key={ct.dependency_id}>
+                    {i > 0 && ', '}
+                    {ct.title}
+                  </span>
+                ))}
+              </span>
+            </Tooltip>
+          </div>
+        </div>
+      )}
 
       <div className="space-y-5 md:space-y-8">
         <div id="rating-preview-dice" className="dice-perspective">

--- a/frontend/src/pages/RollPage/components/RatingView.tsx
+++ b/frontend/src/pages/RollPage/components/RatingView.tsx
@@ -130,7 +130,7 @@ export function RatingView({
             <Tooltip content={`This thread is linked to ${connectedThreads.length} other thread${connectedThreads.length !== 1 ? 's' : ''} via dependencies.`}>
               <span className="text-[9px] text-blue-500 cursor-help border-b border-dashed border-blue-800">
                 {connectedThreads.map((ct, i) => (
-                  <span key={ct.dependency_id}>
+                  <span key={ct.thread_id}>
                     {i > 0 && ', '}
                     {ct.title}
                   </span>
@@ -174,7 +174,7 @@ export function RatingView({
         </div>
 
         <div className="text-center space-y-4">
-          <Tooltip content={`Ratings of ${RATING_THRESHOLD.toFixed(1)}+ move the thread to the front and step the die down. Lower ratings move it back and step the die up.`}>
+          <Tooltip content={`Ratings of ${RATING_THRESHOLD.toFixed(1)}+ move the thread to the front and step the die down. Lower ratings move it past the next roll range and step the die up.`}>
             <p className="text-[10px] font-black uppercase tracking-[0.4em] text-stone-500 cursor-help">How was it?</p>
           </Tooltip>
           <div id="rating-value" className={`text-4xl font-black ${rating >= RATING_THRESHOLD ? 'text-amber-500' : 'text-red-700'}`}>
@@ -203,7 +203,7 @@ export function RatingView({
           <p id="queue-effect" className="text-[10px] font-black text-stone-300 text-center uppercase tracking-[0.15em] leading-relaxed">
             {rating >= RATING_THRESHOLD
               ? `Excellent! Die steps down 🎲 Move to front${predictedDie !== currentDie ? ` (d${predictedDie})` : ''}`
-              : `Okay. Die steps up 🎲 Move to back${predictedDie !== currentDie ? ` (d${predictedDie})` : ''}`}
+              : `Okay. Die steps up 🎲 Move past next roll range${predictedDie !== currentDie ? ` (d${predictedDie})` : ''}`}
           </p>
         </div>
 

--- a/frontend/src/pages/RollPage/components/RatingView.tsx
+++ b/frontend/src/pages/RollPage/components/RatingView.tsx
@@ -128,7 +128,7 @@ export function RatingView({
           <div className="inline-flex items-center gap-2 px-3 py-1.5 bg-blue-900/20 border border-blue-700/30 rounded-lg">
             <span className="text-[10px] font-black uppercase tracking-wider text-blue-400">Connected</span>
             <Tooltip content={`This thread is linked to ${connectedThreads.length} other thread${connectedThreads.length !== 1 ? 's' : ''} via dependencies.`}>
-              <span className="text-[9px] text-blue-500 cursor-help border-b border-dashed border-blue-800">
+              <span tabIndex={0} className="text-[9px] text-blue-500 cursor-help border-b border-dashed border-blue-800">
                 {connectedThreads.map((ct, i) => (
                   <span key={ct.thread_id}>
                     {i > 0 && ', '}

--- a/frontend/src/pages/RollPage/index.tsx
+++ b/frontend/src/pages/RollPage/index.tsx
@@ -30,7 +30,7 @@ import { readingOrdersApi } from '../../services/api-reading-orders'
 import { reviewsApi } from '../../services/api-reviews'
 import { getApiErrorStatus, getApiErrorDetail } from '../../utils/apiError'
 import { isDiceSide } from '../../components/diceTypes'
-import type { Thread, RollResponse, SessionThread, Collection, ReviewCreatePayload, Review } from '../../types'
+import type { Thread, RollResponse, SessionThread, Collection, ReviewCreatePayload, Review, ConnectedThreadInfo } from '../../types'
 import { useRollPageState } from './useRollPageState'
 import type { RatingThread, ThreadMetadata } from './types'
 import {
@@ -82,6 +82,7 @@ export default function RollPage() {
   const [pendingRatingAction, setPendingRatingAction] = useState<{finishSession: boolean} | null>(null)
   const [existingReview, setExistingReview] = useState<Review | null>(null)
   const [readingOrders, setReadingOrders] = useState<import('../../services/api-reading-orders').ReadingOrder[]>([])
+  const [connectedThreads, setConnectedThreads] = useState<ConnectedThreadInfo[]>([])
 
   const { data: session, refetch: refetchSession, isPending: isSessionLoading, isError: isSessionError, error: sessionError } = useSession()
   const { activeCollectionId = null } = useCollections()
@@ -229,8 +230,16 @@ export default function RollPage() {
         console.error('Failed to fetch reading orders:', error)
         setReadingOrders([])
       }
+      try {
+        const connectedResponse = await dependenciesApi.getConnectedThreads(threadId)
+        setConnectedThreads(connectedResponse.connected_threads)
+      } catch (error) {
+        console.error('Failed to fetch connected threads:', error)
+        setConnectedThreads([])
+      }
     } else {
       setReadingOrders([])
+      setConnectedThreads([])
     }
   }, [reviewsEnabled, session, currentDie, suppressPendingAutoOpenRef, setSelectedThreadId, setRolledResult, setActiveRatingThread, setRating, setErrorMessage, setPredictedDie, setIsRatingView])
 
@@ -865,6 +874,7 @@ useEffect(() => {
                 snoozeIsPending={snoozeMutation.isPending}
                 dismissIsPending={dismissPendingMutation.isPending}
                 readingOrders={readingOrders}
+                connectedThreads={connectedThreads}
                 onUpdateRating={updateRatingUI}
                 onSubmitRating={handleSubmitRating}
                 onSnooze={handleSnooze}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -13,6 +13,7 @@ import type {
   CollectionCreate,
   CollectionListResponse,
   CollectionUpdate,
+  ConnectedDependenciesResponse,
   Dependency,
   DependencyCreatePayload,
   IssueDependenciesResponse,
@@ -339,6 +340,8 @@ export const dependenciesApi = {
     api.get<IssueDependenciesResponse>(`/v1/issues/${issueId}/dependencies`),
   getBlockingInfo: (threadId: number) =>
     api.post<BlockingInfoResponse>(`/v1/threads/${threadId}:getBlockingInfo`),
+  getConnectedThreads: (threadId: number) =>
+    api.get<ConnectedDependenciesResponse>(`/v1/threads/${threadId}/connected`),
   createDependency: ({ sourceType = 'thread', sourceId, targetType = 'thread', targetId }: DependencyCreatePayload) =>
     api.post<Dependency, { source_type: 'thread' | 'issue'; source_id: number; target_type: 'thread' | 'issue'; target_id: number }>('/v1/dependencies/', {
       source_type: sourceType,

--- a/frontend/src/test/issue-320-mobile-safari-overscroll.spec.ts
+++ b/frontend/src/test/issue-320-mobile-safari-overscroll.spec.ts
@@ -12,7 +12,9 @@ test.describe('Issue #320: Mobile Safari Overscroll Prevention', () => {
 
   test('overscroll-prevention CSS is loaded in stylesheets', async ({ page }) => {
     await page.goto('/');
+    await page.waitForLoadState('networkidle');
     await expect(page.locator('#root')).toBeVisible();
+    await page.waitForFunction(() => document.readyState === 'complete');
 
     const hasOverscrollBehavior = await page.evaluate(() => {
       const stylesheets = Array.from(document.styleSheets);

--- a/frontend/src/test/issue-325-correct-issue-rating-view.spec.ts
+++ b/frontend/src/test/issue-325-correct-issue-rating-view.spec.ts
@@ -100,6 +100,7 @@ test.describe('Issue #325: Correct Issue Number from Rating View', () => {
     await editIcon.click();
 
     const issueInput = authenticatedWithThreadsPage.locator('input#issue-number');
+    await expect(issueInput).toHaveValue(/\d+/);
     const initialValue = await issueInput.inputValue();
     const initialNum = parseInt(initialValue, 10);
 

--- a/frontend/src/test/roll.spec.ts
+++ b/frontend/src/test/roll.spec.ts
@@ -1028,11 +1028,18 @@ test.describe('Roll Dice Feature', () => {
       await dieButton.click();
       await expect(authenticatedWithThreadsPage.locator('#root')).toBeVisible();
 
+      await expect.poll(async () => {
+        const res = await request.get('/api/sessions/current/', {
+          headers: { 'Authorization': `Bearer ${token}` },
+        });
+        const data = await res.json();
+        return data.manual_die;
+      }, { timeout: 5000 }).toBe(MANUAL_DIE);
+
       const sessionBefore = await request.get('/api/sessions/current/', {
         headers: { 'Authorization': `Bearer ${token}` },
       });
       const sessionBeforeData = await sessionBefore.json();
-      expect(sessionBeforeData.manual_die).toBe(MANUAL_DIE);
       expect(sessionBeforeData.current_die).toBe(MANUAL_DIE);
 
       await authenticatedWithThreadsPage.click(SELECTORS.roll.mainDie);
@@ -1068,11 +1075,18 @@ test.describe('Roll Dice Feature', () => {
       await dieButton.click();
       await expect(authenticatedWithThreadsPage.locator('#root')).toBeVisible();
 
+      await expect.poll(async () => {
+        const res = await request.get('/api/sessions/current/', {
+          headers: { 'Authorization': `Bearer ${token}` },
+        });
+        const data = await res.json();
+        return data.manual_die;
+      }, { timeout: 5000 }).toBe(MANUAL_DIE);
+
       const sessionBeforeRoll = await request.get('/api/sessions/current/', {
         headers: { 'Authorization': `Bearer ${token}` },
       });
       const sessionBeforeRollData = await sessionBeforeRoll.json();
-      expect(sessionBeforeRollData.manual_die).toBe(MANUAL_DIE);
       expect(sessionBeforeRollData.current_die).toBe(MANUAL_DIE);
 
       await authenticatedWithThreadsPage.click(SELECTORS.roll.mainDie);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -338,6 +338,30 @@ export interface ThreadDependenciesResponse {
 }
 
 /**
+ * A thread connected via issue-level dependencies
+ */
+export interface ConnectedThreadInfo {
+  /** ID of the connected thread */
+  thread_id: number;
+  /** Title of the connected thread */
+  title: string;
+  /** Direction of the relationship */
+  connection_type: 'blocks' | 'blocked_by';
+  /** ID of the dependency edge */
+  dependency_id: number;
+}
+
+/**
+ * Response from the thread connected-dependencies endpoint
+ */
+export interface ConnectedDependenciesResponse {
+  /** The queried thread ID */
+  thread_id: number;
+  /** Threads connected via dependency edges */
+  connected_threads: ConnectedThreadInfo[];
+}
+
+/**
  * Represents a single dependency edge for an issue
  */
 export interface IssueDependencyEdge {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -346,7 +346,7 @@ export interface ConnectedThreadInfo {
   /** Title of the connected thread */
   title: string;
   /** Direction of the relationship */
-  connection_type: 'blocks' | 'blocked_by';
+  connection_type: 'blocks' | 'blocked_by' | 'blocks & blocked_by';
   /** ID of the dependency edge */
   dependency_id: number;
 }

--- a/frontend/src/unit/RollPage.test.tsx
+++ b/frontend/src/unit/RollPage.test.tsx
@@ -77,6 +77,7 @@ vi.mock('../services/api', async (importOriginal) => {
     ...actual,
     dependenciesApi: {
       getBlockingInfo: vi.fn().mockResolvedValue({ is_blocked: false, blocking_reasons: [] }),
+      getConnectedThreads: vi.fn().mockResolvedValue({ thread_id: 0, connected_threads: [] }),
     },
   }
 })

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -684,3 +684,61 @@ async def test_dep_does_not_block_when_next_unread_past_dep_target(async_db):
 
     blocked = await get_blocked_thread_ids(user.id, async_db)
     assert target_thread.id not in blocked
+
+
+@pytest.mark.asyncio
+async def test_connected_threads_deduplicates_multiple_edges(
+    async_db, auth_client, default_user
+):
+    """Connected threads endpoint should deduplicate by thread_id when multiple edges exist."""
+    user = default_user
+
+    thread_a = Thread(
+        title="Thread A",
+        format="Comic",
+        issues_remaining=2,
+        queue_position=1,
+        status="active",
+        user_id=user.id,
+        total_issues=2,
+    )
+    thread_b = Thread(
+        title="Thread B",
+        format="Comic",
+        issues_remaining=2,
+        queue_position=2,
+        status="active",
+        user_id=user.id,
+        total_issues=2,
+    )
+    async_db.add_all([thread_a, thread_b])
+    await async_db.flush()
+
+    # Create two issues per thread
+    a_issue_1 = Issue(thread_id=thread_a.id, issue_number="1", position=1, status="unread")
+    a_issue_2 = Issue(thread_id=thread_a.id, issue_number="2", position=2, status="unread")
+    b_issue_1 = Issue(thread_id=thread_b.id, issue_number="1", position=1, status="unread")
+    b_issue_2 = Issue(thread_id=thread_b.id, issue_number="2", position=2, status="unread")
+    async_db.add_all([a_issue_1, a_issue_2, b_issue_1, b_issue_2])
+    await async_db.flush()
+
+    # Create TWO dependency edges between the same threads:
+    # A issue 1 -> B issue 1
+    # A issue 2 -> B issue 2
+    async_db.add_all([
+        Dependency(source_issue_id=a_issue_1.id, target_issue_id=b_issue_1.id),
+        Dependency(source_issue_id=a_issue_2.id, target_issue_id=b_issue_2.id),
+    ])
+    await async_db.commit()
+
+    # The connected threads endpoint should return Thread B only ONCE,
+    # not once per dependency edge.
+    response = await auth_client.get(f"/api/v1/threads/{thread_a.id}/connected")
+    assert response.status_code == 200
+
+    data = response.json()
+    connected = data["connected_threads"]
+    thread_ids = [ct["thread_id"] for ct in connected]
+    assert len(connected) == 1, f"Expected 1 connected thread, got {len(connected)}"
+    assert thread_ids.count(thread_b.id) == 1, "Thread B should appear only once"
+    assert connected[0]["title"] == "Thread B"

--- a/tests/test_queue_safe_position.py
+++ b/tests/test_queue_safe_position.py
@@ -10,7 +10,7 @@ from comic_pile.queue import move_to_safe_position
 async def test_move_to_safe_position_no_blocked(
     async_db: AsyncSession, default_user, sample_data
 ) -> None:
-    """With die=d6 and no blocked threads, thread lands at position 7."""
+    """With die=d6 and fewer threads than die+1, thread lands at position 4 (back of queue)."""
     thread = sample_data["threads"][0]  # Superman, pos 1
     # Superman is at position 1, die=6 => safe position should be min(7, active_count)
     # Active threads after superman: Batman(2), Flash(4), Aquaman(5) = 4 total

--- a/tests/test_queue_safe_position.py
+++ b/tests/test_queue_safe_position.py
@@ -1,0 +1,161 @@
+"""Tests for move_to_safe_position queue function."""
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Thread
+from comic_pile.queue import move_to_safe_position
+
+
+@pytest.mark.asyncio
+async def test_move_to_safe_position_no_blocked(
+    async_db: AsyncSession, default_user, sample_data
+) -> None:
+    """With die=d6 and no blocked threads, thread lands at position 7."""
+    thread = sample_data["threads"][0]  # Superman, pos 1
+    # Superman is at position 1, die=6 => safe position should be min(7, active_count)
+    # Active threads after superman: Batman(2), Flash(4), Aquaman(5) = 4 total
+    # So die_size(6) + 1 = 7, but max is 4 => position 4 (back)
+    await move_to_safe_position(thread.id, default_user.id, 6, async_db)
+    await async_db.refresh(thread)
+    # Die size=6, 4 active threads. count blocked in range = 0
+    # target = min(6+1+0, 4) = min(7, 4) = 4 (back)
+    assert thread.queue_position == 4
+
+
+@pytest.mark.asyncio
+async def test_move_to_safe_position_with_blocked_threads(
+    async_db: AsyncSession, default_user, sample_data
+) -> None:
+    """Blocked threads count as occupied slots in the safe-position calculation."""
+    thread = sample_data["threads"][0]  # Superman, pos 1
+
+    # Mark Flash (currently pos 4) as blocked
+    flash = sample_data["threads"][3]
+    flash.is_blocked = True
+    await async_db.flush()
+
+    # Now active threads: Superman(1), Batman(2), Aquaman(3)
+    # But Flash(4) is blocked, so there's a blocked thread at seq 4
+    # die=6 => die_size(6) + 1 + blocked_in_range(1) = 8, min(8, 3) = 3
+    # blocked threads in first (6+0=6) slots: Flash is at seq 4, which is < 6, so yes
+    await move_to_safe_position(thread.id, default_user.id, 6, async_db)
+    await async_db.refresh(thread)
+    assert thread.queue_position == 4  # Went to back (4 is max with 4 active threads)
+
+    # Cleanup
+    flash.is_blocked = False
+    await async_db.flush()
+
+
+@pytest.mark.asyncio
+async def test_move_to_safe_position_many_threads(
+    async_db: AsyncSession, default_user
+) -> None:
+    """With more than die_size+1 active threads, lands at precise die+1 position."""
+    user = default_user
+    threads = []
+    for i in range(1, 15):
+        t = Thread(
+            title=f"Thread {i}",
+            format="Comic",
+            issues_remaining=5,
+            queue_position=i,
+            status="active",
+            user_id=user.id,
+        )
+        async_db.add(t)
+        threads.append(t)
+    await async_db.flush()
+    for t in threads:
+        await async_db.refresh(t)
+
+    target = threads[0]  # pos 1
+    await move_to_safe_position(target.id, user.id, 6, async_db)
+    await async_db.refresh(target)
+    # 14 active threads, die=6, no blocked
+    # target = min(6+1+0, 14) = 7
+    assert target.queue_position == 7
+
+
+@pytest.mark.asyncio
+async def test_move_to_safe_position_at_back_when_small_pool(
+    async_db: AsyncSession, default_user
+) -> None:
+    """When there are fewer threads than die+1, thread goes to the last position."""
+    user = default_user
+    threads = []
+    for i in range(1, 5):
+        t = Thread(
+            title=f"Thread {i}",
+            format="Comic",
+            issues_remaining=5,
+            queue_position=i,
+            status="active",
+            user_id=user.id,
+        )
+        async_db.add(t)
+        threads.append(t)
+    await async_db.flush()
+    for t in threads:
+        await async_db.refresh(t)
+
+    target = threads[0]  # pos 1
+    await move_to_safe_position(target.id, user.id, 6, async_db)
+    await async_db.refresh(target)
+    # 4 active threads, die=6 => target = min(6+1+0, 4) = 4
+    assert target.queue_position == 4
+
+
+@pytest.mark.asyncio
+async def test_move_to_safe_position_single_thread_noop(
+    async_db: AsyncSession, default_user
+) -> None:
+    """With only one active thread, moving to safe position is a no-op."""
+    user = default_user
+    t = Thread(
+        title="Lonely Thread",
+        format="Comic",
+        issues_remaining=5,
+        queue_position=1,
+        status="active",
+        user_id=user.id,
+    )
+    async_db.add(t)
+    await async_db.flush()
+    await async_db.refresh(t)
+
+    await move_to_safe_position(t.id, user.id, 6, async_db)
+    await async_db.refresh(t)
+    assert t.queue_position == 1
+
+
+@pytest.mark.asyncio
+async def test_move_to_safe_position_blocked_threads_in_range(
+    async_db: AsyncSession, default_user
+) -> None:
+    """Blocked threads within the die range increase the offset."""
+    user = default_user
+    threads = []
+    for i in range(1, 15):
+        t = Thread(
+            title=f"Thread {i}",
+            format="Comic",
+            issues_remaining=5,
+            queue_position=i,
+            is_blocked=(i == 4 or i == 6),
+            status="active",
+            user_id=user.id,
+        )
+        async_db.add(t)
+        threads.append(t)
+    await async_db.flush()
+    for t in threads:
+        await async_db.refresh(t)
+
+    target = threads[0]  # pos 1
+    await move_to_safe_position(target.id, user.id, 6, async_db)
+    await async_db.refresh(target)
+    # 14 active threads, die=6
+    # blocked threads in first (6+0=6) positions: seq 4 and seq 6 are blocked = 2
+    # target = min(6+1+2, 14) = min(9, 14) = 9
+    assert target.queue_position == 9


### PR DESCRIPTION
## Summary

Two features requested to improve the reading flow:

### Feature 1: Smart penalty placement
Low-rated threads (<4.0) were sent to the back of the queue, burying them for months. Instead, they now go to position `current_die + 1` (adjusted for blocked threads), putting them just outside the rollable pool but still reachable.

### Feature 2: Dependency connection indicator
When reading a thread, you now see a Connected badge in the rating view showing which threads are linked via dependencies.

## Changes

- **comic_pile/queue.py** - Add `move_to_safe_position` function and `do_commit` param to `move_to_position`
- **app/api/rate.py** - Call `move_to_safe_position` (not `move_to_back`) for low ratings
- **app/api/dependency.py** - New `GET /v1/threads/{thread_id}/connected` endpoint
- **app/schemas/dependency.py** - Add `ConnectedThreadInfo` and `ThreadConnectedResponse`
- **frontend/** - New API call, types, RatingView Connected badge
- **tests/test_queue_safe_position.py** - 6 tests for the new function

## Verification
- 154 backend tests passing
- 252 frontend tests passing
- Lint and typecheck clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “connected” dependencies view in the rating UI with a badge/tooltip listing connected thread titles and their relationship type.
  * Introduced a new API endpoint to fetch connected threads for a given thread.

* **Improvements**
  * Low-rated, incomplete actions now reposition threads using a safer queue placement based on die range, including blocked-thread occupancy.
  * Updated rating guidance and messaging to reflect the new queue-effect behavior.

* **Tests**
  * Added backend coverage for safe queue placement and connected-thread deduplication.
  * Updated frontend and UI tests to use the new dependencies endpoint and loading expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->