### PR TITLE
fix: Increase swipe threshold (direction lock 5→12px, open 48→64px)

### DIFF
--- a/frontend/src/components/Swipeable.tsx
+++ b/frontend/src/components/Swipeable.tsx
@@ -27,7 +27,8 @@ export default function Swipeable({
   const startOffsetRef = useRef(0)
   const isHorizontalRef = useRef<boolean | null>(null)
   const ACTION_WIDTH = 192
-  const SWIPE_THRESHOLD = 48
+  const SWIPE_THRESHOLD = 64
+  const DIRECTION_LOCK_THRESHOLD = 12
 
   function handleTouchStart(e: TouchEvent) {
     const touch = e.touches[0]
@@ -44,7 +45,7 @@ export default function Swipeable({
     const dy = touch.clientY - startYRef.current
 
     if (isHorizontalRef.current === null) {
-      if (Math.abs(dx) < 5 && Math.abs(dy) < 5) return
+      if (Math.abs(dx) < DIRECTION_LOCK_THRESHOLD && Math.abs(dy) < DIRECTION_LOCK_THRESHOLD) return
       isHorizontalRef.current = Math.abs(dx) > Math.abs(dy)
     }
 

--- a/frontend/src/unit/Swipeable.test.tsx
+++ b/frontend/src/unit/Swipeable.test.tsx
@@ -1,0 +1,136 @@
+import { act, render, screen } from '@testing-library/react'
+import { expect, it, vi } from 'vitest'
+import Swipeable from '../components/Swipeable'
+
+function renderSwipeable() {
+  const onCardClick = vi.fn()
+  const onAction = vi.fn()
+
+  render(
+    <Swipeable
+      data-testid="swipeable-card"
+      onCardClick={onCardClick}
+      actions={[
+        { icon: '📖', label: 'Read', onClick: onAction, color: 'bg-amber-600/30 text-amber-300' },
+      ]}
+    >
+      <p>Card content</p>
+    </Swipeable>,
+  )
+
+  const wrapper = screen.getByTestId('swipeable-card')
+  // The sliding card div is the last child of the wrapper (after the action panel)
+  const slidingCard = wrapper.lastElementChild as HTMLElement
+
+  return { onCardClick, onAction, wrapper, slidingCard }
+}
+
+function createTouchEvent(type: string, options: { x: number; y: number }) {
+  const event = new TouchEvent(type, { bubbles: true, cancelable: true })
+  const touch = { clientX: options.x, clientY: options.y }
+
+  // jsdom does not reliably set touches/changedTouches from the TouchEventInit
+  // dictionary, so we define them directly on the instance.
+  Object.defineProperty(event, 'touches', {
+    value: type === 'touchend' ? [] : [touch],
+    configurable: true,
+  })
+  Object.defineProperty(event, 'changedTouches', {
+    value: [touch],
+    configurable: true,
+  })
+
+  return event
+}
+
+it('does not reveal actions on vertical scroll when dx is locked by direction threshold', () => {
+  const { slidingCard } = renderSwipeable()
+
+  act(() => {
+    slidingCard.dispatchEvent(createTouchEvent('touchstart', { x: 200, y: 100 }))
+  })
+  // Move vertically: dx=5 (< 12 threshold), dy=100 (large) → direction resolves to vertical
+  act(() => {
+    slidingCard.dispatchEvent(createTouchEvent('touchmove', { x: 205, y: 200 }))
+  })
+  act(() => {
+    slidingCard.dispatchEvent(createTouchEvent('touchend', { x: 205, y: 200 }))
+  })
+
+  // Card must remain closed
+  expect(slidingCard.style.transform).toBe('translateX(0px)')
+})
+
+it('does not reveal actions when both axes are within direction-lock threshold (tiny jitter)', () => {
+  const { slidingCard } = renderSwipeable()
+
+  act(() => {
+    slidingCard.dispatchEvent(createTouchEvent('touchstart', { x: 200, y: 100 }))
+  })
+  // Both dx and dy are < 12 → early return before direction is resolved
+  act(() => {
+    slidingCard.dispatchEvent(createTouchEvent('touchmove', { x: 208, y: 108 }))
+  })
+  act(() => {
+    slidingCard.dispatchEvent(createTouchEvent('touchend', { x: 208, y: 108 }))
+  })
+
+  expect(slidingCard.style.transform).toBe('translateX(0px)')
+})
+
+it('reveals actions on horizontal swipe past threshold', () => {
+  const { slidingCard } = renderSwipeable()
+
+  act(() => {
+    slidingCard.dispatchEvent(createTouchEvent('touchstart', { x: 200, y: 100 }))
+  })
+  // Swipe left 150px: dx=-150, dy=5 → horizontal → past SWIPE_THRESHOLD(64)
+  act(() => {
+    slidingCard.dispatchEvent(createTouchEvent('touchmove', { x: 50, y: 105 }))
+  })
+  act(() => {
+    slidingCard.dispatchEvent(createTouchEvent('touchend', { x: 50, y: 105 }))
+  })
+
+  // Card should stay open at -ACTION_WIDTH
+  expect(slidingCard.style.transform).toBe('translateX(-192px)')
+})
+
+it('snaps closed when horizontal swipe is released before SWIPE_THRESHOLD', () => {
+  const { slidingCard } = renderSwipeable()
+
+  act(() => {
+    slidingCard.dispatchEvent(createTouchEvent('touchstart', { x: 200, y: 100 }))
+  })
+  // Swipe left only 30px: dx=-30, dy=5 → horizontal but < SWIPE_THRESHOLD(64)
+  act(() => {
+    slidingCard.dispatchEvent(createTouchEvent('touchmove', { x: 170, y: 105 }))
+  })
+  act(() => {
+    slidingCard.dispatchEvent(createTouchEvent('touchend', { x: 170, y: 105 }))
+  })
+
+  // Card should snap back closed
+  expect(slidingCard.style.transform).toBe('translateX(0px)')
+})
+
+it('fires onCardClick when card is tapped without swiping', () => {
+  const { onCardClick, slidingCard } = renderSwipeable()
+
+  act(() => {
+    slidingCard.dispatchEvent(createTouchEvent('touchstart', { x: 200, y: 100 }))
+  })
+  // Move within direction-lock threshold — acting as a tap
+  act(() => {
+    slidingCard.dispatchEvent(createTouchEvent('touchmove', { x: 203, y: 103 }))
+  })
+  act(() => {
+    slidingCard.dispatchEvent(createTouchEvent('touchend', { x: 203, y: 103 }))
+  })
+  act(() => {
+    slidingCard.click()
+  })
+
+  expect(onCardClick).toHaveBeenCalledTimes(1)
+})
+


### PR DESCRIPTION
Closes #580.

## What changed

**frontend/src/components/Swipeable.tsx** (3 insertions, 2 deletions):
- Extract inline `5` direction-lock threshold into named constant `DIRECTION_LOCK_THRESHOLD = 12`
- Bump `SWIPE_THRESHOLD` from `48` to `64` (need a more deliberate swipe to reveal actions)
- The direction-lock now waits for 12px before committing horizontal vs. vertical

**frontend/src/unit/Swipeable.test.tsx** (new file — first Swipeable test coverage):
- 5 tests covering vertical scroll, jitter, full swipe, partial swipe, and tap

## Why

When scrolling vertically on mobile, dx/dy values of +/-5px were enough to commit the swipe direction as horizontal, causing action buttons to appear accidentally during normal scrolling. The new 12px threshold matches natural finger jitter, and 64px ensures actions require a deliberate swipe.

Before: direction lock at 5px, open threshold at 48px
After:  direction lock at 12px, open threshold at 64px

## Verification

- `cd frontend && pnpm run lint` — clean
- `cd frontend && pnpm run typecheck` — clean
- `cd frontend && pnpm run build` — clean (1.55s)
- `cd frontend && pnpm test` — 257 tests pass (43 files) including the 5 new Swipeable tests

## Manual testing needed

- Mobile device/emulator: scroll vertically → no accidental swipe
- Deliberate horizontal swipe → actions reveal
- Partial swipe (< 64px) → snaps closed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swipe gesture detection to better distinguish horizontal swipes from vertical scrolling and minor touch jitter.
  * Adjusted the swipe activation distance for more predictable action reveals.
  * Ensured incomplete swipes snap closed while taps continue to trigger card actions.

* **Tests**
  * Added coverage for scrolling, jitter, swipe thresholds, snap-back behavior, and tap interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->