### PR TITLE
Fix mobile modal focus and queue menu layering

### DIFF
--- a/frontend/src/components/DependencyBuilder.tsx
+++ b/frontend/src/components/DependencyBuilder.tsx
@@ -616,7 +616,7 @@ const [isSavingNote, setIsSavingNote] = useState(false)
   }
 
   return (
-    <Modal isOpen={isOpen} title={`Dependencies: ${thread?.title || ''}`} onClose={onClose}>
+    <Modal isOpen={isOpen} title={`Dependencies: ${thread?.title || ''}`} onClose={onClose} autoFocus={false}>
       <div className="space-y-4">
       {/* Flowchart toggle */}
       {thread && (dependencies.blocking.length > 0 || dependencies.blocked_by.length > 0) && (

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -122,7 +122,7 @@ export default function Modal({
       <div
         ref={modalRef}
         data-testid={testId}
-        className="relative w-full max-w-lg modal-card max-h-[90vh] md:max-h-[85vh] flex flex-col rounded-t-2xl md:rounded-lg animate-slide-up md:animate-fade-in pb-[env(safe-area-inset-bottom)]"
+        className="relative w-full max-w-lg h-[calc(100dvh-1rem)] md:h-auto modal-card max-h-[calc(100dvh-1rem)] md:max-h-[85vh] flex flex-col overflow-hidden rounded-t-2xl md:rounded-lg animate-slide-up md:animate-fade-in pb-[env(safe-area-inset-bottom)]"
         role="dialog"
         aria-modal="true"
         aria-labelledby="modal-title"
@@ -131,7 +131,7 @@ export default function Modal({
           <div className="w-10 h-1 bg-white/20 rounded-full" />
         </div>
         <div className="flex items-start justify-between gap-2 md:gap-4 px-4 md:px-6 pt-2 md:pt-0 pb-3 md:pb-4 shrink-0">
-          <h2 id="modal-title" className="text-lg md:text-xl font-black tracking-tight text-stone-200 uppercase">{title}</h2>
+          <h2 id="modal-title" className="min-w-0 flex-1 text-base md:text-xl font-black tracking-tight text-stone-200 uppercase">{title}</h2>
           <button
             ref={closeButtonRef}
             type="button"

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -77,7 +77,11 @@ export default function Modal({
     const firstInput = focusableArray.find(
       el => el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT'
     )
-    const targetElement = autoFocus ? firstInput || firstElement : closeButtonRef.current
+    const targetElement = autoFocus
+      ? firstInput || firstElement
+      : closeButtonRef.current ||
+        focusableArray.find(el => !['INPUT', 'TEXTAREA', 'SELECT'].includes(el.tagName)) ||
+        modal
     targetElement?.focus()
 
     return () => {
@@ -122,6 +126,7 @@ export default function Modal({
       <div
         ref={modalRef}
         data-testid={testId}
+        tabIndex={-1}
         className="relative w-full max-w-lg h-[calc(100dvh-1rem)] md:h-auto modal-card max-h-[calc(100dvh-1rem)] md:max-h-[85vh] flex flex-col overflow-hidden rounded-t-2xl md:rounded-lg animate-slide-up md:animate-fade-in pb-[env(safe-area-inset-bottom)]"
         role="dialog"
         aria-modal="true"

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -7,6 +7,7 @@ interface ModalProps {
   children: React.ReactNode
   'data-testid'?: string
   overlayClassName?: string
+  autoFocus?: boolean
 }
 
 // Module-level lock counter so nested/overlapping modals don't prematurely
@@ -22,6 +23,7 @@ export default function Modal({
   children,
   'data-testid': testId,
   overlayClassName,
+  autoFocus = true,
 }: ModalProps) {
   const modalRef = useRef<HTMLDivElement>(null)
   const previousFocusRef = useRef<HTMLElement | null>(null)
@@ -74,14 +76,16 @@ export default function Modal({
     const firstInput = focusableArray.find(
       el => el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT'
     )
-    const targetElement = firstInput || firstElement
-    targetElement?.focus()
+    if (autoFocus) {
+      const targetElement = firstInput || firstElement
+      targetElement?.focus()
+    }
 
     return () => {
       document.removeEventListener('keydown', handleKeyDown)
       previousFocusRef.current?.focus()
     }
-  }, [isOpen])
+  }, [autoFocus, isOpen])
 
   // Lock the #root scroller while a modal is open (fixes iOS scroll-bleed).
   // This app scrolls via #root, NOT <body> (see src/styles.css: html/body are

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -26,6 +26,7 @@ export default function Modal({
   autoFocus = true,
 }: ModalProps) {
   const modalRef = useRef<HTMLDivElement>(null)
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
   const previousFocusRef = useRef<HTMLElement | null>(null)
   const onCloseRef = useRef(onClose)
 
@@ -76,10 +77,8 @@ export default function Modal({
     const firstInput = focusableArray.find(
       el => el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT'
     )
-    if (autoFocus) {
-      const targetElement = firstInput || firstElement
-      targetElement?.focus()
-    }
+    const targetElement = autoFocus ? firstInput || firstElement : closeButtonRef.current
+    targetElement?.focus()
 
     return () => {
       document.removeEventListener('keydown', handleKeyDown)
@@ -134,6 +133,7 @@ export default function Modal({
         <div className="flex items-start justify-between gap-2 md:gap-4 px-4 md:px-6 pt-2 md:pt-0 pb-3 md:pb-4 shrink-0">
           <h2 id="modal-title" className="text-lg md:text-xl font-black tracking-tight text-stone-200 uppercase">{title}</h2>
           <button
+            ref={closeButtonRef}
             type="button"
             onClick={onClose}
             className="text-stone-500 hover:text-stone-300 transition-colors text-2xl leading-none"

--- a/frontend/src/pages/QueuePage/QueueThreadCard.tsx
+++ b/frontend/src/pages/QueuePage/QueueThreadCard.tsx
@@ -60,7 +60,7 @@ export default function QueueThreadCard({
     <Swipeable
       data-testid="queue-thread-item"
       onCardClick={onCardClick}
-      className="rounded-xl"
+      className="queue-thread-swipeable rounded-xl"
       actions={[
         { icon: '📖', label: 'Read', onClick: onSwipeRead, color: 'bg-amber-600/30 text-amber-300' },
         { icon: '✏️', label: 'Edit', onClick: onSwipeEdit, color: 'bg-white/10 text-stone-300' },
@@ -69,7 +69,7 @@ export default function QueueThreadCard({
       ]}
     >
       <div
-        className={`glass-card p-3 md:p-4 space-y-2 md:space-y-3 group transition-all hover:border-white/20 ${isDragOver ? 'border-amber-400/60' : ''} ${isBlocked ? 'border-red-400/30 bg-red-500/5' : ''}`}
+        className={`queue-thread-card glass-card p-3 md:p-4 space-y-2 md:space-y-3 group transition-all hover:border-white/20 ${isDragOver ? 'border-amber-400/60' : ''} ${isBlocked ? 'border-red-400/30 bg-red-500/5' : ''}`}
         onDragOver={onDragOver}
         onDrop={onDrop}
         role="button"

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -255,6 +255,18 @@ body {
   border-radius: 0.75rem;
 }
 
+/* Let an open actions menu paint above adjacent cards in the queue grid. */
+.queue-thread-card:has([aria-expanded="true"]) {
+  position: relative;
+  z-index: 50;
+}
+
+.queue-thread-swipeable:has([aria-expanded="true"]) {
+  overflow: visible;
+  position: relative;
+  z-index: 50;
+}
+
 .modal-card {
   background: rgba(255, 255, 255, 0.03);
   backdrop-filter: var(--glass-blur);

--- a/frontend/src/test/issue-320-mobile-safari-overscroll.spec.ts
+++ b/frontend/src/test/issue-320-mobile-safari-overscroll.spec.ts
@@ -2,12 +2,11 @@ import { test, expect } from './fixtures';
 
 test.describe('Issue #320: Mobile Safari Overscroll Prevention', () => {
   test('viewport meta tag includes viewport-fit=cover', async ({ page }) => {
-    await page.goto('/');
-    await page.waitForSelector('meta[name="viewport"]', { state: 'attached' });
-
-    const contentAttribute = await page.$eval('meta[name="viewport"]', (meta) => meta.getAttribute('content'));
-
-    expect(contentAttribute).toContain('viewport-fit=cover');
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('meta[name="viewport"]')).toHaveAttribute(
+      'content',
+      /viewport-fit=cover/,
+    );
   });
 
   test('overscroll-prevention CSS is loaded in stylesheets', async ({ page }) => {

--- a/frontend/src/test/issue-325-correct-issue-rating-view.spec.ts
+++ b/frontend/src/test/issue-325-correct-issue-rating-view.spec.ts
@@ -71,7 +71,7 @@ test.describe('Issue #325: Correct Issue Number from Rating View', () => {
     await editIcon.click();
 
     const issueInput = authenticatedWithThreadsPage.locator('input#issue-number');
-    await expect(issueInput).not.toHaveValue('');
+    await expect(issueInput).toHaveValue(/\d+/);
     const initialValue = await issueInput.inputValue();
 
     const incrementButton = authenticatedWithThreadsPage.locator('button[aria-label="Increase issue number"]');

--- a/frontend/src/test/issue-325-correct-issue-rating-view.spec.ts
+++ b/frontend/src/test/issue-325-correct-issue-rating-view.spec.ts
@@ -71,6 +71,7 @@ test.describe('Issue #325: Correct Issue Number from Rating View', () => {
     await editIcon.click();
 
     const issueInput = authenticatedWithThreadsPage.locator('input#issue-number');
+    await expect(issueInput).not.toHaveValue('');
     const initialValue = await issueInput.inputValue();
 
     const incrementButton = authenticatedWithThreadsPage.locator('button[aria-label="Increase issue number"]');


### PR DESCRIPTION
## Summary

- Prevent the dependency modal from auto-focusing its search field and opening the mobile keyboard on inspection.
- Keep queue action menus above adjacent cards and outside the swipe wrapper clipping boundary.
- Harden the issue correction Playwright test against async issue loading.

## Root cause

The shared modal focused the first input on open, while queue menus were clipped by the Swipeable wrapper’s overflow-hidden stacking context.

## Validation

- Frontend lint, typecheck, build, and Vitest: passed (296 tests).
- Chromium Playwright suite: 318 passed; one unrelated async test race was fixed, then the affected issue-325 suite passed 9/9.

## Related issues

Related to #602 (mobile input focus/zoom behavior). This PR does not address #614, which concerns the bug-report modal width.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional control to disable automatic focus when opening modal dialogs (defaults to enabled).
* **Bug Fixes**
  * Improved queue action menu stacking so expanded menus render above neighboring queue cards.
* **Tests**
  * Strengthened issue rating UI coverage by asserting the issue number input contains a numeric value before interacting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->