### PR TITLE
Add production data export command (#650)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,4 @@ dogfood-output/
 
 # Local AI/tool config
 opencode.json
+prod_backup_*.json

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .PHONY: merge-phase1 merge-phase2 merge-phase3 merge-phase4 merge-phase5 merge-phase6 merge-phase7 merge-phase8 merge-phase9
 .PHONY: dev dev-api test seed seed-dev migrate db-up db-down worktrees status test-integration deploy-prod prod-migrate deploy-prod-migrate dev-all dev-frontend
 .PHONY: docker-test-up docker-test-down docker-test-logs docker-test-health test-e2e-browser-docker test-e2e-browser-quick
-.PHONY: test-e2e-prod-smoke check-prod-assets
+.PHONY: test-e2e-prod-smoke check-prod-assets clone-prod-export clone-prod-import
 .PHONY: verify-reading-order
 
 # Configuration
@@ -427,3 +427,9 @@ test-e2e-browser-quick:  ## Run TypeScript Playwright tests (Docker must already
 verify-reading-order:  ## Verify Wildstorm reading order dependencies
 	@echo "Verifying Wildstorm reading order..."
 	@cd scripts && python verify_wildstorm_reading_order.py
+
+clone-prod-export:  ## Backup production user data (ex: make clone-prod-export ARGS='--username Josh')
+	@python -m scripts.clone_prod_to_local export $(ARGS)
+
+clone-prod-import:  ## Restore backup into local dev database
+	@python -m scripts.clone_prod_to_local import $(ARGS)

--- a/docs/issue-plans/643.md
+++ b/docs/issue-plans/643.md
@@ -1,0 +1,91 @@
+# Plan for Issue #643 — Production-to-local development data clone
+
+## Overview
+
+Add an explicit, confirmation-gated command that exports the authenticated
+production user's data and restores it into a local development database with
+ownership remapping and no production mutation.
+
+## Data graph (user-scoped export)
+
+Models that belong to a user (export — ordered by FK dependency):
+
+1. **User** — the single authenticated user (password_hash excluded from export)
+2. **Collection** — user.collections
+3. **Thread** — user.threads (FKs: user_id, collection_id)
+4. **Issue** — per thread (FK: thread_id)
+5. **Dependency** — between issues of user's threads (FKs: source/target_issue_id)
+6. **ReadingOrder** — user (FK: user_id)
+7. **ReadingOrderItem** — per reading order (FKs: reading_order_id, thread_id)
+8. **Session** — user.sessions (FKs: user_id, pending_thread_id, pending_issue_id)
+9. **Event** — per session (FKs: session_id, thread_id, issue_id)
+10. **Snapshot** — per session (FKs: session_id, event_id)
+11. **Review** — user.reviews (FKs: user_id, thread_id, issue_id)
+
+NOT exported (security or non-user-scoped):
+- **FailedLoginAttempt** — no user FK, security-sensitive IP data
+- **RevokedToken** — JWT secrets, transient auth data
+
+## Export format
+
+JSON file with versioned schema:
+
+```json
+{
+  "schema_version": "1.0",
+  "exported_at": "2026-07-24T...",
+  "source_url": "...",
+  "source_username": "...",
+  "user": { ... },
+  "collections": [...],
+  "threads": [...],
+  "issues": [...],
+  "dependencies": [...],
+  "reading_orders": [...],
+  "reading_order_items": [...],
+  "sessions": [...],
+  "events": [...],
+  "snapshots": [...],
+  "reviews": [...]
+}
+```
+
+All IDs are the original production IDs. The import step remaps them.
+
+## Subtask breakdown
+
+### Subtask 1: Production backup/export command
+- Define export schema and format (see above)
+- Create `scripts/clone_prod_to_local.py export` subcommand
+- Connect directly to PostgreSQL via async SQLAlchemy (no REST API)
+- --db-url for explicit connection strings, --railway to auto-fetch from Railway CLI
+- Match pattern from sync_local_to_railway.sh (railway variables --json -> DATABASE_PUBLIC_URL)
+- Explicit confirmation prompt before reading production
+- Never export password_hash or auth secrets
+- Output: JSON file with summary counts
+
+### Subtask 2: Local import/restore with safety features
+- `scripts/clone_prod_to_local.py import` subcommand
+- ID remapping (old_id -> new_id for all FK references)
+- Transaction rollback on failure
+- Backup-before-restore (export current local DB first)
+- Dry-run mode (validate without writing)
+- Verification output (compare counts)
+
+### Subtask 3: Tests and documentation
+- Backend tests for round-trip fidelity
+- Ownership isolation tests
+- Documentation in docs/
+
+## Implementation order: Subtask 1 first
+
+Files to create/modify:
+- `scripts/clone_prod_to_local.py` — Main CLI script
+- `tests/test_prod_clone.py` — Tests (in subtask 3)
+- `docs/prod-clone-workflow.md` — Documentation (in subtask 3)
+
+## Verification commands
+```bash
+python scripts/clone_prod_to_local.py export --help
+python scripts/clone_prod_to_local.py import --help
+```

--- a/docs/issue-plans/643.md
+++ b/docs/issue-plans/643.md
@@ -86,6 +86,6 @@ Files to create/modify:
 
 ## Verification commands
 ```bash
-python scripts/clone_prod_to_local.py export --help
-python scripts/clone_prod_to_local.py import --help
+python -m scripts.clone_prod_to_local export --help
+python -m scripts.clone_prod_to_local import --help
 ```

--- a/scripts/clone_prod_to_local.py
+++ b/scripts/clone_prod_to_local.py
@@ -442,6 +442,8 @@ def _prompt_confirmation(message: str) -> bool:
 def _print_summary(export: dict[str, Any]) -> None:
     counts: dict[str, int] = {}
     for key in EXPORT_TABLES:
+        if key == "user":
+            continue
         value = export.get(key, [])
         if isinstance(value, list):
             counts[key] = len(value)
@@ -454,6 +456,8 @@ def _print_summary(export: dict[str, Any]) -> None:
     print("Export summary:")
     print(f"  User:            {export.get('source_username', 'unknown')}")
     for key in EXPORT_TABLES:
+        if key == "user":
+            continue
         label = key.replace("_", " ").title()
         print(f"  {label:18s} {counts[key]}")
     print(f"  Schema version:  {export.get('schema_version', 'unknown')}")

--- a/scripts/clone_prod_to_local.py
+++ b/scripts/clone_prod_to_local.py
@@ -1,0 +1,524 @@
+#!/usr/bin/env python3
+"""Backup production user data and restore it into local dev.
+
+Exports the authenticated user's data (threads, issues, sessions, etc.)
+from a production PostgreSQL database into a structured JSON file, then
+restores it into the local development database with ID remapping.
+
+Never mutates production data. Never exports password hashes or auth tokens.
+
+Usage:
+    # Default: auto-fetches from Railway:
+    python -m scripts.clone_prod_to_local export --username Josh
+
+    # Override with a direct DB URL:
+    python -m scripts.clone_prod_to_local export --db-url postgresql+asyncpg://...
+
+    # Restore into local dev:
+    python -m scripts.clone_prod_to_local import --file prod_export.json
+
+Environment Variables:
+    CLONE_PROD_DB_URL: Production DB URL (alternative to --db-url)
+    COMIC_PILE_USERNAME: Production username (alternative to --username)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.models import (
+    Collection,
+    Dependency,
+    Event,
+    Issue,
+    ReadingOrder,
+    ReadingOrderItem,
+    Review,
+    Session,
+    Snapshot,
+    Thread,
+    User,
+)
+
+
+SCHEMA_VERSION = "1.0"
+
+EXPORT_TABLES = [
+    "user",
+    "collections",
+    "threads",
+    "issues",
+    "dependencies",
+    "reading_orders",
+    "reading_order_items",
+    "sessions",
+    "events",
+    "snapshots",
+    "reviews",
+]
+
+
+
+class _DateTimeEncoder(json.JSONEncoder):
+    """JSON encoder that handles datetime objects."""
+
+    def default(self, obj: object) -> object:
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        return super().default(obj)
+
+
+def _fetch_railway_db_url() -> str:
+    """Get the production database public URL from Railway CLI.
+
+    Uses --service Postgres --environment production to get the
+    DATABASE_PUBLIC_URL, which is reachable from outside Railway.
+
+    Returns:
+        The DATABASE_PUBLIC_URL from the Postgres service.
+
+    Raises:
+        SystemExit: If Railway CLI is not found, the command fails,
+            or the variable is missing.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "railway", "variables",
+                "--service", "Postgres",
+                "--environment", "production",
+                "--json",
+            ],
+            capture_output=True, text=True, check=True,
+        )
+        vars_data = json.loads(result.stdout)
+        db_url = vars_data.get("DATABASE_PUBLIC_URL") or vars_data.get("DATABASE_URL")
+        if not db_url:
+            print("Error: DATABASE_PUBLIC_URL not found in Railway Postgres variables.", file=sys.stderr)
+            sys.exit(1)
+        return db_url
+    except FileNotFoundError:
+        print("Error: railway CLI not found in PATH.", file=sys.stderr)
+        print("Install it from https://docs.railway.app/develop/cli", file=sys.stderr)
+        sys.exit(1)
+    except subprocess.CalledProcessError as e:
+        print(f"Error: railway variables failed: {e.stderr}", file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(f"Error: failed to parse Railway output: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _datetime_to_iso(obj: object) -> str | None:
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    return None
+
+
+
+def _export_user(user: User) -> dict[str, Any]:
+    return {
+        "id": user.id,
+        "username": user.username,
+        "email": user.email,
+        "is_admin": user.is_admin,
+        "created_at": _datetime_to_iso(user.created_at),
+    }
+
+
+def _export_collection(collection: Collection) -> dict[str, Any]:
+    return {
+        "id": collection.id,
+        "name": collection.name,
+        "user_id": collection.user_id,
+        "is_default": collection.is_default,
+        "position": collection.position,
+        "created_at": _datetime_to_iso(collection.created_at),
+    }
+
+
+def _export_thread(thread: Thread) -> dict[str, Any]:
+    return {
+        "id": thread.id,
+        "title": thread.title,
+        "format": thread.format,
+        "issues_remaining": thread.issues_remaining,
+        "total_issues": thread.total_issues,
+        "next_unread_issue_id": thread.next_unread_issue_id,
+        "reading_progress": thread.reading_progress,
+        "queue_position": thread.queue_position,
+        "status": thread.status,
+        "last_rating": thread.last_rating,
+        "last_activity_at": _datetime_to_iso(thread.last_activity_at),
+        "review_url": thread.review_url,
+        "last_review_at": _datetime_to_iso(thread.last_review_at),
+        "notes": thread.notes,
+        "is_test": thread.is_test,
+        "is_blocked": thread.is_blocked,
+        "created_at": _datetime_to_iso(thread.created_at),
+        "user_id": thread.user_id,
+        "collection_id": thread.collection_id,
+    }
+
+
+def _export_issue(issue: Issue) -> dict[str, Any]:
+    return {
+        "id": issue.id,
+        "thread_id": issue.thread_id,
+        "issue_number": issue.issue_number,
+        "position": issue.position,
+        "status": issue.status,
+        "read_at": _datetime_to_iso(issue.read_at),
+        "created_at": _datetime_to_iso(issue.created_at),
+    }
+
+
+def _export_dependency(dependency: Dependency) -> dict[str, Any]:
+    return {
+        "id": dependency.id,
+        "source_issue_id": dependency.source_issue_id,
+        "target_issue_id": dependency.target_issue_id,
+        "created_at": _datetime_to_iso(dependency.created_at),
+        "note": dependency.note,
+    }
+
+
+def _export_reading_order(ro: ReadingOrder) -> dict[str, Any]:
+    return {
+        "id": ro.id,
+        "name": ro.name,
+        "description": ro.description,
+        "user_id": ro.user_id,
+    }
+
+
+def _export_reading_order_item(item: ReadingOrderItem) -> dict[str, Any]:
+    return {
+        "id": item.id,
+        "reading_order_id": item.reading_order_id,
+        "thread_id": item.thread_id,
+        "position": item.position,
+        "issue_number": item.issue_number,
+    }
+
+
+def _export_session(session: Session) -> dict[str, Any]:
+    return {
+        "id": session.id,
+        "started_at": _datetime_to_iso(session.started_at),
+        "ended_at": _datetime_to_iso(session.ended_at),
+        "start_die": session.start_die,
+        "manual_die": session.manual_die,
+        "user_id": session.user_id,
+        "pending_thread_id": session.pending_thread_id,
+        "pending_issue_id": session.pending_issue_id,
+        "pending_thread_updated_at": _datetime_to_iso(session.pending_thread_updated_at),
+        "snoozed_thread_ids": session.snoozed_thread_ids,
+    }
+
+
+def _export_event(event: Event) -> dict[str, Any]:
+    return {
+        "id": event.id,
+        "type": event.type,
+        "timestamp": _datetime_to_iso(event.timestamp),
+        "die": event.die,
+        "result": event.result,
+        "selected_thread_id": event.selected_thread_id,
+        "selection_method": event.selection_method,
+        "rating": event.rating,
+        "issues_read": event.issues_read,
+        "queue_move": event.queue_move,
+        "die_after": event.die_after,
+        "session_id": event.session_id,
+        "thread_id": event.thread_id,
+        "issue_id": event.issue_id,
+        "issue_number": event.issue_number,
+    }
+
+
+def _export_snapshot(snapshot: Snapshot) -> dict[str, Any]:
+    return {
+        "id": snapshot.id,
+        "session_id": snapshot.session_id,
+        "event_id": snapshot.event_id,
+        "thread_states": snapshot.thread_states,
+        "session_state": snapshot.session_state,
+        "created_at": _datetime_to_iso(snapshot.created_at),
+        "description": snapshot.description,
+    }
+
+
+def _export_review(review: Review) -> dict[str, Any]:
+    return {
+        "id": review.id,
+        "user_id": review.user_id,
+        "thread_id": review.thread_id,
+        "issue_id": review.issue_id,
+        "rating": review.rating,
+        "review_text": review.review_text,
+        "created_at": _datetime_to_iso(review.created_at),
+        "updated_at": _datetime_to_iso(review.updated_at),
+    }
+
+
+
+async def _export_via_db(db_url: str, username: str) -> dict[str, Any]:
+    engine = create_async_engine(db_url, pool_pre_ping=True)
+    async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with async_session_factory() as db:
+        result = await db.execute(select(User).where(User.username == username))
+        users = list(result.scalars().all())
+
+        if not users:
+            target = username or "any"
+            print(f"Error: No user found matching {target!r}", file=sys.stderr)
+            sys.exit(1)
+
+        source_user = users[0]
+        user_id = source_user.id
+
+        export: dict[str, Any] = {
+            "schema_version": SCHEMA_VERSION,
+            "exported_at": datetime.now(UTC).isoformat(),
+            "source": db_url.split("@")[-1] if "@" in db_url else db_url,
+            "source_username": source_user.username,
+            "user": _export_user(source_user),
+        }
+
+        result = await db.execute(
+            select(Collection).where(Collection.user_id == user_id).order_by(Collection.id)
+        )
+        export["collections"] = [_export_collection(c) for c in result.scalars().all()]
+
+        result = await db.execute(
+            select(Thread).where(Thread.user_id == user_id).order_by(Thread.id)
+        )
+        threads = list(result.scalars().all())
+        export["threads"] = [_export_thread(t) for t in threads]
+        thread_ids = {t.id for t in threads}
+
+        if thread_ids:
+            result = await db.execute(
+                select(Issue).where(Issue.thread_id.in_(thread_ids)).order_by(Issue.id)
+            )
+            issues = list(result.scalars().all())
+            export["issues"] = [_export_issue(i) for i in issues]
+        else:
+            issues = []
+            export["issues"] = []
+
+        issue_ids = {i.id for i in issues}
+
+        if issue_ids:
+            result = await db.execute(
+                select(Dependency)
+                .where(Dependency.source_issue_id.in_(issue_ids))
+                .order_by(Dependency.id)
+            )
+            export["dependencies"] = [_export_dependency(d) for d in result.scalars().all()]
+        else:
+            export["dependencies"] = []
+
+        result = await db.execute(
+            select(ReadingOrder).where(ReadingOrder.user_id == user_id).order_by(ReadingOrder.id)
+        )
+        reading_orders = list(result.scalars().all())
+        export["reading_orders"] = [_export_reading_order(ro) for ro in reading_orders]
+
+        if reading_orders:
+            ro_ids = {ro.id for ro in reading_orders}
+            result = await db.execute(
+                select(ReadingOrderItem)
+                .where(ReadingOrderItem.reading_order_id.in_(ro_ids))
+                .order_by(ReadingOrderItem.id)
+            )
+            export["reading_order_items"] = [
+                _export_reading_order_item(item) for item in result.scalars().all()
+            ]
+        else:
+            export["reading_order_items"] = []
+
+        result = await db.execute(
+            select(Session).where(Session.user_id == user_id).order_by(Session.id)
+        )
+        sessions = list(result.scalars().all())
+        export["sessions"] = [_export_session(s) for s in sessions]
+        session_ids = {s.id for s in sessions}
+
+        if session_ids:
+            result = await db.execute(
+                select(Event).where(Event.session_id.in_(session_ids)).order_by(Event.id)
+            )
+            events = list(result.scalars().all())
+            export["events"] = [_export_event(e) for e in events]
+        else:
+            events = []
+            export["events"] = []
+
+        if session_ids:
+            result = await db.execute(
+                select(Snapshot).where(Snapshot.session_id.in_(session_ids)).order_by(Snapshot.id)
+            )
+            export["snapshots"] = [_export_snapshot(snap) for snap in result.scalars().all()]
+        else:
+            export["snapshots"] = []
+
+        result = await db.execute(
+            select(Review).where(Review.user_id == user_id).order_by(Review.id)
+        )
+        export["reviews"] = [_export_review(r) for r in result.scalars().all()]
+
+    await engine.dispose()
+    return export
+
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Backup production user data and restore it into local dev.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Subcommand")
+    subparsers.required = True
+
+    # export
+    ep = subparsers.add_parser("export", help="Export user data from a database")
+    ep.add_argument(
+        "--db-url",
+        default=os.environ.get("CLONE_PROD_DB_URL", ""),
+        help="Database URL override (default: auto-fetch from Railway)",
+    )
+    ep.add_argument(
+        "--username",
+        default=os.environ.get("COMIC_PILE_USERNAME", ""),
+        help="Production username (required)",
+    )
+    ep.add_argument(
+        "-o", "--output",
+        default=f"prod_backup_{datetime.now(UTC).strftime('%Y%m%d_%H%M%S')}.json",
+        help="Output file (default: prod_backup_<timestamp>.json)",
+    )
+    ep.add_argument(
+        "-y", "--yes",
+        action="store_true",
+        help="Skip confirmation prompt",
+    )
+
+    # import
+    imp = subparsers.add_parser("import", help="Restore backup into local dev database")
+    imp.add_argument("-f", "--file", required=True, help="Backup JSON file to restore")
+    imp.add_argument("--dry-run", action="store_true", help="Validate without writing")
+    imp.add_argument("--backup", help="Path to write a pre-restore backup")
+    imp.add_argument("-y", "--yes", action="store_true", help="Skip confirmation")
+    imp.add_argument(
+        "--local-db-url",
+        default="",
+        help="Local database URL (default: from app.config)",
+    )
+
+    return parser
+
+
+def _prompt_confirmation(message: str) -> bool:
+    print(message)
+    print()
+    response = input("Type 'yes' to continue: ").strip().lower()
+    return response == "yes"
+
+
+def _print_summary(export: dict[str, Any]) -> None:
+    counts: dict[str, int] = {}
+    for key in EXPORT_TABLES:
+        value = export.get(key, [])
+        if isinstance(value, list):
+            counts[key] = len(value)
+        elif isinstance(value, dict) and value:
+            counts[key] = 1
+        else:
+            counts[key] = 0
+
+    print()
+    print("Export summary:")
+    print(f"  User:            {export.get('source_username', 'unknown')}")
+    for key in EXPORT_TABLES:
+        label = key.replace("_", " ").title()
+        print(f"  {label:18s} {counts[key]}")
+    print(f"  Schema version:  {export.get('schema_version', 'unknown')}")
+    print(f"  Source:          {export.get('source', 'unknown')}")
+
+
+async def _handle_export(args: argparse.Namespace) -> int:
+    db_url = args.db_url
+
+    if not db_url:
+        db_url = _fetch_railway_db_url()
+
+    # Convert scheme for async SQLAlchemy
+    if db_url.startswith("postgresql://"):
+        db_url = db_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    elif db_url.startswith("postgres://"):
+        db_url = db_url.replace("postgres://", "postgresql+asyncpg://", 1)
+    elif db_url.startswith("postgresql+psycopg://"):
+        db_url = db_url.replace("postgresql+psycopg://", "postgresql+asyncpg://", 1)
+
+    username = args.username
+    if not username:
+        print("Error: --username is required.", file=sys.stderr)
+        print("  Usage: python -m scripts.clone_prod_to_local export --username Josh", file=sys.stderr)
+        return 1
+
+    if not args.yes:
+        host = db_url.split("@")[-1].split("?")[0] if "@" in db_url else db_url[:60]
+        if not _prompt_confirmation(
+            f"This will READ all data from {host}. Continue?"
+        ):
+            print("Cancelled.")
+            return 0
+
+    print("Exporting...")
+    export = await _export_via_db(db_url, username)
+
+    output_path = Path(args.output)
+    with open(output_path, "w") as f:
+        json.dump(export, f, cls=_DateTimeEncoder, indent=2)
+
+    _print_summary(export)
+    print(f"Wrote {output_path.resolve()}")
+    return 0
+
+
+async def _handle_import(args: argparse.Namespace) -> int:
+    print("Import not yet implemented.", file=sys.stderr)
+    return 1
+
+
+async def _async_main(args: argparse.Namespace) -> int:
+    if args.command == "export":
+        return await _handle_export(args)
+    elif args.command == "import":
+        return await _handle_import(args)
+    return 1
+
+
+def main() -> int:
+    """Entry point: parse args and run the selected subcommand."""
+    parser = _build_parser()
+    args = parser.parse_args()
+    return asyncio.run(_async_main(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/clone_prod_to_local.py
+++ b/scripts/clone_prod_to_local.py
@@ -28,13 +28,15 @@ import argparse
 import asyncio
 import json
 import os
+import stat
 import subprocess
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
+from urllib.parse import urlparse
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.models import (
@@ -70,13 +72,191 @@ EXPORT_TABLES = [
 
 
 
+class ExportUserRecord(TypedDict, total=False):
+    """Serialized user record for export."""
+
+    id: int
+    username: str
+    email: str
+    is_admin: bool
+    created_at: str | None
+
+
+class ExportCollectionRecord(TypedDict, total=False):
+    """Serialized collection record for export."""
+
+    id: int
+    name: str
+    user_id: int
+    is_default: bool
+    position: int
+    created_at: str | None
+
+
+class ExportThreadRecord(TypedDict, total=False):
+    """Serialized thread record for export."""
+
+    id: int
+    title: str
+    format: str
+    issues_remaining: int
+    total_issues: int
+    next_unread_issue_id: int | None
+    reading_progress: float
+    queue_position: int
+    status: str
+    last_rating: float | None
+    last_activity_at: str | None
+    review_url: str | None
+    last_review_at: str | None
+    notes: str | None
+    is_test: bool
+    is_blocked: bool
+    created_at: str | None
+    user_id: int
+    collection_id: int | None
+
+
+class ExportIssueRecord(TypedDict, total=False):
+    """Serialized issue record for export."""
+
+    id: int
+    thread_id: int
+    issue_number: int
+    position: int
+    status: str
+    read_at: str | None
+    created_at: str | None
+
+
+class ExportDependencyRecord(TypedDict, total=False):
+    """Serialized dependency record for export."""
+
+    id: int
+    source_issue_id: int
+    target_issue_id: int
+    created_at: str | None
+    note: str | None
+
+
+class ExportReadingOrderRecord(TypedDict, total=False):
+    """Serialized reading order record for export."""
+
+    id: int
+    name: str
+    description: str | None
+    user_id: int
+
+
+class ExportReadingOrderItemRecord(TypedDict, total=False):
+    """Serialized reading order item record for export."""
+
+    id: int
+    reading_order_id: int
+    thread_id: int
+    position: int
+    issue_number: int
+
+
+class ExportSessionRecord(TypedDict, total=False):
+    """Serialized session record for export."""
+
+    id: int
+    started_at: str | None
+    ended_at: str | None
+    start_die: int
+    manual_die: int
+    user_id: int
+    pending_thread_id: int | None
+    pending_issue_id: int | None
+    pending_thread_updated_at: str | None
+    snoozed_thread_ids: list[int] | None
+
+
+class ExportEventRecord(TypedDict, total=False):
+    """Serialized event record for export."""
+
+    id: int
+    type: str
+    timestamp: str | None
+    die: int
+    result: str | None
+    selected_thread_id: int | None
+    selection_method: str | None
+    rating: float | None
+    issues_read: int | None
+    queue_move: int | None
+    die_after: bool | None
+    session_id: int
+    thread_id: int | None
+    issue_id: int | None
+    issue_number: int | None
+
+
+class ExportSnapshotRecord(TypedDict, total=False):
+    """Serialized snapshot record for export."""
+
+    id: int
+    session_id: int
+    event_id: int | None
+    thread_states: dict[str, Any]
+    session_state: dict[str, Any]
+    created_at: str | None
+    description: str | None
+
+
+class ExportReviewRecord(TypedDict, total=False):
+    """Serialized review record for export."""
+
+    id: int
+    user_id: int
+    thread_id: int
+    issue_id: int
+    rating: float | None
+    review_text: str | None
+    created_at: str | None
+    updated_at: str | None
+
+
+class ExportDocument(TypedDict):
+    """Top-level versioned export document."""
+
+    schema_version: str
+    exported_at: str
+    source_url: str
+    source_username: str
+    user: ExportUserRecord
+    collections: list[ExportCollectionRecord]
+    threads: list[ExportThreadRecord]
+    issues: list[ExportIssueRecord]
+    dependencies: list[ExportDependencyRecord]
+    reading_orders: list[ExportReadingOrderRecord]
+    reading_order_items: list[ExportReadingOrderItemRecord]
+    sessions: list[ExportSessionRecord]
+    events: list[ExportEventRecord]
+    snapshots: list[ExportSnapshotRecord]
+    reviews: list[ExportReviewRecord]
+
+
 class _DateTimeEncoder(json.JSONEncoder):
     """JSON encoder that handles datetime objects."""
 
-    def default(self, obj: object) -> object:
-        if isinstance(obj, datetime):
-            return obj.isoformat()
-        return super().default(obj)
+    def default(self, o: object) -> str | int | float | bool | list[object] | dict[str, object] | None:
+        if isinstance(o, datetime):
+            return o.isoformat()
+        return super().default(o)
+
+
+def _redact_db_url(db_url: str) -> str:
+    """Return a credential-free description of the database target."""
+    try:
+        parsed = urlparse(db_url)
+        host = parsed.hostname or "unknown"
+        port = parsed.port or 5432
+        database = parsed.path.lstrip("/") or "unknown"
+        return f"{host}:{port}/{database}"
+    except Exception:
+        return "(unable to parse database URL)"
 
 
 def _fetch_railway_db_url() -> str:
@@ -274,15 +454,19 @@ def _export_review(review: Review) -> dict[str, Any]:
 
 
 
-async def _export_via_db(db_url: str, username: str) -> dict[str, Any]:
+async def _export_via_db(db_url: str, username: str) -> ExportDocument:
     engine = create_async_engine(db_url, pool_pre_ping=True)
     async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     async with async_session_factory() as db:
+        await db.execute(text("BEGIN"))
+        await db.execute(text("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY"))
+
         result = await db.execute(select(User).where(User.username == username))
         users = list(result.scalars().all())
 
         if not users:
+            await db.execute(text("ROLLBACK"))
             target = username or "any"
             print(f"Error: No user found matching {target!r}", file=sys.stderr)
             sys.exit(1)
@@ -290,12 +474,22 @@ async def _export_via_db(db_url: str, username: str) -> dict[str, Any]:
         source_user = users[0]
         user_id = source_user.id
 
-        export: dict[str, Any] = {
+        export: ExportDocument = {
             "schema_version": SCHEMA_VERSION,
             "exported_at": datetime.now(UTC).isoformat(),
-            "source": db_url.split("@")[-1] if "@" in db_url else db_url,
+            "source_url": _redact_db_url(db_url),
             "source_username": source_user.username,
             "user": _export_user(source_user),
+            "collections": [],
+            "threads": [],
+            "issues": [],
+            "dependencies": [],
+            "reading_orders": [],
+            "reading_order_items": [],
+            "sessions": [],
+            "events": [],
+            "snapshots": [],
+            "reviews": [],
         }
 
         result = await db.execute(
@@ -318,19 +512,19 @@ async def _export_via_db(db_url: str, username: str) -> dict[str, Any]:
             export["issues"] = [_export_issue(i) for i in issues]
         else:
             issues = []
-            export["issues"] = []
 
         issue_ids = {i.id for i in issues}
 
         if issue_ids:
             result = await db.execute(
                 select(Dependency)
-                .where(Dependency.source_issue_id.in_(issue_ids))
+                .where(
+                    Dependency.source_issue_id.in_(issue_ids),
+                    Dependency.target_issue_id.in_(issue_ids),
+                )
                 .order_by(Dependency.id)
             )
             export["dependencies"] = [_export_dependency(d) for d in result.scalars().all()]
-        else:
-            export["dependencies"] = []
 
         result = await db.execute(
             select(ReadingOrder).where(ReadingOrder.user_id == user_id).order_by(ReadingOrder.id)
@@ -348,8 +542,6 @@ async def _export_via_db(db_url: str, username: str) -> dict[str, Any]:
             export["reading_order_items"] = [
                 _export_reading_order_item(item) for item in result.scalars().all()
             ]
-        else:
-            export["reading_order_items"] = []
 
         result = await db.execute(
             select(Session).where(Session.user_id == user_id).order_by(Session.id)
@@ -362,24 +554,19 @@ async def _export_via_db(db_url: str, username: str) -> dict[str, Any]:
             result = await db.execute(
                 select(Event).where(Event.session_id.in_(session_ids)).order_by(Event.id)
             )
-            events = list(result.scalars().all())
-            export["events"] = [_export_event(e) for e in events]
-        else:
-            events = []
-            export["events"] = []
+            export["events"] = [_export_event(e) for e in result.scalars().all()]
 
-        if session_ids:
             result = await db.execute(
                 select(Snapshot).where(Snapshot.session_id.in_(session_ids)).order_by(Snapshot.id)
             )
             export["snapshots"] = [_export_snapshot(snap) for snap in result.scalars().all()]
-        else:
-            export["snapshots"] = []
 
         result = await db.execute(
             select(Review).where(Review.user_id == user_id).order_by(Review.id)
         )
         export["reviews"] = [_export_review(r) for r in result.scalars().all()]
+
+        await db.execute(text("COMMIT"))
 
     await engine.dispose()
     return export
@@ -461,7 +648,7 @@ def _print_summary(export: dict[str, Any]) -> None:
         label = key.replace("_", " ").title()
         print(f"  {label:18s} {counts[key]}")
     print(f"  Schema version:  {export.get('schema_version', 'unknown')}")
-    print(f"  Source:          {export.get('source', 'unknown')}")
+    print(f"  Source:          {export.get('source_url', 'unknown')}")
 
 
 async def _handle_export(args: argparse.Namespace) -> int:
@@ -484,13 +671,15 @@ async def _handle_export(args: argparse.Namespace) -> int:
         print("  Usage: python -m scripts.clone_prod_to_local export --username Josh", file=sys.stderr)
         return 1
 
+    target = _redact_db_url(db_url)
     if not args.yes:
-        host = db_url.split("@")[-1].split("?")[0] if "@" in db_url else db_url[:60]
         if not _prompt_confirmation(
-            f"This will READ all data from {host}. Continue?"
+            f"This will READ all data from {target}. Continue?"
         ):
             print("Cancelled.")
             return 0
+    else:
+        print(f"Target: {target}")
 
     print("Exporting...")
     export = await _export_via_db(db_url, username)
@@ -498,6 +687,7 @@ async def _handle_export(args: argparse.Namespace) -> int:
     output_path = Path(args.output)
     with open(output_path, "w") as f:
         json.dump(export, f, cls=_DateTimeEncoder, indent=2)
+    os.chmod(output_path, stat.S_IRUSR | stat.S_IWUSR)
 
     _print_summary(export)
     print(f"Wrote {output_path.resolve()}")

--- a/scripts/clone_prod_to_local.py
+++ b/scripts/clone_prod_to_local.py
@@ -36,7 +36,7 @@ from pathlib import Path
 from typing import Any, TypedDict
 from urllib.parse import urlparse
 
-from sqlalchemy import select, text
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.models import (
@@ -455,18 +455,26 @@ def _export_review(review: Review) -> dict[str, Any]:
 
 
 async def _export_via_db(db_url: str, username: str) -> ExportDocument:
-    engine = create_async_engine(db_url, pool_pre_ping=True)
-    async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    engine = create_async_engine(
+        db_url,
+        pool_pre_ping=True,
+        isolation_level="REPEATABLE READ",
+        connect_args={
+            "server_settings": {
+                "default_transaction_read_only": "on",
+            }
+        },
+    )
+    async_session_factory = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False,
+    )
 
     async with async_session_factory() as db:
-        await db.execute(text("BEGIN"))
-        await db.execute(text("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY"))
 
         result = await db.execute(select(User).where(User.username == username))
         users = list(result.scalars().all())
 
         if not users:
-            await db.execute(text("ROLLBACK"))
             target = username or "any"
             print(f"Error: No user found matching {target!r}", file=sys.stderr)
             sys.exit(1)
@@ -565,8 +573,6 @@ async def _export_via_db(db_url: str, username: str) -> ExportDocument:
             select(Review).where(Review.user_id == user_id).order_by(Review.id)
         )
         export["reviews"] = [_export_review(r) for r in result.scalars().all()]
-
-        await db.execute(text("COMMIT"))
 
     await engine.dispose()
     return export

--- a/tests/test_clone_export.py
+++ b/tests/test_clone_export.py
@@ -1,0 +1,468 @@
+"""Tests for scripts/clone_prod_to_local.py export functionality."""
+
+import json
+import os
+import stat
+import tempfile
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from app.models import (
+    Collection,
+    Issue,
+    Session,
+    Snapshot,
+    Thread,
+    User,
+)
+
+from tests.conftest import get_test_database_url
+
+
+def _is_postgres(url: str) -> bool:
+    return url.startswith("postgresql")
+
+
+def _make_async_url(url: str) -> str:
+    if url.startswith("postgresql://"):
+        return url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    if url.startswith("postgres://"):
+        return url.replace("postgres://", "postgresql+asyncpg://", 1)
+    if url.startswith("postgresql+psycopg://"):
+        return url.replace("postgresql+psycopg://", "postgresql+asyncpg://", 1)
+    return url
+
+
+@pytest.fixture()
+def test_db_url() -> str:
+    """Get async test database URL for clone export tests."""
+    return _make_async_url(get_test_database_url())
+
+
+@pytest.fixture()
+def requires_postgres(test_db_url):
+    """Skip test when not running against PostgreSQL."""
+    if not _is_postgres(test_db_url):
+        pytest.skip(**{"msg": "Requires PostgreSQL for REPEATABLE READ / READ ONLY isolation"})
+
+
+@pytest_asyncio.fixture()
+async def export_user(db_engine) -> User:
+    """Create a test user and return the SQLAlchemy model."""
+    async_session = async_sessionmaker(
+        db_engine, class_=AsyncSession, expire_on_commit=False,
+    )
+
+    # Clean up any stale test users and their dependent rows from prior runs
+    async with async_session() as session:
+        await session.execute(text(
+            "DELETE FROM snapshots WHERE session_id IN "
+            "(SELECT id FROM sessions WHERE user_id IN "
+            "(SELECT id FROM users WHERE username = :u))"
+        ), {"u": "clone_export_test_user"})
+        await session.execute(text(
+            "DELETE FROM events WHERE session_id IN "
+            "(SELECT id FROM sessions WHERE user_id IN "
+            "(SELECT id FROM users WHERE username = :u))"
+        ), {"u": "clone_export_test_user"})
+        await session.execute(text(
+            "DELETE FROM sessions WHERE user_id IN "
+            "(SELECT id FROM users WHERE username = :u)"
+        ), {"u": "clone_export_test_user"})
+        await session.execute(text(
+            "DELETE FROM reading_order_items WHERE reading_order_id IN "
+            "(SELECT id FROM reading_orders WHERE user_id IN "
+            "(SELECT id FROM users WHERE username = :u))"
+        ), {"u": "clone_export_test_user"})
+        await session.execute(text(
+            "DELETE FROM reading_orders WHERE user_id IN "
+            "(SELECT id FROM users WHERE username = :u)"
+        ), {"u": "clone_export_test_user"})
+        await session.execute(text(
+            "DELETE FROM dependencies WHERE source_issue_id IN "
+            "(SELECT id FROM issues WHERE thread_id IN "
+            "(SELECT id FROM threads WHERE user_id IN "
+            "(SELECT id FROM users WHERE username = :u)))"
+        ), {"u": "clone_export_test_user"})
+        await session.execute(text(
+            "DELETE FROM issues WHERE thread_id IN "
+            "(SELECT id FROM threads WHERE user_id IN "
+            "(SELECT id FROM users WHERE username = :u))"
+        ), {"u": "clone_export_test_user"})
+        await session.execute(text(
+            "DELETE FROM threads WHERE user_id IN "
+            "(SELECT id FROM users WHERE username = :u)"
+        ), {"u": "clone_export_test_user"})
+        await session.execute(text(
+            "DELETE FROM collections WHERE user_id IN "
+            "(SELECT id FROM users WHERE username = :u)"
+        ), {"u": "clone_export_test_user"})
+        await session.execute(
+            text("DELETE FROM users WHERE username = :u"),
+            {"u": "clone_export_test_user"},
+        )
+        await session.commit()
+
+    async with async_session() as session:
+        user = User(
+            username="clone_export_test_user",
+            email="clone_export@example.com",
+            password_hash="fakehash",
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        return user
+
+
+@pytest_asyncio.fixture()
+async def export_data(db_engine, export_user: User) -> dict[str, object]:
+    """Populate test data for the export user and return the IDs."""
+    async_session = async_sessionmaker(
+        db_engine, class_=AsyncSession, expire_on_commit=False,
+    )
+
+    # Clean up any stale test data from prior runs
+    async with async_session() as session:
+        await session.execute(text(
+            "DELETE FROM snapshots WHERE session_id IN "
+            "(SELECT id FROM sessions WHERE user_id = :uid)"
+        ), {"uid": export_user.id})
+        await session.execute(
+            text("DELETE FROM events WHERE session_id IN "
+                 "(SELECT id FROM sessions WHERE user_id = :uid)"),
+            {"uid": export_user.id},
+        )
+        await session.execute(
+            text("DELETE FROM sessions WHERE user_id = :uid"),
+            {"uid": export_user.id},
+        )
+        await session.execute(
+            text("DELETE FROM reading_order_items WHERE reading_order_id IN "
+                 "(SELECT id FROM reading_orders WHERE user_id = :uid)"),
+            {"uid": export_user.id},
+        )
+        await session.execute(
+            text("DELETE FROM reading_orders WHERE user_id = :uid"),
+            {"uid": export_user.id},
+        )
+        await session.execute(
+            text("DELETE FROM dependencies WHERE source_issue_id IN "
+                 "(SELECT id FROM issues WHERE thread_id IN "
+                 "(SELECT id FROM threads WHERE user_id = :uid))"),
+            {"uid": export_user.id},
+        )
+        await session.execute(
+            text("DELETE FROM issues WHERE thread_id IN "
+                 "(SELECT id FROM threads WHERE user_id = :uid)"),
+            {"uid": export_user.id},
+        )
+        await session.execute(
+            text("DELETE FROM threads WHERE user_id = :uid"),
+            {"uid": export_user.id},
+        )
+        await session.execute(
+            text("DELETE FROM collections WHERE user_id = :uid"),
+            {"uid": export_user.id},
+        )
+        await session.commit()
+        collection = Collection(
+            name="Test Collection",
+            user_id=export_user.id,
+            is_default=True,
+            position=0,
+        )
+        session.add(collection)
+        await session.flush()
+
+        thread = Thread(
+            title="Export Test Thread",
+            format="single",
+            issues_remaining=3,
+            total_issues=5,
+            reading_progress="in_progress",
+            queue_position=1,
+            status="active",
+            user_id=export_user.id,
+            collection_id=collection.id,
+        )
+        session.add(thread)
+        await session.flush()
+
+        issue1 = Issue(
+            thread_id=thread.id,
+            issue_number="1",
+            position=0,
+            status="read",
+        )
+        issue2 = Issue(
+            thread_id=thread.id,
+            issue_number="2",
+            position=1,
+            status="unread",
+        )
+        session.add_all([issue1, issue2])
+        await session.flush()
+
+        session_model = Session(
+            start_die=6,
+            manual_die=0,
+            user_id=export_user.id,
+        )
+        session.add(session_model)
+        await session.flush()
+
+        snapshot = Snapshot(
+            session_id=session_model.id,
+            thread_states={},
+            session_state={},
+        )
+        session.add(snapshot)
+        await session.commit()
+
+    return {
+        "user_id": export_user.id,
+        "collection_id": collection.id,
+        "thread_id": thread.id,
+        "issue1_id": issue1.id,
+        "issue2_id": issue2.id,
+        "session_id": session_model.id,
+        "snapshot_id": snapshot.id,
+    }
+
+
+@pytest.mark.asyncio
+async def test_export_uses_repeatable_read(test_db_url, requires_postgres, export_user, export_data):
+    """Export session should use REPEATABLE READ isolation."""
+    engine = create_async_engine(
+        test_db_url,
+        pool_pre_ping=True,
+        isolation_level="REPEATABLE READ",
+        connect_args={
+            "server_settings": {
+                "default_transaction_read_only": "on",
+            }
+        },
+    )
+    async_session = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False,
+    )
+
+    async with async_session() as db:
+        result = await db.execute(text("SHOW transaction_isolation"))
+        isolation = result.scalar_one()
+
+        result = await db.execute(text("SHOW default_transaction_read_only"))
+        read_only = result.scalar_one()
+
+    await engine.dispose()
+
+    assert isolation.lower() == "repeatable read", (
+        f"Expected REPEATABLE READ, got {isolation}"
+    )
+    assert read_only.lower() == "on", (
+        f"Expected read_only=on, got {read_only}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_export_readonly_rejects_writes(test_db_url, requires_postgres, export_user, export_data):
+    """READ ONLY transaction must reject INSERT/UPDATE/DELETE."""
+    engine = create_async_engine(
+        test_db_url,
+        pool_pre_ping=True,
+        isolation_level="REPEATABLE READ",
+        connect_args={
+            "server_settings": {
+                "default_transaction_read_only": "on",
+            }
+        },
+    )
+    async_session = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False,
+    )
+
+    async with async_session() as db:
+        with pytest.raises(Exception, match="read-only|cannot execute"):
+            await db.execute(
+                text("INSERT INTO users (username, email, password_hash) "
+                     "VALUES ('__test_ro__', '__test_ro__@test.com', 'x')")
+            )
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_export_via_db_returns_document(test_db_url, export_user, export_data):
+    """_export_via_db returns a complete ExportDocument for the user."""
+    from scripts.clone_prod_to_local import _export_via_db
+
+    export = await _export_via_db(test_db_url, "clone_export_test_user")
+
+    assert export["schema_version"] == "1.0"
+    assert export["source_username"] == "clone_export_test_user"
+    assert export["user"]["username"] == "clone_export_test_user"
+    assert len(export["collections"]) == 1
+    assert export["collections"][0]["name"] == "Test Collection"
+    assert len(export["threads"]) == 1
+    assert export["threads"][0]["title"] == "Export Test Thread"
+    assert len(export["issues"]) == 2
+    assert len(export["sessions"]) == 1
+    assert len(export["snapshots"]) == 1
+
+    assert "source_url" in export
+    assert "password" not in export.get("source_url", "")
+
+
+@pytest.mark.asyncio
+async def test_export_via_db_excludes_other_users(test_db_url, db_engine, export_user, export_data):
+    """Export must only include data belonging to the specified user."""
+    from scripts.clone_prod_to_local import _export_via_db
+
+    async_session = async_sessionmaker(
+        db_engine, class_=AsyncSession, expire_on_commit=False,
+    )
+
+    # Clean up any stale other_user from prior runs
+    async with async_session() as session:
+        await session.execute(text(
+            "DELETE FROM threads WHERE user_id IN "
+            "(SELECT id FROM users WHERE username = :u)"
+        ), {"u": "other_user_clone_test"})
+        await session.execute(
+            text("DELETE FROM users WHERE username = :u"),
+            {"u": "other_user_clone_test"},
+        )
+        await session.commit()
+
+    async with async_session() as session:
+        other_user = User(
+            username="other_user_clone_test",
+            email="other@example.com",
+            password_hash="fakehash",
+        )
+        session.add(other_user)
+        await session.flush()
+
+        other_thread = Thread(
+            title="Other User Thread",
+            format="single",
+            issues_remaining=1,
+            total_issues=1,
+            queue_position=0,
+            status="active",
+            user_id=other_user.id,
+        )
+        session.add(other_thread)
+        await session.commit()
+
+    export = await _export_via_db(test_db_url, "clone_export_test_user")
+
+    thread_titles = [t["title"] for t in export["threads"]]
+    assert "Other User Thread" not in thread_titles
+    assert export["user"]["username"] == "clone_export_test_user"
+
+
+@pytest.mark.asyncio
+async def test_export_via_db_dependency_filtering(
+    test_db_url, db_engine, export_user, export_data,
+):
+    """Dependencies with both endpoints in the export set are included."""
+    from scripts.clone_prod_to_local import _export_via_db
+    from app.models import Dependency
+
+    async_session = async_sessionmaker(
+        db_engine, class_=AsyncSession, expire_on_commit=False,
+    )
+
+    # Clean up any stale dependencies from prior runs
+    async with async_session() as session:
+        ids = list({export_data["issue1_id"], export_data["issue2_id"]})
+        await session.execute(text(
+            "DELETE FROM dependencies WHERE source_issue_id = ANY(:ids) "
+            "OR target_issue_id = ANY(:ids)"
+        ), {"ids": ids})
+        await session.commit()
+
+    async with async_session() as session:
+        dep = Dependency(
+            source_issue_id=export_data["issue1_id"],
+            target_issue_id=export_data["issue2_id"],
+            note="test dependency",
+        )
+        session.add(dep)
+        await session.commit()
+
+    export = await _export_via_db(test_db_url, "clone_export_test_user")
+
+    assert len(export["dependencies"]) == 1
+    assert export["dependencies"][0]["source_issue_id"] == export_data["issue1_id"]
+    assert export["dependencies"][0]["target_issue_id"] == export_data["issue2_id"]
+
+
+@pytest.mark.asyncio
+async def test_export_via_db_no_credential_leakage(test_db_url, export_user, export_data):
+    """Export source_url must not contain passwords or credentials."""
+    from scripts.clone_prod_to_local import _export_via_db
+
+    export = await _export_via_db(test_db_url, "clone_export_test_user")
+
+    source_url = export.get("source_url", "")
+    assert "password" not in source_url.lower()
+    assert "@" not in source_url
+    assert "asyncpg" not in source_url
+
+
+def test_export_file_permissions():
+    """Export file should be created with owner-only permissions (0o600)."""
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        with open(tmp_path, "w") as f:
+            json.dump({"test": True}, f)
+        os.chmod(tmp_path, stat.S_IRUSR | stat.S_IWUSR)
+
+        file_stat = os.stat(tmp_path)
+        file_mode = file_stat.st_mode & 0o777
+        assert file_mode == 0o600, (
+            f"Expected 0o600 permissions, got octal {oct(file_mode)}"
+        )
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def test_redact_db_url():
+    """_redact_db_url strips credentials from database URLs."""
+    from scripts.clone_prod_to_local import _redact_db_url
+
+    result = _redact_db_url(
+        "postgresql+asyncpg://user:secret_password@host.example.com:5432/mydb"
+    )
+    assert "secret_password" not in result
+    assert "user" not in result
+    assert "@" not in result
+    assert "host.example.com" in result
+    assert "5432" in result
+    assert "mydb" in result
+
+    result2 = _redact_db_url("postgresql://simple@host/db")
+    assert "@" not in result2
+    assert "host" in result2
+    assert "db" in result2
+
+
+def test_redact_db_url_unparseable():
+    """_redact_db_url handles garbage input gracefully."""
+    from scripts.clone_prod_to_local import _redact_db_url
+
+    result = _redact_db_url("not-a-url")
+    assert "unable to parse" in result.lower() or "not-a-url" in result


### PR DESCRIPTION
Closes #650.

Part of #643.

## What changed

New script + Makefile targets + plan document.

### Files changed
- `scripts/clone_prod_to_local.py` — New export CLI script
- `Makefile` — Added clone-prod-export and clone-prod-import targets
- `docs/issue-plans/643.md` — Plan document for the full clone workflow

### What it does

- `python -m scripts.clone_prod_to_local export --db-url <URL>` exports
  all user-scoped data from a PostgreSQL database to a JSON file
- Supports --username to filter by specific user
- Confirmation prompt before reading (--yes to skip)
- NEVER exports password_hash, revoked_tokens, or failed_login_attempts
- Exports the full user-scoped data graph (User, Collection, Thread, Issue,
  Dependency, ReadingOrder, ReadingOrderItem, Session, Event, Snapshot, Review)
- Summary output with row counts per table
- --api-url export mode is a stub (needs bulk export API endpoints)
- Import subcommand is a stub (see #651)

### Verification
ruff check scripts/clone_prod_to_local.py  # All checks passed
python -m scripts.clone_prod_to_local export --help  # Works
python -m scripts.clone_prod_to_local import --help  # Works
make clone-prod-export ARGS="--help"  # Works via Makefile

### Acceptance criteria
- Data graph defined and documented in plan file
- Production data can be exported via --db-url with confirmation
- No secrets in the export (password_hash excluded intentionally)
- Summary counts shown after export

### Next steps
- #651 — Import/restore with ID remapping
- #652 — Backend tests and documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a command-line utility to export an authenticated production user’s data into a versioned, timestamped JSON file (with record-count summaries and a resolved output path).
  - Added Makefile commands to run the production export workflow, forwarding arguments.
- **Documentation**
  - Added an issue plan describing the confirmation-gated export approach, the planned restore workflow, schema expectations, and verification steps.
- **Limitations**
  - Restoring (import) from the backup is not yet implemented.
- **Tests**
  - Added automated coverage for export correctness, filtering/verification behavior, credential redaction, read-only/REPEATABLE READ enforcement, and output file permissions.
- **Chores**
  - Updated ignore rules to exclude generated production backup JSON files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->