### PR TITLE
Fix low-rating placement with snoozed threads

### DIFF
--- a/app/api/rate.py
+++ b/app/api/rate.py
@@ -371,7 +371,13 @@ async def rate_thread(
         await move_to_front(thread_id, user_id, db, commit=False)
     else:
         # Use the expanded die so the thread is outside the next roll pool.
-        await move_to_safe_position(thread_id, user_id, new_die, db)
+        await move_to_safe_position(
+            thread_id,
+            user_id,
+            new_die,
+            db,
+            excluded_thread_ids=current_session.snoozed_thread_ids,
+        )
 
     if rate_data.finish_session:
         current_session.ended_at = datetime.now(UTC)

--- a/comic_pile/queue.py
+++ b/comic_pile/queue.py
@@ -1,5 +1,6 @@
 """Queue management functions."""
 
+from collections.abc import Collection
 import logging
 import random
 from datetime import UTC, datetime, timedelta
@@ -236,6 +237,7 @@ async def move_to_safe_position(
     user_id: int,
     die_size: int,
     db: AsyncSession,
+    excluded_thread_ids: Collection[int] | None = None,
 ) -> None:
     """Move thread to a position just beyond the current die range.
 
@@ -263,7 +265,11 @@ async def move_to_safe_position(
         user_id: Thread owner.
         die_size: Current die size from the dice ladder.
         db: Async database session (caller handles commit/rollback).
+        excluded_thread_ids: Thread IDs excluded from the current roll pool,
+            such as threads snoozed in the active session.
     """
+    excluded_ids = set(excluded_thread_ids or ())
+
     result = await db.execute(
         select(Thread)
         .where(Thread.user_id == user_id)
@@ -274,7 +280,7 @@ async def move_to_safe_position(
     all_active = list(result.scalars().all())
 
     # Build the rollable pool (same filter as get_roll_pool: non-blocked only)
-    rollable = [t for t in all_active if not t.is_blocked]
+    rollable = [t for t in all_active if not t.is_blocked and t.id not in excluded_ids]
 
     target_rollable_index = next(
         (i for i, t in enumerate(rollable) if t.id == thread_id), -1
@@ -300,7 +306,7 @@ async def move_to_safe_position(
     for i, t in enumerate(all_active):
         if t.id == thread_id:
             continue
-        if not t.is_blocked:
+        if not t.is_blocked and t.id not in excluded_ids:
             non_blocked_seen += 1
         if non_blocked_seen >= die_size:
             target_seq = i + 1  # 1-indexed position in all_active

--- a/tests/test_queue_safe_position.py
+++ b/tests/test_queue_safe_position.py
@@ -3,7 +3,8 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import Thread
+from app.models import Dependency, Issue, Thread
+from comic_pile.dependencies import refresh_user_blocked_status
 from comic_pile.queue import get_roll_pool, move_to_safe_position
 
 
@@ -289,3 +290,68 @@ async def test_move_to_safe_position_excludes_snoozed_threads_from_roll_pool(
         and thread.queue_position < target.queue_position
     )
     assert eligible_before == 8
+
+
+@pytest.mark.asyncio
+async def test_move_to_safe_position_mixed_issues_dependencies_and_snoozes(
+    async_db: AsyncSession, default_user
+) -> None:
+    """Safe placement must match a mixed issue/dependency/snooze roll pool."""
+    user = default_user
+    threads = []
+    for position in range(1, 26):
+        thread = Thread(
+            title=f"Mixed pool thread {position}",
+            format="Comic",
+            issues_remaining=5,
+            total_issues=5,
+            queue_position=position,
+            status="active",
+            user_id=user.id,
+        )
+        async_db.add(thread)
+        threads.append(thread)
+    await async_db.flush()
+
+    issues = []
+    for thread in threads:
+        issue = Issue(
+            thread_id=thread.id,
+            issue_number="1",
+            position=1,
+            status="unread",
+        )
+        async_db.add(issue)
+        issues.append(issue)
+    await async_db.flush()
+    for thread, issue in zip(threads, issues, strict=True):
+        thread.next_unread_issue_id = issue.id
+
+    # Four issue-level dependencies make queue positions 4-7 unavailable.
+    # The source remains unread, so those target threads are genuinely blocked.
+    async_db.add_all(
+        [
+            Dependency(source_issue_id=issues[1].id, target_issue_id=issues[i].id)
+            for i in range(3, 7)
+        ]
+    )
+    await async_db.commit()
+    await refresh_user_blocked_status(user.id, async_db)
+    await async_db.commit()
+
+    target = threads[0]
+    snoozed_ids = {threads[7].id, threads[8].id, threads[9].id}
+    await move_to_safe_position(
+        target.id,
+        user.id,
+        8,
+        async_db,
+        excluded_thread_ids=snoozed_ids,
+    )
+    await async_db.refresh(target)
+
+    # Eligible threads before the target are positions 2-3 and 11-16:
+    # two ordinary + six after four blocked and three snoozed = eight.
+    assert target.queue_position == 16
+    pool = await get_roll_pool(user.id, async_db, list(snoozed_ids))
+    assert target.id not in {thread.id for thread in pool[:8]}

--- a/tests/test_queue_safe_position.py
+++ b/tests/test_queue_safe_position.py
@@ -237,3 +237,55 @@ async def test_move_to_safe_position_many_blocked_before_target_bug_597(
         f"Only {non_blocked_before} non-blocked threads before target at "
         f"position {target_pos} — need >= 6 to be outside d6 pool!"
     )
+
+
+@pytest.mark.asyncio
+async def test_move_to_safe_position_excludes_snoozed_threads_from_roll_pool(
+    async_db: AsyncSession, default_user
+) -> None:
+    """Snoozed threads must not consume slots in the expanded roll pool."""
+    user = default_user
+    threads = []
+    for i in range(1, 15):
+        thread = Thread(
+            title=f"Snooze Thread {i}",
+            format="Comic",
+            issues_remaining=5,
+            queue_position=i,
+            status="active",
+            user_id=user.id,
+        )
+        async_db.add(thread)
+        threads.append(thread)
+    await async_db.flush()
+
+    target = threads[0]
+    snoozed_ids = {threads[1].id, threads[2].id}
+    await move_to_safe_position(
+        target.id,
+        user.id,
+        8,
+        async_db,
+        excluded_thread_ids=snoozed_ids,
+    )
+    await async_db.refresh(target)
+
+    # The target must follow eight eligible threads. Two snoozed threads occupy
+    # raw queue slots, so the target lands at raw position 11, not position 9.
+    assert target.queue_position == 11
+
+    result = await async_db.execute(
+        select(Thread)
+        .where(Thread.user_id == user.id)
+        .where(Thread.status == "active")
+        .order_by(Thread.queue_position)
+    )
+    all_active = result.scalars().all()
+    eligible_before = sum(
+        1
+        for thread in all_active
+        if thread.id != target.id
+        and thread.id not in snoozed_ids
+        and thread.queue_position < target.queue_position
+    )
+    assert eligible_before == 8


### PR DESCRIPTION
## What changed
Low-rated threads now calculate their safe queue position from the same eligible roll pool used by rolling, excluding session-snoozed threads as well as dependency-blocked threads.

## Root cause
The low-rating path passed the expanded die to the safe-position helper, but the helper still counted snoozed threads when determining how many eligible threads preceded the rated thread.

## Validation
- Targeted queue/rating tests pass.
- Mutation check: the test fails against the old snooze-counting implementation (9 vs 11), then passes after restoring the fix.
- `make verify` passes with the worktree virtualenv.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Snoozed threads are now excluded when calculating safe queue placement.
  - Queue positioning more accurately accounts for unavailable threads and issue dependencies, helping rated threads land in the intended location.

- **Tests**
  - Added coverage for queue placement involving snoozed threads and mixed dependency scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->