### PR TITLE
Add clone workflow tests and documentation

### DIFF
--- a/docs/prod-clone-workflow.md
+++ b/docs/prod-clone-workflow.md
@@ -1,0 +1,99 @@
+# Production-to-local data clone workflow
+
+This workflow copies one Comic Pile user's data from the production PostgreSQL
+database into a local development database. The export is read-only, the import
+remaps every exported ID, and authentication secrets are never copied.
+
+## Prerequisites
+
+- A working local checkout with the project virtual environment installed.
+- The Railway CLI authenticated to the production project, or a production
+  PostgreSQL URL supplied through `CLONE_PROD_DB_URL`.
+- A local PostgreSQL database with the current schema. Run migrations first:
+
+```bash
+make migrate
+```
+
+The local database URL can be supplied with `--local-db-url`, or the script can
+use the normal application database configuration.
+
+## Export production data
+
+The default export command obtains `DATABASE_PUBLIC_URL` from the Railway
+Postgres service. Always review the redacted target and confirm the username
+before proceeding.
+
+```bash
+python -m scripts.clone_prod_to_local export \
+  --username YOUR_PRODUCTION_USERNAME \
+  --output prod_backup.json
+```
+
+For an explicit connection URL:
+
+```bash
+CLONE_PROD_DB_URL='postgresql+asyncpg://USER:PASSWORD@HOST:5432/DB' \
+python -m scripts.clone_prod_to_local export \
+  --username YOUR_PRODUCTION_USERNAME \
+  --output prod_backup.json
+```
+
+The output is a private (`0600`) JSON file. It contains user-scoped
+collections, threads, issues, dependencies, reading orders, sessions, events,
+snapshots, and reviews. It does not contain `password_hash`, revoked tokens,
+failed-login records, or database credentials.
+
+## Validate without writing
+
+Run the import in dry-run mode before changing the local database:
+
+```bash
+python -m scripts.clone_prod_to_local import \
+  --file prod_backup.json \
+  --dry-run \
+  --local-db-url 'postgresql+asyncpg://USER:PASSWORD@localhost:5435/comic_pile'
+```
+
+Dry-run validates the schema and all exported foreign-key references, prints
+the records that would be imported, and performs no database writes.
+
+## Import into local development
+
+The normal import creates a backup of the destination user's current data,
+then replaces that user's clone data in one transaction. A failed import is
+rolled back. Use an explicit backup path when you need a predictable location:
+
+```bash
+python -m scripts.clone_prod_to_local import \
+  --file prod_backup.json \
+  --backup local_before_clone.json \
+  --local-db-url 'postgresql+asyncpg://USER:PASSWORD@localhost:5435/comic_pile'
+```
+
+Type `yes` at the confirmation prompt after checking the destination. For
+non-interactive automation, add `--yes` only after validating the file:
+
+```bash
+python -m scripts.clone_prod_to_local import \
+  --file prod_backup.json \
+  --dry-run \
+  --yes
+```
+
+After a successful import, sign in with the imported username. The imported
+user has no production password hash, so set a local password through the
+normal registration or administrative workflow rather than expecting the
+production password to work.
+
+## Safety checklist
+
+1. Confirm the export target is production and the username is correct.
+2. Keep export and pre-import backup files private; do not commit them.
+3. Run `--dry-run` against the intended local database.
+4. Keep the pre-import backup until the clone has been verified.
+5. Confirm thread counts, reading orders, sessions, and reviews in the local UI.
+
+The command never mutates production. It only reads production during export;
+the import connects to the local database URL supplied by configuration or
+`--local-db-url`.

--- a/scripts/clone_prod_to_local.py
+++ b/scripts/clone_prod_to_local.py
@@ -33,10 +33,10 @@ import subprocess
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, TypedDict
+from typing import TypedDict, cast
 from urllib.parse import urlparse
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.models import (
@@ -69,6 +69,8 @@ EXPORT_TABLES = [
     "snapshots",
     "reviews",
 ]
+
+type JsonValue = None | bool | int | float | str | list[JsonValue] | dict[str, JsonValue]
 
 
 def _async_database_url(db_url: str) -> str:
@@ -130,7 +132,7 @@ class ExportIssueRecord(TypedDict, total=False):
 
     id: int
     thread_id: int
-    issue_number: int
+    issue_number: str
     position: int
     status: str
     read_at: str | None
@@ -163,7 +165,7 @@ class ExportReadingOrderItemRecord(TypedDict, total=False):
     reading_order_id: int
     thread_id: int
     position: int
-    issue_number: int
+    issue_number: str
 
 
 class ExportSessionRecord(TypedDict, total=False):
@@ -188,12 +190,12 @@ class ExportEventRecord(TypedDict, total=False):
     type: str
     timestamp: str | None
     die: int
-    result: str | None
+    result: int | None
     selected_thread_id: int | None
     selection_method: str | None
     rating: float | None
     issues_read: int | None
-    queue_move: int | None
+    queue_move: str | None
     die_after: bool | None
     session_id: int
     thread_id: int | None
@@ -207,8 +209,8 @@ class ExportSnapshotRecord(TypedDict, total=False):
     id: int
     session_id: int
     event_id: int | None
-    thread_states: dict[str, Any]
-    session_state: dict[str, Any]
+    thread_states: dict[str, JsonValue]
+    session_state: dict[str, JsonValue] | None
     created_at: str | None
     description: str | None
 
@@ -244,6 +246,20 @@ class ExportDocument(TypedDict):
     events: list[ExportEventRecord]
     snapshots: list[ExportSnapshotRecord]
     reviews: list[ExportReviewRecord]
+
+
+type ExportRecord = (
+    ExportCollectionRecord
+    | ExportThreadRecord
+    | ExportIssueRecord
+    | ExportDependencyRecord
+    | ExportReadingOrderRecord
+    | ExportReadingOrderItemRecord
+    | ExportSessionRecord
+    | ExportEventRecord
+    | ExportSnapshotRecord
+    | ExportReviewRecord
+)
 
 
 class _DateTimeEncoder(json.JSONEncoder):
@@ -315,29 +331,29 @@ def _datetime_to_iso(obj: object) -> str | None:
 
 
 
-def _export_user(user: User) -> dict[str, Any]:
-    return {
+def _export_user(user: User) -> ExportUserRecord:
+    return ExportUserRecord(**{
         "id": user.id,
         "username": user.username,
         "email": user.email,
         "is_admin": user.is_admin,
         "created_at": _datetime_to_iso(user.created_at),
-    }
+    })
 
 
-def _export_collection(collection: Collection) -> dict[str, Any]:
-    return {
+def _export_collection(collection: Collection) -> ExportCollectionRecord:
+    return ExportCollectionRecord(**{
         "id": collection.id,
         "name": collection.name,
         "user_id": collection.user_id,
         "is_default": collection.is_default,
         "position": collection.position,
         "created_at": _datetime_to_iso(collection.created_at),
-    }
+    })
 
 
-def _export_thread(thread: Thread) -> dict[str, Any]:
-    return {
+def _export_thread(thread: Thread) -> ExportThreadRecord:
+    return ExportThreadRecord(**{
         "id": thread.id,
         "title": thread.title,
         "format": thread.format,
@@ -357,11 +373,11 @@ def _export_thread(thread: Thread) -> dict[str, Any]:
         "created_at": _datetime_to_iso(thread.created_at),
         "user_id": thread.user_id,
         "collection_id": thread.collection_id,
-    }
+    })
 
 
-def _export_issue(issue: Issue) -> dict[str, Any]:
-    return {
+def _export_issue(issue: Issue) -> ExportIssueRecord:
+    return ExportIssueRecord(**{
         "id": issue.id,
         "thread_id": issue.thread_id,
         "issue_number": issue.issue_number,
@@ -369,40 +385,40 @@ def _export_issue(issue: Issue) -> dict[str, Any]:
         "status": issue.status,
         "read_at": _datetime_to_iso(issue.read_at),
         "created_at": _datetime_to_iso(issue.created_at),
-    }
+    })
 
 
-def _export_dependency(dependency: Dependency) -> dict[str, Any]:
-    return {
+def _export_dependency(dependency: Dependency) -> ExportDependencyRecord:
+    return ExportDependencyRecord(**{
         "id": dependency.id,
         "source_issue_id": dependency.source_issue_id,
         "target_issue_id": dependency.target_issue_id,
         "created_at": _datetime_to_iso(dependency.created_at),
         "note": dependency.note,
-    }
+    })
 
 
-def _export_reading_order(ro: ReadingOrder) -> dict[str, Any]:
-    return {
+def _export_reading_order(ro: ReadingOrder) -> ExportReadingOrderRecord:
+    return ExportReadingOrderRecord(**{
         "id": ro.id,
         "name": ro.name,
         "description": ro.description,
         "user_id": ro.user_id,
-    }
+    })
 
 
-def _export_reading_order_item(item: ReadingOrderItem) -> dict[str, Any]:
-    return {
+def _export_reading_order_item(item: ReadingOrderItem) -> ExportReadingOrderItemRecord:
+    return ExportReadingOrderItemRecord(**{
         "id": item.id,
         "reading_order_id": item.reading_order_id,
         "thread_id": item.thread_id,
         "position": item.position,
         "issue_number": item.issue_number,
-    }
+    })
 
 
-def _export_session(session: Session) -> dict[str, Any]:
-    return {
+def _export_session(session: Session) -> ExportSessionRecord:
+    return ExportSessionRecord(**{
         "id": session.id,
         "started_at": _datetime_to_iso(session.started_at),
         "ended_at": _datetime_to_iso(session.ended_at),
@@ -413,11 +429,11 @@ def _export_session(session: Session) -> dict[str, Any]:
         "pending_issue_id": session.pending_issue_id,
         "pending_thread_updated_at": _datetime_to_iso(session.pending_thread_updated_at),
         "snoozed_thread_ids": session.snoozed_thread_ids,
-    }
+    })
 
 
-def _export_event(event: Event) -> dict[str, Any]:
-    return {
+def _export_event(event: Event) -> ExportEventRecord:
+    return ExportEventRecord(**{
         "id": event.id,
         "type": event.type,
         "timestamp": _datetime_to_iso(event.timestamp),
@@ -433,23 +449,23 @@ def _export_event(event: Event) -> dict[str, Any]:
         "thread_id": event.thread_id,
         "issue_id": event.issue_id,
         "issue_number": event.issue_number,
-    }
+    })
 
 
-def _export_snapshot(snapshot: Snapshot) -> dict[str, Any]:
-    return {
+def _export_snapshot(snapshot: Snapshot) -> ExportSnapshotRecord:
+    return ExportSnapshotRecord(**{
         "id": snapshot.id,
         "session_id": snapshot.session_id,
         "event_id": snapshot.event_id,
-        "thread_states": snapshot.thread_states,
-        "session_state": snapshot.session_state,
+        "thread_states": cast(dict[str, JsonValue], snapshot.thread_states),
+        "session_state": cast(dict[str, JsonValue] | None, snapshot.session_state),
         "created_at": _datetime_to_iso(snapshot.created_at),
         "description": snapshot.description,
-    }
+    })
 
 
-def _export_review(review: Review) -> dict[str, Any]:
-    return {
+def _export_review(review: Review) -> ExportReviewRecord:
+    return ExportReviewRecord(**{
         "id": review.id,
         "user_id": review.user_id,
         "thread_id": review.thread_id,
@@ -458,7 +474,36 @@ def _export_review(review: Review) -> dict[str, Any]:
         "review_text": review.review_text,
         "created_at": _datetime_to_iso(review.created_at),
         "updated_at": _datetime_to_iso(review.updated_at),
-    }
+    })
+
+
+def _records_for_table(export: ExportDocument, table: str) -> list[ExportRecord]:
+    """Return typed records for a non-user export table."""
+    records: object
+    match table:
+        case "collections":
+            records = export["collections"]
+        case "threads":
+            records = export["threads"]
+        case "issues":
+            records = export["issues"]
+        case "dependencies":
+            records = export["dependencies"]
+        case "reading_orders":
+            records = export["reading_orders"]
+        case "reading_order_items":
+            records = export["reading_order_items"]
+        case "sessions":
+            records = export["sessions"]
+        case "events":
+            records = export["events"]
+        case "snapshots":
+            records = export["snapshots"]
+        case "reviews":
+            records = export["reviews"]
+        case _:
+            raise ValueError(f"Unsupported export table {table!r}")
+    return cast(list[ExportRecord], records)
 
 
 
@@ -591,7 +636,7 @@ def _parse_datetime(value: str | None) -> datetime | None:
     return datetime.fromisoformat(value) if value else None
 
 
-def _validate_export(export: dict[str, Any]) -> None:
+def _validate_export(export: ExportDocument) -> None:
     """Validate schema version and all exported foreign-key references."""
     if export.get("schema_version") != SCHEMA_VERSION:
         raise ValueError(
@@ -613,7 +658,7 @@ def _validate_export(export: dict[str, Any]) -> None:
 
     ids: dict[str, set[int]] = {key: set() for key in list_keys}
     for key in list_keys:
-        for record in export[key]:
+        for record in _records_for_table(export, key):
             if not isinstance(record, dict) or not isinstance(record.get("id"), int):
                 raise ValueError(f"Every {key} record must have an integer id")
             record_id = record["id"]
@@ -653,7 +698,7 @@ def _validate_export(export: dict[str, Any]) -> None:
         ],
     }
     for table, fields in checks.items():
-        for record in export[table]:
+        for record in _records_for_table(export, table):
             for field, target in fields:
                 value = record.get(field)
                 if value is None and field.endswith("_id"):
@@ -698,9 +743,35 @@ async def _delete_local_user_data(db: AsyncSession, user_id: int) -> None:
     await db.execute(delete(Collection).where(Collection.user_id == user_id))
 
 
+async def _sync_id_sequences(db: AsyncSession) -> None:
+    """Advance PostgreSQL identity sequences after importing explicit record IDs."""
+    tables = (
+        "users",
+        "collections",
+        "threads",
+        "issues",
+        "dependencies",
+        "reading_orders",
+        "reading_order_items",
+        "sessions",
+        "events",
+        "snapshots",
+        "reviews",
+    )
+    for table in tables:
+        await db.execute(
+            text(
+                "SELECT setval("
+                f"pg_get_serial_sequence('{table}', 'id'), "
+                f"COALESCE((SELECT MAX(id) FROM {table}), 1), "
+                f"(SELECT MAX(id) IS NOT NULL FROM {table}))"
+            )
+        )
+
+
 async def _import_document(
     db_url: str,
-    export: dict[str, Any],
+    export: ExportDocument,
     backup_path: Path | None,
     dry_run: bool,
 ) -> dict[str, int]:
@@ -715,7 +786,11 @@ async def _import_document(
             existing_user_id = existing_user.id if existing_user is not None else None
             if dry_run:
                 print("Dry run: validated export; no database changes made.")
-                return {key: len(export[key]) for key in EXPORT_TABLES if key != "user"}
+                return {
+                    key: len(_records_for_table(export, key))
+                    for key in EXPORT_TABLES
+                    if key != "user"
+                }
 
             if backup_path is not None:
                 if existing_user is None:
@@ -733,6 +808,8 @@ async def _import_document(
                 print(f"Pre-import backup: {backup_path.resolve()}")
 
             await db.rollback()
+            await _sync_id_sequences(db)
+            await db.commit()
             async with db.begin():
                 if existing_user_id is None:
                     local_user = User(
@@ -832,9 +909,15 @@ async def _import_document(
                     session_map[record["id"]] = item.id
                 event_map: dict[int, int] = {}
                 for record in export["events"]:
+                    selected_thread_id = record.get("selected_thread_id")
                     item = Event(
                         type=record["type"], timestamp=_parse_datetime(record.get("timestamp")) or datetime.now(UTC), die=record.get("die"),
-                        result=record.get("result"), selected_thread_id=thread_map.get(record.get("selected_thread_id"), record.get("selected_thread_id")),
+                        result=record.get("result"),
+                        selected_thread_id=(
+                            thread_map.get(selected_thread_id)
+                            if selected_thread_id is not None
+                            else None
+                        ),
                         selection_method=record.get("selection_method"), rating=record.get("rating"), issues_read=record.get("issues_read"),
                         queue_move=record.get("queue_move"), die_after=record.get("die_after"), session_id=_remap(record.get("session_id"), session_map),
                         thread_id=_remap(record.get("thread_id"), thread_map), issue_id=_remap(record.get("issue_id"), issue_map), issue_number=record.get("issue_number"),
@@ -856,7 +939,14 @@ async def _import_document(
                     ))
                 await db.flush()
 
-            counts = {key: len(export[key]) for key in EXPORT_TABLES if key != "user"}
+            await _sync_id_sequences(db)
+            await db.commit()
+
+            counts = {
+                key: len(_records_for_table(export, key))
+                for key in EXPORT_TABLES
+                if key != "user"
+            }
             return counts
     finally:
         await engine.dispose()
@@ -923,7 +1013,7 @@ def _prompt_confirmation(message: str) -> bool:
     return response == "yes"
 
 
-def _print_summary(export: dict[str, Any]) -> None:
+def _print_summary(export: ExportDocument) -> None:
     counts: dict[str, int] = {}
     for key in EXPORT_TABLES:
         if key == "user":
@@ -995,13 +1085,14 @@ async def _handle_import(args: argparse.Namespace) -> int:
     input_path = Path(args.file)
     try:
         with input_path.open() as source:
-            export = json.load(source)
+            parsed: object = json.load(source)
     except (OSError, json.JSONDecodeError) as error:
         print(f"Error: unable to read export file {input_path}: {error}", file=sys.stderr)
         return 1
-    if not isinstance(export, dict):
+    if not isinstance(parsed, dict):
         print("Error: export file must contain a JSON object.", file=sys.stderr)
         return 1
+    export = cast(ExportDocument, parsed)
 
     db_url = args.local_db_url
     if not db_url:

--- a/tests/test_clone_export.py
+++ b/tests/test_clone_export.py
@@ -4,6 +4,7 @@ import json
 import os
 import stat
 import tempfile
+from collections.abc import AsyncIterator
 from pathlib import Path
 
 import pytest
@@ -17,7 +18,12 @@ from sqlalchemy.ext.asyncio import (
 
 from app.models import (
     Collection,
+    Dependency,
+    Event,
     Issue,
+    ReadingOrder,
+    ReadingOrderItem,
+    Review,
     Session,
     Snapshot,
     Thread,
@@ -54,62 +60,52 @@ def requires_postgres(test_db_url):
         pytest.skip(**{"msg": "Requires PostgreSQL for REPEATABLE READ / READ ONLY isolation"})
 
 
+@pytest_asyncio.fixture(autouse=True)
+async def clean_clone_users(db_engine) -> AsyncIterator[None]:
+    """Remove clone test users before and after each test."""
+    usernames = ("clone_export_test_user", "clone_round_trip_target", "clone_import_target")
+    params = {f"u{index}": username for index, username in enumerate(usernames)}
+    placeholders = ", ".join(f":u{index}" for index in range(len(usernames)))
+    statements = (
+        "DELETE FROM snapshots WHERE session_id IN "
+        f"(SELECT id FROM sessions WHERE user_id IN (SELECT id FROM users WHERE username IN ({placeholders})))",
+        "DELETE FROM events WHERE session_id IN "
+        f"(SELECT id FROM sessions WHERE user_id IN (SELECT id FROM users WHERE username IN ({placeholders})))",
+        f"DELETE FROM sessions WHERE user_id IN (SELECT id FROM users WHERE username IN ({placeholders}))",
+        "DELETE FROM reading_order_items WHERE reading_order_id IN "
+        f"(SELECT id FROM reading_orders WHERE user_id IN (SELECT id FROM users WHERE username IN ({placeholders})))",
+        f"DELETE FROM reading_orders WHERE user_id IN (SELECT id FROM users WHERE username IN ({placeholders}))",
+        "DELETE FROM dependencies WHERE source_issue_id IN "
+        f"(SELECT id FROM issues WHERE thread_id IN (SELECT id FROM threads WHERE user_id IN (SELECT id FROM users WHERE username IN ({placeholders}))))",
+        "DELETE FROM reviews WHERE user_id IN "
+        f"(SELECT id FROM users WHERE username IN ({placeholders}))",
+        "DELETE FROM issues WHERE thread_id IN "
+        f"(SELECT id FROM threads WHERE user_id IN (SELECT id FROM users WHERE username IN ({placeholders})))",
+        f"DELETE FROM threads WHERE user_id IN (SELECT id FROM users WHERE username IN ({placeholders}))",
+        f"DELETE FROM collections WHERE user_id IN (SELECT id FROM users WHERE username IN ({placeholders}))",
+        f"DELETE FROM users WHERE username IN ({placeholders})",
+    )
+
+    async def cleanup() -> None:
+        async_session = async_sessionmaker(
+            db_engine, class_=AsyncSession, expire_on_commit=False,
+        )
+        async with async_session() as session:
+            for statement in statements:
+                await session.execute(text(statement), params)
+            await session.commit()
+
+    await cleanup()
+    yield
+    await cleanup()
+
+
 @pytest_asyncio.fixture()
 async def export_user(db_engine) -> User:
     """Create a test user and return the SQLAlchemy model."""
     async_session = async_sessionmaker(
         db_engine, class_=AsyncSession, expire_on_commit=False,
     )
-
-    # Clean up any stale test users and their dependent rows from prior runs
-    async with async_session() as session:
-        await session.execute(text(
-            "DELETE FROM snapshots WHERE session_id IN "
-            "(SELECT id FROM sessions WHERE user_id IN "
-            "(SELECT id FROM users WHERE username = :u))"
-        ), {"u": "clone_export_test_user"})
-        await session.execute(text(
-            "DELETE FROM events WHERE session_id IN "
-            "(SELECT id FROM sessions WHERE user_id IN "
-            "(SELECT id FROM users WHERE username = :u))"
-        ), {"u": "clone_export_test_user"})
-        await session.execute(text(
-            "DELETE FROM sessions WHERE user_id IN "
-            "(SELECT id FROM users WHERE username = :u)"
-        ), {"u": "clone_export_test_user"})
-        await session.execute(text(
-            "DELETE FROM reading_order_items WHERE reading_order_id IN "
-            "(SELECT id FROM reading_orders WHERE user_id IN "
-            "(SELECT id FROM users WHERE username = :u))"
-        ), {"u": "clone_export_test_user"})
-        await session.execute(text(
-            "DELETE FROM reading_orders WHERE user_id IN "
-            "(SELECT id FROM users WHERE username = :u)"
-        ), {"u": "clone_export_test_user"})
-        await session.execute(text(
-            "DELETE FROM dependencies WHERE source_issue_id IN "
-            "(SELECT id FROM issues WHERE thread_id IN "
-            "(SELECT id FROM threads WHERE user_id IN "
-            "(SELECT id FROM users WHERE username = :u)))"
-        ), {"u": "clone_export_test_user"})
-        await session.execute(text(
-            "DELETE FROM issues WHERE thread_id IN "
-            "(SELECT id FROM threads WHERE user_id IN "
-            "(SELECT id FROM users WHERE username = :u))"
-        ), {"u": "clone_export_test_user"})
-        await session.execute(text(
-            "DELETE FROM threads WHERE user_id IN "
-            "(SELECT id FROM users WHERE username = :u)"
-        ), {"u": "clone_export_test_user"})
-        await session.execute(text(
-            "DELETE FROM collections WHERE user_id IN "
-            "(SELECT id FROM users WHERE username = :u)"
-        ), {"u": "clone_export_test_user"})
-        await session.execute(
-            text("DELETE FROM users WHERE username = :u"),
-            {"u": "clone_export_test_user"},
-        )
-        await session.commit()
 
     async with async_session() as session:
         user = User(
@@ -120,6 +116,14 @@ async def export_user(db_engine) -> User:
         session.add(user)
         await session.commit()
         await session.refresh(user)
+        await session.execute(
+            text(
+                "SELECT setval(pg_get_serial_sequence('users', 'id'), "
+                "COALESCE((SELECT MAX(id) FROM users), 1), "
+                "(SELECT MAX(id) IS NOT NULL FROM users))"
+            )
+        )
+        await session.commit()
         return user
 
 
@@ -211,21 +215,77 @@ async def export_data(db_engine, export_user: User) -> dict[str, object]:
         )
         session.add_all([issue1, issue2])
         await session.flush()
+        thread.next_unread_issue_id = issue2.id
+
+        dependency = Dependency(
+            source_issue_id=issue1.id,
+            target_issue_id=issue2.id,
+            note="read the first issue first",
+        )
+        session.add(dependency)
+
+        reading_order = ReadingOrder(
+            name="Test Reading Order",
+            description="Round-trip test order",
+            user_id=export_user.id,
+        )
+        session.add(reading_order)
+        await session.flush()
+        session.add(
+            ReadingOrderItem(
+                reading_order_id=reading_order.id,
+                thread_id=thread.id,
+                position=0,
+                issue_number="1",
+            )
+        )
 
         session_model = Session(
             start_die=6,
             manual_die=0,
             user_id=export_user.id,
+            pending_thread_id=thread.id,
+            pending_issue_id=issue2.id,
+            snoozed_thread_ids=[thread.id],
         )
         session.add(session_model)
         await session.flush()
 
+        event = Event(
+            type="rate",
+            die=6,
+            result=3,
+            selected_thread_id=thread.id,
+            selection_method="random",
+            rating=4.5,
+            issues_read=1,
+            queue_move="stay",
+            die_after=6,
+            session_id=session_model.id,
+            thread_id=thread.id,
+            issue_id=issue1.id,
+            issue_number="1",
+        )
+        session.add(event)
+        await session.flush()
+
         snapshot = Snapshot(
             session_id=session_model.id,
-            thread_states={},
-            session_state={},
+            event_id=event.id,
+            thread_states={str(thread.id): {"issues_remaining": 3}},
+            session_state={"pending_thread_id": thread.id},
+            description="Before rating",
         )
         session.add(snapshot)
+        session.add(
+            Review(
+                user_id=export_user.id,
+                thread_id=thread.id,
+                issue_id=issue1.id,
+                rating=4.5,
+                review_text="Strong opening issue.",
+            )
+        )
         await session.commit()
 
     return {
@@ -234,7 +294,10 @@ async def export_data(db_engine, export_user: User) -> dict[str, object]:
         "thread_id": thread.id,
         "issue1_id": issue1.id,
         "issue2_id": issue2.id,
+        "dependency_id": dependency.id,
+        "reading_order_id": reading_order.id,
         "session_id": session_model.id,
+        "event_id": event.id,
         "snapshot_id": snapshot.id,
     }
 
@@ -451,7 +514,210 @@ async def test_import_remaps_relationships_and_writes_backup(
         assert result.fetchall()
         assert collection_id is not None
         assert thread_id != export_data["thread_id"]
-        assert collection_id != export_data["collection_id"]
+    assert collection_id != export_data["collection_id"]
+
+
+@pytest.mark.asyncio
+async def test_clone_round_trip_preserves_counts_and_relationships(
+    test_db_url, db_engine, export_user, export_data, tmp_path,
+):
+    """Exporting and importing preserves the complete user data graph."""
+    from scripts.clone_prod_to_local import _export_via_db, _import_document
+
+    export = await _export_via_db(test_db_url, "clone_export_test_user")
+    export["user"]["username"] = "clone_round_trip_target"
+    export["user"]["email"] = "clone_round_trip_target@example.com"
+    counts = await _import_document(test_db_url, export, tmp_path / "backup.json", dry_run=False)
+
+    assert counts == {
+        "collections": 1,
+        "threads": 1,
+        "issues": 2,
+        "dependencies": 1,
+        "reading_orders": 1,
+        "reading_order_items": 1,
+        "sessions": 1,
+        "events": 1,
+        "snapshots": 1,
+        "reviews": 1,
+    }
+
+    async_session = async_sessionmaker(
+        db_engine, class_=AsyncSession, expire_on_commit=False,
+    )
+    async with async_session() as session:
+        imported_user_id = (
+            await session.execute(
+                text("SELECT id FROM users WHERE username = 'clone_round_trip_target'")
+            )
+        ).scalar_one()
+        thread = (
+            await session.execute(
+                text("SELECT id, user_id, collection_id, next_unread_issue_id "
+                     "FROM threads WHERE title = 'Export Test Thread' AND user_id = :user_id"),
+                {"user_id": imported_user_id},
+            )
+        ).one()
+        thread_id, user_id, collection_id, next_issue_id = thread
+        issue_rows = (
+            await session.execute(
+                text("SELECT id, issue_number, thread_id FROM issues "
+                     "WHERE thread_id = :thread_id ORDER BY position"),
+                {"thread_id": thread_id},
+            )
+        ).all()
+        issue_ids = {row.id for row in issue_rows}
+        dependency = (
+            await session.execute(
+                text("SELECT source_issue_id, target_issue_id, note FROM dependencies "
+                     "WHERE source_issue_id IN (SELECT id FROM issues WHERE thread_id = :thread_id) "
+                     "AND target_issue_id IN (SELECT id FROM issues WHERE thread_id = :thread_id)"),
+                {"thread_id": thread_id},
+            )
+        ).one()
+        order_item = (
+            await session.execute(
+                text("SELECT reading_order_id, thread_id, issue_number FROM reading_order_items "
+                     "WHERE thread_id = :thread_id"),
+                {"thread_id": thread_id},
+            )
+        ).one()
+        imported_session = (
+            await session.execute(
+                text("SELECT id, user_id, pending_thread_id, pending_issue_id, snoozed_thread_ids "
+                     "FROM sessions WHERE user_id = :user_id"),
+                {"user_id": user_id},
+            )
+        ).one()
+        imported_event = (
+            await session.execute(
+                text("SELECT id, session_id, thread_id, issue_id, selected_thread_id FROM events "
+                     "WHERE session_id = :session_id"),
+                {"session_id": imported_session.id},
+            )
+        ).one()
+        snapshot = (
+            await session.execute(
+                text("SELECT session_id, event_id, description FROM snapshots "
+                     "WHERE session_id = :session_id"),
+                {"session_id": imported_session.id},
+            )
+        ).one()
+        review = (
+            await session.execute(
+                text("SELECT user_id, thread_id, issue_id, review_text FROM reviews "
+                     "WHERE user_id = :user_id"),
+                {"user_id": user_id},
+            )
+        ).one()
+
+    assert user_id != export_data["user_id"]
+    assert collection_id != export_data["collection_id"]
+    assert next_issue_id in issue_ids
+    assert {row.thread_id for row in issue_rows} == {thread_id}
+    assert dependency.source_issue_id in issue_ids
+    assert dependency.target_issue_id in issue_ids
+    assert dependency.note == "read the first issue first"
+    assert order_item.thread_id == thread_id
+    assert imported_session.user_id == user_id
+    assert imported_session.pending_thread_id == thread_id
+    assert imported_session.pending_issue_id in issue_ids
+    assert imported_session.snoozed_thread_ids == [thread_id]
+    assert imported_event.session_id == imported_session.id
+    assert imported_event.thread_id == thread_id
+    assert imported_event.issue_id in issue_ids
+    assert imported_event.selected_thread_id == thread_id
+    assert snapshot.event_id == imported_event.id
+    assert snapshot.description == "Before rating"
+    assert review.user_id == user_id
+    assert review.thread_id == thread_id
+    assert review.issue_id in issue_ids
+    assert review.review_text == "Strong opening issue."
+
+
+@pytest.mark.asyncio
+async def test_import_preserves_ownership_isolation(
+    test_db_url, db_engine, export_user, export_data, tmp_path,
+):
+    """Imported rows belong only to the destination user and not the source user."""
+    from scripts.clone_prod_to_local import _export_via_db, _import_document
+
+    export = await _export_via_db(test_db_url, "clone_export_test_user")
+    export["user"]["username"] = "clone_import_target"
+    export["user"]["email"] = "clone_import_target@example.com"
+    await _import_document(test_db_url, export, tmp_path / "backup.json", dry_run=False)
+
+    async_session = async_sessionmaker(
+        db_engine, class_=AsyncSession, expire_on_commit=False,
+    )
+    async with async_session() as session:
+        users = (
+            await session.execute(
+                text("SELECT id, username FROM users WHERE username IN "
+                     "('clone_export_test_user', 'clone_import_target')")
+            )
+        ).all()
+        target_id = next(row.id for row in users if row.username == "clone_import_target")
+        source_id = next(row.id for row in users if row.username == "clone_export_test_user")
+        target_thread_users = (
+            await session.execute(
+                text("SELECT DISTINCT user_id FROM threads WHERE title = 'Export Test Thread'")
+            )
+        ).scalars().all()
+        target_collection_users = (
+            await session.execute(
+                text("SELECT DISTINCT user_id FROM collections WHERE name = 'Test Collection'")
+            )
+        ).scalars().all()
+        source_thread_count = (
+            await session.execute(
+                text("SELECT count(*) FROM threads WHERE user_id = :user_id"),
+                {"user_id": source_id},
+            )
+        ).scalar_one()
+
+    assert target_id != source_id
+    assert source_id in target_thread_users
+    assert target_id in target_thread_users
+    assert source_id in target_collection_users
+    assert target_id in target_collection_users
+    assert source_thread_count == 1
+
+
+@pytest.mark.asyncio
+async def test_import_dry_run_does_not_write(
+    test_db_url, db_engine, export_user, export_data,
+):
+    """Dry-run validates an export and leaves the destination database unchanged."""
+    from scripts.clone_prod_to_local import _export_via_db, _import_document
+
+    export = await _export_via_db(test_db_url, "clone_export_test_user")
+    export["threads"][0]["title"] = "Dry Run Must Not Persist"
+    counts = await _import_document(test_db_url, export, None, dry_run=True)
+
+    assert counts["threads"] == 1
+    async_session = async_sessionmaker(
+        db_engine, class_=AsyncSession, expire_on_commit=False,
+    )
+    async with async_session() as session:
+        title = (
+            await session.execute(
+                text("SELECT title FROM threads WHERE id = :thread_id"),
+                {"thread_id": export_data["thread_id"]},
+            )
+        ).scalar_one()
+    assert title == "Export Test Thread"
+
+
+@pytest.mark.asyncio
+async def test_export_excludes_auth_secrets(test_db_url, export_user, export_data):
+    """Export documents contain neither password hashes nor revoked token data."""
+    from scripts.clone_prod_to_local import _export_via_db
+
+    export = await _export_via_db(test_db_url, "clone_export_test_user")
+
+    assert "password_hash" not in export["user"]
+    assert "revoked_tokens" not in export
 
 
 def test_export_file_permissions():


### PR DESCRIPTION
## Summary
- add full export/import round-trip coverage across the user data graph
- verify ownership isolation, auth-secret exclusion, dry-run non-mutation, and backup behavior
- harden clone export typing and synchronize PostgreSQL sequences around explicit-ID imports
- document a reproducible production-to-local workflow

## Verification
- `VIRTUAL_ENV=/mnt/extra/josh/code/comic-pile/.venv make lint`
- `.venv/bin/python -m pytest` — 709 passed, 96.97% coverage
- `.venv/bin/python -m pytest tests/test_clone_export.py -q --no-cov` — 16 passed
- project `.venv` `ty` and Ruff checks passed

Closes #652

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a guide for safely cloning production data to a local environment.
  * Covers prerequisites, export, validation, import, backups, confirmation options, sign-in guidance, and safety checks.
  * Clarifies that production data is never modified.

* **Improvements**
  * Improved export/import validation and handling of related data.
  * Added automatic database sequence synchronization after imports.
  * Ensured authentication secrets are excluded from exported data.

* **Tests**
  * Expanded coverage for round-trip imports, relationship preservation, ownership isolation, and dry-run behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->