### PR TITLE
Fix: QA hardening for virtualization PRs (memoization, E2E robustness)

### DIFF
--- a/frontend/src/pages/QueuePage/VirtualizedThreadList.helpers.ts
+++ b/frontend/src/pages/QueuePage/VirtualizedThreadList.helpers.ts
@@ -45,11 +45,16 @@ export const EDGE_SCROLL_ZONE = 80
  * viewport size.
  */
 export const COL_BREAKPOINTS = {
-  /** Container width at viewport `md` (768px) — switches to 2 columns. */
+  /** Container width at viewport `md` (768px) — active boundary that switches to 2 columns. */
   tablet: 640,
-  /** Container width at viewport `lg` (1024px) — still 2 columns. */
+  /**
+   * Container width at viewport `lg` (1024px) — still 2 columns.
+   * Descriptive only: not referenced as a boundary in `getColumnCount`
+   * (only `tablet` and `wide` are active boundaries), but kept for
+   * documentation parity with the Tailwind breakpoint table above.
+   */
   desktop: 864,
-  /** Container width at viewport `xl` (1280px) — switches to 3 columns. */
+  /** Container width at viewport `xl` (1280px) — active boundary that switches to 3 columns. */
   wide: 992,
 } as const
 

--- a/frontend/src/pages/QueuePage/VirtualizedThreadList.tsx
+++ b/frontend/src/pages/QueuePage/VirtualizedThreadList.tsx
@@ -136,6 +136,13 @@ export default function VirtualizedThreadList<T>({
 
   const virtualizer = useVirtualizer(virtualizerOptions)
 
+  // Keep a ref to the latest virtualizer so the drag-over handler stays
+  // referentially stable. useVirtualizer returns a new object every render,
+  // so putting it in a useCallback deps array would recreate the handler
+  // (and the onDragOver prop) each render — ineffective memoization.
+  const virtualizerRef = useRef(virtualizer)
+  virtualizerRef.current = virtualizer
+
   // ── Drag-reorder edge auto-scroll (583-D) ──
   // Throttle timestamp to avoid calling scrollToIndex faster than the virtualizer
   // can re-measure (~50ms is generous for the resize → remeasure cycle).
@@ -150,9 +157,10 @@ export default function VirtualizedThreadList<T>({
       // Throttle to avoid flooding scrollToIndex with 60+ calls per second.
       if (now - lastEdgeScrollRef.current < 50) return
 
+      const vz = virtualizerRef.current
       const rect = container.getBoundingClientRect()
       const y = event.clientY - rect.top
-      const visibleItems = virtualizer.getVirtualItems()
+      const visibleItems = vz.getVirtualItems()
       if (visibleItems.length === 0) return
 
       const firstIndex = visibleItems[0].index
@@ -160,17 +168,17 @@ export default function VirtualizedThreadList<T>({
 
       if (y < EDGE_SCROLL_ZONE) {
         lastEdgeScrollRef.current = now
-        virtualizer.scrollToIndex(Math.max(0, firstIndex - 1), {
+        vz.scrollToIndex(Math.max(0, firstIndex - 1), {
           align: 'start',
         })
       } else if (y > rect.height - EDGE_SCROLL_ZONE) {
         lastEdgeScrollRef.current = now
-        virtualizer.scrollToIndex(Math.min(rowCount - 1, lastIndex + 1), {
+        vz.scrollToIndex(Math.min(rowCount - 1, lastIndex + 1), {
           align: 'end',
         })
       }
     },
-    [rowCount, virtualizer],
+    [rowCount],
   )
 
   // Defensive empty state — QueuePage gates on empty/filtered-empty before reaching this

--- a/frontend/src/test/issue-583-virtualized-drag-reorder.spec.ts
+++ b/frontend/src/test/issue-583-virtualized-drag-reorder.spec.ts
@@ -43,12 +43,14 @@ test.describe('Virtualized drag-to-reorder (#583-D)', () => {
       })
       .not.toBe(sourceText);
 
-    // Also verify the target card changed (its position was affected)
-    const targetCardAfter = visibleCards.nth(4);
-    const targetTextAfter = await targetCardAfter.textContent();
-    if (targetText && targetTextAfter) {
-      expect(targetText).not.toBe(targetTextAfter);
-    }
+    // The card now at position 5 should show a different thread than before
+    // the reorder. Poll because the refetch + re-render can briefly detach
+    // the element.
+    await expect
+      .poll(async () => {
+        return await page.locator('[data-testid="queue-thread-item"]').nth(4).textContent();
+      })
+      .not.toBe(targetText);
   });
 
   test('dragging near the bottom edge auto-scrolls to reveal off-screen items', async ({ authenticatedWithLargeQueuePage }) => {

--- a/frontend/src/test/issue-583-virtualized-grid.spec.ts
+++ b/frontend/src/test/issue-583-virtualized-grid.spec.ts
@@ -100,11 +100,13 @@ test.describe('Responsive multi-column virtualized grid (#583-C)', () => {
       .locator('button[aria-label="Read"]')
       .evaluate((btn) => (btn as HTMLButtonElement).click());
 
-    // After clicking Read in the queue, the user should be navigated to the roll page
-    // We expect either a URL change or a specific UI state
-    await page.waitForURL(/^\/(roll)?$/, { timeout: 5000 }).catch(() => {
-      // Fallback: if URL didn't change (same SPA page), check for roll page indicators
-    });
+    // After clicking Read, the app navigates to the roll page (/). Polling
+    // avoids swallowing navigation failures (the previous
+    // waitForURL().catch(() => {}) masked real bugs). If already on /,
+    // this passes immediately; otherwise it waits for the SPA navigation.
+    await expect
+      .poll(async () => new URL(page.url()).pathname)
+      .toMatch(/^\/(roll)?$/);
 
     // The roll page should show the die or roll pool
     const mainDie = page.locator('[data-testid="d20-die"]');


### PR DESCRIPTION
## Summary

QA hardening from code review of the recent virtualization PRs (#592, #587, #594). Four minor fixes — no production bugs, all tests green.

## Changes

### 1. Effective memoization for drag-over handler
**`VirtualizedThreadList.tsx`** — `handleContainerDragOver`'s `useCallback` had `[rowCount, virtualizer]` in deps, but `useVirtualizer` returns a new object every render, defeating the memoization. Replaced with a stable ref-based pattern: `virtualizerRef` holds the latest instance, deps reduced to `[rowCount]`.

### 2. Remove silent assertion skip in drag-reorder E2E
**`issue-583-virtualized-drag-reorder.spec.ts`** — The target-card assertion was guarded by `if (targetText && targetTextAfter)`, which silently skipped if `textContent()` returned `null` or `""`. Replaced with a deterministic `expect.poll` that always asserts the card text changed.

### 3. Stop swallowing navigation failures in swipe E2E
**`issue-583-virtualized-grid.spec.ts`** — Replaced `waitForURL().catch(() => {})` with `expect.poll` on `pathname`. **Also fixed a pre-existing bug:** the original regex `/^\/(roll)?$/` was matching against the full URL (`http://localhost:9000/`), so it *never* matched — the URL check was dead code that always fell through to `.catch()`. Now correctly extracts `new URL(page.url()).pathname`.

### 4. Clarify unused breakpoint constant
**`VirtualizedThreadList.helpers.ts`** — `COL_BREAKPOINTS.desktop` is never referenced as a boundary in `getColumnCount`. Added JSDoc noting it's descriptive-only, and labeled `tablet`/`wide` as active boundaries for symmetry.

## Validation
- Lint — clean
- TypeScript — clean
- 282 unit tests pass
- Build — succeeds
- 6/6 affected E2E tests pass