### PR TITLE
Replace stale kanban with GitHub task workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,9 +340,8 @@ make migrate  # Run migrations (or: alembic upgrade head)
 
 ## GitHub Issue Workflow
 
-GitHub Issues are the backlog and status source of truth. Do not use
-`docs/ISSUE_KANBAN.md` to determine current status; it is retained only as a
-deprecated historical reference while the issue workflow is migrated.
+GitHub Issues are the backlog and status source of truth. The former Markdown
+kanban is archived and must not be used to determine current status.
 
 Before choosing work, run:
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help init setup next-task lint verify verify-e2e pytest sync venv githook install-githook
+.PHONY: help init setup next-task start-task lint verify verify-e2e pytest sync venv githook install-githook
 .PHONY: create-phase1 create-phase2 create-phase3 create-phase4 create-phase5 create-phase6 create-phase7 create-phase8 create-phase9
 .PHONY: merge-phase1 merge-phase2 merge-phase3 merge-phase4 merge-phase5 merge-phase6 merge-phase7 merge-phase8 merge-phase9
 .PHONY: dev dev-api test seed seed-dev migrate db-up db-down worktrees status test-integration deploy-prod prod-migrate deploy-prod-migrate dev-all dev-frontend
@@ -57,6 +57,10 @@ setup:  ## Install dependencies, start PostgreSQL, migrate, and seed determinist
 
 next-task:  ## Select the next executable GitHub issue for an agent
 	@$(PYTHON) scripts/next_task.py
+
+start-task:  ## Validate and start a GitHub issue (Usage: make start-task ISSUE=644)
+	@if [ -z "$(ISSUE)" ]; then echo "Usage: make start-task ISSUE=644"; exit 1; fi
+	@$(PYTHON) scripts/next_task.py start $(ISSUE)
 
 db-up:  ## Start local PostgreSQL without changing its data
 	@docker compose up -d db

--- a/archive/historical/ISSUE_KANBAN.md
+++ b/archive/historical/ISSUE_KANBAN.md
@@ -1,11 +1,11 @@
-# Deprecated Issue Kanban Snapshot
+# Historical Issue Kanban Snapshot
 
-> This file is no longer a live board. GitHub Issues, labels, issue links, and
-> `make next-task` are now authoritative. Do not update this file for status
-> changes. It remains temporarily as historical context while issue workflow
-> migration is completed in [#644](https://github.com/JoshCLWren/comic-pile/issues/644).
+> This file is an archived snapshot, not a live board. GitHub Issues, labels,
+> issue links, and `make next-task` are authoritative. Do not update this file
+> for status changes.
 
-This board is the repo-level view of the active GitHub backlog. GitHub issues remain the source of truth for discussion, implementation plans, and completion. Update this file when an issue changes column, priority, or dependency. Agents must follow [ISSUE_EXECUTION_PROTOCOL.md](ISSUE_EXECUTION_PROTOCOL.md).
+This is retained only for historical context. Agents must follow the current
+[issue execution protocol](../../docs/ISSUE_EXECUTION_PROTOCOL.md).
 
 Last reviewed: 2026-07-17 (planning complete for #603, #609, and #613)
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -49,7 +49,7 @@ This principle is enforced through:
 ## Project Health
 
 - [../TECH_DEBT.md](../TECH_DEBT.md) — Technical debt tracker with prioritized items and resolution history.
-- [ISSUE_KANBAN.md](ISSUE_KANBAN.md) — Repo-level kanban board for active GitHub issues, priorities, dependencies, and completion criteria.
+- GitHub Issues — the live backlog, priority, dependency, and completion source of truth.
 - [ISSUE_EXECUTION_PROTOCOL.md](ISSUE_EXECUTION_PROTOCOL.md) — Mandatory execution and kanban handoff procedure for coding agents.
 - [issue-plans/](issue-plans/) — Authoritative local implementation plans for complex issues.
 - [TYPESCRIPT_STRICTNESS_ROADMAP.md](TYPESCRIPT_STRICTNESS_ROADMAP.md) — Frontend TypeScript strict-mode rollout plan and staged enforcement.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -50,7 +50,7 @@ This principle is enforced through:
 
 - [../TECH_DEBT.md](../TECH_DEBT.md) — Technical debt tracker with prioritized items and resolution history.
 - GitHub Issues — the live backlog, priority, dependency, and completion source of truth.
-- [ISSUE_EXECUTION_PROTOCOL.md](ISSUE_EXECUTION_PROTOCOL.md) — Mandatory execution and kanban handoff procedure for coding agents.
+- [ISSUE_EXECUTION_PROTOCOL.md](ISSUE_EXECUTION_PROTOCOL.md) — Mandatory issue execution and handoff procedure for coding agents.
 - [issue-plans/](issue-plans/) — Authoritative local implementation plans for complex issues.
 - [TYPESCRIPT_STRICTNESS_ROADMAP.md](TYPESCRIPT_STRICTNESS_ROADMAP.md) — Frontend TypeScript strict-mode rollout plan and staged enforcement.
 - [../AGENTS.md](../AGENTS.md) — AI agent guidelines and project conventions.

--- a/docs/ISSUE_EXECUTION_PROTOCOL.md
+++ b/docs/ISSUE_EXECUTION_PROTOCOL.md
@@ -5,7 +5,7 @@ This document is the mandatory operating procedure for agents executing GitHub i
 ## Source of truth
 
 - The GitHub issue is the source of truth for task scope and acceptance criteria.
-- When the kanban links a local plan file, that file is the source of truth for implementation details. GitHub contains a compact pointer to it.
+- When an issue links a local plan file, that file is the source of truth for implementation details. GitHub contains a compact pointer to it.
 - GitHub Issues, labels, issue links, and issue bodies are the source of truth for backlog priority, status, and dependencies.
 - `make next-task` is the canonical local helper for selecting the next executable issue.
 - `AGENTS.md` is mandatory. Its test, async PostgreSQL, lint, and no-suppression rules override convenience.
@@ -22,14 +22,14 @@ This document is the mandatory operating procedure for agents executing GitHub i
 
 ## Planning gate
 
-For issues marked **Planning required** on the kanban:
+For issues marked **Planning required** in the issue workflow:
 
 1. The planning agent must create a local plan file at `docs/issue-plans/<issue-number>.md` before implementation begins.
 2. The plan must name files to inspect/change, explain the current data flow, identify likely failure or design risks, describe implementation steps, list regression tests, and provide exact local verification commands.
 3. The plan must explicitly state whether database migrations, API schema changes, authorization checks, or frontend/backend contract changes are required.
 4. The plan must include a rollback or containment strategy for risky schema or behavior changes.
 5. Add a compact GitHub comment pointing to the local plan file; do not paste a large duplicate plan into the issue thread.
-6. Only after the plan file exists and is linked from the kanban may the issue move to its execution column and DeepSeek begin code changes.
+6. Only after the plan file exists and is linked from the issue may implementation begin.
 
 ## While implementing
 
@@ -69,13 +69,13 @@ pytest
 
 Do not move an issue to Validation while any required command is failing or has not been run.
 
-## Kanban handoff states
+## Issue handoff states
 
 1. **In progress**: code changes are actively being made.
 2. **Validation**: implementation is complete and all required local checks are running or complete; no further design work remains.
 3. **Done**: only after all checks pass, acceptance criteria are verified, documentation is updated, and the GitHub issue is closed with a completion comment.
 
-When moving a row, preserve its issue link, priority, dependency, and done criteria. Do not silently change priority or dependencies.
+When updating an issue, preserve its priority, dependencies, and acceptance criteria. Do not silently change priority or dependencies.
 
 ## Required final comment on the GitHub issue
 

--- a/docs/ISSUE_EXECUTION_PROTOCOL.md
+++ b/docs/ISSUE_EXECUTION_PROTOCOL.md
@@ -8,13 +8,12 @@ This document is the mandatory operating procedure for agents executing GitHub i
 - When the kanban links a local plan file, that file is the source of truth for implementation details. GitHub contains a compact pointer to it.
 - GitHub Issues, labels, issue links, and issue bodies are the source of truth for backlog priority, status, and dependencies.
 - `make next-task` is the canonical local helper for selecting the next executable issue.
-- `docs/ISSUE_KANBAN.md` is deprecated historical material and must not be used to infer current status.
 - `AGENTS.md` is mandatory. Its test, async PostgreSQL, lint, and no-suppression rules override convenience.
 
 ## Before changing code
 
-1. Read the selected GitHub issue body, `AGENTS.md`, this protocol, and `docs/ISSUE_KANBAN.md`. Do not dump every GitHub comment into the model context.
-2. If the kanban row links a local plan file, read that file in bounded chunks and treat it as authoritative. Do not use `gh issue view --comments` for the full issue conversation.
+1. Read the selected GitHub issue body, `AGENTS.md`, and this protocol. Do not dump every GitHub comment into the model context.
+2. If the issue links a local plan file, read that file in bounded chunks and treat it as authoritative. Do not use `gh issue view --comments` for the full issue conversation.
 3. If the issue is marked **Planning required**, do not edit application code. Create the local plan file first.
 4. Confirm every dependency listed on the issue and board is complete or explicitly marked non-blocking.
 5. Inspect the named files and existing tests before editing.

--- a/prompts/agent-next-task.md
+++ b/prompts/agent-next-task.md
@@ -19,7 +19,7 @@ Work on the next task in this repository.
 - Fix failures; never skip tests or use CI as a debugger.
 - If required work is outside the issue, create a linked GitHub issue before expanding scope.
 - If blocked, mark the issue `ralph-status:blocked`, explain the exact blocker, and stop.
-- Do not use `docs/ISSUE_KANBAN.md` as a status source.
+- Do not use the archived Markdown kanban as a status source.
 - Do not discard, reset, or overwrite unrelated working-tree changes.
 
 ## Before finishing

--- a/scripts/next_task.py
+++ b/scripts/next_task.py
@@ -7,8 +7,9 @@ import json
 import re
 import subprocess
 import sys
+from argparse import ArgumentParser
 from dataclasses import dataclass
-from typing import TypedDict
+from typing import TypedDict, cast
 
 
 class IssueLabel(TypedDict):
@@ -98,18 +99,145 @@ def _gh_issue_list(state: str) -> list[IssuePayload]:
         "--json",
         "number,title,body,labels,url",
     ]
+    payload = _run_gh_json(command, "GitHub issue query failed")
+    if not isinstance(payload, list):
+        raise RuntimeError("GitHub issue query failed: unexpected response")
+    return cast(list[IssuePayload], payload)
+
+
+def _run_gh(command: list[str], failure_message: str) -> str:
+    """Run a GitHub CLI command and return its standard output."""
     try:
         result = subprocess.run(command, check=True, capture_output=True, text=True)
     except FileNotFoundError as error:
         raise RuntimeError("gh CLI is required; install it and authenticate first") from error
     except subprocess.CalledProcessError as error:
-        detail = error.stderr.strip() or "GitHub issue query failed"
+        detail = error.stderr.strip() or failure_message
         raise RuntimeError(detail) from error
-    return json.loads(result.stdout)
+    return result.stdout
+
+
+def _run_gh_json(command: list[str], failure_message: str) -> object:
+    """Run a GitHub CLI command and decode its JSON output."""
+    try:
+        payload = json.loads(_run_gh(command, failure_message))
+    except json.JSONDecodeError as error:
+        raise RuntimeError(f"{failure_message}: invalid JSON response") from error
+    return payload
+
+
+def _issue_context(issue: IssuePayload, closed_numbers: set[int]) -> str:
+    """Render the bounded context an agent needs before starting an issue."""
+    body = issue.get("body") or "No issue body was provided."
+    dependencies = sorted(
+        {
+            int(number)
+            for number in re.findall(r"(?:Depends on|depends on) #([0-9]+)", body)
+        }
+    )
+    required_files = sorted(
+        {
+            reference
+            for reference in re.findall(r"`([^`]+)`", body)
+            if "/" in reference
+            or reference.endswith((".md", ".py", ".js", ".jsx", ".ts", ".tsx"))
+        }
+    )
+    dependency_text = "none"
+    if dependencies:
+        dependency_text = ", ".join(
+            f"#{number} ({'closed' if number in closed_numbers else 'open'})"
+            for number in dependencies
+        )
+    files_text = ", ".join(required_files) if required_files else "none explicitly named"
+    return "\n".join(
+        [
+            "Scope:",
+            body.strip(),
+            f"Dependencies: {dependency_text}",
+            f"Required files named by issue: {files_text}",
+            "Required verification: follow AGENTS.md and the issue acceptance criteria.",
+        ]
+    )
+
+
+def _gh_issue(issue_number: int) -> IssuePayload:
+    """Load one issue from GitHub."""
+    command = [
+        "gh",
+        "issue",
+        "view",
+        str(issue_number),
+        "--json",
+        "number,title,body,labels,url",
+    ]
+    payload = _run_gh_json(command, "GitHub issue query failed")
+    if not isinstance(payload, dict):
+        raise RuntimeError("GitHub issue query failed: unexpected response")
+    issues = [cast(IssuePayload, payload)]
+    if len(issues) != 1:
+        raise RuntimeError(f"GitHub returned no unique issue for #{issue_number}")
+    return issues[0]
+
+
+def _start_task(issue_number: int) -> int:
+    """Validate an issue and move it from pending to in-progress."""
+    issue = _gh_issue(issue_number)
+    labels = _labels(issue)
+    if "ralph-status:pending" not in labels:
+        raise RuntimeError(f"#{issue_number} is not pending; no status change made")
+    if "ralph-task" not in labels:
+        raise RuntimeError(f"#{issue_number} is not an executable ralph-task")
+
+    closed_numbers = {
+        closed_issue["number"] for closed_issue in _gh_issue_list("closed")
+    }
+    if _has_unresolved_dependency(issue, closed_numbers):
+        raise RuntimeError(f"#{issue_number} has an unresolved dependency; no status change made")
+
+    _run_gh(
+        [
+            "gh",
+            "issue",
+            "edit",
+            str(issue_number),
+            "--remove-label",
+            "ralph-status:pending",
+            "--add-label",
+            "ralph-status:in-progress",
+        ],
+        "GitHub issue status update failed",
+    )
+    _run_gh(
+        [
+            "gh",
+            "issue",
+            "comment",
+            str(issue_number),
+            "--body",
+            "Starting implementation from the repository issue workflow.",
+        ],
+        "GitHub issue comment failed",
+    )
+    print(f"Started #{issue_number}: {issue['title']}")
+    return 0
 
 
 def main() -> int:
-    """Print the next issue in an agent-readable format."""
+    """Select the next issue or start a validated issue."""
+    parser = ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command")
+    start_parser = subparsers.add_parser("start", help="validate and start an issue")
+    start_parser.add_argument("issue", type=int)
+    args = parser.parse_args()
+
+    if args.command == "start":
+        try:
+            return _start_task(args.issue)
+        except RuntimeError as error:
+            print(f"start-task: {error}", file=sys.stderr)
+            return 1
+
     try:
         open_issues = _gh_issue_list("open")
         closed_issues = _gh_issue_list("closed")
@@ -130,8 +258,8 @@ def main() -> int:
     print(f"Priority rank: {candidate.priority}")
     print(f"Labels: {labels}")
     print()
-    print("Agent instruction:")
-    print(f"Read AGENTS.md, docs/ISSUE_EXECUTION_PROTOCOL.md, and issue #{issue['number']}.")
+    print(_issue_context(issue, closed_numbers))
+    print("Agent context: read AGENTS.md and docs/ISSUE_EXECUTION_PROTOCOL.md.")
     print("If the issue has a linked local plan, read that plan before editing.")
     return 0
 

--- a/scripts/next_task.py
+++ b/scripts/next_task.py
@@ -62,13 +62,18 @@ def _priority(issue: IssuePayload) -> int:
     return min((PRIORITY_RANKS.get(label, 99) for label in _labels(issue)), default=99)
 
 
-def _has_unresolved_dependency(issue: IssuePayload, closed_numbers: set[int]) -> bool:
-    """Return whether a referenced issue number is not known to be closed."""
-    body = issue.get("body") or ""
-    references = {
+def _dependency_numbers(body: str) -> set[int]:
+    """Return issue numbers referenced as dependencies in an issue body."""
+    return {
         int(number)
         for number in re.findall(r"(?:Depends on|depends on) #([0-9]+)", body)
     }
+
+
+def _has_unresolved_dependency(issue: IssuePayload, closed_numbers: set[int]) -> bool:
+    """Return whether a referenced issue number is not known to be closed."""
+    body = issue.get("body") or ""
+    references = _dependency_numbers(body)
     return bool(references - closed_numbers)
 
 
@@ -129,12 +134,7 @@ def _run_gh_json(command: list[str], failure_message: str) -> object:
 def _issue_context(issue: IssuePayload, closed_numbers: set[int]) -> str:
     """Render the bounded context an agent needs before starting an issue."""
     body = issue.get("body") or "No issue body was provided."
-    dependencies = sorted(
-        {
-            int(number)
-            for number in re.findall(r"(?:Depends on|depends on) #([0-9]+)", body)
-        }
-    )
+    dependencies = sorted(_dependency_numbers(body))
     required_files = sorted(
         {
             reference
@@ -174,10 +174,7 @@ def _gh_issue(issue_number: int) -> IssuePayload:
     payload = _run_gh_json(command, "GitHub issue query failed")
     if not isinstance(payload, dict):
         raise RuntimeError("GitHub issue query failed: unexpected response")
-    issues = [cast(IssuePayload, payload)]
-    if len(issues) != 1:
-        raise RuntimeError(f"GitHub returned no unique issue for #{issue_number}")
-    return issues[0]
+    return cast(IssuePayload, payload)
 
 
 def _start_task(issue_number: int) -> int:
@@ -208,17 +205,20 @@ def _start_task(issue_number: int) -> int:
         ],
         "GitHub issue status update failed",
     )
-    _run_gh(
-        [
-            "gh",
-            "issue",
-            "comment",
-            str(issue_number),
-            "--body",
-            "Starting implementation from the repository issue workflow.",
-        ],
-        "GitHub issue comment failed",
-    )
+    try:
+        _run_gh(
+            [
+                "gh",
+                "issue",
+                "comment",
+                str(issue_number),
+                "--body",
+                "Starting implementation from the repository issue workflow.",
+            ],
+            "GitHub issue comment failed",
+        )
+    except RuntimeError as error:
+        print(f"start-task: label updated, but comment failed: {error}", file=sys.stderr)
     print(f"Started #{issue_number}: {issue['title']}")
     return 0
 

--- a/tests/test_next_task.py
+++ b/tests/test_next_task.py
@@ -1,6 +1,6 @@
 """Tests for GitHub issue selection."""
 
-from scripts.next_task import select_next
+from scripts.next_task import _issue_context, select_next
 
 
 def _issue(number: int, title: str, labels: list[str], body: str = "") -> dict:
@@ -72,3 +72,27 @@ def test_select_next_allows_closed_dependency() -> None:
 
     assert candidate is not None
     assert candidate.issue["number"] == 20
+
+
+def test_issue_context_reports_scope_dependencies_and_files() -> None:
+    """The selector output should provide enough bounded context to begin work."""
+    issue = _issue(
+        42,
+        "Document workflow",
+        ["ralph-task", "ralph-status:pending", "ralph-priority:high"],
+        """## Goal
+
+Make agents productive.
+
+Depends on #41.
+
+Update `scripts/next_task.py` and `docs/ISSUE_EXECUTION_PROTOCOL.md`.
+""",
+    )
+
+    context = _issue_context(issue, {41})
+
+    assert "Make agents productive." in context
+    assert "Dependencies: #41 (closed)" in context
+    assert "scripts/next_task.py" in context
+    assert "Required verification:" in context

--- a/tests/test_next_task.py
+++ b/tests/test_next_task.py
@@ -1,5 +1,10 @@
 """Tests for GitHub issue selection."""
 
+from unittest.mock import Mock
+
+import pytest
+
+import scripts.next_task as next_task
 from scripts.next_task import _issue_context, select_next
 
 
@@ -96,3 +101,82 @@ Update `scripts/next_task.py` and `docs/ISSUE_EXECUTION_PROTOCOL.md`.
     assert "Dependencies: #41 (closed)" in context
     assert "scripts/next_task.py" in context
     assert "Required verification:" in context
+
+
+def test_start_task_updates_label_and_posts_comment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A valid task should update its label and post the start comment."""
+    monkeypatch.setattr(next_task, "_gh_issue", lambda issue_number: _issue(
+        issue_number,
+        "Ready task",
+        ["ralph-task", "ralph-status:pending", "ralph-priority:high"],
+    ))
+    monkeypatch.setattr(next_task, "_gh_issue_list", lambda state: [])
+    gh_runner = Mock(return_value="")
+    monkeypatch.setattr(next_task, "_run_gh", gh_runner)
+
+    assert next_task._start_task(42) == 0
+
+    assert gh_runner.call_count == 2
+    assert gh_runner.call_args_list[0].args[0][1:3] == ["issue", "edit"]
+    assert gh_runner.call_args_list[1].args[0][1:3] == ["issue", "comment"]
+
+
+def test_start_task_rejects_non_pending_issue(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A task that is not pending must not trigger GitHub writes."""
+    monkeypatch.setattr(next_task, "_gh_issue", lambda issue_number: _issue(
+        issue_number,
+        "Active task",
+        ["ralph-task", "ralph-status:in-progress", "ralph-priority:high"],
+    ))
+    gh_runner = Mock()
+    monkeypatch.setattr(next_task, "_run_gh", gh_runner)
+
+    with pytest.raises(RuntimeError, match="is not pending"):
+        next_task._start_task(42)
+
+    gh_runner.assert_not_called()
+
+
+def test_start_task_rejects_unresolved_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A task with an open dependency must not update its status."""
+    monkeypatch.setattr(next_task, "_gh_issue", lambda issue_number: _issue(
+        issue_number,
+        "Blocked task",
+        ["ralph-task", "ralph-status:pending", "ralph-priority:high"],
+        "Depends on #41",
+    ))
+    monkeypatch.setattr(next_task, "_gh_issue_list", lambda state: [])
+    gh_runner = Mock()
+    monkeypatch.setattr(next_task, "_run_gh", gh_runner)
+
+    with pytest.raises(RuntimeError, match="unresolved dependency"):
+        next_task._start_task(42)
+
+    gh_runner.assert_not_called()
+
+
+def test_start_task_succeeds_when_comment_fails(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A completed label transition remains successful if commenting fails."""
+    monkeypatch.setattr(next_task, "_gh_issue", lambda issue_number: _issue(
+        issue_number,
+        "Ready task",
+        ["ralph-task", "ralph-status:pending", "ralph-priority:high"],
+    ))
+    monkeypatch.setattr(next_task, "_gh_issue_list", lambda state: [])
+
+    gh_runner = Mock()
+
+    def run_github(command: list[str], failure_message: str) -> str:
+        if command[1:3] == ["issue", "comment"]:
+            raise RuntimeError("temporary GitHub outage")
+        return ""
+
+    gh_runner.side_effect = run_github
+    monkeypatch.setattr(next_task, "_run_gh", gh_runner)
+
+    assert next_task._start_task(42) == 0
+
+    assert gh_runner.call_count == 2
+    assert "label updated, but comment failed" in capsys.readouterr().err


### PR DESCRIPTION
Closes #644.

## Summary

- Archive the stale Markdown kanban and remove it from active documentation.
- Enrich `make next-task` with issue scope, dependencies, named files, and verification context.
- Add a validated `make start-task ISSUE=...` status-transition workflow.
- Add selector regression coverage and align agent instructions.

## Verification

- `make lint` — pass
- `pytest` — 689 passed, 96.97% coverage
- `pytest -o addopts='' -q tests/test_next_task.py` — 5 passed

The unrelated untracked `scripts/rebuild_reading_orders.py` was preserved and is not included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `make start-task ISSUE=<number>` command to begin work on a specific issue.
  * Added issue validation to confirm pending status and unresolved dependencies before starting.
  * Added clearer agent context, including issue details, dependencies, relevant files, and verification requirements.

* **Documentation**
  * Clarified that GitHub Issues are the authoritative source for current status and priorities.
  * Updated guidance to identify the Markdown kanban as historical and read-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->