### PR TITLE
Fix virtualized queue menu layering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,7 @@ jobs:
         run: pytest tests_e2e/test_dice_ladder_e2e.py --no-cov -v
 
   test-e2e-playwright:
-    name: E2E Playwright Tests (Shard ${{ matrix.shardIndex }}/${{ matrix.totalShards }})
+    name: E2E Playwright Tests (${{ matrix.browser }}, shard ${{ matrix.shardIndex }}/${{ matrix.totalShards }})
     runs-on: ubuntu-latest
     container:
       image: ${{ needs.build.outputs.image-ref }}
@@ -383,6 +383,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        browser: [firefox, webkit, chromium]
         shardIndex: [1, 2, 3, 4, 5, 6]
         totalShards: [6]
     env:
@@ -467,7 +468,7 @@ jobs:
           exit 1
 
       - name: Run Playwright tests
-        run: cd frontend && REUSE_EXISTING_SERVER=true BASE_URL=http://localhost:9000 pnpm exec playwright test --project=chromium --shard=${{ matrix.shardIndex }}/${{ matrix.totalShards }}
+        run: cd frontend && REUSE_EXISTING_SERVER=true BASE_URL=http://localhost:9000 pnpm exec playwright test --project=${{ matrix.browser }} --shard=${{ matrix.shardIndex }}/${{ matrix.totalShards }}
 
   check-all-jobs:
     name: CI Summary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,6 +388,9 @@ jobs:
         totalShards: [6]
     env:
       CI: true
+      # Firefox refuses to launch when Actions' mounted HOME is not owned by
+      # the container user. Playwright browsers are installed under /root.
+      HOME: /root
       TEST_ENVIRONMENT: "true"
       SECRET_KEY: test-secret-key-for-testing-only
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@postgres:5432/comic_pile_test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ CI is not a debugging tool. Every failed CI run wastes compute, blocks the pipel
 1. Run `cd frontend && pnpm run lint && pnpm run typecheck` - must be clean
 2. Run `cd frontend && pnpm run build` - must succeed
 3. Run `cd frontend && pnpm test` (vitest) - all must pass
-4. Run `cd frontend && pnpm run build && REUSE_EXISTING_SERVER=true npx playwright test --project=chromium` - all E2E must pass (requires backend running on port 9000)
+4. Run `cd frontend && pnpm run build && REUSE_EXISTING_SERVER=true npx playwright test` - all E2E must pass in Firefox, WebKit, and Chromium (requires backend running on port 9000). Firefox is the primary desktop acceptance browser and WebKit covers the mobile Safari rendering path.
 5. Only after ALL of the above are green, you may push
 
 **If E2E tests need a backend:** Start one locally with `.venv/bin/python3 -m uvicorn app.main:app --host 0.0.0.0 --port 9000` and set `REUSE_EXISTING_SERVER=true`. Do not push to trigger CI to run them for you.

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -55,7 +55,7 @@ RUN npm install -g pnpm@10.15.0
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY frontend/package.json frontend/
 RUN pnpm install --frozen-lockfile && \
-    pnpm --filter frontend exec playwright install --with-deps chromium firefox
+    pnpm --filter frontend exec playwright install --with-deps chromium firefox webkit
 
 # Stage 6: Frontend build.
 FROM frontend-deps AS frontend-build

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,8 @@
 - Mobile modals now use the available viewport height with an independently scrollable content area.
 - Non-autofocus modals keep keyboard focus inside the modal, with a safe close-control fallback.
 - Queue thread-action menus now appear above adjacent cards instead of being clipped in Safari.
+- Queue thread-action menus now also raise their virtualized row, keeping them visible and clickable above the next row in Firefox.
+- Browser verification now covers Firefox, WebKit, and Chromium so desktop Firefox and mobile Safari behavior are release gates.
 
 ## 2026-07-15
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -41,6 +41,10 @@ export default defineConfig({
       name: 'firefox',
       use: { ...devices['Desktop Firefox'] },
     },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
   ],
   webServer: {
     command: process.env.REUSE_EXISTING_SERVER

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -272,6 +272,12 @@ body {
   z-index: 200;
 }
 
+/* A transformed virtual row is its own stacking context. Raise the entire row
+   while its menu is open so the following row cannot paint over the menu. */
+#queue-container [data-index]:has([aria-expanded="true"]) {
+  z-index: 100;
+}
+
 .modal-card {
   background: rgba(255, 255, 255, 0.03);
   backdrop-filter: var(--glass-blur);

--- a/frontend/src/test/issue-583-virtualized-grid.spec.ts
+++ b/frontend/src/test/issue-583-virtualized-grid.spec.ts
@@ -59,6 +59,28 @@ test.describe('Responsive multi-column virtualized grid (#583-C)', () => {
     await expect(firstRowItems).toHaveCount(1);
   });
 
+  test('keeps an open thread action menu above the following virtual row', async ({ authenticatedWithLargeQueuePage }) => {
+    const page = authenticatedWithLargeQueuePage;
+
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto('/queue', { waitUntil: 'domcontentloaded' });
+    await waitForQueueReady(page);
+
+    const firstCard = page.locator('[data-index="0"] [data-testid="queue-thread-item"]').first();
+    await firstCard.getByLabel('Thread actions').click();
+
+    const menu = firstCard.getByRole('menu', { name: 'Thread actions' });
+    await expect(menu).toBeVisible();
+
+    const menuReceivesPointerEvents = await menu.evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      const target = document.elementFromPoint(rect.left + 16, rect.top + 16);
+      return target !== null && element.contains(target);
+    });
+
+    expect(menuReceivesPointerEvents).toBe(true);
+  });
+
   test('scroll reveals more virtualized items', async ({ authenticatedWithLargeQueuePage }) => {
     const page = authenticatedWithLargeQueuePage;
 

--- a/frontend/src/test/issue-583-virtualized-grid.spec.ts
+++ b/frontend/src/test/issue-583-virtualized-grid.spec.ts
@@ -72,13 +72,11 @@ test.describe('Responsive multi-column virtualized grid (#583-C)', () => {
     const menu = firstCard.getByRole('menu', { name: 'Thread actions' });
     await expect(menu).toBeVisible();
 
-    const menuReceivesPointerEvents = await menu.evaluate((element) => {
-      const rect = element.getBoundingClientRect();
-      const target = document.elementFromPoint(rect.left + 16, rect.top + 16);
-      return target !== null && element.contains(target);
-    });
-
-    expect(menuReceivesPointerEvents).toBe(true);
+    const menuBox = await menu.boundingBox();
+    if (!menuBox) {
+      throw new Error('Expected the thread actions menu to have a bounding box.');
+    }
+    await menu.hover({ position: { x: 16, y: menuBox.height - 16 } });
   });
 
   test('scroll reveals more virtualized items', async ({ authenticatedWithLargeQueuePage }) => {


### PR DESCRIPTION
## Summary
- raise the virtualized queue row while its thread-action menu is open
- add a Firefox regression test that verifies the menu receives pointer events above the following row
- make Firefox, WebKit, and Chromium the required Playwright browser matrix

## Root cause
Each transformed virtual row created its own stacking context. Raising only the card and menu could not place the menu above the following row in Firefox.

## Validation
- frontend lint, typecheck, production build, and 296 unit tests passed
- full Chromium E2E suite: 320 passed
- focused Firefox virtualized-grid regression: 5 passed
- full Firefox and WebKit suites are running locally in parallel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed queue thread-action menus being obscured by adjacent virtualized rows, ensuring they remain visible and clickable.
  * Improved menu behavior in Firefox and responsive layouts.

* **Tests**
  * Added browser coverage for Chromium, Firefox, and WebKit, including mobile Safari rendering paths.
  * Added automated verification that virtualized grid menus receive pointer interactions correctly.

* **Documentation**
  * Updated browser verification and release-gate coverage in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->