### PR TITLE
Fix auth refresh bootstrap and production dependency install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -328,6 +328,8 @@ deploy-prod:  ## Deploy to Railway production
 		echo "Rebase/merge and push before deploy to ensure deterministic release."; \
 		exit 1; \
 	fi
+	@echo "Installing locked frontend dependencies..."
+	@pnpm install --frozen-lockfile
 	@echo "Running frontend TypeScript typecheck..."
 	@pnpm --filter frontend run typecheck
 	@echo "Deploying to Railway project $(RAILWAY_PROJECT_ID) service $(RAILWAY_APP_SERVICE) in $(RAILWAY_PROD_ENV)..."

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -148,6 +148,19 @@ function redirectToLogin(): void {
   window.location.href = '/login'
 }
 
+function isAuthenticationFailure(error: AxiosError): boolean {
+  if (error.response?.status === 401) {
+    return true
+  }
+
+  if (error.response?.status !== 403) {
+    return false
+  }
+
+  const responseData = error.response.data as { detail?: unknown } | undefined
+  return responseData?.detail === 'Not authenticated'
+}
+
 rawApi.interceptors.request.use(
   async (config: InternalAxiosRequestConfig) => {
     const token = getAccessToken()
@@ -199,7 +212,7 @@ rawApi.interceptors.response.use(
       })
     }
 
-    if (error.response.status === 401 && !originalRequest._retry) {
+    if (isAuthenticationFailure(error) && !originalRequest._retry) {
       const requestUrl = originalRequest.url ?? ''
       const isAuthEndpoint =
         requestUrl.includes('/auth/login') ||

--- a/frontend/src/test/issue-656-auth-refresh.spec.ts
+++ b/frontend/src/test/issue-656-auth-refresh.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from './fixtures'
+import { generateTestUser } from './helpers'
+
+test('recovers authentication when /auth/me initially returns missing-bearer 403', async ({ page }) => {
+  const user = generateTestUser()
+  const registerResponse = await page.request.post('/api/auth/register', {
+    data: {
+      username: user.username,
+      email: user.email,
+      password: user.password,
+    },
+  })
+  expect(registerResponse.ok()).toBeTruthy()
+
+  // Keep the refresh cookie from registration, but reproduce a fresh browser bootstrap
+  // with no in-memory access token.
+  await page.goto('/login')
+  await page.evaluate(() => {
+    localStorage.clear()
+    delete (window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN
+  })
+
+  let meRequestCount = 0
+  await page.route('**/api/auth/me', async (route) => {
+    meRequestCount += 1
+    if (meRequestCount === 1) {
+      await route.fulfill({
+        status: 403,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'Not authenticated' }),
+      })
+      return
+    }
+    await route.continue()
+  })
+
+  await page.goto('/')
+
+  await expect(page).toHaveURL('/')
+  await expect(page.getByText(user.username, { exact: true })).toBeVisible()
+  await expect(page.getByText('Not authenticated', { exact: true })).toHaveCount(0)
+  expect(meRequestCount).toBeGreaterThanOrEqual(2)
+})

--- a/frontend/src/unit/api.test.ts
+++ b/frontend/src/unit/api.test.ts
@@ -228,6 +228,34 @@ it('handles response success, network errors, validation errors, and auth errors
   await expect(responseInterceptor({ config: { url: '/x', _retry: true } as never, response: { status: 401 } })).rejects.toEqual(expect.objectContaining({ response: { status: 401 } }))
 })
 
+it('refreshes when FastAPI rejects a request without a bearer header', async () => {
+  post.mockResolvedValue({ access_token: 'refreshed-token' })
+  apiMock.request.mockResolvedValue({ authenticated: true })
+
+  const result = responseInterceptor({
+    config: { url: '/auth/me', headers: {} },
+    response: { status: 403, data: { detail: 'Not authenticated' } },
+  } as never)
+
+  await expect(result).resolves.toEqual({ authenticated: true })
+  expect(post).toHaveBeenCalledWith('/auth/refresh')
+  expect(apiMock.request).toHaveBeenCalledWith(expect.objectContaining({
+    url: '/auth/me',
+    _retry: true,
+    headers: { Authorization: 'Bearer refreshed-token' },
+  }))
+})
+
+it('does not refresh for unrelated forbidden responses', async () => {
+  await expect(responseInterceptor({
+    config: { url: '/threads/1' },
+    response: { status: 403, data: { detail: 'Forbidden' } },
+  } as never)).rejects.toEqual(expect.objectContaining({
+    response: expect.objectContaining({ status: 403 }),
+  }))
+  expect(post).not.toHaveBeenCalled()
+})
+
 it('rejects a failed token refresh without retrying the original request', async () => {
   post.mockRejectedValueOnce(new Error('refresh failed'))
   await expect(responseInterceptor({ config: { url: '/threads/1' }, response: { status: 401 } })).rejects.toThrow('refresh failed')


### PR DESCRIPTION
## Summary
- refresh access tokens when FastAPI returns 403 Not authenticated for missing bearer headers
- add unit and focused Chromium E2E regression coverage for issue #656
- install locked frontend dependencies before deploy typechecking

## Verification
- pnpm --filter frontend test (60 files, 567 tests)
- pnpm --filter frontend run typecheck
- pnpm --filter frontend run build
- pnpm --filter frontend run lint
- pnpm --filter frontend exec playwright test src/test/issue-656-auth-refresh.spec.ts --project=chromium

Closes #656

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication recovery when requests return a 403 “Not authenticated” response.
  * Automatically refreshes credentials and retries the request when appropriate.
  * Prevents unnecessary refresh attempts for unrelated 403 Forbidden errors.
  * Ensures users remain signed in when authentication is successfully restored.

* **Chores**
  * Added dependency installation to the production deployment workflow before frontend checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->