### PR TITLE
Contain queue actions in overlay layer

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@
 - Queue thread-action menus now appear above adjacent cards instead of being clipped in Safari.
 - Queue thread-action menus now also raise their virtualized row, keeping them visible and clickable above the next row in Firefox.
 - Browser verification now covers Firefox, WebKit, and Chromium so desktop Firefox and mobile Safari behavior are release gates.
+- Queue action menus now use a dedicated overlay layer, keeping hidden swipe actions contained and removing the oversized empty hover callout.
 
 ## 2026-07-15
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,7 +8,7 @@
 - Queue thread-action menus now appear above adjacent cards instead of being clipped in Safari.
 - Queue thread-action menus now also raise their virtualized row, keeping them visible and clickable above the next row in Firefox.
 - Browser verification now covers Firefox, WebKit, and Chromium so desktop Firefox and mobile Safari behavior are release gates.
-- Queue action menus now use a dedicated overlay layer, keeping hidden swipe actions contained and removing the oversized empty hover callout.
+- Queue action menus now open without being cut off by the card container, keeping hidden swipe actions contained, and removing the oversized empty hover callout.
 
 ## 2026-07-15
 

--- a/frontend/src/components/PositionMenu.tsx
+++ b/frontend/src/components/PositionMenu.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
+import { createPortal } from 'react-dom'
 import type { Thread } from '../types'
 import { usePositionMenu } from '../contexts/usePositionMenu'
 
@@ -17,9 +18,22 @@ export default function PositionMenu({ thread, onMoveToFront, onReposition, onMo
   const isOpen = openThreadId === thread.id
 
   const triggerRef = useRef<HTMLButtonElement>(null)
+  const triggerContainerRef = useRef<HTMLDivElement>(null)
   const menuRef = useRef<HTMLDivElement>(null)
   const menuItemsRef = useRef<(HTMLButtonElement | null)[]>([])
   const clickFromKeyboardRef = useRef(false)
+  const [menuPosition, setMenuPosition] = useState<{ top: number; right: number } | null>(null)
+
+  const updateMenuPosition = useCallback(() => {
+    const trigger = triggerRef.current
+    if (!trigger) return
+
+    const rect = trigger.getBoundingClientRect()
+    setMenuPosition({
+      top: rect.bottom + 4,
+      right: window.innerWidth - rect.right,
+    })
+  }, [])
 
   const closeMenu = useCallback(() => {
     closeContextMenu()
@@ -72,8 +86,25 @@ export default function PositionMenu({ thread, onMoveToFront, onReposition, onMo
   useEffect(() => {
     if (!isOpen) return
 
+    updateMenuPosition()
+    window.addEventListener('resize', updateMenuPosition)
+    document.addEventListener('scroll', updateMenuPosition, true)
+
+    return () => {
+      window.removeEventListener('resize', updateMenuPosition)
+      document.removeEventListener('scroll', updateMenuPosition, true)
+    }
+  }, [isOpen, updateMenuPosition])
+
+  useEffect(() => {
+    if (!isOpen) return
+
     const handleClickOutside = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+      const target = e.target as Node
+      if (
+        !menuRef.current?.contains(target) &&
+        !triggerContainerRef.current?.contains(target)
+      ) {
         closeMenu()
       }
     }
@@ -146,7 +177,7 @@ export default function PositionMenu({ thread, onMoveToFront, onReposition, onMo
     },
     {
       label: 'Dependencies',
-      icon: '\u26D3\uFE0F',
+      icon: '\u26D3\uFE0E',
       ariaLabel: 'Manage dependencies',
       action: () => {
         onDependencies(thread)
@@ -166,24 +197,24 @@ export default function PositionMenu({ thread, onMoveToFront, onReposition, onMo
   ]
 
   return (
-    <div className="relative" ref={menuRef}>
-      <Tooltip content="Thread actions">
-        <button
-          ref={triggerRef}
-          type="button"
-          onClick={handleTriggerClick}
-          onKeyDown={handleTriggerKeyDown}
-          className="flex items-center justify-center w-11 h-11 text-stone-500 hover:text-white transition-colors text-lg rounded-lg hover:bg-white/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
-          aria-label="Thread actions"
-          aria-haspopup="menu"
-          aria-expanded={isOpen}
-        >
-          &#x22EE;
-        </button>
-      </Tooltip>
-      {isOpen && (
+    <div className="relative" ref={triggerContainerRef}>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={handleTriggerClick}
+        onKeyDown={handleTriggerKeyDown}
+        className="flex items-center justify-center w-11 h-11 text-stone-500 hover:text-white transition-colors text-lg rounded-lg hover:bg-white/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+        aria-label="Thread actions"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+      >
+        &#x22EE;
+      </button>
+      {isOpen && menuPosition && createPortal(
         <div
-          className="absolute right-0 top-full mt-1 w-52 bg-[#1a1410]/95 border border-white/10 rounded-xl shadow-2xl z-50 py-1 overflow-hidden"
+          ref={menuRef}
+          className="fixed w-52 bg-[#1a1410]/95 border border-white/10 rounded-xl shadow-2xl z-[1000] py-1 overflow-hidden"
+          style={menuPosition}
           role="menu"
           aria-label="Thread actions"
         >
@@ -208,29 +239,8 @@ export default function PositionMenu({ thread, onMoveToFront, onReposition, onMo
               <span className="font-medium">{item.label}</span>
             </button>
           ))}
-        </div>
-      )}
-    </div>
-  )
-}
-
-function Tooltip({ children, content }: { children: React.ReactNode; content: string }) {
-  const [isVisible, setIsVisible] = useState(false)
-
-  return (
-    <div
-      className="relative inline-flex"
-      onMouseEnter={() => setIsVisible(true)}
-      onMouseLeave={() => setIsVisible(false)}
-      onFocus={() => setIsVisible(true)}
-      onBlur={() => setIsVisible(false)}
-    >
-      {children}
-      {isVisible && (
-        <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-64 px-3 py-2 bg-[#1a1410]/95 text-stone-300 text-[10px] rounded-lg shadow-xl border border-white/10 z-[60] pointer-events-none">
-          <div className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-1/2 rotate-45 w-2 h-2 bg-[#1a1410]/95 border-r border-b border-white/10"></div>
-          {content}
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   )

--- a/frontend/src/components/PositionMenu.tsx
+++ b/frontend/src/components/PositionMenu.tsx
@@ -29,9 +29,18 @@ export default function PositionMenu({ thread, onMoveToFront, onReposition, onMo
     if (!trigger) return
 
     const rect = trigger.getBoundingClientRect()
-    setMenuPosition({
+    const nextPosition = {
       top: rect.bottom + 4,
-      right: window.innerWidth - rect.right,
+      right: document.documentElement.clientWidth - rect.right,
+    }
+    setMenuPosition((currentPosition) => {
+      if (
+        currentPosition?.top === nextPosition.top &&
+        currentPosition.right === nextPosition.right
+      ) {
+        return currentPosition
+      }
+      return nextPosition
     })
   }, [])
 
@@ -105,13 +114,13 @@ export default function PositionMenu({ thread, onMoveToFront, onReposition, onMo
         !menuRef.current?.contains(target) &&
         !triggerContainerRef.current?.contains(target)
       ) {
-        closeMenu()
+        closeContextMenu()
       }
     }
 
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [isOpen, closeMenu])
+  }, [isOpen, closeContextMenu])
 
   const handleTriggerClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation()
@@ -128,6 +137,9 @@ export default function PositionMenu({ thread, onMoveToFront, onReposition, onMo
       e.stopPropagation()
       clickFromKeyboardRef.current = true
       openMenu(thread.id)
+      window.setTimeout(() => {
+        clickFromKeyboardRef.current = false
+      }, 100)
       setTimeout(() => menuItemsRef.current[0]?.focus(), 0)
     }
   }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -255,29 +255,6 @@ body {
   border-radius: 0.75rem;
 }
 
-/* Let an open actions menu paint above adjacent cards in the queue grid. */
-.queue-thread-card:has([aria-expanded="true"]) {
-  position: relative;
-  z-index: 100;
-}
-
-.queue-thread-swipeable:has([aria-expanded="true"]) {
-  overflow: visible !important;
-  position: relative;
-  z-index: 100;
-}
-
-/* Keep the menu above neighboring virtualized grid rows in Safari. */
-.queue-thread-card:has([aria-expanded="true"]) [role="menu"] {
-  z-index: 200;
-}
-
-/* A transformed virtual row is its own stacking context. Raise the entire row
-   while its menu is open so the following row cannot paint over the menu. */
-#queue-container [data-index]:has([aria-expanded="true"]) {
-  z-index: 100;
-}
-
 .modal-card {
   background: rgba(255, 255, 255, 0.03);
   backdrop-filter: var(--glass-blur);

--- a/frontend/src/test/dependencies.spec.ts
+++ b/frontend/src/test/dependencies.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures'
-import {createThread, openThreadActions} from './helpers'
+import {createThread, clickThreadAction} from './helpers'
 import type { Page } from '@playwright/test'
 
 async function markIssueNumbersRead(
@@ -48,8 +48,7 @@ test.describe('Dependencies', () => {
     await expect(authenticatedPage.locator('#root')).toBeVisible();
 
     const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Target Thread' }).first()
-    await openThreadActions(targetCard)
-    await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
+    await clickThreadAction(targetCard, 'Manage dependencies')
 
     await authenticatedPage.fill('input#search-prereq-thread', 'Source')
     await authenticatedPage.waitForSelector('button:has-text("Source Thread")', { state: 'visible' })
@@ -170,8 +169,7 @@ test.describe('Dependencies', () => {
       await expect(authenticatedPage.locator('#root')).toBeVisible();
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Target Comic' }).first()
-      await openThreadActions(targetCard)
-      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
+      await clickThreadAction(targetCard, 'Manage dependencies')
 
       await authenticatedPage.fill('input#search-prereq-thread', 'Prerequisite')
       await authenticatedPage.waitForSelector('button:has-text("Prerequisite Comic")', { state: 'visible' })
@@ -200,8 +198,7 @@ test.describe('Dependencies', () => {
       await expect(authenticatedPage.locator('#root')).toBeVisible();
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Target Series' }).first()
-      await openThreadActions(targetCard)
-      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
+      await clickThreadAction(targetCard, 'Manage dependencies')
 
       await authenticatedPage.fill('input#search-prereq-thread', 'Source')
       await authenticatedPage.waitForSelector('button:has-text("Source Series")', { state: 'visible' })
@@ -240,8 +237,7 @@ test.describe('Dependencies', () => {
       await expect(authenticatedPage.locator('#root')).toBeVisible();
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Main Series' }).first()
-      await openThreadActions(targetCard)
-      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
+      await clickThreadAction(targetCard, 'Manage dependencies')
 
       await authenticatedPage.fill('input#search-prereq-thread', 'Prequel')
       await authenticatedPage.waitForSelector('button:has-text("Prequel Series")', { state: 'visible' })
@@ -278,8 +274,7 @@ test.describe('Dependencies', () => {
       await expect(authenticatedPage.locator('#root')).toBeVisible();
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Target Comic' }).first()
-      await openThreadActions(targetCard)
-      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
+      await clickThreadAction(targetCard, 'Manage dependencies')
 
       await authenticatedPage.fill('input#search-prereq-thread', 'Source')
       await authenticatedPage.waitForSelector('button:has-text("Source Comic")', { state: 'visible' })
@@ -319,8 +314,7 @@ test.describe('Dependencies', () => {
       await expect(authenticatedPage.locator('#root')).toBeVisible();
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Dependent Series' }).first()
-      await openThreadActions(targetCard)
-      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
+      await clickThreadAction(targetCard, 'Manage dependencies')
 
       await authenticatedPage.fill('input#search-prereq-thread', 'Required')
       await authenticatedPage.waitForSelector('button:has-text("Required Series")', { state: 'visible' })
@@ -355,8 +349,7 @@ test.describe('Dependencies', () => {
       await expect(authenticatedPage.locator('#root')).toBeVisible();
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Loading Target' }).first()
-      await openThreadActions(targetCard)
-      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
+      await clickThreadAction(targetCard, 'Manage dependencies')
 
       await authenticatedPage.fill('input#search-prereq-thread', 'Loading')
       await authenticatedPage.waitForSelector('button:has-text("Loading Source")', { state: 'visible' })
@@ -392,8 +385,7 @@ test.describe('Dependencies', () => {
       await expect(authenticatedPage.locator('#root')).toBeVisible();
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Issue Target' }).first()
-      await openThreadActions(targetCard)
-      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
+      await clickThreadAction(targetCard, 'Manage dependencies')
 
       await authenticatedPage.fill('input#search-prereq-thread', 'Issue Source')
       await authenticatedPage.waitForSelector('button:has-text("Issue Source")', { state: 'visible' })
@@ -430,8 +422,7 @@ test.describe('Dependencies', () => {
       await expect(authenticatedPage.locator('#root')).toBeVisible();
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'No Issues Target' }).first()
-      await openThreadActions(targetCard)
-      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
+      await clickThreadAction(targetCard, 'Manage dependencies')
 
       await authenticatedPage.fill('input#search-prereq-thread', 'No Issues')
       await authenticatedPage.waitForSelector('button:has-text("No Issues Source")', { state: 'visible' })
@@ -468,8 +459,7 @@ test.describe('Dependencies', () => {
       await expect(authenticatedPage.locator('#root')).toBeVisible();
 
       const targetCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'All Read Target' }).first()
-      await openThreadActions(targetCard)
-      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
+      await clickThreadAction(targetCard, 'Manage dependencies')
 
       await authenticatedPage.fill('input#search-prereq-thread', 'All Read')
       await authenticatedPage.waitForSelector('button:has-text("All Read Source")', { state: 'visible' })

--- a/frontend/src/test/flowchart.spec.ts
+++ b/frontend/src/test/flowchart.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures'
-import {createThread, openThreadActions} from './helpers'
+import {createThread, clickThreadAction} from './helpers'
 
 async function getIssueIdByNumber(authenticatedPage: any, threadId: number, issueNumber: string, token: string | null | undefined): Promise<number> {
   if (!token) {
@@ -46,8 +46,7 @@ test('shows flowchart toggle after creating a dependency', async ({ authenticate
       .locator('#queue-container .glass-card')
       .filter({ hasText: 'Flowchart Target' })
       .first()
-    await openThreadActions(targetCard)
-    await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
+    await clickThreadAction(targetCard, 'Manage dependencies')
 
     // Search and add a dependency
     await authenticatedPage.fill('input#search-prereq-thread', 'Flowchart Source')
@@ -134,8 +133,7 @@ test('renders flowchart with nodes and edges when toggled', async ({ authenticat
       .locator('#queue-container .glass-card')
       .filter({ hasText: 'FC Node Target' })
       .first()
-    await openThreadActions(targetCard)
-    await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
+    await clickThreadAction(targetCard, 'Manage dependencies')
 
     await openFlowchartView(authenticatedPage)
 
@@ -229,8 +227,7 @@ test('flowchart zoom controls work', async ({ authenticatedPage }) => {
       .locator('#queue-container .glass-card')
       .filter({ hasText: 'Zoom Target' })
       .first()
-    await openThreadActions(targetCard)
-    await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
+    await clickThreadAction(targetCard, 'Manage dependencies')
     await openFlowchartView(authenticatedPage)
     await expect(authenticatedPage.locator('[data-testid="flowchart-svg"]')).toBeVisible()
 
@@ -313,8 +310,7 @@ test('flowchart shows tooltip on node hover', async ({ authenticatedPage }) => {
       .locator('#queue-container .glass-card')
       .filter({ hasText: 'Hover Target Thread' })
       .first()
-    await openThreadActions(targetCard)
-    await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
+    await clickThreadAction(targetCard, 'Manage dependencies')
     await openFlowchartView(authenticatedPage)
     await expect(authenticatedPage.locator('[data-testid="flowchart-svg"]')).toBeVisible()
 
@@ -390,8 +386,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
       .locator('#queue-container .glass-card')
       .filter({ hasText: 'Blocked Thread FC' })
       .first()
-    await openThreadActions(targetCard)
-    await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
+    await clickThreadAction(targetCard, 'Manage dependencies')
     await openFlowchartView(authenticatedPage)
     await expect(authenticatedPage.locator('[data-testid="flowchart-svg"]')).toBeVisible()
 
@@ -463,8 +458,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
       .locator('#queue-container .glass-card')
       .filter({ hasText: 'Toggle Target' })
       .first()
-    await openThreadActions(targetCard)
-    await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
+    await clickThreadAction(targetCard, 'Manage dependencies')
 
     // Toggle on and switch to graph view
     await openFlowchartView(authenticatedPage)
@@ -489,8 +483,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
       .locator('#queue-container .glass-card')
       .filter({ hasText: 'Lonely Thread' })
       .first()
-    await openThreadActions(card)
-    await card.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
+    await clickThreadAction(card, 'Manage dependencies')
 
     // Should not show flowchart toggle when there are no dependencies
     await expect(authenticatedPage.locator('[data-testid="toggle-reading-order"]')).not.toBeVisible()
@@ -557,8 +550,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
         .locator('#queue-container .glass-card')
         .filter({ hasText: 'Swamp Thing' })
         .first()
-      await openThreadActions(targetCard)
-      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
+      await clickThreadAction(targetCard, 'Manage dependencies')
 
       // Wait for toggle button to appear
       await authenticatedPage.waitForSelector('[data-testid="toggle-reading-order"]', { state: 'visible', timeout: 10000 })
@@ -666,8 +658,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
         .locator('#queue-container .glass-card')
         .filter({ hasText: 'Animal Man' })
         .first()
-      await openThreadActions(animalManCard)
-      await animalManCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
+      await clickThreadAction(animalManCard, 'Manage dependencies')
       await openFlowchartView(authenticatedPage)
 
       // Should have 4 distinct issue nodes visible
@@ -750,8 +741,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
         .locator('#queue-container .glass-card')
         .filter({ hasText: 'Target Series' })
         .first()
-      await openThreadActions(targetCard)
-      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
+      await clickThreadAction(targetCard, 'Manage dependencies')
       await openFlowchartView(authenticatedPage)
 
       // Check issue node styling
@@ -824,8 +814,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
         .locator('#queue-container .glass-card')
         .filter({ hasText: 'Blocked Target' })
         .first()
-      await openThreadActions(targetCard)
-      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
+      await clickThreadAction(targetCard, 'Manage dependencies')
       await openFlowchartView(authenticatedPage)
 
       // Issue node should not have lock icon
@@ -901,8 +890,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
         .locator('#queue-container .glass-card')
         .filter({ hasText: 'Edge Target' })
         .first()
-      await openThreadActions(targetCard)
-      await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
+      await clickThreadAction(targetCard, 'Manage dependencies')
       await openFlowchartView(authenticatedPage)
 
       // Check that issue-level edge has the dashed cyan class
@@ -1007,8 +995,7 @@ test('flowchart shows blocked nodes with lock icon', async ({ authenticatedPage 
         .locator('#queue-container .glass-card')
         .filter({ hasText: 'Thread Beta' })
         .first()
-      await openThreadActions(betaCard)
-      await betaCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
+      await clickThreadAction(betaCard, 'Manage dependencies')
       await openFlowchartView(authenticatedPage)
 
       // Should have all three thread nodes

--- a/frontend/src/test/helpers.ts
+++ b/frontend/src/test/helpers.ts
@@ -57,9 +57,24 @@ export async function waitForEditThreadModal(page: Page): Promise<void> {
   await expect(page.getByRole('heading', { name: 'Edit Thread' })).toBeVisible()
 }
 
-export async function openThreadActions(threadItem: Locator): Promise<void> {
+/**
+ * Opens a thread's action menu and returns its portaled overlay.
+ *
+ * The menu renders under document.body so it can escape virtualized-card clipping.
+ * Callers must use the returned locator for menu actions rather than searching inside
+ * the thread card.
+ */
+export async function openThreadActions(threadItem: Locator): Promise<Locator> {
   await threadItem.locator('button[aria-label="Thread actions"]').click()
-  await threadItem.locator('[role="menu"]').waitFor({ state: 'visible' })
+  const menu = threadItem.page().getByRole('menu')
+  await expect(menu).toBeVisible()
+  return menu
+}
+
+/** Opens a thread's action menu and invokes a named menu item. */
+export async function clickThreadAction(threadItem: Locator, actionName: string): Promise<void> {
+  const menu = await openThreadActions(threadItem)
+  await menu.getByRole('menuitem', { name: actionName }).click()
 }
 
 function isAuthResponse(data: unknown): data is { access_token: string } {

--- a/frontend/src/test/issue-326-collapsible-issue-list.spec.ts
+++ b/frontend/src/test/issue-326-collapsible-issue-list.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures';
-import {createThread, gotoQueue, waitForEditThreadModal, openThreadActions} from './helpers';
+import { createThread, gotoQueue, waitForEditThreadModal, clickThreadAction } from './helpers';
 
 test.describe('Issue #326: Collapsible Issue List', () => {
   test('should show only issues around next unread by default when thread has many issues', async ({ authenticatedPage }) => {
@@ -20,8 +20,7 @@ test.describe('Issue #326: Collapsible Issue List', () => {
     // Open the edit modal
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
     await threadItem.waitFor({ state: 'visible', timeout: 5000 });
-    const menu = await openThreadActions(threadItem)
-    await menu.getByRole('menuitem', { name: 'Edit thread' }).click();
+    await clickThreadAction(threadItem, 'Edit thread');
 
     // Wait for edit modal to open
     await waitForEditThreadModal(authenticatedPage);
@@ -58,8 +57,7 @@ test.describe('Issue #326: Collapsible Issue List', () => {
 
     // Open the edit modal
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
-    const menu = await openThreadActions(threadItem)
-    await menu.getByRole('menuitem', { name: 'Edit thread' }).click();
+    await clickThreadAction(threadItem, 'Edit thread');
 
     // Wait for edit modal to open
     await waitForEditThreadModal(authenticatedPage);
@@ -96,8 +94,7 @@ test.describe('Issue #326: Collapsible Issue List', () => {
 
     // Open the edit modal
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
-    const menu = await openThreadActions(threadItem)
-    await menu.getByRole('menuitem', { name: 'Edit thread' }).click();
+    await clickThreadAction(threadItem, 'Edit thread');
 
     // Wait for edit modal to open
     await waitForEditThreadModal(authenticatedPage);
@@ -140,8 +137,7 @@ test.describe('Issue #326: Collapsible Issue List', () => {
 
     // Open the edit modal
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
-    const menu = await openThreadActions(threadItem)
-    await menu.getByRole('menuitem', { name: 'Edit thread' }).click();
+    await clickThreadAction(threadItem, 'Edit thread');
 
     // Wait for edit modal to open
     await waitForEditThreadModal(authenticatedPage);
@@ -175,8 +171,7 @@ test.describe('Issue #326: Collapsible Issue List', () => {
 
     // Open the edit modal
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
-    const menu = await openThreadActions(threadItem)
-    await menu.getByRole('menuitem', { name: 'Edit thread' }).click();
+    await clickThreadAction(threadItem, 'Edit thread');
 
     await waitForEditThreadModal(authenticatedPage);
     const editModal = authenticatedPage.locator('.fixed.inset-0').filter({ hasText: 'Edit Thread' });

--- a/frontend/src/test/issue-326-collapsible-issue-list.spec.ts
+++ b/frontend/src/test/issue-326-collapsible-issue-list.spec.ts
@@ -20,8 +20,8 @@ test.describe('Issue #326: Collapsible Issue List', () => {
     // Open the edit modal
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
     await threadItem.waitFor({ state: 'visible', timeout: 5000 });
-    await openThreadActions(threadItem)
-    await threadItem.locator('button[aria-label="Edit thread"]').click();
+    const menu = await openThreadActions(threadItem)
+    await menu.getByRole('menuitem', { name: 'Edit thread' }).click();
 
     // Wait for edit modal to open
     await waitForEditThreadModal(authenticatedPage);
@@ -58,8 +58,8 @@ test.describe('Issue #326: Collapsible Issue List', () => {
 
     // Open the edit modal
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
-    await openThreadActions(threadItem)
-    await threadItem.locator('button[aria-label="Edit thread"]').click();
+    const menu = await openThreadActions(threadItem)
+    await menu.getByRole('menuitem', { name: 'Edit thread' }).click();
 
     // Wait for edit modal to open
     await waitForEditThreadModal(authenticatedPage);
@@ -96,8 +96,8 @@ test.describe('Issue #326: Collapsible Issue List', () => {
 
     // Open the edit modal
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
-    await openThreadActions(threadItem)
-    await threadItem.locator('button[aria-label="Edit thread"]').click();
+    const menu = await openThreadActions(threadItem)
+    await menu.getByRole('menuitem', { name: 'Edit thread' }).click();
 
     // Wait for edit modal to open
     await waitForEditThreadModal(authenticatedPage);
@@ -140,8 +140,8 @@ test.describe('Issue #326: Collapsible Issue List', () => {
 
     // Open the edit modal
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
-    await openThreadActions(threadItem)
-    await threadItem.locator('button[aria-label="Edit thread"]').click();
+    const menu = await openThreadActions(threadItem)
+    await menu.getByRole('menuitem', { name: 'Edit thread' }).click();
 
     // Wait for edit modal to open
     await waitForEditThreadModal(authenticatedPage);
@@ -175,8 +175,8 @@ test.describe('Issue #326: Collapsible Issue List', () => {
 
     // Open the edit modal
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
-    await openThreadActions(threadItem)
-    await threadItem.locator('button[aria-label="Edit thread"]').click();
+    const menu = await openThreadActions(threadItem)
+    await menu.getByRole('menuitem', { name: 'Edit thread' }).click();
 
     await waitForEditThreadModal(authenticatedPage);
     const editModal = authenticatedPage.locator('.fixed.inset-0').filter({ hasText: 'Edit Thread' });

--- a/frontend/src/test/issue-583-virtualized-grid.spec.ts
+++ b/frontend/src/test/issue-583-virtualized-grid.spec.ts
@@ -67,9 +67,13 @@ test.describe('Responsive multi-column virtualized grid (#583-C)', () => {
     await waitForQueueReady(page);
 
     const firstCard = page.locator('[data-index="0"] [data-testid="queue-thread-item"]').first();
-    await firstCard.getByLabel('Thread actions').click();
+    const threadActions = firstCard.getByLabel('Thread actions', { exact: true });
+    await threadActions.hover();
+    await expect(page.getByText('Thread actions', { exact: true })).toHaveCount(0);
+    await expect.poll(() => firstCard.evaluate((element) => getComputedStyle(element).overflow)).toBe('hidden');
+    await threadActions.click();
 
-    const menu = firstCard.getByRole('menu', { name: 'Thread actions' });
+    const menu = page.getByRole('menu', { name: 'Thread actions' });
     await expect(menu).toBeVisible();
 
     const menuBox = await menu.boundingBox();

--- a/frontend/src/test/issue-list.spec.ts
+++ b/frontend/src/test/issue-list.spec.ts
@@ -106,7 +106,7 @@ test.describe('Thread Creation with Issue Ranges', () => {
     await authenticatedPage.waitForSelector('button:has-text("Add Thread")', { state: 'visible', timeout: 10000 });
 
     await authenticatedPage.click('button:has-text("Add Thread")');
-    await authenticatedPage.waitForSelector('label:has-text("Title") + input', { state: 'visible', timeout: 5000 });
+    await expect(authenticatedPage.locator('label:has-text("Title") + input')).toBeVisible({ timeout: 15000 });
 
     await authenticatedPage.fill('label:has-text("Title") + input', uniqueTitle);
     await authenticatedPage.selectOption('label:has-text("Format") + select', 'Comics');
@@ -192,7 +192,7 @@ test.describe('Thread Creation with Issue Ranges', () => {
     await authenticatedPage.waitForSelector('button:has-text("Add Thread")', { state: 'visible', timeout: 10000 });
 
     await authenticatedPage.click('button:has-text("Add Thread")');
-    await authenticatedPage.waitForSelector('label:has-text("Title") + input', { state: 'visible', timeout: 5000 });
+    await expect(authenticatedPage.locator('label:has-text("Title") + input')).toBeVisible({ timeout: 15000 });
 
     await authenticatedPage.fill('label:has-text("Title") + input', uniqueTitle);
     await authenticatedPage.selectOption('label:has-text("Format") + select', 'Comics');

--- a/frontend/src/test/migration.spec.ts
+++ b/frontend/src/test/migration.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures';
-import { openThreadActions } from './helpers';
+import { clickThreadAction } from './helpers';
 
 /**
  * Helper to create a thread without total_issues (old system) via API
@@ -569,8 +569,7 @@ test.describe('Migrating from Edit Modal', () => {
 
     // Click the Edit button for old thread
     const oldThreadCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: oldThreadTitle }).first();
-    await openThreadActions(oldThreadCard)
-    await oldThreadCard.locator('button[aria-label="Edit thread"]').click();
+    await clickThreadAction(oldThreadCard, 'Edit thread')
 
     const oldEditModal = authenticatedPage.locator('.edit-modal__overlay');
     await expect(oldEditModal).toBeVisible();
@@ -583,8 +582,7 @@ test.describe('Migrating from Edit Modal', () => {
 
     // Click the Edit button for migrated thread
     const migratedThreadCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: migratedThreadTitle }).first();
-    await openThreadActions(migratedThreadCard)
-    await migratedThreadCard.locator('button[aria-label="Edit thread"]').click();
+    await clickThreadAction(migratedThreadCard, 'Edit thread')
 
     const migratedEditModal = authenticatedPage.locator('.edit-modal__overlay');
     await expect(migratedEditModal).toBeVisible();
@@ -606,8 +604,7 @@ test.describe('Migrating from Edit Modal', () => {
 
     // Click the Edit button, not the thread card
     const threadCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: threadTitle }).first();
-    await openThreadActions(threadCard)
-    await threadCard.locator('button[aria-label="Edit thread"]').click();
+    await clickThreadAction(threadCard, 'Edit thread')
 
     const editModal = authenticatedPage.locator('.edit-modal__overlay');
     await expect(editModal).toBeVisible();
@@ -652,8 +649,7 @@ test.describe('Migrating from Edit Modal', () => {
 
     // Click the Edit button, not the thread card itself
     const threadCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: threadTitle }).first();
-    await openThreadActions(threadCard)
-    await threadCard.locator('button[aria-label="Edit thread"]').click();
+    await clickThreadAction(threadCard, 'Edit thread')
 
     const editModal = authenticatedPage.locator('.edit-modal__overlay');
     await expect(editModal).toBeVisible();
@@ -685,8 +681,7 @@ test.describe('Migrating from Edit Modal', () => {
 
     // Click the Edit button, not the thread card itself
     const threadCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: threadTitle }).first();
-    await openThreadActions(threadCard)
-    await threadCard.locator('button[aria-label="Edit thread"]').click();
+    await clickThreadAction(threadCard, 'Edit thread')
 
     const editModal = authenticatedPage.locator('.edit-modal__overlay');
     await expect(editModal).toBeVisible();
@@ -721,8 +716,7 @@ test.describe('Migrating from Edit Modal', () => {
 
     // Click the Edit button, not the thread card
     const threadCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: threadTitle }).first();
-    await openThreadActions(threadCard)
-    await threadCard.locator('button[aria-label="Edit thread"]').click();
+    await clickThreadAction(threadCard, 'Edit thread')
 
     const editModal = authenticatedPage.locator('.edit-modal__overlay');
     await expect(editModal).toBeVisible();
@@ -759,8 +753,7 @@ test.describe('Migrating from Edit Modal', () => {
 
     // Click the Edit button, not the thread card
     const threadCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: threadTitle }).first();
-    await openThreadActions(threadCard)
-    await threadCard.locator('button[aria-label="Edit thread"]').click();
+    await clickThreadAction(threadCard, 'Edit thread')
 
     const editModal = authenticatedPage.locator('.edit-modal__overlay');
     await expect(editModal).toBeVisible();
@@ -791,8 +784,7 @@ test.describe('Migrating from Edit Modal', () => {
 
     // Click the Edit button, not the thread card
     const threadCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: threadTitle }).first();
-    await openThreadActions(threadCard)
-    await threadCard.locator('button[aria-label="Edit thread"]').click();
+    await clickThreadAction(threadCard, 'Edit thread')
 
     const editModal = authenticatedPage.locator('.edit-modal__overlay');
     await expect(editModal).toBeVisible();

--- a/frontend/src/test/readingOrderTimeline.spec.ts
+++ b/frontend/src/test/readingOrderTimeline.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures'
-import {createThread, extractThreadsFromResponse, findByTitle, findByIssueNumber, openThreadActions} from './helpers'
+import {createThread, extractThreadsFromResponse, findByTitle, findByIssueNumber, clickThreadAction} from './helpers'
 
 test.describe('Reading Order Timeline', () => {
   test('displays grouped gates and tabs', async ({ authenticatedPage }) => {
@@ -50,8 +50,7 @@ test.describe('Reading Order Timeline', () => {
     await page.goto('/queue')
     await expect(page.locator('#root')).toBeVisible();
     const targetCard = page.locator('#queue-container .glass-card').filter({ hasText: 'Target' }).first()
-    await openThreadActions(targetCard)
-    await targetCard.locator('button[role="menuitem"][aria-label="Manage dependencies"]').click()
+    await clickThreadAction(targetCard, 'Manage dependencies')
     await page.waitForSelector('button[data-testid="toggle-reading-order"]')
     await page.click('button[data-testid="toggle-reading-order"]')
     await page.waitForSelector('[role="tablist"]')

--- a/frontend/src/test/session-timestamps.spec.ts
+++ b/frontend/src/test/session-timestamps.spec.ts
@@ -8,7 +8,7 @@ test.describe('Session Timestamp Consistency (Issue #245)', () => {
     await authenticatedWithThreadsPage.waitForSelector(SELECTORS.roll.mainDie, { timeout: 10000 });
 
     await authenticatedWithThreadsPage.click(SELECTORS.roll.mainDie);
-    await authenticatedWithThreadsPage.waitForSelector(SELECTORS.rate.ratingInput, { timeout: 5000 });
+    await expect(authenticatedWithThreadsPage.locator(SELECTORS.rate.ratingInput)).toBeVisible({ timeout: 15000 });
 
     await setRangeInput(authenticatedWithThreadsPage, SELECTORS.rate.ratingInput, '4.0');
     await authenticatedWithThreadsPage.click(SELECTORS.rate.submitButton);
@@ -39,7 +39,7 @@ test.describe('Session Timestamp Consistency (Issue #245)', () => {
     await authenticatedWithThreadsPage.waitForSelector(SELECTORS.roll.mainDie, { timeout: 10000 });
 
     await authenticatedWithThreadsPage.click(SELECTORS.roll.mainDie);
-    await authenticatedWithThreadsPage.waitForSelector(SELECTORS.rate.ratingInput, { timeout: 5000 });
+    await expect(authenticatedWithThreadsPage.locator(SELECTORS.rate.ratingInput)).toBeVisible({ timeout: 15000 });
 
     await setRangeInput(authenticatedWithThreadsPage, SELECTORS.rate.ratingInput, '3.5');
     await authenticatedWithThreadsPage.click(SELECTORS.rate.submitButton);

--- a/frontend/src/test/thread-detail-view.spec.ts
+++ b/frontend/src/test/thread-detail-view.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures';
-import {createThread, gotoQueue, openThreadActions} from './helpers';
+import {createThread, gotoQueue, clickThreadAction} from './helpers';
 
 test.describe('Thread Detail View', () => {
   test('should navigate to thread detail view when clicking a thread', async ({ authenticatedPage }) => {
@@ -123,8 +123,7 @@ test.describe('Thread Detail View', () => {
     const threadCard = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'Notes Test' });
     await threadCard.waitFor({ state: 'visible', timeout: 5000 });
 
-    await openThreadActions(threadCard)
-    await threadCard.locator('button[aria-label="Edit thread"]').click();
+    await clickThreadAction(threadCard, 'Edit thread')
     await authenticatedPage.waitForSelector('label:has-text("Notes") + textarea', { state: 'visible', timeout: 5000 });
 
     await authenticatedPage.fill('label:has-text("Notes") + textarea', 'These are test notes for the thread');

--- a/frontend/src/test/thread-editing-bugs.spec.ts
+++ b/frontend/src/test/thread-editing-bugs.spec.ts
@@ -5,7 +5,7 @@ import {createThread,
   findByTitle,
   gotoQueue,
   waitForEditThreadModal,
-  openThreadActions,
+  clickThreadAction,
 } from './helpers';
 
 async function makeAuthenticatedRequest(page: any, method: string, url: string, data?: any, maxRetries = 3): Promise<any> {
@@ -78,8 +78,7 @@ test.describe('Thread Editing - Issue Adding Bug Reproduction', () => {
     // Step 3: Open the edit modal for the thread
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
     await threadItem.waitFor({ state: 'visible', timeout: 5000 });
-    await openThreadActions(threadItem)
-    await threadItem.locator('button[aria-label="Edit thread"]').click();
+    await clickThreadAction(threadItem, 'Edit thread')
 
     // Wait for edit modal to open - wait for the modal heading
     await waitForEditThreadModal(authenticatedPage);
@@ -156,8 +155,7 @@ test.describe('Thread Editing - Issue Adding Bug Reproduction', () => {
     await expect(authenticatedPage.locator('#root')).toBeVisible();
 
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
-    await openThreadActions(threadItem)
-    await threadItem.locator('button[aria-label="Edit thread"]').click();
+    await clickThreadAction(threadItem, 'Edit thread')
 
     const editModal = authenticatedPage.locator('.fixed.inset-0').filter({ hasText: 'Edit Thread' });
     await expect(editModal).toBeVisible();
@@ -197,8 +195,7 @@ test.describe('Thread Editing - Issue Adding Bug Reproduction', () => {
     await expect(authenticatedPage.locator('#root')).toBeVisible();
 
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
-    await openThreadActions(threadItem)
-    await threadItem.locator('button[aria-label="Edit thread"]').click();
+    await clickThreadAction(threadItem, 'Edit thread')
 
     const editModal = authenticatedPage.locator('.fixed.inset-0').filter({ hasText: 'Edit Thread' });
     await expect(editModal).toBeVisible();
@@ -246,8 +243,7 @@ test.describe('Thread Editing - Issue Adding Bug Reproduction', () => {
 
     // Open edit modal
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
-    await openThreadActions(threadItem)
-    await threadItem.locator('button[aria-label="Edit thread"]').click();
+    await clickThreadAction(threadItem, 'Edit thread')
     await authenticatedPage.waitForSelector('h2:has-text("Edit Thread")', { state: 'visible', timeout: 5000 });
 
     const editModal = authenticatedPage.locator('.fixed.inset-0').filter({ hasText: 'Edit Thread' });
@@ -314,8 +310,7 @@ test.describe('Thread Editing - Issue Adding Bug Reproduction', () => {
 
     // Open edit modal
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
-    await openThreadActions(threadItem)
-    await threadItem.locator('button[aria-label="Edit thread"]').click();
+    await clickThreadAction(threadItem, 'Edit thread')
     await authenticatedPage.waitForSelector('h2:has-text("Edit Thread")', { state: 'visible', timeout: 5000 });
 
     const editModal = authenticatedPage.locator('.fixed.inset-0').filter({ hasText: 'Edit Thread' });
@@ -371,8 +366,7 @@ test.describe('Thread Editing - Issue Adding Bug Reproduction', () => {
 
     // Open edit modal and add issue
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
-    await openThreadActions(threadItem)
-    await threadItem.locator('button[aria-label="Edit thread"]').click();
+    await clickThreadAction(threadItem, 'Edit thread')
     await authenticatedPage.waitForSelector('h2:has-text("Edit Thread")', { state: 'visible', timeout: 5000 });
 
     const editModal = authenticatedPage.locator('.fixed.inset-0').filter({ hasText: 'Edit Thread' });
@@ -441,8 +435,7 @@ test.describe('Thread Editing - Issue Adding Bug Reproduction', () => {
     // Step 3: Open the edit modal for the thread
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: uniqueTitle });
     await threadItem.waitFor({ state: 'visible', timeout: 5000 });
-    await openThreadActions(threadItem)
-    await threadItem.locator('button[aria-label="Edit thread"]').click();
+    await clickThreadAction(threadItem, 'Edit thread')
 
     // Wait for edit modal to open
     await authenticatedPage.waitForSelector('h2:has-text("Edit Thread")', { state: 'visible', timeout: 5000 });

--- a/frontend/src/test/threads.spec.ts
+++ b/frontend/src/test/threads.spec.ts
@@ -4,6 +4,7 @@ import {createThread,
   SELECTORS,
   waitForEditThreadModal,
   waitForThreadInQueue,
+  clickThreadAction,
   openThreadActions,
 } from './helpers';
 
@@ -114,8 +115,7 @@ test.describe('Thread Management', () => {
     await gotoQueue(authenticatedPage);
 
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').first();
-    await openThreadActions(threadItem)
-    await threadItem.locator('button[aria-label="Edit thread"]').click();
+    await clickThreadAction(threadItem, 'Edit thread')
     await waitForEditThreadModal(authenticatedPage);
 
     await authenticatedPage.fill('label:has-text("Title") + input', 'Updated Title');
@@ -144,13 +144,13 @@ test.describe('Thread Management', () => {
 
     const threadItem = authenticatedPage.locator('#queue-container .glass-card').filter({ hasText: 'To Be Deleted' });
     await threadItem.waitFor({ state: 'visible', timeout: 5000 });
-    await openThreadActions(threadItem)
+    const menu = await openThreadActions(threadItem)
     await Promise.all([
       authenticatedPage.waitForResponse((response) =>
         response.url().includes('/api/threads/') &&
         response.request().method() === 'DELETE'
       ),
-      threadItem.locator('button[aria-label="Delete thread"]').click(),
+      menu.getByRole('menuitem', { name: 'Delete thread' }).click(),
     ]);
     await authenticatedPage.reload({ waitUntil: 'domcontentloaded' });
     await expect(authenticatedPage.getByRole('heading', { name: 'Read Queue' })).toBeVisible();


### PR DESCRIPTION
## Summary
- Move queue action menus into the overlay layer so they escape clipped and transformed card containers.
- Restore strict swipe clipping and remove the obsolete oversized hover tooltip.
- Include the focused release-note entry.

## Validation
Local lint and tests were not rerun as part of splitting the existing PR, per request.

## Stack
First PR in the split series; merge before PR 629.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved queue action menus by displaying them in a dedicated overlay layer.
  - Hidden swipe actions now remain contained, preventing oversized empty hover callouts.
  - Menus remain correctly positioned while scrolling or resizing the window.
  - Improved menu interaction and click-outside behavior.

- **Tests**
  - Updated coverage for thread actions, dependency management, editing, deletion, and migration flows.
  - Increased readiness timeouts for more reliable UI checks.

- **Documentation**
  - Added the change to the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->