### PR TITLE
fix: apply PR #605 feedback — validate diagnostics, escape Markdown, simplify payload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,20 @@ If a test is failing:
 - **Write regression tests** for bugs you find and fix
 - **Update documentation** when you find gaps or outdated information
 
+
+## CORE PRINCIPLE: PR FEEDBACK TASKS ARE NOT DONE UNTIL PUSHED
+
+**⚠️ When asked to apply PR feedback, the job is: edit → verify → commit → push. All four steps. Every time.**
+
+If you edit files and run tests but stop before pushing, you have **not completed the task**. The user asked you to apply feedback to a PR — leaving changes local is not applying them.
+
+**Requirements:**
+- Edit the files with the requested changes
+- Verify all tests pass (Python + frontend)
+- Commit with a descriptive message
+- **Push to the remote branch immediately** — do not wait for the user to ask
+
+
 ## CRITICAL: NEVER USE CI AS A LOCAL DEBUGGER
 
 **⚠️ ALL TESTS MUST PASS LOCALLY BEFORE PUSHING. NO EXCEPTIONS.**

--- a/app/api/bug_report.py
+++ b/app/api/bug_report.py
@@ -48,14 +48,7 @@ async def create_bug_report(
             detail="GitHub integration not configured",
         )
 
-    diagnostics_data = None
-    if body.diagnostics:
-        if not isinstance(body.diagnostics, dict):
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="diagnostics must be a JSON object",
-            )
-        diagnostics_data = body.diagnostics
+    diagnostics_data = body.diagnostics
 
     try:
         issue_url = await create_bug_report_issue(

--- a/app/schemas/bug_report.py
+++ b/app/schemas/bug_report.py
@@ -1,6 +1,61 @@
 """Bug report request/response schemas."""
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class DiagnosticScreen(BaseModel):
+    """Screen diagnostic information."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    width: int
+    height: int
+    pixel_ratio: float = Field(alias="pixelRatio")
+
+
+class DiagnosticViewport(BaseModel):
+    """Viewport diagnostic information."""
+
+    width: int
+    height: int
+
+
+class DiagnosticScroll(BaseModel):
+    """Scroll position diagnostic information."""
+
+    x: int
+    y: int
+
+
+class DiagnosticPerformance(BaseModel):
+    """Performance timing diagnostic information."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    dom_content_loaded: float | None = Field(default=None, alias="domContentLoaded")
+    load_complete: float | None = Field(default=None, alias="loadComplete")
+
+
+class DiagnosticError(BaseModel):
+    """A captured console error entry."""
+
+    message: str
+    timestamp: str
+
+
+class BugReportDiagnostics(BaseModel):
+    """Structured diagnostics collected from the browser."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    timestamp: str
+    url: str
+    user_agent: str = Field(alias="userAgent")
+    screen: DiagnosticScreen
+    viewport: DiagnosticViewport
+    scroll: DiagnosticScroll
+    performance: DiagnosticPerformance
+    errors: list[DiagnosticError]
 
 
 class BugReportCreate(BaseModel):
@@ -8,7 +63,7 @@ class BugReportCreate(BaseModel):
 
     title: str = Field(..., min_length=1, max_length=200)
     description: str = Field(..., min_length=1, max_length=2000)
-    diagnostics: dict | None = None
+    diagnostics: BugReportDiagnostics | None = None
 
 
 class BugReportResponse(BaseModel):

--- a/app/services/github_service.py
+++ b/app/services/github_service.py
@@ -3,13 +3,19 @@
 from github import Github, GithubException
 
 from app.config import get_github_settings
+from app.schemas.bug_report import BugReportDiagnostics
+
+
+def _escape_markdown_code(value: str) -> str:
+    """Escape backticks in a string to prevent breaking Markdown code blocks."""
+    return value.replace("`", "\\`")
 
 
 async def create_bug_report_issue(
     title: str,
     description: str,
     username: str,
-    diagnostics_data: dict | None = None,
+    diagnostics_data: BugReportDiagnostics | None = None,
 ) -> str:
     """Create a GitHub issue for a bug report. Returns the issue HTML URL."""
     settings = get_github_settings()
@@ -19,29 +25,25 @@ async def create_bug_report_issue(
     except GithubException as e:
         raise RuntimeError(f"Failed to access GitHub repository: {e.data}") from e
 
-    body = f"**Reported by:** {username}\n\n{description}"
+    body = f"**Reported by:** {_escape_markdown_code(username)}\n\n{description}"
 
     if diagnostics_data:
-        timestamp = diagnostics_data.get("timestamp", "unknown")
-        url = diagnostics_data.get("url", "unknown")
-        user_agent = diagnostics_data.get("userAgent", "unknown")
+        timestamp = diagnostics_data.timestamp
+        url = diagnostics_data.url
+        user_agent = diagnostics_data.user_agent
 
-        screen = diagnostics_data.get("screen", {})
-        screen_width = screen.get("width", 0)
-        screen_height = screen.get("height", 0)
-        pixel_ratio = screen.get("pixelRatio", 1)
+        screen_width = diagnostics_data.screen.width
+        screen_height = diagnostics_data.screen.height
+        pixel_ratio = diagnostics_data.screen.pixel_ratio
 
-        viewport = diagnostics_data.get("viewport", {})
-        viewport_width = viewport.get("width", 0)
-        viewport_height = viewport.get("height", 0)
+        viewport_width = diagnostics_data.viewport.width
+        viewport_height = diagnostics_data.viewport.height
 
-        scroll = diagnostics_data.get("scroll", {})
-        scroll_x = scroll.get("x", 0)
-        scroll_y = scroll.get("y", 0)
+        scroll_x = diagnostics_data.scroll.x
+        scroll_y = diagnostics_data.scroll.y
 
-        perf = diagnostics_data.get("performance", {})
-        dom_complete = perf.get("domContentLoaded")
-        load_complete = perf.get("loadComplete")
+        dom_complete = diagnostics_data.performance.dom_content_loaded
+        load_complete = diagnostics_data.performance.load_complete
 
         perf_str = ""
         if dom_complete is not None or load_complete is not None:
@@ -52,8 +54,10 @@ async def create_bug_report_issue(
                 parts.append(f"Load: {load_complete:.0f}ms")
             perf_str = ", ".join(parts)
 
-        errors = diagnostics_data.get("errors", [])
-        errors_str = "\n".join(f"```\n{error.get('message', 'unknown')}\n```" for error in errors)
+        errors = diagnostics_data.errors
+        errors_str = "\n".join(
+            f"```\n{_escape_markdown_code(error.message)}\n```" for error in errors
+        )
         if not errors:
             errors_str = "None"
 
@@ -62,9 +66,9 @@ async def create_bug_report_issue(
 <details>
 <summary>Diagnostic Information</summary>
 
-**Timestamp:** {timestamp}
-**URL:** {url}
-**User Agent:** {user_agent}
+**Timestamp:** {_escape_markdown_code(timestamp)}
+**URL:** {_escape_markdown_code(url)}
+**User Agent:** {_escape_markdown_code(user_agent)}
 **Screen:** {screen_width}×{screen_height} @{pixel_ratio}x
 **Viewport:** {viewport_width}×{viewport_height}
 **Scroll:** ({scroll_x}, {scroll_y})

--- a/frontend/src/hooks/useBugReport.ts
+++ b/frontend/src/hooks/useBugReport.ts
@@ -17,14 +17,11 @@ export function useBugReport() {
     setError(null)
     setIssueUrl(null)
     try {
-      const payload: { title: string; description: string; diagnostics?: object } = {
+      const response = await bugReportsApi.create({
         title,
         description,
-      }
-      if (diagnosticData) {
-        payload.diagnostics = diagnosticData
-      }
-      const response = await bugReportsApi.create(payload)
+        ...(diagnosticData ? { diagnostics: diagnosticData } : {}),
+      })
       setIssueUrl(response.issue_url)
     } catch (err: unknown) {
       setError(getApiErrorDetail(err) ?? 'Failed to submit bug report')

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -383,6 +383,6 @@ export const migrationApi = {
 }
 
 export const bugReportsApi = {
-  create: (data: { title: string; description: string; diagnostics?: object }) =>
+  create: (data: { title: string; description: string; diagnostics?: unknown }) =>
     api.post<BugReportResponse>('/bug-reports/', data),
 }

--- a/tests/test_bug_report_api.py
+++ b/tests/test_bug_report_api.py
@@ -339,7 +339,7 @@ async def test_github_service_escapes_backticks_in_diagnostics(
     diagnostics_model = BugReportDiagnostics(
         timestamp="2024-01-01T00:00:00.000Z",
         url="http://test.com",
-        user_agent="test-agent```injected```",
+        userAgent="test-agent```injected```",
         screen={"width": 390, "height": 844, "pixelRatio": 3},
         viewport={"width": 390, "height": 664},
         scroll={"x": 0, "y": 0},

--- a/tests/test_bug_report_api.py
+++ b/tests/test_bug_report_api.py
@@ -147,7 +147,18 @@ async def test_create_bug_report_with_diagnostics(auth_client: AsyncClient) -> N
     assert data["issue_url"] == mock_issue_url
     mock_create.assert_called_once()
     call_kwargs = mock_create.call_args.kwargs
-    assert call_kwargs["diagnostics_data"] == diagnostics_data
+    assert call_kwargs["diagnostics_data"] is not None
+    from app.schemas.bug_report import BugReportDiagnostics
+
+    assert isinstance(call_kwargs["diagnostics_data"], BugReportDiagnostics)
+    dumped = call_kwargs["diagnostics_data"].model_dump()
+    assert dumped["timestamp"] == diagnostics_data["timestamp"]
+    assert dumped["url"] == diagnostics_data["url"]
+    assert dumped["user_agent"] == diagnostics_data["userAgent"]
+    assert dumped["screen"]["width"] == diagnostics_data["screen"]["width"]
+    assert dumped["screen"]["height"] == diagnostics_data["screen"]["height"]
+    assert dumped["screen"]["pixel_ratio"] == float(diagnostics_data["screen"]["pixelRatio"])
+    assert dumped["errors"] == diagnostics_data["errors"]
 
 
 @pytest.mark.asyncio
@@ -231,3 +242,137 @@ async def test_create_bug_report_description_too_long(auth_client: AsyncClient) 
         )
 
     assert response.status_code == 422
+
+
+@pytest.mark.parametrize(
+    "input_str, expected",
+    [
+        ("no backticks", "no backticks"),
+        ("with `backtick` here", "with \\`backtick\\` here"),
+        ("```code```", "\\`\\`\\`code\\`\\`\\`"),
+        ("", ""),
+    ],
+)
+def test_escape_markdown_code(input_str: str, expected: str) -> None:
+    """_escape_markdown_code escapes backticks in strings."""
+    from app.services.github_service import _escape_markdown_code
+
+    assert _escape_markdown_code(input_str) == expected
+
+
+@pytest.mark.asyncio
+async def test_create_bug_report_diagnostics_missing_required_fields(
+    auth_client: AsyncClient,
+) -> None:
+    """POST /api/bug-reports/ with missing required diagnostics fields returns 422."""
+    mock_settings = MagicMock()
+    mock_settings.is_configured = True
+
+    with patch("app.api.bug_report.get_github_settings") as mock_get_settings:
+        mock_get_settings.return_value = mock_settings
+
+        # Missing 'screen' field
+        response = await auth_client.post(
+            "/api/bug-reports/",
+            json={
+                "title": "Bug with partial diagnostics",
+                "description": "Missing screen",
+                "diagnostics": {
+                    "timestamp": "2024-01-01T00:00:00.000Z",
+                    "url": "http://test.com",
+                    "userAgent": "test-agent",
+                    "viewport": {"width": 390, "height": 664},
+                    "scroll": {"x": 0, "y": 0},
+                    "performance": {},
+                    "errors": [],
+                },
+            },
+        )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_bug_report_diagnostics_wrong_nested_type(
+    auth_client: AsyncClient,
+) -> None:
+    """POST /api/bug-reports/ with wrong nested diagnostics type returns 422."""
+    mock_settings = MagicMock()
+    mock_settings.is_configured = True
+
+    with patch("app.api.bug_report.get_github_settings") as mock_get_settings:
+        mock_get_settings.return_value = mock_settings
+
+        # 'screen' should be a dict, not a string
+        response = await auth_client.post(
+            "/api/bug-reports/",
+            json={
+                "title": "Bug with malformed diagnostics",
+                "description": "Screen is a string",
+                "diagnostics": {
+                    "timestamp": "2024-01-01T00:00:00.000Z",
+                    "url": "http://test.com",
+                    "userAgent": "test-agent",
+                    "screen": "bad",
+                    "viewport": {"width": 390, "height": 664},
+                    "scroll": {"x": 0, "y": 0},
+                    "performance": {},
+                    "errors": [],
+                },
+            },
+        )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_github_service_escapes_backticks_in_diagnostics(
+    auth_client: AsyncClient,
+) -> None:
+    """create_bug_report_issue escapes backticks in diagnostic values."""
+    mock_issue_url = "https://github.com/test/repo/issues/5"
+    mock_settings = MagicMock()
+    mock_settings.is_configured = True
+
+    from app.schemas.bug_report import BugReportDiagnostics
+
+    diagnostics_model = BugReportDiagnostics(
+        timestamp="2024-01-01T00:00:00.000Z",
+        url="http://test.com",
+        user_agent="test-agent```injected```",
+        screen={"width": 390, "height": 844, "pixelRatio": 3},
+        viewport={"width": 390, "height": 664},
+        scroll={"x": 0, "y": 0},
+        performance={},
+        errors=[{"message": "error with `backtick`", "timestamp": "2024-01-01T00:00:00.000Z"}],
+    )
+
+    with (
+        patch("app.api.bug_report.get_github_settings") as mock_get_settings,
+        patch("app.services.github_service.Github") as mock_github,
+    ):
+        mock_get_settings.return_value = mock_settings
+        mock_repo = MagicMock()
+        mock_issue = MagicMock()
+        mock_issue.html_url = mock_issue_url
+        mock_repo.create_issue.return_value = mock_issue
+        mock_github.return_value.get_repo.return_value = mock_repo
+
+        response = await auth_client.post(
+            "/api/bug-reports/",
+            json={
+                "title": "Bug with backticks",
+                "description": "Testing backtick escaping",
+                "diagnostics": diagnostics_model.model_dump(by_alias=True),
+            },
+        )
+
+    assert response.status_code == 201
+    assert response.json()["issue_url"] == mock_issue_url
+    mock_repo.create_issue.assert_called_once()
+    issue_body = mock_repo.create_issue.call_args.kwargs["body"]
+    # Unescaped backticks should NOT appear in diagnostic values
+    assert "```injected```" not in issue_body
+    assert "error with `backtick`" not in issue_body
+    # The Markdown code fence syntax should still be present for error formatting
+    assert "```" in issue_body


### PR DESCRIPTION
## Changes\n\n- Add nested Pydantic models for diagnostics validation (prevents crashes from malformed nested data)\n- Remove redundant isinstance check in API (Pydantic handles it)\n- Fix empty dict being silently discarded\n- Add Markdown backtick escaping in generated issue body\n- Simplify frontend payload construction\n- Add regression tests for escaping, missing fields, and wrong nested types\n\nCloses #605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured browser diagnostics to bug reports, including screen, viewport, scrolling, performance timings, and console errors.
  * Bug report submissions now perform stronger diagnostics validation and return clearer errors for invalid/missing diagnostic details.
* **Bug Fixes**
  * Improved bug report rendering by escaping backticks in diagnostic content to prevent malformed formatting.
  * Ensured diagnostic values are forwarded and displayed consistently when creating the report.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->