### PR TITLE
Keep roll pool controls above navigation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,8 +141,8 @@ jobs:
           cp -a /opt/ci-assets/static/react static/react
           pnpm install --frozen-lockfile
 
-      - name: Run vitest unit tests
-        run: pnpm --filter frontend test
+      - name: Run vitest unit tests with 94% coverage gate
+        run: pnpm --filter frontend test:coverage
 
   migration-health:
     name: Migration Health

--- a/frontend/src/pages/RollPage/components/ThreadPool.tsx
+++ b/frontend/src/pages/RollPage/components/ThreadPool.tsx
@@ -49,7 +49,7 @@ export function ThreadPool({
 }: ThreadPoolProps) {
   const navigate = useNavigate()
   return (
-    <div className={`px-3 md:px-4 pb-3 md:pb-4 flex flex-col ${!isRatingView ? 'flex-1 min-h-[300px]' : 'border-t border-white/5 pt-4 md:pt-8'}`}>
+    <div className={`px-3 md:px-4 pb-20 md:pb-28 flex flex-col ${!isRatingView ? 'flex-1 min-h-[300px]' : 'border-t border-white/5 pt-4 md:pt-8'}`}>
       {!isRolling && rolledResult === null && !isRatingView && pool.length > 0 && (
         <p
           id="tap-instruction"

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -36,6 +36,12 @@ export default defineConfig({
         'src/dice-playground-main.tsx',
         '**/*.d.ts',
       ],
+      thresholds: {
+        statements: 94,
+        branches: 94,
+        functions: 94,
+        lines: 94,
+      },
     },
   },
   resolve: {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ addopts = [
     "--cov=comic_pile",
     "--cov-report=term-missing",
     "--cov-report=html",
-    "--cov-fail-under=0",
+    "--cov-fail-under=94",
 ]
 asyncio_mode = "auto"
 markers = [
@@ -76,6 +76,7 @@ markers = [
 
 [tool.coverage.run]
 source = ["app", "comic_pile"]
+branch = true
 omit = [
     "*/tests/*",
     "*/test_*.py",


### PR DESCRIPTION
## Summary
- Keep roll pool controls above the navigation layer with the intended stacking order.
- Apply the frontend and backend coverage gates only after the complete stacked change set is present.

## Validation
Local lint and tests were not rerun as part of splitting the existing PR, per request.

## Stack
Depends on PR 633. Merge last.