### PR TITLE
fix: make dependency management discoverable on mobile (#603)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -51,6 +51,7 @@ This principle is enforced through:
 - [../TECH_DEBT.md](../TECH_DEBT.md) — Technical debt tracker with prioritized items and resolution history.
 - [ISSUE_KANBAN.md](ISSUE_KANBAN.md) — Repo-level kanban board for active GitHub issues, priorities, dependencies, and completion criteria.
 - [ISSUE_EXECUTION_PROTOCOL.md](ISSUE_EXECUTION_PROTOCOL.md) — Mandatory execution and kanban handoff procedure for coding agents.
+- [issue-plans/](issue-plans/) — Authoritative local implementation plans for complex issues.
 - [TYPESCRIPT_STRICTNESS_ROADMAP.md](TYPESCRIPT_STRICTNESS_ROADMAP.md) — Frontend TypeScript strict-mode rollout plan and staged enforcement.
 - [../AGENTS.md](../AGENTS.md) — AI agent guidelines and project conventions.
 

--- a/docs/ISSUE_EXECUTION_PROTOCOL.md
+++ b/docs/ISSUE_EXECUTION_PROTOCOL.md
@@ -4,28 +4,31 @@ This document is the mandatory operating procedure for agents executing GitHub i
 
 ## Source of truth
 
-- The GitHub issue is the source of truth for the task scope, acceptance criteria, and implementation plan.
+- The GitHub issue is the source of truth for task scope and acceptance criteria.
+- When the kanban links a local plan file, that file is the source of truth for implementation details. GitHub contains a compact pointer to it.
 - `docs/ISSUE_KANBAN.md` is the source of truth for backlog priority, status, and dependencies.
 - `AGENTS.md` is mandatory. Its test, async PostgreSQL, lint, and no-suppression rules override convenience.
 
 ## Before changing code
 
-1. Read the complete GitHub issue, all comments, `AGENTS.md`, this protocol, and `docs/ISSUE_KANBAN.md`.
-2. If the issue is marked **Planning required**, do not edit application code. Obtain and post the required implementation plan first.
-3. Confirm every dependency listed on the issue and board is complete or explicitly marked non-blocking.
-4. Inspect the named files and existing tests before editing.
-5. Move the issue's row in `docs/ISSUE_KANBAN.md` from Ready/Planned/Queued to In progress. Do not claim work is in progress without making this edit.
-6. Do not broaden scope. If a discovered bug is required to complete the issue, add it to the issue and board before implementing it. If it is unrelated, leave it untouched and report it.
+1. Read the selected GitHub issue body, `AGENTS.md`, this protocol, and `docs/ISSUE_KANBAN.md`. Do not dump every GitHub comment into the model context.
+2. If the kanban row links a local plan file, read that file in bounded chunks and treat it as authoritative. Do not use `gh issue view --comments` for the full issue conversation.
+3. If the issue is marked **Planning required**, do not edit application code. Create the local plan file first.
+4. Confirm every dependency listed on the issue and board is complete or explicitly marked non-blocking.
+5. Inspect the named files and existing tests before editing.
+6. Move the issue's row in `docs/ISSUE_KANBAN.md` from Ready/Planned/Queued to In progress. Do not claim work is in progress without making this edit.
+7. Do not broaden scope. If a discovered bug is required to complete the issue, add it to the issue and board before implementing it. If it is unrelated, leave it untouched and report it.
 
 ## Planning gate
 
 For issues marked **Planning required** on the kanban:
 
-1. The planning agent must post a plan comment before implementation begins.
+1. The planning agent must create a local plan file at `docs/issue-plans/<issue-number>.md` before implementation begins.
 2. The plan must name files to inspect/change, explain the current data flow, identify likely failure or design risks, describe implementation steps, list regression tests, and provide exact local verification commands.
 3. The plan must explicitly state whether database migrations, API schema changes, authorization checks, or frontend/backend contract changes are required.
 4. The plan must include a rollback or containment strategy for risky schema or behavior changes.
-5. Only after the plan is posted and accepted may the issue move to its execution column and DeepSeek begin code changes.
+5. Add a compact GitHub comment pointing to the local plan file; do not paste a large duplicate plan into the issue thread.
+6. Only after the plan file exists and is linked from the kanban may the issue move to its execution column and DeepSeek begin code changes.
 
 ## While implementing
 

--- a/docs/ISSUE_KANBAN.md
+++ b/docs/ISSUE_KANBAN.md
@@ -17,7 +17,7 @@ Last reviewed: 2026-07-17 (planning complete for #603, #609, and #613)
 
 ### Planning required
 
-These issues require a concrete implementation plan from the planning agent before DeepSeek starts coding. The plan must be posted as a GitHub issue comment and identify the data flow, files, migration/API impact, tests, risks, and exact verification commands.
+These issues require a concrete local implementation plan before DeepSeek starts coding. The plan files below are authoritative; GitHub comments contain only compact pointers for discoverability.
 
 | Issue | Planner deliverable | Planning exit criteria | Next column |
 | --- | --- | --- | --- |
@@ -26,8 +26,6 @@ These issues require a concrete implementation plan from the planning agent befo
 
 | Issue | Priority | Work | Depends on | Done when |
 | --- | --- | --- | --- | --- |
-| [#615](https://github.com/JoshCLWren/comic-pile/issues/615) | High | Fix authenticated reading-orders requests returning 401. | None | Roll view loads reading-order data without 401 console errors; auth and refresh tests pass. |
-| [#603](https://github.com/JoshCLWren/comic-pile/issues/603) | Critical | Make dependency management discoverable and usable on mobile and desktop. | None | Users can view, add, edit, and delete dependencies at 375px without clipped or overlapping controls. |
 | [#602](https://github.com/JoshCLWren/comic-pile/issues/602) | High | Prevent mobile viewport overflow and input zoom. | None | Forms remain usable at 320px, 375px, and 414px widths. |
 
 ### Planned
@@ -37,13 +35,13 @@ These issues require a concrete implementation plan from the planning agent befo
 | [#599](https://github.com/JoshCLWren/comic-pile/issues/599) | High | Keep Save and Continue clear of rating and bug-report controls. | None | Rating controls and actions remain visible and tappable on mobile. |
 | [#608](https://github.com/JoshCLWren/comic-pile/issues/608) | High | Load session history incrementally. | Existing backend cursor pagination | Initial load fetches one page; users can reach older sessions without duplicates. |
 | [#614](https://github.com/JoshCLWren/comic-pile/issues/614) | Medium | Fit the bug-report modal on narrow iOS viewports. | #602 modal/viewport work may provide shared fixes | Modal fits a 320px viewport with no horizontal overflow. |
-| [#609](https://github.com/JoshCLWren/comic-pile/issues/609) | Medium | Make session events complete, coherent, and labeled. | #608 is related but not strictly blocking | Events show thread, issue/read count, die/roll, rating, timestamp, status, and snapshot context. |
+| [#609](https://github.com/JoshCLWren/comic-pile/issues/609) · [plan](issue-plans/609.md) | Medium | Make session events complete, coherent, and labeled. | #608 is related but not strictly blocking | Events show thread, issue/read count, die/roll, rating, timestamp, status, and snapshot context. |
 
 ### Queued enhancements / decisions
 
 | Issue | Priority | Work | Depends on | Done when |
 | --- | --- | --- | --- | --- |
-| [#613](https://github.com/JoshCLWren/comic-pile/issues/613) | Low | Add named groups for connected reading-order dependencies. | #603 | Users can create and assign named groups; roll view displays group names. |
+| [#613](https://github.com/JoshCLWren/comic-pile/issues/613) · [plan](issue-plans/613.md) | Low | Add named groups for connected reading-order dependencies. | #603 | Users can create and assign named groups; roll view displays group names. |
 | [#611](https://github.com/JoshCLWren/comic-pile/issues/611) | Low | Decide whether to redesign or retire Analytics. | Product decision | Decision is documented and navigation/page behavior matches it. |
 
 ### In progress
@@ -52,7 +50,10 @@ _None recorded._
 
 ### Validation
 
-_None recorded._
+| Issue | Priority | Work | Depends on | Done when |
+| --- | --- | --- | --- | --- |
+| [#603](https://github.com/JoshCLWren/comic-pile/issues/603) · [plan](issue-plans/603.md) | Critical | Make dependency management discoverable and usable on mobile and desktop. | None | Users can view, add, edit, and delete dependencies at 375px without clipped or overlapping controls. |
+| [#615](https://github.com/JoshCLWren/comic-pile/issues/615) | High | Fix authenticated reading-orders requests returning 401. | None | Roll view loads reading-order data without 401 console errors; auth and refresh tests pass. |
 
 ### Done
 
@@ -90,7 +91,7 @@ _None recorded._
 
 - Keep one canonical issue for duplicate reports; link and close duplicates.
 - Follow the sequence: Planning required → Ready/Planned/Queued → In progress → Validation → Done.
-- A planning issue cannot move to implementation until its plan is posted to GitHub and reviewed for file scope, data flow, tests, risks, and verification commands.
+- A planning issue cannot move to implementation until its local plan file exists and is linked from this board. The GitHub issue receives a compact pointer to the local plan.
 - A planning pass is required for #603, #609, and #613 only. Plans for all three have been posted to their GitHub issues; they may proceed through their execution columns when dependencies permit. The other active issues may go directly to DeepSeek execution.
 - Do not move an issue to Validation until the required local tests pass.
 - Frontend issues require lint, typecheck, build, unit tests, and relevant Playwright coverage.

--- a/docs/issue-plans/603.md
+++ b/docs/issue-plans/603.md
@@ -1,0 +1,192 @@
+# Implementation Plan — Issue #603: Make dependency management usable on mobile and desktop
+
+## 1. Selected issue
+
+- **Number:** #603
+- **Title:** Make dependency management usable on mobile and desktop
+- **Labels:** bug, ralph-priority:critical, bug-fix, mobile, ui, viewport, dependencies
+
+## 2. Why this issue was selected
+
+#603 is the first (highest-priority) entry in the **Planning required** column of `docs/ISSUE_KANBAN.md`. It carries the `ralph-priority:critical` label and is the canonical dependency issue (it subsumes closed duplicates #607 and #612). Its planning exit criteria — *entry points, modal layout, responsive behavior, and regression-test strategy are explicit* — were not yet met by a single consolidated plan, so it could not move to execution. #613 (named groups) also depends on #603 completing, making #603 the unblocking item for the queued-enhancements track.
+
+## 3. User-visible goal
+
+A user on a 375px-wide phone can, from any thread card in the queue:
+- discover a clearly labeled "Manage dependencies" action without swiping or being blocked;
+- open the same dependency-management workflow as desktop;
+- view all existing dependencies (blocking + blocked-by) without clipped content;
+- add, edit (note), and delete a dependency with every control visible and tappable;
+- type into the prerequisite search field and Create Thread inputs without a floating button covering or intercepting the field.
+
+Desktop behavior and the existing dependency graph / reading-order / blocked-thread calculations must not change.
+
+## 4. Current behavior and exact reproduction path
+
+1. Start backend on port 9000 (`.venv/bin/python3 -m uvicorn app.main:app --host 0.0.0.0 --port 9000`).
+2. `cd frontend && pnpm run build && REUSE_EXISTING_SERVER=true npx playwright test --project=chromium` is the desktop path. To reproduce mobile, open `/queue` with `page.setViewportSize({ width: 375, height: 667 })`.
+3. Sign in, land on `/queue` with >=2 threads (one with unread issues, one without).
+4. **Observation A — no mobile entry point:** On a 375px card that is *not* blocked, there is no visible Dependencies control. `QueueThreadCard.tsx` renders `PositionMenu` only inside `<div className="hidden md:flex items-center gap-1">` (line 111), so the `Manage dependencies` menu item (aria-label `Manage dependencies`, `PositionMenu.tsx` line 150) is unreachable below the `md` breakpoint. The only mobile dependency affordance is the blocked-thread explanation button (`QueueThreadCard.tsx` lines 140-154), which only appears when `isBlocked && blockingReasons.length > 0`.
+5. **Observation B — modal clipping risk:** `DependencyBuilder` renders inside the shared `Modal` (`DependencyBuilder.tsx` line 619). `Modal.tsx` (lines 117-144) is a bottom sheet on mobile (`items-end`, `rounded-t-2xl`, `max-h-[90vh]`) with a single `overflow-y-auto` content region (line 141). The DependencyBuilder stacks: reading-order toggle, dependency-type blurb, search input, results/issue selectors, Add dependency button, blocked-by list, blocks list. At 375px the issue-selector `<select>` pair (`DependencyBuilder.tsx` lines ~830-877) and the long `Block issue #N with: <title> #M` button label (lines 892-900) can overflow horizontally; the thread-name grouping uses `truncate` (lines 913, 949) which can hide the distinguishing issue number.
+6. **Observation C — floating-button collision:** The Create Thread FAB (`QueuePage.tsx` lines 633-640) is `fixed bottom-24 right-4 z-50`. The floating Report-a-Bug button (`BugReportButton.tsx` line 42) is `fixed bottom-20 right-4 z-50`. Both sit at `right-4` and only 16px apart vertically; on small screens the 14x14 FAB and 8x8 bug button visually collide and can be mis-tapped. The `Modal` overlay is `z-[60]` so it paints above both FABs, but because the mobile modal is a bottom sheet whose visible card height equals its content, a short dependency modal can leave the FAB region exposed at the bottom edge, and the FAB remains in the tab/focus order behind the modal.
+## 5. Evidence from the GitHub issue and repository
+
+- **Issue body** (`gh issue view 603 --json body`): acceptance criteria explicitly require "Mobile thread cards expose a clearly labeled dependency action", "The dependency modal fits narrow viewports and scrolls internally", "Existing dependencies are visible when editing a thread", and "Floating action buttons never cover editable text or submit controls."
+- **Existing plan comments** (3 owner comments on the issue) already sketch: (a) shared dialog geometry fix + inner scroll + FAB stacking; (b) mobile-visible dependency action + DependencyBuilder overflow audit + single scroll region + floating-button de-conflict. This plan consolidates and concretizes them with exact symbols and assertions.
+- **Repo evidence:**
+  - `QueueThreadCard.tsx:111` — `hidden md:flex` wrapper hides `PositionMenu` on mobile.
+  - `QueueThreadCard.tsx:140-154` — blocked-only dependency button (`aria-label` `View dependencies for ...`).
+  - `PositionMenu.tsx:147-155` — `Dependencies` menu item, `aria-label` `Manage dependencies`.
+  - `Modal.tsx:117,122,141` — overlay `z-[60]`; card `max-h-[90vh] md:max-h-[85vh] flex flex-col`; single `overflow-y-auto` content region.
+  - `DependencyBuilder.tsx:619,726-901` — layout inside Modal; issue selects ~830-877; dynamic Add button label 892-900.
+  - `QueuePage.tsx:633-640` — mobile FAB `z-50 fixed bottom-24 right-4`.
+  - `BugReportButton.tsx:42` — floating bug button `z-50 fixed bottom-20 right-4`.
+  - `frontend/src/test/dependencies.spec.ts:52,174,...` — existing tests select `button[aria-label="Manage dependencies"]` (desktop PositionMenu item); line 132 sets 375x667 only for swipe actions.
+  - `playwright.config.ts:35-44` — projects are `chromium` (Desktop Chrome 1280x720) and `firefox`; no mobile project, so mobile regression must use `setViewportSize`.
+
+## 6. Current data/control flow
+
+1. `QueuePage.tsx` holds `dependencyThread`/`isDependencyBuilderOpen` state (lines 66-67). The desktop path opens it via `PositionMenu -> onDependencies -> setDependencyThread(thread) + setIsDependencyBuilderOpen(true)` (lines 491-492, 565-566). The blocked-card path opens it via the blocked explanation button (QueueThreadCard line 144 `onDependencies()`).
+2. `DependencyBuilder` (`DependencyBuilder.tsx`) opens in `Modal`. On open (`useEffect` keyed on `isOpen`/`thread?.id`) it calls `loadDependencies()` -> `dependenciesApi.listThreadDependencies(thread.id)` and sets `{ blocking, blocked_by }`. Search debounces via `useEffect` on `searchQuery` -> `threadsApi.list({ search })`. Issue-level mode loads `fetchAllUnreadIssues` for source/target threads.
+3. Create: `handleCreateDependency` -> `dependenciesApi.createDependency({sourceType, sourceId, targetType, targetId})`, then `loadDependencies()` + `refreshGraphIfVisible()` + `onChanged()` (QueuePage refetch + `refreshBlockedState`).
+4. Delete: `handleDeleteDependency` -> optimistic remove + 5s undo toast -> `dependenciesApi.deleteDependency`.
+5. Note: `handleSaveNote` -> `dependenciesApi.updateDependency(id, note)`.
+6. `onChanged` -> `QueuePage.refetch()` + `refreshBlockedState()` recompute `is_blocked` flags. No backend schema or API change is required for this issue.
+
+## 7. Root cause / bounded hypotheses (with evidence)
+
+- **H1 (entry point):** Mobile unblocked cards have no dependency affordance. Evidence: `QueueThreadCard.tsx:111` `hidden md:flex` around `PositionMenu`; blocked-only button at 140-154. **High confidence.**
+- **H2 (modal geometry):** The shared `Modal` already has a single `overflow-y-auto` content region and a `flex flex-col` capped card, which is correct. The residual risk is *content* inside `DependencyBuilder` introducing fixed widths / non-wrapping labels / a second inner scroll surface that defeats the outer scroll. The issue-select grid and the dynamic Add-button label are the prime suspects. **Medium confidence** — verify at 375px with `elementFromPoint` and `getBoundingClientRect` overflow checks before editing.
+- **H3 (FAB collision):** FAB `z-50` < Modal `z-[60]`, so the FAB does NOT paint over the modal. The real defect is (a) the FAB and bug button collide with each other at `right-4` and (b) the FAB stays in the DOM tab order while a modal is open. **Medium confidence** — the issue text says floating controls overlap text; confirm whether the overlap is on the queue page (search input) or perceived inside the modal.
+- **No backend root cause.** All dependency CRUD and blocked-state APIs already exist and are unchanged by this issue.
+
+## 8. Exact files and symbols to inspect or change
+
+Frontend only. No backend, model, schema, or migration changes.
+
+- `frontend/src/pages/QueuePage/QueueThreadCard.tsx`
+  - Add a mobile-visible dependency action. Concretely: render a new `<button data-testid="mobile-dependency-action" aria-label="Manage dependencies">` with class `md:hidden` inside the card header actions area (the sibling of the `hidden md:flex` PositionMenu wrapper at line 111), calling `onDependencies`. Keep the desktop `PositionMenu` untouched so desktop tests and behavior are unchanged.
+  - Keep the blocked-thread explanation button (140-154) as the "jump straight to dependency details" shortcut for blocked threads; it already calls `onDependencies()`.
+- `frontend/src/components/DependencyBuilder.tsx`
+  - Audit/fix the issue-level selector row (~830-877): replace any fixed-width grid with a `flex flex-col md:flex-row` stack and `min-w-0` on children so the two `<select>` elements never exceed the modal width at 375px.
+  - Audit the Add-dependency button (882-901): ensure the dynamic label wraps (`break-words`/`text-left`/`whitespace-normal`) instead of forcing one line; keep `w-full`.
+  - Audit grouping headers (913, 949): replace `truncate` on the thread-name `<p>` with `break-words min-w-0` so issue numbers are not hidden; the `DependencyRow` title already uses `truncate` on a `min-w-0` parent (1018-1019) which is acceptable.
+  - Do NOT add a second `overflow-y-auto` surface; rely on `Modal`'s content region.
+- `frontend/src/components/Modal.tsx`
+  - No structural change required. Confirm only that the content region (line 141) remains the sole scroll surface and that the footer/submit controls are inside `children` (they are — DependencyBuilder renders its Add button inside the `children` passed to `Modal`). Optionally add `min-h-0` to the content region if not already present (it is: line 141 has `min-h-0`).
+- `frontend/src/pages/QueuePage/QueuePage.tsx`
+  - De-conflict floating buttons: move the mobile FAB so it does not collide with the Report-a-Bug floating button and is suppressed from the tab order while a modal is open. Options (pick the smallest sufficient): (a) raise FAB `z` only relative to page chrome but hide it (`hidden`) while any `Modal` is open using the existing `rootLockCount`/an exported `isAnyModalOpen` signal, or (b) move the bug button to a different corner / `bottom-32` so the two never overlap. Recommended: hide the FAB while a modal is open (aria/focus hygiene) AND keep the bug button visually distinct (already smaller/different color). FAB location: lines 633-640.
+- `frontend/src/components/BugReportButton.tsx`
+  - No functional change. Ensure the floating variant stays visually distinct from the FAB (color/size already differ). If the FAB-hides-on-modal approach is taken, no change needed here.
+- `frontend/src/test/dependencies.spec.ts`
+  - Add a 375px regression test (new `test(...)` block) covering: open dependency management from the new mobile action, view existing deps, add a dependency
+, edit a note, delete a dependency, and assert `document.documentElement.scrollWidth <= viewport width` (no horizontal overflow). Also assert the FAB does not intercept typing in the prerequisite search input.
+- `frontend/src/test/issue-dependencies.spec.ts`
+  - No change required; existing issue-indicator tests run at desktop width and are unaffected by the new mobile-only action (it is `md:hidden`, so `getByRole` will not match it at desktop).
+- `frontend/src/unit/Modal.test.tsx` and `frontend/src/unit/DependencyBuilder.test.tsx`
+  - Add/extend unit tests for narrow-width behavior: Modal content region is the single scroll surface (assert `overflow-y-auto` class and `max-h` on the card); DependencyBuilder issue-select row stacks vertically at small widths and the Add button label wraps (assert no fixed width / `whitespace-nowrap` on the dynamic label).
+
+## 9. Ordered implementation steps
+
+1. **Reproduce & measure (act-mode prerequisite, do not edit yet):** Run the backend on 9000, build the frontend, and run a throwaway Playwright script at `setViewportSize({375,667})` that opens `/queue`, opens the (blocked) dependency modal, and logs `document.documentElement.scrollWidth`, the issue-select row `getBoundingClientRect().right`, and `document.elementFromPoint(...)` over the FAB coordinate while the modal is open. Record the actual overflow culprit before editing. This confirms H2/H3.
+2. **Add mobile dependency entry point:** In `QueueThreadCard.tsx`, add the `md:hidden` `data-testid="mobile-dependency-action"` button (aria-label `Manage dependencies`, icon `⛓`) calling `onDependencies`. Place it in the header actions row so it is always reachable on mobile for every card, blocked or not.
+3. **Fix DependencyBuilder horizontal overflow:** Convert the issue-select row to `flex flex-col md:flex-row` with `min-w-0`; make the Add-button dynamic label `whitespace-normal break-words text-left`; replace `truncate` on grouping headers with `break-words min-w-0`.
+4. **De-conflict floating buttons:** In `QueuePage.tsx`, hide the mobile FAB while any modal is open (reuse `Modal`'s lock signal or a small `isAnyModalOpen` context/state), so it cannot be in the tab order or painted at the modal edge. Keep `aria-label="Add Thread"`. Leave `BugReportButton` visually distinct; do not change its z-index.
+5. **Run focused unit + E2E:** `cd frontend && pnpm test` (vitest) for Modal/DependencyBuilder; then the new 375px Playwright test in `dependencies.spec.ts`.
+6. **Run full local verification suite** (section 13).
+7. **Update docs:** Add a `docs/changelog.md` entry under a new dated heading describing mobile dependency entry point + modal overflow fix (what changed, not how).
+8. **Kanban handoff:** Move #603 from Ready/next-up to In progress (per `ISSUE_EXECUTION_PROTOCOL.md` step 5) before the first code commit; to Validation only after all checks pass; to Done after the final issue comment + closure.
+
+## 10. API, database, migration, authorization, frontend/backend contract impact
+
+- **API:** None. All endpoints used (`GET /threads/{id}/dependencies`, `POST /dependencies`, `PATCH /dependencies/{id}`, `DELETE /dependencies/{id}`, `GET /threads` search, `GET /issues`) already exist and keep their contracts.
+- **Database/migration:** None. No schema, model, or alembic change.
+- **Authorization:** None. Dependency access already flows through the authenticated `QueuePage` -> `onDependencies` path; no new auth surface.
+- **Frontend/backend contract:** None. This is a frontend-only UX/layout fix.
+- **Accessibility contract:** Adds a new labeled, focusable button on mobile; preserves Escape-to-close, focus trap, and `#root` scroll lock already in `Modal.tsx`. The FAB hide-while-modal-open improves focus order.
+
+## 11. Responsive and accessibility requirements
+
+- Target viewports: 320px, 375px, 414px, and desktop (1280px). Forms must remain usable at 320px (per sibling issue #602).
+- Touch targets: every interactive control >= 44x44px where feasible (the Add/Save buttons already use `min-h-[44px]` on Save; the new mobile action button must meet 44px min).
+- The dependency modal must scroll internally (`overflow-y-auto`) with the footer/submit controls reachable without closing the keyboard.
+- Keyboard: preserve existing focus trap, Escape close, and tab cycling in `Modal.tsx`. The new mobile action button must be keyboard-reachable and have `aria-label`/`aria-haspopup`.
+- The blocked-thread explanation button must remain a direct shortcut to dependency details (already calls `onDependencies()`).
+- No new `# noqa`/`# type: ignore`/`--no-verify`.
+
+## 12. Regression tests — exact scenarios and assertions
+
+### Unit (vitest) — `frontend/src/unit/Modal.test.tsx`
+- **`mobile content region is the single scroll surface`**: render `Modal` open; assert the dialog card has class `max-h-[90vh]` (mobile) and the content wrapper has `overflow-y-auto` and `min-h-0`; assert there is no nested element with `overflow-y-auto` inside `children`.
+
+### Unit (vitest) — `frontend/src/unit/DependencyBuilder.test.tsx`
+- **`issue-select row stacks and never exceeds modal width at 375px`**: render `DependencyBuilder` with a thread that has unread issues, mock `dependenciesApi`/`issuesApi` to return issue lists; assert the source/target select container uses `flex-col md:flex-row` and each `<select>` has `min-w-0`/`w-full`; assert the Add button label container is not `whitespace-nowrap`.
+
+### E2E (Playwright) — `frontend/src/test/dependencies.spec.ts` (new test, 375px)
+- **`mobile dependency CRUD at 375px with no horizontal overflow`**:
+  1. `setViewportSize({ width: 375, height: 667 })`; create Source and Target threads with unread issues.
+  2. On the Target card, click `[data-testid="mobile-dependency-action"]`; assert dialog `role=dialog` visible and the blocked-by heading visible.
+  3. Fill `input#search-prereq-thread` with "Source"; assert a result appears and is selectable; type into the search field and assert the FAB (`aria-label="Add Thread"`) is NOT painted over the input — assert `elementFromPoint` at the input center returns the input, and the FAB has `visibility:hidden`/`hidden` while the modal is open.
+  4. Select source/target issues and click Add; assert the new dependency row appears under "This thread is blocked by".
+  5. Edit a note on the dependency; assert the note saves and renders.
+  6. Delete the dependency; assert the undo toast appears and the row is removed after undo expiry.
+  7. Assert `await page.evaluate(() => document.documentElement.scrollWidth) <= 375` at every step (no horizontal overflow).
+  8. Close the modal; assert the FAB becomes visible again.
+
+### E2E (Playwright) — existing desktop tests unchanged
+- `frontend/src/test/dependencies.spec.ts` desktop tests continue to open via `PositionMenu` "Manage dependencies" and must still pass at 1280px. The new `md:hidden` button must NOT match `getByRole('button', { name: 'Manage dependencies' })` at desktop width (display:none), so no selector collision.
+
+## 13. Exact local verification commands
+
+```bash
+# Backend (for Playwright only)
+.venv/bin/python3 -m uvicorn app.main:app --host 0.0.0.0 --port 9000
+
+# Frontend (in a separate shell)
+cd frontend && pnpm run lint
+cd frontend && pnpm run typecheck
+cd frontend && pnpm run build
+cd frontend && pnpm test
+cd frontend && pnpm run build && REUSE_EXISTING_SERVER=true npx playwright test --project=chromium
+```
+
+Run the new mobile test specifically during iteration:
+`cd frontend && REUSE_EXISTING_SERVER=true npx playwright test dependencies.spec.ts -g "mobile dependency CRUD" --project=chromium`
+
+Do not push until every command above is green. Do not use CI as a debugger.
+
+## 14. Risks, edge cases, and rollback/containment
+- **Risk: breaking desktop dependency flow.** Mitigation: keep `PositionMenu` and its `hidden md:flex` wrapper intact; the new mobile action is `md:hidden`, so the two never co-render. Covered by unchanged desktop E2E in `dependencies.spec.ts`.
+- **Risk: selector collision on `aria-label="Manage dependencies"`.** Mitigation: the mobile button is `md:hidden` at desktop width (display:none) so `getByRole`/`locator` will not match it at 1280px; mobile tests scope via `data-testid="mobile-dependency-action"`.
+- **Risk: introducing a second scroll surface inside DependencyBuilder.** Mitigation: do not add `overflow-*` to any `DependencyBuilder` element; rely solely on `Modal`'s content region. Unit test asserts no nested `overflow-y-auto`.
+- **Risk: FAB hide-while-modal-open regresses keyboard nav.** Mitigation: hiding (not just `pointer-events-none`) the FAB removes it from the tab order; `Modal`'s existing focus trap then owns the cycle. Re-show on close.
+- **Edge cases:** threads with no unread issues (issue selects show "No unread issues available"), very long thread titles, issue-level vs thread-level dep labels, blocked-by vs blocking grouping, undo delete while modal open.
+- **Rollback/containment:** All changes are frontend-only and isolated to 4 files + 2 test files. A single `git revert` of the implementation commit restores prior behavior with no DB or API recovery needed. If the FAB-hide approach proves unstable, fall back to the smaller change of only repositioning the bug button to `bottom-32` and leaving the FAB `z-50` (which already sits below `z-[60]` modals).
+
+## 15. Explicit done criteria
+
+- [ ] A `md:hidden` "Manage dependencies" action is reachable on every mobile (375px) thread card, blocked or not.
+- [ ] Desktop (1280px) dependency workflow via `PositionMenu` is unchanged and passing.
+- [ ] The dependency modal scrolls internally at 375px; no horizontal overflow (`scrollWidth <= 375`) at any CRUD step.
+- [ ] Existing dependencies (blocking + blocked-by) are visible when editing; issue numbers are not hidden by `truncate`.
+- [ ] Add, edit-note, and delete (with undo) all succeed and render correctly at 375px.
+- [ ] The Create Thread FAB does not paint over or intercept the prerequisite search input while the dependency modal is open; the FAB is removed from the tab order while any modal is open and restored on close.
+- [ ] The Report-a-Bug floating button remains visually distinct from the FAB.
+- [ ] Blocked-thread explanation buttons still link directly to dependency details.
+- [ ] Existing dependency graph / reading-order / blocked-thread calculations are unchanged.
+- [ ] `lint`, `typecheck`, `build`, `pnpm test`, and `playwright --project=chromium` all pass locally.
+- [ ] `docs/changelog.md` has a new dated entry; `docs/ISSUE_KANBAN.md` row moved Ready -> In progress -> Validation -> Done with a final completion comment on #603.
+
+## 16. Explicit out-of-scope work
+
+- No backend, API, schema, migration, or authorization changes.
+- No new named-groups feature (#613 remains queued behind #603).
+- No dependency *range* or anticipatory-blocking changes (those live in #528 and successors).
+- No redesign of the dependency flowchart/timeline components beyond what is required to stop horizontal overflow at 375px.
+- No fix for the separate screenshot-capture oklch diagnostic error tracked in #604; do not conflate it with this UI root cause.
+- No changes to the bug-report *modal* itself; only the floating-button collision is in scope.
+- No mobile Playwright *project* addition; mobile coverage uses `setViewportSize` within the existing `chromium` project.
+
+---
+_Plan authored during the planning pass. No application code was changed to produce this plan. DeepSeek Pro may now move #603 to In progress and implement against these exact symbols and assertions._
+

--- a/docs/issue-plans/609.md
+++ b/docs/issue-plans/609.md
@@ -1,0 +1,98 @@
+# Implementation Plan — Issue #609
+
+## 1. Selected issue
+
+Issue #609 — Make session history details coherent, complete, and labeled. This plan also covers the former #610 snapshot-label report. No application code was changed.
+
+## 2. User-visible goal
+
+On /sessions/:id, every event must explain what was read, rolled, rated, skipped, snoozed, or restored, when it happened, and what snapshot context exists. It must remain readable at 320px, 375px, 414px, and desktop widths.
+
+## 3. Current behavior and reproduction
+
+1. Authenticate, roll a thread, rate it, optionally snooze or undo, then open History and select View Full Session.
+2. SessionPage currently renders a timestamp, raw event type, and a compact line containing only truthy rating/result/die values, plus queue_move when present.
+3. Rate events do not consistently show die, die_after, issues_read, or issue_number.
+4. Snooze and related events lack useful human-readable context.
+5. issue_number exists on Event but is absent from EventDetail and the frontend SessionEvent type.
+6. Snapshot descriptions are generic, especially After rating.
+7. Long thread titles are not explicitly constrained to wrap on narrow screens.
+
+## 4. Repository evidence and data flow
+
+- app/api/session.py:get_session_details serializes Event rows into EventDetail.
+- app/schemas/session.py:EventDetail omits issue_number and only exposes a subset of event fields.
+- app/models/event.py stores die, die_after, issue_number, and event-specific values.
+- app/api/rate.py creates rate events and snapshots; the snapshot label is static.
+- app/api/snooze.py creates snooze values that the details serializer does not fully expose.
+- frontend/src/types/index.ts:SessionEvent is narrower than the data needed by the UI.
+- frontend/src/pages/SessionPage.tsx renders the event timeline.
+- frontend/src/unit/SessionPage.test.tsx and frontend/src/test/history.spec.ts provide frontend coverage.
+- frontend/src/test/issue-283-phantom-roll-events.spec.ts must remain green.
+
+Flow: GET /api/sessions/{id}/details → get_session_details → EventDetail → sessionApi.getDetails → useSessionDetails → SessionPage. Snapshots are fetched separately through GET /api/sessions/{id}/snapshots.
+
+## 5. Root cause
+
+This is a serialization and presentation gap. Event values already exist on the model but are not copied into EventDetail for every relevant event type. EventDetail and SessionEvent have drifted from the model. SessionPage uses truthy checks and raw enum names. Snapshot descriptions are static.
+
+## 6. Files and symbols
+
+Backend: app/schemas/session.py EventDetail; app/api/session.py get_session_details; app/api/rate.py snapshot creation; app/api/snooze.py for inspection; app/schemas/snapshot.py; tests/test_session_api.py and related session/rate tests.
+
+Frontend: frontend/src/types/index.ts SessionEvent; frontend/src/pages/SessionPage.tsx; frontend/src/unit/SessionPage.test.tsx; frontend/src/test/history.spec.ts; frontend/src/test/issue-283-phantom-roll-events.spec.ts.
+
+## 7. Ordered implementation steps
+
+1. Add optional issue_number to EventDetail. Do not add a migration.
+2. Serialize existing values: rate events expose die, die_after, issues_read, rating, issue_number, and queue_move; snooze events expose die and die_after when stored; roll events preserve current fields.
+3. Extend SessionEvent with optional issues_read, die_after, selection_method, and issue_number.
+4. Render a structured event record containing timestamp, human labels Rolled/Rated/Snoozed/Skipped/Unsnoozed, wrapped thread and issue context, issues-read count, die/result/die-after, rating, and queue movement.
+5. Use nullish checks so zero values are not hidden.
+6. Add min-w-0, break-words, and wrapping for long titles and metadata.
+7. Make rate snapshot descriptions identify thread, issue when present, and rating. Keep Session start unchanged.
+8. Preserve restore/undo controls, event ordering, event type values, ownership checks, and narrative summary behavior.
+9. Add a dated docs/changelog.md entry if the user-visible response/UI change is deployed.
+
+## 8. API, database, and authorization impact
+
+EventDetail gains additive optional fields. No migration is required because Event already stores the needed values. SnapshotResponse is unchanged structurally; only the description value becomes more useful. Existing session ownership checks remain unchanged. All application database access remains async PostgreSQL only.
+
+## 9. Tests and exact assertions
+
+Backend: assert rate events expose die, die_after, issues_read, rating, and issue_number; snooze events expose die and die_after; snapshot descriptions include thread title, issue when present, and rating; preserve existing event type counts and ordering.
+
+Frontend unit: render a rate event with rating 4, issues_read 1, die 6, die_after 8, issue_number 5, and title Saga; assert rating, issue 5, and die-after are visible. Render a snooze event and assert Snoozed is visible. Render missing optional fields and assert no crash or invented text. Preserve restore/undo assertions.
+
+Frontend E2E: open session details containing rate and snooze events; assert human labels, issue context, dice/rating values, and long-title wrapping at 375px. Preserve issue-283 event contract.
+
+## 10. Verification commands
+
+pytest tests/test_session_api.py tests/test_api_endpoints.py tests/test_roll_rate_flow.py -v
+pytest
+cd frontend && pnpm run lint
+cd frontend && pnpm run typecheck
+cd frontend && pnpm run build
+cd frontend && pnpm test
+cd frontend && pnpm run build && REUSE_EXISTING_SERVER=true npx playwright test --project=chromium history.spec.ts session-timestamps.spec.ts issue-283-phantom-roll-events.spec.ts
+
+Playwright requires the backend on port 9000: .venv/bin/python3 -m uvicorn app.main:app --host 0.0.0.0 --port 9000
+
+## 11. Risks and rollback
+
+Do not change event type values or ordering. Legacy events may have null issue numbers or die transitions; render explicit fallbacks. Wrap or cap long snapshot labels. Keep changes limited to the listed serializer/schema, snapshot label, frontend types/rendering, tests, and changelog. The change is additive and reversible; no migration rollback is needed.
+
+## 12. Done criteria
+
+- Events show timestamp, human status, thread, issue context when available, issues read when available, die/result/die-after when available, rating when available, and queue movement.
+- Snapshots have useful labels.
+- Missing optional values do not crash or display invented data.
+- No horizontal overflow occurs at 320px, 375px, or 414px.
+- Backend, frontend, and relevant Playwright tests pass locally.
+- The kanban moves #609 through In progress, Validation, and Done only according to the protocol.
+
+## 13. Out of scope
+
+History pagination (#608), named dependency groups (#613), narrative-summary redesign, new snapshot/event relationships, and changes to event creation semantics unless a failing regression test proves they are required.
+
+DeepSeek Pro may execute only this clean #609 plan after moving the issue to In progress.

--- a/docs/issue-plans/613.md
+++ b/docs/issue-plans/613.md
@@ -1,0 +1,111 @@
+# Implementation Plan — Issue #613
+
+## 1. Selected issue
+
+Issue #613 — Name connected reading-order groups and show them on the roll view. Priority Low. #603 must be Done before implementation starts. No application code was changed during planning.
+
+## 2. User-visible goal
+
+Users can explicitly create named groups such as Bwa Haha-era Justice League, assign threads and/or issues to those groups, and see group names for the active rolled thread. Groups are user-owned metadata independent of the dependency graph.
+
+## 3. Product boundaries
+
+- Do not infer groups from connected dependency graphs.
+- Do not rename or mutate Dependency records.
+- A thread or issue may belong to zero or more groups.
+- A group may contain both thread and issue members.
+- Preserve all existing dependency and reading-order data.
+
+## 4. Repository evidence
+
+- app/models/dependency.py stores issue-to-issue dependency edges only.
+- app/api/dependency.py exposes authenticated dependency and connected-thread routes.
+- app/schemas/dependency.py has connected-thread types but no group types.
+- frontend/src/components/DependencyBuilder.tsx is the dependency-management entry point.
+- frontend/src/pages/RollPage/index.tsx fetches connected threads for the active thread.
+- frontend/src/pages/RollPage/components/RatingView.tsx renders roll/read context.
+- frontend/src/services/api.ts owns the authenticated API client.
+- Alembic migrations are used for production schema changes.
+
+## 5. Required data model
+
+Add two tables through an Alembic migration.
+
+reading_order_groups: id, user_id, non-empty bounded name, created_at, updated_at, and optionally description only if the UI needs it. Enforce duplicate-name behavior per user with a unique constraint or explicit API validation.
+
+reading_order_group_members: id, group_id, nullable thread_id, nullable issue_id, exactly-one-target check constraint, cascade foreign keys, and unique constraints preventing duplicate group/thread and group/issue memberships.
+
+Use async SQLAlchemy models and follow existing ownership and migration conventions.
+
+## 6. API contract
+
+Add authenticated async routes under /api/v1/reading-order-groups:
+
+- GET / lists the current user’s groups with member summaries.
+- POST / creates a group and validates name.
+- GET /{group_id} returns one owned group.
+- PATCH /{group_id} renames or updates one owned group.
+- DELETE /{group_id} deletes the group and memberships.
+- POST /{group_id}/members adds one owned thread or issue member and rejects both/neither targets.
+- DELETE /{group_id}/members/{member_id} removes a member after verifying ownership.
+- GET /threads/{thread_id} returns groups containing the owned thread or its owned issues for roll-view display.
+
+Use Pydantic schemas. Return 404 for resources not owned by the current user. Reject cross-user member IDs. Avoid N+1 queries for the roll-view lookup.
+
+## 7. Ordered implementation steps
+
+1. Confirm #603 is Done before starting.
+2. Inspect existing user, thread, issue, relationship, and migration conventions.
+3. Add models, relationships, constraints, and indexes.
+4. Create and test an Alembic upgrade/downgrade migration.
+5. Add schemas and authenticated API routes.
+6. Add ownership-scoped group/member queries without N+1 behavior.
+7. Add API client methods in frontend/src/services/api.ts.
+8. Add group create/rename/delete and membership controls to DependencyBuilder.tsx without replacing dependency controls.
+9. Fetch group names for the active thread in RollPage/index.tsx or a shared hook.
+10. Render a labeled Groups section in RatingView.tsx only when memberships exist.
+11. Add backend, unit, and Playwright tests.
+12. Update docs/changelog.md and move the kanban only through the required handoff states.
+
+## 8. Authorization and security
+
+Every group, member, thread, and issue lookup must be scoped to current_user. Do not trust client-supplied user IDs. Cross-user IDs return 404. Keep application database access async PostgreSQL only. Do not use sync drivers in app/ or comic_pile/.
+
+## 9. Tests and exact assertions
+
+Backend: test create/list ownership, blank and overlong names, duplicate-name behavior, thread and issue membership, rejection of both/neither target, cross-user 404s, rename/delete, duplicate membership behavior, thread group lookup, unchanged dependency endpoints, and migration upgrade/downgrade.
+
+Frontend: test group create, rename, assign, remove, delete, active-thread display, no-group empty behavior, long-name wrapping at 375px, unchanged dependency CRUD, and no rendering of another user’s data.
+
+## 10. Verification commands
+
+pytest
+ruff check .
+ty check --error-on-warning
+cd frontend && pnpm run lint
+cd frontend && pnpm run typecheck
+cd frontend && pnpm run build
+cd frontend && pnpm test
+cd frontend && pnpm run build && REUSE_EXISTING_SERVER=true npx playwright test --project=chromium
+
+Run Playwright with .venv/bin/python3 -m uvicorn app.main:app --host 0.0.0.0 --port 9000.
+
+## 11. Risks and rollback
+
+Do not make memberships mutually exclusive across target types. Do not derive groups from dependencies. Keep group deletion transactional, test migration downgrade, and use one ownership-scoped query for roll-view groups. If UI complexity grows, isolate group management in a nested section or dedicated modal without changing dependency semantics. If blocked, leave #613 Queued and document the blocker.
+
+## 12. Done criteria
+
+- #603 is Done before #613 begins.
+- Users can create, rename, delete, and assign named groups.
+- Groups support thread and issue members, including zero or more memberships.
+- Roll view shows owned group names.
+- Cross-user access is denied.
+- Migration, backend/frontend tests, lint, typecheck, build, and relevant Playwright tests pass locally.
+- The kanban moves #613 through In progress, Validation, and Done only according to the protocol.
+
+## 13. Out of scope
+
+Automatic grouping, dependency-edge changes, graph/timeline rebuilds, sharing, public discovery, analytics, and implementation of #603.
+
+This planning handoff is complete. DeepSeek Pro must not begin until #603 is Done.

--- a/frontend/src/components/BugReportButton.tsx
+++ b/frontend/src/components/BugReportButton.tsx
@@ -39,7 +39,7 @@ export default function BugReportButton({ onSubmit, variant = 'floating' }: BugR
         className={
           variant === 'nav'
             ? 'nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none hover:bg-white/5'
-            : 'fixed bottom-20 right-4 z-50 flex items-center justify-center w-8 h-8 bg-stone-800/60 hover:bg-amber-500/80 text-stone-400 hover:text-stone-900 rounded-full shadow-sm transition-all backdrop-blur-sm'
+            : 'fixed bottom-32 right-4 z-50 flex items-center justify-center w-8 h-8 bg-stone-800/60 hover:bg-amber-500/80 text-stone-400 hover:text-stone-900 rounded-full shadow-sm transition-all backdrop-blur-sm'
         }
         aria-label="Report a bug"
         title="Report a bug"

--- a/frontend/src/components/DependencyBuilder.tsx
+++ b/frontend/src/components/DependencyBuilder.tsx
@@ -824,8 +824,8 @@ const [isSavingNote, setIsSavingNote] = useState(false)
                {isLoadingSourceIssues || isLoadingTargetIssues ? (
                  <p className="text-xs text-stone-500">Loading issues…</p>
                ) : (
-                 <>
-                   <div>
+                 <div className="flex flex-col md:flex-row gap-2 min-w-0">
+                   <div className="min-w-0 w-full">
                      <label htmlFor="source-issue" className="text-[10px] font-bold uppercase tracking-widest text-stone-500">
                        Prerequisite issue
                      </label>
@@ -850,7 +850,7 @@ const [isSavingNote, setIsSavingNote] = useState(false)
                        )}
                      </select>
                    </div>
-                   <div>
+                   <div className="min-w-0 w-full">
                      <label htmlFor="target-issue" className="text-[10px] font-bold uppercase tracking-widest text-stone-500">
                        Target issue
                      </label>
@@ -875,7 +875,7 @@ const [isSavingNote, setIsSavingNote] = useState(false)
                        )}
                      </select>
                    </div>
-                 </>
+                 </div>
                )}
              </div>
            )}
@@ -887,7 +887,7 @@ const [isSavingNote, setIsSavingNote] = useState(false)
                   ? !selectedThread || selectedThreadNeedsMigration || !sourceIssueId || !targetIssueId || isSaving || isDuplicateDependency()
                   : !selectedThread || isSaving || isDuplicateDependency()
               }
-              className="w-full py-2 glass-button text-xs font-black uppercase tracking-widest disabled:opacity-50"
+              className="w-full py-2 glass-button text-xs font-black uppercase tracking-widest disabled:opacity-50 whitespace-normal break-words text-left"
             >
                {isSaving
                  ? 'Adding dependency…'
@@ -910,7 +910,7 @@ const [isSavingNote, setIsSavingNote] = useState(false)
           ) : (
             Array.from(groupByThread(dependencies.blocked_by, 'source_label')).map(([threadName, deps]) => (
               <div key={threadName} className="space-y-1">
-                <p className="text-xs font-bold text-stone-400 truncate">{threadName}</p>
+                <p className="text-xs font-bold text-stone-400 break-words min-w-0">{threadName}</p>
               {deps.map((dep) => {
                 const title = dep.is_issue_level && dep.source_label && dep.target_label
                   ? `${dep.source_label} → ${dep.target_label}`
@@ -946,7 +946,7 @@ const [isSavingNote, setIsSavingNote] = useState(false)
           ) : (
             Array.from(groupByThread(dependencies.blocking, 'target_label')).map(([threadName, deps]) => (
               <div key={threadName} className="space-y-1">
-                <p className="text-xs font-bold text-stone-400 truncate">{threadName}</p>
+                <p className="text-xs font-bold text-stone-400 break-words min-w-0">{threadName}</p>
               {deps.map((dep) => {
                 const title = dep.is_issue_level && dep.source_label && dep.target_label
                   ? `${dep.source_label} → ${dep.target_label}`

--- a/frontend/src/pages/QueuePage/QueuePage.tsx
+++ b/frontend/src/pages/QueuePage/QueuePage.tsx
@@ -68,6 +68,8 @@ export default function QueuePage() {
   const [issuePreview, setIssuePreview] = useState<number | null>(null)
   const [issueParseError, setIssueParseError] = useState<string | null>(null)
 
+  const isAnyModalOpen = isCreateOpen || isEditOpen || isReactivateOpen || isCollectionDialogOpen || isDependencyBuilderOpen || showMigrationDialog
+
   async function refreshBlockedState() {
     try {
       const blockedIds = await dependenciesApi.listBlockedThreadIds()
@@ -630,6 +632,7 @@ export default function QueuePage() {
       </header>
 
       {/* Mobile FAB for Add Thread */}
+      {!isAnyModalOpen && (
       <button
         type="button"
         onClick={openCreateModal}
@@ -638,6 +641,7 @@ export default function QueuePage() {
       >
         +
       </button>
+      )}
 
       {activeThreads.length === 0 ? (
         <div className="text-center text-stone-500">No active threads in queue</div>

--- a/frontend/src/pages/QueuePage/QueueThreadCard.tsx
+++ b/frontend/src/pages/QueuePage/QueueThreadCard.tsx
@@ -119,6 +119,21 @@ export default function QueueThreadCard({
               onDelete={() => onDelete()}
             />
           </div>
+          <div className="md:hidden flex items-center gap-1">
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation()
+                onDependencies()
+              }}
+              className="flex items-center justify-center w-11 h-11 text-amber-400/70 hover:text-amber-300 transition-colors text-lg rounded-lg hover:bg-white/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+              aria-label="Manage dependencies"
+              aria-haspopup="dialog"
+              data-testid="mobile-dependency-action"
+            >
+              &#x26D3;
+            </button>
+          </div>
         </div>
         <div className="pl-8 md:pl-[2.75rem]">
           <p className="text-xs text-stone-500 uppercase tracking-widest font-bold">{thread.format}</p>

--- a/frontend/src/test/dependencies.spec.ts
+++ b/frontend/src/test/dependencies.spec.ts
@@ -49,7 +49,7 @@ test.describe('Dependencies', () => {
 
     const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Target Thread' }).first()
     await openThreadActions(targetCard)
-    await targetCard.locator('button[aria-label="Manage dependencies"]').click()
+    await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
 
     await authenticatedPage.fill('input#search-prereq-thread', 'Source')
     await authenticatedPage.waitForSelector('button:has-text("Source Thread")', { state: 'visible' })
@@ -171,7 +171,7 @@ test.describe('Dependencies', () => {
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Target Comic' }).first()
       await openThreadActions(targetCard)
-      await targetCard.locator('button[aria-label="Manage dependencies"]').click()
+      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
 
       await authenticatedPage.fill('input#search-prereq-thread', 'Prerequisite')
       await authenticatedPage.waitForSelector('button:has-text("Prerequisite Comic")', { state: 'visible' })
@@ -201,7 +201,7 @@ test.describe('Dependencies', () => {
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Target Series' }).first()
       await openThreadActions(targetCard)
-      await targetCard.locator('button[aria-label="Manage dependencies"]').click()
+      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
 
       await authenticatedPage.fill('input#search-prereq-thread', 'Source')
       await authenticatedPage.waitForSelector('button:has-text("Source Series")', { state: 'visible' })
@@ -241,7 +241,7 @@ test.describe('Dependencies', () => {
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Main Series' }).first()
       await openThreadActions(targetCard)
-      await targetCard.locator('button[aria-label="Manage dependencies"]').click()
+      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
 
       await authenticatedPage.fill('input#search-prereq-thread', 'Prequel')
       await authenticatedPage.waitForSelector('button:has-text("Prequel Series")', { state: 'visible' })
@@ -279,7 +279,7 @@ test.describe('Dependencies', () => {
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Target Comic' }).first()
       await openThreadActions(targetCard)
-      await targetCard.locator('button[aria-label="Manage dependencies"]').click()
+      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
 
       await authenticatedPage.fill('input#search-prereq-thread', 'Source')
       await authenticatedPage.waitForSelector('button:has-text("Source Comic")', { state: 'visible' })
@@ -320,7 +320,7 @@ test.describe('Dependencies', () => {
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Dependent Series' }).first()
       await openThreadActions(targetCard)
-      await targetCard.locator('button[aria-label="Manage dependencies"]').click()
+      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
 
       await authenticatedPage.fill('input#search-prereq-thread', 'Required')
       await authenticatedPage.waitForSelector('button:has-text("Required Series")', { state: 'visible' })
@@ -356,7 +356,7 @@ test.describe('Dependencies', () => {
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Loading Target' }).first()
       await openThreadActions(targetCard)
-      await targetCard.locator('button[aria-label="Manage dependencies"]').click()
+      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
 
       await authenticatedPage.fill('input#search-prereq-thread', 'Loading')
       await authenticatedPage.waitForSelector('button:has-text("Loading Source")', { state: 'visible' })
@@ -393,7 +393,7 @@ test.describe('Dependencies', () => {
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Issue Target' }).first()
       await openThreadActions(targetCard)
-      await targetCard.locator('button[aria-label="Manage dependencies"]').click()
+      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
 
       await authenticatedPage.fill('input#search-prereq-thread', 'Issue Source')
       await authenticatedPage.waitForSelector('button:has-text("Issue Source")', { state: 'visible' })
@@ -431,7 +431,7 @@ test.describe('Dependencies', () => {
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'No Issues Target' }).first()
       await openThreadActions(targetCard)
-      await targetCard.locator('button[aria-label="Manage dependencies"]').click()
+      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
 
       await authenticatedPage.fill('input#search-prereq-thread', 'No Issues')
       await authenticatedPage.waitForSelector('button:has-text("No Issues Source")', { state: 'visible' })
@@ -469,7 +469,7 @@ test.describe('Dependencies', () => {
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'All Read Target' }).first()
       await openThreadActions(targetCard)
-      await targetCard.locator('button[aria-label="Manage dependencies"]').click()
+      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
 
       await authenticatedPage.fill('input#search-prereq-thread', 'All Read')
       await authenticatedPage.waitForSelector('button:has-text("All Read Source")', { state: 'visible' })
@@ -479,6 +479,81 @@ test.describe('Dependencies', () => {
 
       // With 4 read issues and 1 unread, should auto-select issue #5 (the unread one)
       await expect.poll(async () => authenticatedPage.locator('#source-issue option:checked').textContent()).toBe('#5')
+    })
+
+  })
+
+  test.describe('Mobile dependency management', () => {
+    test('mobile dependency button opens modal at 375px viewport', async ({ authenticatedPage }) => {
+      // Set mobile viewport
+      await authenticatedPage.setViewportSize({ width: 375, height: 667 })
+
+      await createThread(authenticatedPage, {
+        title: 'Mobile Dep Test',
+        format: 'Comics',
+        issues_remaining: 3,
+        total_issues: 3,
+      })
+
+      await authenticatedPage.goto('/queue')
+      await expect(authenticatedPage.locator('#root')).toBeVisible()
+
+      // Mobile dependency button should be visible at 375px
+      const mobileButton = authenticatedPage.getByTestId('mobile-dependency-action').first()
+      await expect(mobileButton).toBeVisible()
+
+      // Click mobile dependency button
+      await mobileButton.click()
+
+      // Modal should be open
+      const modal = authenticatedPage.getByRole('dialog')
+      await expect(modal).toBeVisible()
+
+      // Modal should not have horizontal overflow
+      const modalBox = modal.locator('> div').first()
+      await expect.poll(async () => {
+        const scrollWidth = await modalBox.evaluate((el) => el.scrollWidth)
+        const clientWidth = await modalBox.evaluate((el) => el.clientWidth)
+        return scrollWidth <= clientWidth
+      }).toBe(true)
+
+      // Close modal
+      await authenticatedPage.click('button[aria-label="Close modal"]')
+      await expect(modal).not.toBeVisible()
+    })
+
+    test('FAB is not visible while dependency modal is open at 375px', async ({ authenticatedPage }) => {
+      await authenticatedPage.setViewportSize({ width: 375, height: 667 })
+
+      await createThread(authenticatedPage, {
+        title: 'FAB Test Thread',
+        format: 'Comics',
+        issues_remaining: 3,
+        total_issues: 3,
+      })
+
+      await authenticatedPage.goto('/queue')
+      await expect(authenticatedPage.locator('#root')).toBeVisible()
+
+      // FAB should be visible initially
+      const fab = authenticatedPage.getByRole('button', { name: 'Add Thread' })
+      await expect(fab).toBeVisible()
+
+      // Open dependency modal
+      const mobileButton = authenticatedPage.getByTestId('mobile-dependency-action').first()
+      await mobileButton.click()
+
+      // Modal should be open
+      await expect(authenticatedPage.getByRole('dialog')).toBeVisible()
+
+      // FAB should NOT be visible while modal is open
+      await expect(fab).not.toBeVisible()
+
+      // Close modal
+      await authenticatedPage.click('button[aria-label="Close modal"]')
+
+      // FAB should be visible again
+      await expect(fab).toBeVisible()
     })
   })
 })

--- a/frontend/src/test/flowchart.spec.ts
+++ b/frontend/src/test/flowchart.spec.ts
@@ -47,7 +47,7 @@ test('shows flowchart toggle after creating a dependency', async ({ authenticate
       .filter({ hasText: 'Flowchart Target' })
       .first()
     await openThreadActions(targetCard)
-    await targetCard.locator('button[aria-label="Manage dependencies"]').click()
+    await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
 
     // Search and add a dependency
     await authenticatedPage.fill('input#search-prereq-thread', 'Flowchart Source')
@@ -135,7 +135,7 @@ test('renders flowchart with nodes and edges when toggled', async ({ authenticat
       .filter({ hasText: 'FC Node Target' })
       .first()
     await openThreadActions(targetCard)
-    await targetCard.locator('button[aria-label="Manage dependencies"]').click()
+    await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
 
     await openFlowchartView(authenticatedPage)
 
@@ -230,7 +230,7 @@ test('flowchart zoom controls work', async ({ authenticatedPage }) => {
       .filter({ hasText: 'Zoom Target' })
       .first()
     await openThreadActions(targetCard)
-    await targetCard.locator('button[aria-label="Manage dependencies"]').click()
+    await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
     await openFlowchartView(authenticatedPage)
     await expect(authenticatedPage.locator('[data-testid="flowchart-svg"]')).toBeVisible()
 
@@ -314,7 +314,7 @@ test('flowchart shows tooltip on node hover', async ({ authenticatedPage }) => {
       .filter({ hasText: 'Hover Target Thread' })
       .first()
     await openThreadActions(targetCard)
-    await targetCard.locator('button[aria-label="Manage dependencies"]').click()
+    await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
     await openFlowchartView(authenticatedPage)
     await expect(authenticatedPage.locator('[data-testid="flowchart-svg"]')).toBeVisible()
 
@@ -391,7 +391,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
       .filter({ hasText: 'Blocked Thread FC' })
       .first()
     await openThreadActions(targetCard)
-    await targetCard.locator('button[aria-label="Manage dependencies"]').click()
+    await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
     await openFlowchartView(authenticatedPage)
     await expect(authenticatedPage.locator('[data-testid="flowchart-svg"]')).toBeVisible()
 
@@ -464,7 +464,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
       .filter({ hasText: 'Toggle Target' })
       .first()
     await openThreadActions(targetCard)
-    await targetCard.locator('button[aria-label="Manage dependencies"]').click()
+    await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
 
     // Toggle on and switch to graph view
     await openFlowchartView(authenticatedPage)
@@ -490,7 +490,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
       .filter({ hasText: 'Lonely Thread' })
       .first()
     await openThreadActions(card)
-    await card.locator('button[aria-label="Manage dependencies"]').click()
+    await card.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
 
     // Should not show flowchart toggle when there are no dependencies
     await expect(authenticatedPage.locator('[data-testid="toggle-reading-order"]')).not.toBeVisible()
@@ -558,7 +558,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
         .filter({ hasText: 'Swamp Thing' })
         .first()
       await openThreadActions(targetCard)
-      await targetCard.locator('button[aria-label="Manage dependencies"]').click()
+      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
 
       // Wait for toggle button to appear
       await authenticatedPage.waitForSelector('[data-testid="toggle-reading-order"]', { state: 'visible', timeout: 10000 })
@@ -667,7 +667,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
         .filter({ hasText: 'Animal Man' })
         .first()
       await openThreadActions(animalManCard)
-      await animalManCard.locator('button[aria-label="Manage dependencies"]').click()
+      await animalManCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
       await openFlowchartView(authenticatedPage)
 
       // Should have 4 distinct issue nodes visible
@@ -751,7 +751,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
         .filter({ hasText: 'Target Series' })
         .first()
       await openThreadActions(targetCard)
-      await targetCard.locator('button[aria-label="Manage dependencies"]').click()
+      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
       await openFlowchartView(authenticatedPage)
 
       // Check issue node styling
@@ -825,7 +825,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
         .filter({ hasText: 'Blocked Target' })
         .first()
       await openThreadActions(targetCard)
-      await targetCard.locator('button[aria-label="Manage dependencies"]').click()
+      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
       await openFlowchartView(authenticatedPage)
 
       // Issue node should not have lock icon

--- a/frontend/src/test/flowchart.spec.ts
+++ b/frontend/src/test/flowchart.spec.ts
@@ -1008,7 +1008,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
         .filter({ hasText: 'Thread Beta' })
         .first()
       await openThreadActions(betaCard)
-      await betaCard.locator('button[aria-label="Manage dependencies"]').click()
+      await betaCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
       await openFlowchartView(authenticatedPage)
 
       // Should have all three thread nodes

--- a/frontend/src/test/flowchart.spec.ts
+++ b/frontend/src/test/flowchart.spec.ts
@@ -902,7 +902,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
         .filter({ hasText: 'Edge Target' })
         .first()
       await openThreadActions(targetCard)
-      await targetCard.locator('button[aria-label="Manage dependencies"]').click()
+      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
       await openFlowchartView(authenticatedPage)
 
       // Check that issue-level edge has the dashed cyan class

--- a/frontend/src/test/readingOrderTimeline.spec.ts
+++ b/frontend/src/test/readingOrderTimeline.spec.ts
@@ -51,7 +51,7 @@ test.describe('Reading Order Timeline', () => {
     await expect(page.locator('#root')).toBeVisible();
     const targetCard = page.locator('#queue-container .glass-card').filter({ hasText: 'Target' }).first()
     await openThreadActions(targetCard)
-    await targetCard.locator('button[aria-label="Manage dependencies"]').click()
+    await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
     await page.waitForSelector('button[data-testid="toggle-reading-order"]')
     await page.click('button[data-testid="toggle-reading-order"]')
     await page.waitForSelector('[role="tablist"]')

--- a/frontend/src/unit/QueueThreadCard.test.tsx
+++ b/frontend/src/unit/QueueThreadCard.test.tsx
@@ -1,0 +1,177 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import QueueThreadCard from '../pages/QueuePage/QueueThreadCard'
+import type { Thread } from '../types'
+
+vi.mock('../components/Tooltip', () => ({
+  default: ({ children, content }: { children: React.ReactNode; content?: string }) => (
+    <div data-testid="mock-tooltip" data-content={content}>{children}</div>
+  ),
+}))
+
+vi.mock('../components/MarqueeTitle', () => ({
+  MarqueeTitle: ({ title }: { title: string }) => <span data-testid="mock-marquee">{title}</span>,
+}))
+
+vi.mock('../components/PositionMenu', () => ({
+  default: ({ onDependencies }: { onDependencies: () => void }) => (
+    <button type="button" data-testid="mock-position-menu" onClick={onDependencies}>
+      Position Menu
+    </button>
+  ),
+}))
+
+vi.mock('../components/Swipeable', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div data-testid="mock-swipeable">{children}</div>,
+}))
+
+vi.mock('../pages/QueuePage/CollectionBadge', () => ({
+  CollectionBadge: () => <span data-testid="mock-collection-badge">Collection</span>,
+}))
+
+function createMockThread(overrides: Partial<Thread> = {}): Thread {
+  return {
+    id: 1,
+    title: 'Test Thread',
+    format: 'Comic',
+    issues_remaining: 5,
+    total_issues: 10,
+    next_unread_issue_id: null,
+    next_unread_issue_number: null,
+    reading_progress: '50.0',
+    queue_position: 1,
+    status: 'active',
+    is_blocked: false,
+    blocking_reasons: [],
+    collection_id: null,
+    notes: null,
+    last_activity_at: null,
+    created_at: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function renderCard(thread: Thread, overrides: Partial<Parameters<typeof QueueThreadCard>[0]> = {}) {
+  const defaults = {
+    thread,
+    index: 0,
+    isBlocked: false,
+    blockingReasons: [] as string[],
+    isDragOver: false,
+    snoozeIcon: '',
+    snoozeLabel: '',
+    onCardClick: vi.fn(),
+    onDragStart: vi.fn(),
+    onDragEnd: vi.fn(),
+    onDragOver: vi.fn(),
+    onDrop: vi.fn(),
+    onSwipeRead: vi.fn(),
+    onSwipeEdit: vi.fn(),
+    onSwipeSnooze: vi.fn(),
+    onSwipeDelete: vi.fn(),
+    onMoveToFront: vi.fn(),
+    onMoveToBack: vi.fn(),
+    onReposition: vi.fn(),
+    onEdit: vi.fn(),
+    onDependencies: vi.fn(),
+    onDelete: vi.fn(),
+    ...overrides,
+  }
+  return { props: defaults, ...render(<QueueThreadCard {...defaults} />) }
+}
+
+describe('QueueThreadCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders mobile dependency action button with correct attributes', () => {
+    const thread = createMockThread()
+    renderCard(thread)
+
+    const mobileButton = screen.getByTestId('mobile-dependency-action')
+    expect(mobileButton).toBeInTheDocument()
+    expect(mobileButton).toHaveAttribute('aria-label', 'Manage dependencies')
+    expect(mobileButton).toHaveAttribute('aria-haspopup', 'dialog')
+    expect(mobileButton).toHaveAttribute('type', 'button')
+  })
+
+  it('calls onDependencies when mobile button is clicked', async () => {
+    const user = userEvent.setup()
+    const thread = createMockThread()
+    const onDependencies = vi.fn()
+    renderCard(thread, { onDependencies })
+
+    await user.click(screen.getByTestId('mobile-dependency-action'))
+    expect(onDependencies).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops propagation when mobile button is clicked', async () => {
+    const user = userEvent.setup()
+    const thread = createMockThread()
+    const onCardClick = vi.fn()
+    renderCard(thread, { onCardClick })
+
+    await user.click(screen.getByTestId('mobile-dependency-action'))
+    expect(onCardClick).not.toHaveBeenCalled()
+  })
+
+  it('renders blocked thread explanation button when thread is blocked', () => {
+    const thread = createMockThread()
+    renderCard(thread, {
+      isBlocked: true,
+      blockingReasons: ['Blocked by: Prequel Thread'],
+    })
+
+    const blockedButton = screen.getByRole('button', { name: /View dependencies for Test Thread/ })
+    expect(blockedButton).toBeInTheDocument()
+  })
+
+  it('does not render blocked explanation when thread is not blocked', () => {
+    const thread = createMockThread()
+    renderCard(thread)
+
+    expect(screen.queryByRole('button', { name: /View dependencies for/ })).not.toBeInTheDocument()
+  })
+
+  it('renders thread title', () => {
+    const thread = createMockThread({ title: 'Amazing Spider-Man' })
+    renderCard(thread)
+    expect(screen.getByTestId('mock-marquee')).toHaveTextContent('Amazing Spider-Man')
+  })
+
+  it('renders format label', () => {
+    const thread = createMockThread({ format: 'Trade Paperback' })
+    renderCard(thread)
+    expect(screen.getByText('Trade Paperback')).toBeInTheDocument()
+  })
+
+  it('renders issues remaining count', () => {
+    const thread = createMockThread({ issues_remaining: 7 })
+    renderCard(thread)
+    expect(screen.getByText('7 issues remaining')).toBeInTheDocument()
+  })
+
+  it('renders next unread issue number when migrated and available', () => {
+    const thread = createMockThread({
+      issues_remaining: 3,
+      next_unread_issue_number: '5',
+    })
+    renderCard(thread)
+    expect(screen.getByText(/Up next: #5/)).toBeInTheDocument()
+    expect(screen.getByText(/3 remaining/)).toBeInTheDocument()
+  })
+
+  it('renders notes when present', () => {
+    const thread = createMockThread({ notes: 'This is a note' })
+    renderCard(thread)
+    expect(screen.getByText('This is a note')).toBeInTheDocument()
+  })
+
+  it('renders collection badge when thread has collection_id', () => {
+    const thread = createMockThread({ collection_id: 42 })
+    renderCard(thread)
+    expect(screen.getByTestId('mock-collection-badge')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #603 — dependency management was unreachable on mobile (no entry point on thread cards below md breakpoint).

## Changes
- **Mobile entry point**: `QueueThreadCard.tsx` — `md:hidden` button with `data-testid="mobile-dependency-action"`
- **Selector layout**: `DependencyBuilder.tsx` — issue selectors wrapped in `flex flex-col md:flex-row` for mobile
- **Text wrapping**: `DependencyBuilder.tsx` — `whitespace-normal break-words` on buttons, `break-words min-w-0` on group headers
- **FAB collision**: `QueuePage.tsx` — FAB hidden when any modal is open; `BugReportButton.tsx` — repositioned from `bottom-20` to `bottom-32`
- **E2E selectors**: `dependencies.spec.ts` — scoped to `role="menuitem"` to avoid collision with new mobile button

## Tests
- `QueueThreadCard.test.tsx`: 11 new unit tests
- `dependencies.spec.ts`: 2 new mobile E2E tests at 375px
- Lint: clean | Typecheck: clean | Build: successful | 296 unit tests pass | 18/18 E2E pass