### PR TITLE
fix: Lock background scroll when modals open on iOS

### DIFF
--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -77,11 +77,31 @@ export default function Modal({
     }
   }, [isOpen])
 
+  // Lock the #root scroller while a modal is open (fixes iOS scroll-bleed).
+  // This app scrolls via #root, NOT <body> (see src/styles.css: html/body are
+  // overflow:hidden, so locking <body> is a no-op). Use overflow:hidden ONLY on
+  // #root — do NOT set touch-action:none on #root: the modal content is a DOM
+  // descendant of #root (Modal renders inline, no portal), and an ancestor
+  // touch-action:none would disable touch-panning for descendants, breaking
+  // in-modal scrolling on mobile.
+  useEffect(() => {
+    if (!isOpen) return
+    const root = document.getElementById('root')
+    if (!root) return
+    const prevOverflow = root.style.overflow
+    const prevScrollTop = root.scrollTop
+    root.style.overflow = 'hidden'
+    return () => {
+      root.style.overflow = prevOverflow
+      root.scrollTop = prevScrollTop
+    }
+  }, [isOpen])
+
   if (!isOpen) return null
 
   return (
     <div data-exclude-from-screenshot="true" className={`fixed inset-0 z-[60] flex items-end md:items-center justify-center md:px-4 ${overlayClassName || ''}`}>
-      <div className="absolute inset-0 bg-[#110e0a]/60 backdrop-blur-sm" onClick={onClose} aria-hidden="true"></div>
+      <div className="absolute inset-0 bg-[#110e0a]/60 backdrop-blur-sm touch-none" onClick={onClose} aria-hidden="true"></div>
       <div
         ref={modalRef}
         data-testid={testId}
@@ -104,7 +124,7 @@ export default function Modal({
             &times;
           </button>
         </div>
-        <div className="overflow-y-auto space-y-4 md:space-y-6 min-h-0 px-4 md:px-6 pb-4 md:pb-6">
+        <div className="overflow-y-auto space-y-4 md:space-y-6 min-h-0 px-4 md:px-6 pb-4 md:pb-6 overscroll-contain">
           {children}
         </div>
       </div>

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -9,6 +9,12 @@ interface ModalProps {
   overlayClassName?: string
 }
 
+// Module-level lock counter so nested/overlapping modals don't prematurely
+// unlock #root scroll. The lock is only released when the last modal closes.
+let rootLockCount = 0
+let savedOverflow = ''
+let savedScrollTop = 0
+
 export default function Modal({
   isOpen,
   title,
@@ -84,16 +90,24 @@ export default function Modal({
   // descendant of #root (Modal renders inline, no portal), and an ancestor
   // touch-action:none would disable touch-panning for descendants, breaking
   // in-modal scrolling on mobile.
+  // Uses a module-level ref count so nested/overlapping modals don't prematurely
+  // unlock #root — the lock is only released when the last modal closes.
   useEffect(() => {
     if (!isOpen) return
     const root = document.getElementById('root')
     if (!root) return
-    const prevOverflow = root.style.overflow
-    const prevScrollTop = root.scrollTop
-    root.style.overflow = 'hidden'
+    if (rootLockCount === 0) {
+      savedOverflow = root.style.overflow
+      savedScrollTop = root.scrollTop
+      root.style.overflow = 'hidden'
+    }
+    rootLockCount++
     return () => {
-      root.style.overflow = prevOverflow
-      root.scrollTop = prevScrollTop
+      rootLockCount--
+      if (rootLockCount === 0) {
+        root.style.overflow = savedOverflow
+        root.scrollTop = savedScrollTop
+      }
     }
   }, [isOpen])
 

--- a/frontend/src/test/issue-582-modal-scroll-lock.spec.ts
+++ b/frontend/src/test/issue-582-modal-scroll-lock.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from './fixtures'
+import { gotoQueue } from './helpers'
+
+test.describe('Issue #582: modal scroll lock on #root', () => {
+  test('locks #root overflow while a modal is open and restores on close', async ({ authenticatedPage }) => {
+    await gotoQueue(authenticatedPage)
+    const root = authenticatedPage.locator('#root')
+
+    // Open the Create Thread modal via the Add Thread button.
+    await authenticatedPage.getByRole('button', { name: 'Add Thread' }).first().click()
+    await expect(authenticatedPage.getByRole('dialog')).toBeVisible()
+
+    // #root is locked while the modal is open.
+    await expect(root).toHaveCSS('overflow', 'hidden')
+
+    // Close via Escape.
+    await authenticatedPage.keyboard.press('Escape')
+    await expect(authenticatedPage.getByRole('dialog')).toHaveCount(0)
+
+    // #root overflow is restored (not hidden).
+    const overflow = await root.evaluate((el) => getComputedStyle(el).overflow)
+    expect(overflow).not.toBe('hidden')
+  })
+
+  test('modal inner container contains overscroll so it cannot chain to #root', async ({ authenticatedPage }) => {
+    await gotoQueue(authenticatedPage)
+    await authenticatedPage.getByRole('button', { name: 'Add Thread' }).first().click()
+    const dialog = authenticatedPage.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+
+    // The inner scroll container (overflow-y-auto) must contain overscroll.
+    const inner = dialog.locator('div.overflow-y-auto').first()
+    await expect(inner).toHaveCSS('overscroll-behavior-y', 'contain')
+  })
+})


### PR DESCRIPTION
## Fixes #582

### Problem
When a modal is open on iOS, the page behind the modal can still scroll (scroll-bleed). This happens because `styles.css` already sets `html`/`body` to `overflow: hidden`, so locking `<body>` is a no-op — the real scroller is `#root` (`overflow-y: auto`).

### Changes

**`frontend/src/components/Modal.tsx`** — 3 changes:
1. **New `useEffect`** — locks `#root` overflow to `hidden` while a modal is open; restores previous `overflow` + `scrollTop` on close (prevents scroll-position drift).
2. **Backdrop `touch-none`** — prevents dragging the backdrop from scrolling `#root`.
3. **Inner container `overscroll-contain`** — prevents in-modal scroll from chaining to `#root` at the boundary.

**New E2E test: `frontend/src/test/issue-582-modal-scroll-lock.spec.ts`**
- Asserts `#root` computed `overflow === 'hidden'` while modal is open, restored on close.
- Asserts inner scroll container has `overscroll-behavior-y: contain`.

### Verification
- `pnpm run lint` → 0 errors
- `pnpm run typecheck` → 0 errors
- `pnpm run build` → success
- `pnpm test` → 42 files, 252 tests passed
- E2E: `issue-582-modal-scroll-lock.spec.ts` → 2/2 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented background page scrolling while a modal is open.
  * Restored the page’s previous scroll position and scrolling behavior after the modal closes.
  * Reduced scroll chaining from modal content to the background page.
  * Improved touch interaction behavior within the modal overlay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->