### PR TITLE
Preserve drag-to-reorder in the virtualized list (#585)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@
 - On desktop, the virtualized list renders in a **responsive multi-column grid** (3 columns at ≥1280px, 2 columns at 768–1279px, 1 column below 768px), restoring desktop grid parity while maintaining virtualization performance.
 - Small queues (<50) continue to use the existing responsive grid with no behavioral change.
 - The scroll container adapts to device orientation changes automatically.
+- Drag-to-reorder now works in the virtualized list: dragging near the top or bottom of the viewport auto-scrolls so off-screen drop targets come into view, restoring reorder parity for large queues.
 
 **Mobile Safari rendering fix**
 - Pages now render their background correctly on mobile Safari instead of appearing stripped or bare.

--- a/frontend/src/pages/QueuePage/VirtualizedThreadList.helpers.ts
+++ b/frontend/src/pages/QueuePage/VirtualizedThreadList.helpers.ts
@@ -18,6 +18,13 @@ export const ROW_HEIGHT_WITH_GAP = CARD_HEIGHT + ROW_GAP
 export const OVERSCAN_PX = 800
 
 /**
+ * Vertical distance (in px) from the top or bottom edge of the scroll
+ * container within which a drag-over triggers auto-scrolling for
+ * drag-to-reorder in the virtualized list.  Matches ~half a card height.
+ */
+export const EDGE_SCROLL_ZONE = 80
+
+/**
  * Cardinality breakpoint boundaries with descriptive names to avoid
  * confusion with Tailwind's `sm`/`md`/`lg`/`xl` naming.
  *

--- a/frontend/src/pages/QueuePage/VirtualizedThreadList.tsx
+++ b/frontend/src/pages/QueuePage/VirtualizedThreadList.tsx
@@ -214,6 +214,7 @@ export default function VirtualizedThreadList<T>({
         role="list"
         aria-label="Thread queue"
         onDragOver={handleContainerDragOver}
+        onDrop={(event) => event.preventDefault()}
         style={{
           height: '100%',
           overflowY: 'auto',

--- a/frontend/src/pages/QueuePage/VirtualizedThreadList.tsx
+++ b/frontend/src/pages/QueuePage/VirtualizedThreadList.tsx
@@ -1,9 +1,10 @@
 import type { ReactNode } from 'react'
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import {
   getColumnCount,
   getRowThreads,
+  EDGE_SCROLL_ZONE,
   ROW_GAP,
   ROW_HEIGHT_WITH_GAP,
   OVERSCAN_PX,
@@ -135,6 +136,43 @@ export default function VirtualizedThreadList<T>({
 
   const virtualizer = useVirtualizer(virtualizerOptions)
 
+  // ── Drag-reorder edge auto-scroll (583-D) ──
+  // Throttle timestamp to avoid calling scrollToIndex faster than the virtualizer
+  // can re-measure (~50ms is generous for the resize → remeasure cycle).
+  const lastEdgeScrollRef = useRef<number>(0)
+
+  const handleContainerDragOver = useCallback(
+    (event: React.DragEvent<HTMLDivElement>) => {
+      const container = scrollRef.current
+      if (!container) return
+
+      const now = performance.now()
+      // Throttle to avoid flooding scrollToIndex with 60+ calls per second.
+      if (now - lastEdgeScrollRef.current < 50) return
+
+      const rect = container.getBoundingClientRect()
+      const y = event.clientY - rect.top
+      const visibleItems = virtualizer.getVirtualItems()
+      if (visibleItems.length === 0) return
+
+      const firstIndex = visibleItems[0].index
+      const lastIndex = visibleItems[visibleItems.length - 1].index
+
+      if (y < EDGE_SCROLL_ZONE) {
+        lastEdgeScrollRef.current = now
+        virtualizer.scrollToIndex(Math.max(0, firstIndex - 1), {
+          align: 'start',
+        })
+      } else if (y > rect.height - EDGE_SCROLL_ZONE) {
+        lastEdgeScrollRef.current = now
+        virtualizer.scrollToIndex(Math.min(rowCount - 1, lastIndex + 1), {
+          align: 'end',
+        })
+      }
+    },
+    [rowCount, virtualizer],
+  )
+
   // Defensive empty state — QueuePage gates on empty/filtered-empty before reaching this
   // component, but this ensures standalone reuse also shows a graceful fallback.
   // Wraps in the same `wrapperRef > scrollRef` tree structure as the populated state
@@ -175,6 +213,7 @@ export default function VirtualizedThreadList<T>({
         id="queue-container"
         role="list"
         aria-label="Thread queue"
+        onDragOver={handleContainerDragOver}
         style={{
           height: '100%',
           overflowY: 'auto',

--- a/frontend/src/test/issue-583-virtualized-drag-reorder.spec.ts
+++ b/frontend/src/test/issue-583-virtualized-drag-reorder.spec.ts
@@ -34,19 +34,14 @@ test.describe('Virtualized drag-to-reorder (#583-D)', () => {
     // Perform the drag: drag the handle from card #1 onto card #5
     await dragHandle.dragTo(targetCard, { force: true });
 
-    // After the drop, refetch threads to confirm reorder happened.
-    // The queue should have changed — the originally-#1 thread is no longer at position 1.
-    await page.waitForTimeout(500); // allow the mutation + refetch to complete
-
-    // Verify the first card changed (drag reorder happened)
-    const firstCardAfter = page.locator('[data-testid="queue-thread-item"]').first();
-    const firstTextAfter = await firstCardAfter.textContent();
-
-    // The first card should either be the former target (moved up) or something different
-    // from the original first (we don't know exact position — just verify it changed)
-    if (sourceText && firstTextAfter) {
-      expect(sourceText).not.toBe(firstTextAfter);
-    }
+    // After the drop, wait for the reorder mutation and refetch to settle.
+    // The originally-#1 thread should no longer be at position 1.
+    await expect
+      .poll(async () => {
+        const text = await page.locator('[data-testid="queue-thread-item"]').first().textContent();
+        return text;
+      })
+      .not.toBe(sourceText);
 
     // Also verify the target card changed (its position was affected)
     const targetCardAfter = visibleCards.nth(4);
@@ -98,13 +93,10 @@ test.describe('Virtualized drag-to-reorder (#583-D)', () => {
       return el.scrollTop;
     });
 
-    // Wait for the virtualizer's smooth scroll to settle
-    await page.waitForTimeout(500);
-
-    // Read final scrollTop
-    const finalScrollTop = await list.evaluate((el) => el.scrollTop);
-
-    // The auto-scroll should have increased scrollTop beyond the baseline
-    expect(finalScrollTop).toBeGreaterThan(initialScrollTop);
+    // Wait for the virtualizer's smooth scroll to settle, polling until
+    // scrollTop increases beyond the baseline.
+    await expect
+      .poll(async () => list.evaluate((el) => el.scrollTop))
+      .toBeGreaterThan(initialScrollTop);
   });
 });

--- a/frontend/src/test/issue-583-virtualized-drag-reorder.spec.ts
+++ b/frontend/src/test/issue-583-virtualized-drag-reorder.spec.ts
@@ -1,0 +1,110 @@
+import { expect } from './fixtures';
+import { test } from './fixtures';
+import { waitForQueueReady } from './helpers';
+
+test.describe('Virtualized drag-to-reorder (#583-D)', () => {
+  test('drag reorder works within the virtualized list', async ({ authenticatedWithLargeQueuePage }) => {
+    const page = authenticatedWithLargeQueuePage;
+
+    await page.goto('/queue', { waitUntil: 'domcontentloaded' });
+    await waitForQueueReady(page);
+
+    const list = page.locator('[data-testid="queue-thread-list"]');
+    await expect(list).toBeVisible();
+
+    // Get the first card's drag handle (⠿ button with aria-label="Drag to reorder")
+    const firstCard = page.locator('[data-testid="queue-thread-item"]').first();
+    const dragHandle = firstCard.locator('button[aria-label="Drag to reorder"]');
+    await expect(dragHandle).toBeVisible();
+
+    // Find a visible lower target card (the 5th visible one)
+    const visibleCards = page.locator('[data-testid="queue-thread-item"]');
+    const cardCount = await visibleCards.count();
+    if (cardCount < 5) {
+      throw new Error(`Expected at least 5 visible cards, found ${cardCount}`);
+    }
+
+    const targetCard = visibleCards.nth(4);
+    await expect(targetCard).toBeVisible();
+
+    // Read the text of the first and target items before drag
+    const sourceText = await firstCard.textContent();
+    const targetText = await targetCard.textContent();
+
+    // Perform the drag: drag the handle from card #1 onto card #5
+    await dragHandle.dragTo(targetCard, { force: true });
+
+    // After the drop, refetch threads to confirm reorder happened.
+    // The queue should have changed — the originally-#1 thread is no longer at position 1.
+    await page.waitForTimeout(500); // allow the mutation + refetch to complete
+
+    // Verify the first card changed (drag reorder happened)
+    const firstCardAfter = page.locator('[data-testid="queue-thread-item"]').first();
+    const firstTextAfter = await firstCardAfter.textContent();
+
+    // The first card should either be the former target (moved up) or something different
+    // from the original first (we don't know exact position — just verify it changed)
+    if (sourceText && firstTextAfter) {
+      expect(sourceText).not.toBe(firstTextAfter);
+    }
+
+    // Also verify the target card changed (its position was affected)
+    const targetCardAfter = visibleCards.nth(4);
+    const targetTextAfter = await targetCardAfter.textContent();
+    if (targetText && targetTextAfter) {
+      expect(targetText).not.toBe(targetTextAfter);
+    }
+  });
+
+  test('dragging near the bottom edge auto-scrolls to reveal off-screen items', async ({ authenticatedWithLargeQueuePage }) => {
+    const page = authenticatedWithLargeQueuePage;
+
+    // Use a narrower viewport to ensure single-column mode for simpler edge detection
+    await page.setViewportSize({ width: 375, height: 812 });
+
+    await page.goto('/queue', { waitUntil: 'domcontentloaded' });
+    await waitForQueueReady(page);
+
+    const list = page.locator('[data-testid="queue-thread-list"]');
+    await expect(list).toBeVisible();
+
+    // Set scrollTop to 0 for a clean baseline
+    await list.evaluate((el) => { el.scrollTop = 0; });
+    const initialScrollTop = await list.evaluate((el) => el.scrollTop);
+    expect(initialScrollTop).toBe(0);
+
+    // Dispatch a series of real DragEvent dragover events near the bottom edge.
+    // The component's container onDragOver handler auto-scrolls via
+    // virtualizer.scrollToIndex when clientY is within EDGE_SCROLL_ZONE (80px)
+    // of the bottom of the container.
+    const scrolled = await list.evaluate((el) => {
+      const rect = el.getBoundingClientRect();
+      const dataTransfer = new DataTransfer();
+
+      // Fire multiple dragover events near the bottom edge to simulate
+      // a dragged item hovering there.  Each event triggers one scroll step.
+      for (let i = 0; i < 5; i++) {
+        const event = new DragEvent('dragover', {
+          clientY: rect.bottom - 40, // well within the 80-px edge zone
+          bubbles: true,
+          cancelable: true,
+          dataTransfer,
+        });
+        el.dispatchEvent(event);
+      }
+
+      // Return scrollTop after the events (scrollToIndex is async, but a
+      // small settle-time wait happens in the caller)
+      return el.scrollTop;
+    });
+
+    // Wait for the virtualizer's smooth scroll to settle
+    await page.waitForTimeout(500);
+
+    // Read final scrollTop
+    const finalScrollTop = await list.evaluate((el) => el.scrollTop);
+
+    // The auto-scroll should have increased scrollTop beyond the baseline
+    expect(finalScrollTop).toBeGreaterThan(initialScrollTop);
+  });
+});

--- a/frontend/src/unit/VirtualizedThreadList.test.tsx
+++ b/frontend/src/unit/VirtualizedThreadList.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { expect, it, vi, beforeAll } from 'vitest'
+import { expect, it, vi, beforeAll, beforeEach } from 'vitest'
 import { getColumnCount, getRowThreads } from '../pages/QueuePage/VirtualizedThreadList.helpers'
 import VirtualizedThreadList from '../pages/QueuePage/VirtualizedThreadList'
 
@@ -30,8 +30,35 @@ vi.mock('@tanstack/react-virtual', () => ({
   }),
 }))
 
-// Stub ResizeObserver (still needed for the component's own ResizeObserver)
+// Stub DragEvent / DataTransfer (not available in jsdom) for drag-reorder tests.
+// Must be defined before the module is loaded so `new DragEvent(...)` works inside
+// tests.  We use a stub DataTransfer object because React's synthetic event system
+// checks `event.dataTransfer`.
+// Also stub ResizeObserver (needed by the component's useEffect).
 beforeAll(() => {
+  if (!globalThis.DataTransfer) {
+    globalThis.DataTransfer = class {
+      effectAllowed = 'none'
+      dropEffect = 'none'
+      items = { length: 0, add: () => {}, clear: () => {} } as unknown as DataTransferItemList
+      types: string[] = []
+      getData = (_format: string) => ''
+      setData = () => {}
+      clearData = () => {}
+      setDragImage = () => {}
+      files = Object.freeze([]) as unknown as FileList
+    } as unknown as typeof DataTransfer
+  }
+  if (!globalThis.DragEvent) {
+    globalThis.DragEvent = class extends MouseEvent {
+      declare dataTransfer: DataTransfer | null
+      constructor(type: string, eventInitDict?: DragEventInit) {
+        super(type, eventInitDict ?? {})
+        this.dataTransfer = (eventInitDict as DragEventInit | undefined)?.dataTransfer ?? null
+      }
+    } as unknown as typeof DragEvent
+  }
+  // Stub ResizeObserver (needed for the component's own ResizeObserver)
   vi.stubGlobal(
     'ResizeObserver',
     vi.fn(function (this: any) {
@@ -372,4 +399,149 @@ it('empty state preserves the same DOM tree structure', () => {
   expect(screen.getByLabelText('Thread queue')).toBeInTheDocument()
   // Should show the empty message
   expect(screen.getByText('No threads in queue')).toBeInTheDocument()
+})
+
+// ── Drag-reorder edge auto-scroll tests (583-D) ──
+
+beforeEach(() => {
+  mockScrollToIndex.mockClear()
+  // Restore the default virtual-items mock populated by the top-level beforeAll
+  mockGetVirtualItems.mockReturnValue(
+    Array.from({ length: 5 }, (_, i) => ({
+      key: i,
+      index: i,
+      start: i * 160,
+      end: (i + 1) * 160,
+      size: 160,
+      lane: 0,
+    })),
+  )
+})
+
+it('calls scrollToIndex toward first visible when dragging near the top edge', () => {
+  const threads = createMockThreads(60)
+
+  const { container } = render(
+    <VirtualizedThreadList
+      threads={threads}
+      renderItem={(thread, _index) => (
+        <div data-testid="queue-thread-item" key={(thread as MockThread).id}>
+          {(thread as MockThread).title}
+        </div>
+      )}
+    />,
+  )
+
+  const scrollEl = container.querySelector('#queue-container') as HTMLElement
+
+  // Spy on getBoundingClientRect so edge detection works.
+  vi.spyOn(scrollEl, 'getBoundingClientRect').mockReturnValue({
+    top: 0,
+    bottom: 600,
+    height: 600,
+    width: 800,
+    left: 0,
+    right: 800,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  })
+
+  // Construct a proper DragEvent so React's synthetic event system
+  // recognizes and dispatches it. jsdom requires passing dataTransfer
+  // via the constructor's second argument.
+  const dataTransfer = new DataTransfer()
+  const dragEvent = new DragEvent('dragover', {
+    clientY: 10,
+    bubbles: true,
+    cancelable: true,
+    dataTransfer,
+  })
+
+  scrollEl.dispatchEvent(dragEvent)
+
+  expect(mockScrollToIndex).toHaveBeenCalledWith(0, { align: 'start' })
+})
+
+it('calls scrollToIndex toward last visible when dragging near the bottom edge', () => {
+  const threads = createMockThreads(60)
+
+  const { container } = render(
+    <VirtualizedThreadList
+      threads={threads}
+      renderItem={(thread, _index) => (
+        <div data-testid="queue-thread-item" key={(thread as MockThread).id}>
+          {(thread as MockThread).title}
+        </div>
+      )}
+    />,
+  )
+
+  const scrollEl = container.querySelector('#queue-container') as HTMLElement
+
+  vi.spyOn(scrollEl, 'getBoundingClientRect').mockReturnValue({
+    top: 0,
+    bottom: 600,
+    height: 600,
+    width: 800,
+    left: 0,
+    right: 800,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  })
+
+  // Drag near bottom edge (clientY=590 → y=590 > 600-80=520)
+  const dataTransfer2 = new DataTransfer()
+  const dragEvent2 = new DragEvent('dragover', {
+    clientY: 590,
+    bubbles: true,
+    cancelable: true,
+    dataTransfer: dataTransfer2,
+  })
+  scrollEl.dispatchEvent(dragEvent2)
+
+  // last visible index is 4, so it should call scrollToIndex(5, { align: 'end' })
+  expect(mockScrollToIndex).toHaveBeenCalledWith(5, { align: 'end' })
+})
+
+it('does not call scrollToIndex when dragging in the middle of the container', () => {
+  const threads = createMockThreads(60)
+
+  const { container } = render(
+    <VirtualizedThreadList
+      threads={threads}
+      renderItem={(thread, _index) => (
+        <div data-testid="queue-thread-item" key={(thread as MockThread).id}>
+          {(thread as MockThread).title}
+        </div>
+      )}
+    />,
+  )
+
+  const scrollEl = container.querySelector('#queue-container') as HTMLElement
+
+  vi.spyOn(scrollEl, 'getBoundingClientRect').mockReturnValue({
+    top: 0,
+    bottom: 600,
+    height: 600,
+    width: 800,
+    left: 0,
+    right: 800,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  })
+
+  // Drag in the middle (clientY=300, well within bounds)
+  const dataTransfer3 = new DataTransfer()
+  const dragEvent3 = new DragEvent('dragover', {
+    clientY: 300,
+    bubbles: true,
+    cancelable: true,
+    dataTransfer: dataTransfer3,
+  })
+  scrollEl.dispatchEvent(dragEvent3)
+
+  expect(mockScrollToIndex).not.toHaveBeenCalled()
 })


### PR DESCRIPTION
Closes #585.
Part of epic #583 — sub-issue D (the last remaining piece).

## Summary

When dragging a thread to reorder in the virtualized list (>50 threads), off-screen drop targets are not in the DOM so native drag-to-reorder breaks. This PR adds **edge auto-scroll**: dragging near the top or bottom of the viewport programmatically scrolls the virtualizer via `scrollToIndex`, bringing off-screen targets into view so they become valid drop targets.

## Changes

- **`VirtualizedThreadList.helpers.ts`**: Added `EDGE_SCROLL_ZONE` constant (80px) — the vertical distance from the container edge that triggers auto-scroll.
- **`VirtualizedThreadList.tsx`**: Added a container-level `onDragOver` handler that detects edge proximity and calls `virtualizer.scrollToIndex` (throttled at 50ms). The handler is self-contained and does not require changes to `QueuePage` or `QueueThreadCard`.
- **Unit tests**: 3 new tests covering top-edge scroll, bottom-edge scroll, and middle-no-scroll behavior using mocked virtualizer and jsdom DragEvent stubs.
- **E2E tests** (`issue-583-virtualized-drag-reorder.spec.ts`): 2 tests — drag-reorder parity within the virtualized list, and edge auto-scroll engagement via dispatched `DragEvent`s.
- **Changelog**: Updated the 2026-07-13 Queue virtualization entry.

## Verification

- ✅ `pnpm run lint` — clean
- ✅ `pnpm run typecheck` — clean
- ✅ `pnpm test` — 282 tests pass (25 in VirtualizedThreadList, 3 new)
- ✅ `pnpm run build` — succeeds
- ✅ E2E `issue-583-virtualized-drag-reorder.spec.ts` — 2 passed (chromium)
- ✅ E2E `issue-583-virtualized-grid.spec.ts` — 4 passed (no regressions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Drag-to-reorder now works smoothly in virtualized queues, including automatic scrolling when dragging near the top or bottom edges to reach off-screen items.

* **Bug Fixes**
  * Improved support for reordering items in large queues.

* **Tests**
  * Added coverage for drag-and-drop reordering and edge-triggered scrolling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->