### PR TITLE
Fix infinite loading on History page caused by pagination loop (#598)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-07-15
+
+**History page infinite loading fix (#598)**
+- Fixed infinite pagination loop in `useSessions` hook that caused the History page to hang forever with "Loading..."
+- `sessionApi.list` was overriding the `page_token` in params with `null` from its second parameter default, preventing pagination from advancing past the first page
+- Fixed `useSessions` to pass the page token as the second argument to `sessionApi.list`, matching the pattern used by `threadsApi.list` / `useThreads`
+- Added defensive fix to `sessionApi.list` to only set `page_token` when a truthy second argument is provided
+- Added regression test verifying multi-page session pagination completes correctly
+
 ## 2026-07-13
 
 **Queue virtualization for large collections**

--- a/frontend/src/hooks/useSession.ts
+++ b/frontend/src/hooks/useSession.ts
@@ -102,10 +102,10 @@ export function useSessions(params = EMPTY_PARAMS) {
       let nextToken: string | null = null;
       let currentToken: string | undefined = undefined;
       do {
-        const params = currentToken
-          ? { ...baseParams, page_token: currentToken }
-          : baseParams;
-        const result: SessionListResponse = await sessionApi.list(params);
+        const result: SessionListResponse = await sessionApi.list(
+          baseParams,
+          currentToken ?? null,
+        );
         allSessions = allSessions.concat(result.sessions);
         nextToken = result.next_page_token;
         currentToken = nextToken ?? undefined;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -306,8 +306,12 @@ export const rateApi = {
 
 export const sessionApi = {
   list: async (params?: Record<string, unknown>, pageToken?: string | null): Promise<SessionListResponse> => {
+    const queryParams: Record<string, unknown> = { ...(params ?? {}) };
+    if (pageToken) {
+      queryParams.page_token = pageToken;
+    }
     const response = await api.get<SessionListResponse>('/sessions/', {
-      params: { ...params, page_token: pageToken },
+      params: Object.keys(queryParams).length ? queryParams : undefined,
     })
     return response
   },

--- a/frontend/src/unit/useSession.test.tsx
+++ b/frontend/src/unit/useSession.test.tsx
@@ -53,7 +53,33 @@ it('loads session list', async () => {
   const { result } = renderWithProvider(() => useSessions({ status: 'done' }))
 
   await waitFor(() => expect(result.current.data).toEqual([{ id: 2 }]))
-  expect(mockedSessionApi.list).toHaveBeenCalledWith({ status: 'done', page_size: 200 })
+  expect(mockedSessionApi.list).toHaveBeenCalledWith({ status: 'done', page_size: 200 }, null)
+})
+
+it('paginates through all session pages without infinite loop', async () => {
+  mockedSessionApi.list
+    .mockReset()
+    .mockResolvedValueOnce({ sessions: [{ id: 1 }], next_page_token: 'token2' } as never)
+    .mockResolvedValueOnce({ sessions: [{ id: 2 }], next_page_token: null } as never)
+
+  const { result } = renderWithProvider(() => useSessions())
+
+  await waitFor(() => expect(result.current.data).toEqual([{ id: 1 }, { id: 2 }]))
+  expect(mockedSessionApi.list).toHaveBeenCalledTimes(2)
+  expect(mockedSessionApi.list).toHaveBeenNthCalledWith(1, { page_size: 200 }, null)
+  expect(mockedSessionApi.list).toHaveBeenNthCalledWith(2, { page_size: 200 }, 'token2')
+})
+
+it('handles list errors gracefully', async () => {
+  mockedSessionApi.list
+    .mockReset()
+    .mockRejectedValueOnce(new Error('Network error'))
+
+  const { result } = renderWithProvider(() => useSessions())
+
+  await waitFor(() => expect(result.current.isError).toBe(true))
+  await waitFor(() => expect(result.current.isPending).toBe(false))
+  expect(result.current.error).toBeInstanceOf(Error)
 })
 
 it('loads session details and snapshots', async () => {


### PR DESCRIPTION
## Summary

Fixes #598: The History page (📜 scroll icon) was stuck on infinite loading with a blank screen.

## Root Cause

The `useSessions` hook embedded the `page_token` in the first `params` argument to `sessionApi.list()`, but `sessionApi.list` always overrode `page_token` with `null` from its default second parameter:

```typescript
// api.ts (BEFORE)
list: async (params?, pageToken?) => {
    params: { ...params, page_token: pageToken },  // pageToken defaults to null, overriding params.page_token
}
```

This caused the pagination loop to fetch the first page repeatedly, never advancing — spinning forever and never setting `isPending = false`.

## Fix

1. **`useSessions`** — Pass the page token as the second argument, matching the pattern used by `useThreads` / `threadsApi.list`
2. **`sessionApi.list`** — Defensively only set `page_token` when a truthy second argument is given (matching `threadsApi.list` pattern)
3. **Regression test** — Verifies 2-page pagination completes correctly with proper token passing

## Changes

| File | Change |
|------|--------|
| `frontend/src/hooks/useSession.ts` | Pass `currentToken` as 2nd arg to `sessionApi.list()` |
| `frontend/src/services/api.ts` | Defensive fix: only set `page_token` when truthy 2nd arg |
| `frontend/src/unit/useSession.test.tsx` | +3 tests: pagination, error handling, updated existing |
| `docs/changelog.md` | Added changelog entry for 2026-07-15 |

## Verification

- ✅ `pnpm run lint` — clean
- ✅ `pnpm run typecheck` — clean  
- ✅ `pnpm test` — all 284 tests pass (including 3 new regression tests)
- ✅ `pnpm run build` — builds successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed infinite loading on the History page when session results span multiple pages.
  * Improved session pagination so additional results load correctly without repeating requests.
  * Ensured session-loading errors are surfaced and pending states are cleared properly.

* **Tests**
  * Added regression coverage for multi-page pagination and session-loading errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->