### PR TITLE
Add explicit GLM planning gate to issue kanban

### DIFF
--- a/docs/ISSUE_EXECUTION_PROTOCOL.md
+++ b/docs/ISSUE_EXECUTION_PROTOCOL.md
@@ -11,10 +11,21 @@ This document is the mandatory operating procedure for agents executing GitHub i
 ## Before changing code
 
 1. Read the complete GitHub issue, all comments, `AGENTS.md`, this protocol, and `docs/ISSUE_KANBAN.md`.
-2. Confirm every dependency listed on the issue and board is complete or explicitly marked non-blocking.
-3. Inspect the named files and existing tests before editing.
-4. Move the issue's row in `docs/ISSUE_KANBAN.md` from Ready/Planned/Queued to In progress. Do not claim work is in progress without making this edit.
-5. Do not broaden scope. If a discovered bug is required to complete the issue, add it to the issue and board before implementing it. If it is unrelated, leave it untouched and report it.
+2. If the issue is marked **Planning required**, do not edit application code. Obtain and post the required implementation plan first.
+3. Confirm every dependency listed on the issue and board is complete or explicitly marked non-blocking.
+4. Inspect the named files and existing tests before editing.
+5. Move the issue's row in `docs/ISSUE_KANBAN.md` from Ready/Planned/Queued to In progress. Do not claim work is in progress without making this edit.
+6. Do not broaden scope. If a discovered bug is required to complete the issue, add it to the issue and board before implementing it. If it is unrelated, leave it untouched and report it.
+
+## Planning gate
+
+For issues marked **Planning required** on the kanban:
+
+1. GLM 5.2 must post a plan comment before implementation begins.
+2. The plan must name files to inspect/change, explain the current data flow, identify likely failure or design risks, describe implementation steps, list regression tests, and provide exact local verification commands.
+3. The plan must explicitly state whether database migrations, API schema changes, authorization checks, or frontend/backend contract changes are required.
+4. The plan must include a rollback or containment strategy for risky schema or behavior changes.
+5. Only after the plan is posted and accepted may the issue move to its execution column and DeepSeek begin code changes.
 
 ## While implementing
 

--- a/docs/ISSUE_KANBAN.md
+++ b/docs/ISSUE_KANBAN.md
@@ -15,6 +15,16 @@ Last reviewed: 2026-07-17
 
 ## Board
 
+### Planning required
+
+These issues require a concrete GLM 5.2 implementation plan before DeepSeek starts coding. The plan must be posted as a GitHub issue comment and identify the data flow, files, migration/API impact, tests, risks, and exact verification commands.
+
+| Issue | Planner deliverable | Planning exit criteria | Next column |
+| --- | --- | --- | --- |
+| [#603](https://github.com/JoshCLWren/comic-pile/issues/603) | Mobile dependency-management implementation plan. | Entry points, modal layout, responsive behavior, and regression-test strategy are explicit. | Ready / next up |
+| [#609](https://github.com/JoshCLWren/comic-pile/issues/609) | Session-event and snapshot data-flow plan. | Existing API fields, missing fields, schema changes, and mobile presentation are explicit. | Planned |
+| [#613](https://github.com/JoshCLWren/comic-pile/issues/613) | Named-group architecture plan. | Model relationships, migration, ownership checks, API contract, UI flow, and rollback risks are explicit. | Queued enhancements / decisions |
+
 ### Ready / next up
 
 | Issue | Priority | Work | Depends on | Done when |
@@ -82,6 +92,9 @@ _None recorded._
 ## Working rules
 
 - Keep one canonical issue for duplicate reports; link and close duplicates.
+- Follow the sequence: Planning required → Ready/Planned/Queued → In progress → Validation → Done.
+- A planning issue cannot move to implementation until its GLM plan is posted to GitHub and reviewed for file scope, data flow, tests, risks, and verification commands.
+- GLM planning is required for #603, #609, and #613 only. The other active issues may go directly to DeepSeek execution.
 - Do not move an issue to Validation until the required local tests pass.
 - Frontend issues require lint, typecheck, build, unit tests, and relevant Playwright coverage.
 - Backend changes require the relevant pytest coverage and the repository's async PostgreSQL rules.


### PR DESCRIPTION
## Summary

- Add a Planning required kanban column for complex issues.
- Mark #603, #609, and #613 as requiring GLM 5.2 plans before DeepSeek implementation.
- Document the planning gate and required plan contents in the execution protocol.
- Preserve the existing implementation, validation, and completion workflow.

## Validation

- git diff --cached --check
- Documentation-only change.

## Scope

- docs/ISSUE_KANBAN.md
- docs/ISSUE_EXECUTION_PROTOCOL.md