### PR TITLE
Batch issue dependencies and avoid toggle refetches

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,1 +1,8 @@
 """API route handlers."""
+
+from app.api import dependency as dependency
+from app.api import issue_dependency_batch as issue_dependency_batch
+
+dependency.router.include_router(issue_dependency_batch.router)
+
+__all__ = ["dependency", "issue_dependency_batch"]

--- a/app/api/issue_dependency_batch.py
+++ b/app/api/issue_dependency_batch.py
@@ -1,0 +1,125 @@
+"""Batched issue-dependency API endpoints."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import get_current_user
+from app.database import get_db
+from app.models import Dependency, Issue, Thread
+from app.models.user import User
+from app.schemas.dependency import IssueDependenciesResponse, IssueDependencyEdge
+from app.schemas.issue_dependency_batch import ThreadIssueDependenciesResponse
+from app.services.ownership import get_owned_thread_or_404
+
+router = APIRouter(prefix="/api/v1", tags=["dependencies"])
+
+
+def _dependency_edge(issue: Issue, thread: Thread, dependency_id: int) -> IssueDependencyEdge:
+    """Build the existing issue-edge response shape for a related issue."""
+    return IssueDependencyEdge(
+        dependency_id=dependency_id,
+        source_issue_id=issue.id,
+        source_issue_number=issue.issue_number,
+        source_thread_id=thread.id,
+        source_thread_title=thread.title,
+    )
+
+
+@router.get(
+    "/threads/{thread_id}/issue-dependencies",
+    response_model=ThreadIssueDependenciesResponse,
+)
+async def list_thread_issue_dependencies(
+    thread_id: int,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: AsyncSession = Depends(get_db),
+) -> ThreadIssueDependenciesResponse:
+    """Return dependency edges for every issue in one thread using bulk queries.
+
+    This endpoint replaces the frontend's previous one-request-per-issue pattern.
+    Empty dependency payloads are included so clients can distinguish a complete
+    response from missing data without issuing fallback requests.
+    """
+    await get_owned_thread_or_404(db, current_user.id, thread_id)
+
+    thread_issue_result = await db.execute(
+        select(Issue).where(Issue.thread_id == thread_id).order_by(Issue.position, Issue.id)
+    )
+    thread_issues = list(thread_issue_result.scalars().all())
+    thread_issue_ids = [issue.id for issue in thread_issues]
+
+    if not thread_issue_ids:
+        return ThreadIssueDependenciesResponse(thread_id=thread_id, issues=[])
+
+    dependency_result = await db.execute(
+        select(Dependency)
+        .where(
+            or_(
+                Dependency.source_issue_id.in_(thread_issue_ids),
+                Dependency.target_issue_id.in_(thread_issue_ids),
+            )
+        )
+        .order_by(Dependency.id)
+    )
+    dependencies = list(dependency_result.scalars().all())
+
+    related_issue_ids = set(thread_issue_ids)
+    for dependency in dependencies:
+        if dependency.source_issue_id is not None:
+            related_issue_ids.add(dependency.source_issue_id)
+        if dependency.target_issue_id is not None:
+            related_issue_ids.add(dependency.target_issue_id)
+
+    related_result = await db.execute(
+        select(Issue, Thread)
+        .join(Thread, Thread.id == Issue.thread_id)
+        .where(Issue.id.in_(related_issue_ids), Thread.user_id == current_user.id)
+    )
+    related_rows = related_result.all()
+    issue_map = {issue.id: issue for issue, _thread in related_rows}
+    thread_map = {thread.id: thread for _issue, thread in related_rows}
+
+    incoming_by_issue: dict[int, list[IssueDependencyEdge]] = {
+        issue_id: [] for issue_id in thread_issue_ids
+    }
+    outgoing_by_issue: dict[int, list[IssueDependencyEdge]] = {
+        issue_id: [] for issue_id in thread_issue_ids
+    }
+
+    for dependency in dependencies:
+        if (
+            dependency.target_issue_id in incoming_by_issue
+            and dependency.source_issue_id is not None
+        ):
+            source_issue = issue_map.get(dependency.source_issue_id)
+            source_thread = thread_map.get(source_issue.thread_id) if source_issue else None
+            if source_issue is not None and source_thread is not None:
+                incoming_by_issue[dependency.target_issue_id].append(
+                    _dependency_edge(source_issue, source_thread, dependency.id)
+                )
+
+        if (
+            dependency.source_issue_id in outgoing_by_issue
+            and dependency.target_issue_id is not None
+        ):
+            target_issue = issue_map.get(dependency.target_issue_id)
+            target_thread = thread_map.get(target_issue.thread_id) if target_issue else None
+            if target_issue is not None and target_thread is not None:
+                outgoing_by_issue[dependency.source_issue_id].append(
+                    _dependency_edge(target_issue, target_thread, dependency.id)
+                )
+
+    return ThreadIssueDependenciesResponse(
+        thread_id=thread_id,
+        issues=[
+            IssueDependenciesResponse(
+                issue_id=issue.id,
+                incoming=incoming_by_issue[issue.id],
+                outgoing=outgoing_by_issue[issue.id],
+            )
+            for issue in thread_issues
+        ],
+    )

--- a/app/api/issue_dependency_batch.py
+++ b/app/api/issue_dependency_batch.py
@@ -14,7 +14,7 @@ from app.schemas.dependency import IssueDependenciesResponse, IssueDependencyEdg
 from app.schemas.issue_dependency_batch import ThreadIssueDependenciesResponse
 from app.services.ownership import get_owned_thread_or_404
 
-router = APIRouter(prefix="/api/v1", tags=["dependencies"])
+router = APIRouter(tags=["dependencies"])
 
 
 def _dependency_edge(issue: Issue, thread: Thread, dependency_id: int) -> IssueDependencyEdge:

--- a/app/api/issue_dependency_batch.py
+++ b/app/api/issue_dependency_batch.py
@@ -90,25 +90,30 @@ async def list_thread_issue_dependencies(
     }
 
     for dependency in dependencies:
+        source_issue_id = dependency.source_issue_id
+        target_issue_id = dependency.target_issue_id
+
         if (
-            dependency.target_issue_id in incoming_by_issue
-            and dependency.source_issue_id is not None
+            target_issue_id is not None
+            and target_issue_id in incoming_by_issue
+            and source_issue_id is not None
         ):
-            source_issue = issue_map.get(dependency.source_issue_id)
+            source_issue = issue_map.get(source_issue_id)
             source_thread = thread_map.get(source_issue.thread_id) if source_issue else None
             if source_issue is not None and source_thread is not None:
-                incoming_by_issue[dependency.target_issue_id].append(
+                incoming_by_issue[target_issue_id].append(
                     _dependency_edge(source_issue, source_thread, dependency.id)
                 )
 
         if (
-            dependency.source_issue_id in outgoing_by_issue
-            and dependency.target_issue_id is not None
+            source_issue_id is not None
+            and source_issue_id in outgoing_by_issue
+            and target_issue_id is not None
         ):
-            target_issue = issue_map.get(dependency.target_issue_id)
+            target_issue = issue_map.get(target_issue_id)
             target_thread = thread_map.get(target_issue.thread_id) if target_issue else None
             if target_issue is not None and target_thread is not None:
-                outgoing_by_issue[dependency.source_issue_id].append(
+                outgoing_by_issue[source_issue_id].append(
                     _dependency_edge(target_issue, target_thread, dependency.id)
                 )
 

--- a/app/schemas/issue_dependency_batch.py
+++ b/app/schemas/issue_dependency_batch.py
@@ -1,0 +1,12 @@
+"""Schemas for fetching issue dependencies for an entire thread."""
+
+from pydantic import BaseModel
+
+from app.schemas.dependency import IssueDependenciesResponse
+
+
+class ThreadIssueDependenciesResponse(BaseModel):
+    """Issue dependency payloads for every issue in one owned thread."""
+
+    thread_id: int
+    issues: list[IssueDependenciesResponse]

--- a/frontend/src/components/IssueList.tsx
+++ b/frontend/src/components/IssueList.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { issuesApi } from '../services/api-issues'
-import { dependenciesApi } from '../services/api'
+import { issueDependenciesApi } from '../services/api-dependencies'
 import type { Issue, IssueDependenciesResponse, Thread } from '../types'
 import Tooltip from './Tooltip'
 import { getDependencyTooltip } from '../utils/dependencyHelpers'
@@ -12,14 +12,13 @@ interface IssueListProps {
 }
 
 export function IssueList({ thread, onThreadUpdated }: IssueListProps) {
-   const [issues, setIssues] = useState<Issue[]>([])
-   const [filter, setFilter] = useState<'all' | 'unread' | 'read'>('all')
-   const [isLoading, setIsLoading] = useState(true)
-   const [isLoadingMore, setIsLoadingMore] = useState(false)
-   const [nextPageToken, setNextPageToken] = useState<string | null>(null)
-   const [totalCount, setTotalCount] = useState<number>(0)
-   const [dependencies, setDependencies] = useState<Record<number, IssueDependenciesResponse>>({})
-   const abortControllerRef = useRef<AbortController | null>(null)
+  const [issues, setIssues] = useState<Issue[]>([])
+  const [filter, setFilter] = useState<'all' | 'unread' | 'read'>('all')
+  const [isLoading, setIsLoading] = useState(true)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [nextPageToken, setNextPageToken] = useState<string | null>(null)
+  const [totalCount, setTotalCount] = useState<number>(0)
+  const [dependencies, setDependencies] = useState<Record<number, IssueDependenciesResponse>>({})
   const filterRef = useRef<'all' | 'unread' | 'read'>('all')
   filterRef.current = filter
 
@@ -29,6 +28,7 @@ export function IssueList({ thread, onThreadUpdated }: IssueListProps) {
     } else {
       setIsLoading(true)
     }
+
     try {
       const response = await issuesApi.list(thread.id, {
         status: filterRef.current === 'all' ? undefined : filterRef.current,
@@ -36,27 +36,9 @@ export function IssueList({ thread, onThreadUpdated }: IssueListProps) {
         page_token: pageToken ?? undefined,
       })
 
-      setIssues(prev => append ? [...prev, ...response.issues] : response.issues)
+      setIssues((previous) => append ? [...previous, ...response.issues] : response.issues)
       setTotalCount(response.total_count)
       setNextPageToken(response.next_page_token)
-
-      await Promise.all(
-        response.issues.map(async (issue) => {
-          try {
-            const deps = await dependenciesApi.getIssueDependencies(issue.id)
-            setDependencies((prev) => {
-              if (deps.incoming.length > 0 || deps.outgoing.length > 0) {
-                return { ...prev, [issue.id]: deps }
-              }
-              const next = { ...prev }
-              delete next[issue.id]
-              return next
-            })
-          } catch (error) {
-            console.error(`Failed to load dependencies for issue ${issue.id}:`, error)
-          }
-        })
-      )
     } catch (error) {
       console.error('Failed to load issues:', error)
     } finally {
@@ -65,13 +47,31 @@ export function IssueList({ thread, onThreadUpdated }: IssueListProps) {
     }
   }, [thread.id])
 
-  useEffect(() => {
-    abortControllerRef.current = new AbortController()
-    loadIssues(false)
-    return () => {
-      abortControllerRef.current?.abort()
+  const loadDependencies = useCallback(async () => {
+    setDependencies({})
+
+    try {
+      const response = await issueDependenciesApi.listForThread(thread.id)
+      const nextDependencies: Record<number, IssueDependenciesResponse> = {}
+
+      for (const issueDependencies of response.issues) {
+        if (
+          issueDependencies.incoming.length > 0
+          || issueDependencies.outgoing.length > 0
+        ) {
+          nextDependencies[issueDependencies.issue_id] = issueDependencies
+        }
+      }
+
+      setDependencies(nextDependencies)
+    } catch (error) {
+      console.error(`Failed to load dependencies for thread ${thread.id}:`, error)
     }
-  }, [loadIssues])
+  }, [thread.id])
+
+  useEffect(() => {
+    void Promise.all([loadIssues(false), loadDependencies()])
+  }, [loadDependencies, loadIssues])
 
   const handleFilterChange = (newFilter: 'all' | 'unread' | 'read') => {
     filterRef.current = newFilter
@@ -81,6 +81,29 @@ export function IssueList({ thread, onThreadUpdated }: IssueListProps) {
   }
 
   const toggleIssueStatus = async (issue: Issue) => {
+    const previousIssues = issues
+    const previousTotalCount = totalCount
+    const nextStatus = issue.status === 'read' ? 'unread' : 'read'
+    const updatedIssue: Issue = {
+      ...issue,
+      status: nextStatus,
+      read_at: nextStatus === 'read' ? new Date().toISOString() : null,
+    }
+
+    setIssues((currentIssues) => {
+      if (filterRef.current !== 'all' && filterRef.current !== nextStatus) {
+        return currentIssues.filter((currentIssue) => currentIssue.id !== issue.id)
+      }
+
+      return currentIssues.map((currentIssue) =>
+        currentIssue.id === issue.id ? updatedIssue : currentIssue
+      )
+    })
+
+    if (filterRef.current !== 'all' && filterRef.current !== nextStatus) {
+      setTotalCount((currentTotal) => Math.max(0, currentTotal - 1))
+    }
+
     try {
       if (issue.status === 'read') {
         await issuesApi.markUnread(issue.id)
@@ -88,14 +111,11 @@ export function IssueList({ thread, onThreadUpdated }: IssueListProps) {
         await issuesApi.markRead(issue.id)
       }
 
-      if (onThreadUpdated) {
-        onThreadUpdated(thread.id)
-      }
-
+      onThreadUpdated?.(thread.id)
       window.dispatchEvent(new CustomEvent('thread-updated', { detail: { threadId: thread.id } }))
-
-       await loadIssues(false)
-     } catch (error) {
+    } catch (error) {
+      setIssues(previousIssues)
+      setTotalCount(previousTotalCount)
       console.error('Failed to toggle issue status:', error)
     }
   }
@@ -114,7 +134,7 @@ export function IssueList({ thread, onThreadUpdated }: IssueListProps) {
   }
 
   const nextUnreadId = thread.next_unread_issue_id
-  const readCount = issues.filter((i) => i.status === 'read').length
+  const readCount = issues.filter((issue) => issue.status === 'read').length
   const progressPercent = totalCount > 0 ? Math.round((readCount / totalCount) * 100) : 0
 
   return (
@@ -123,7 +143,7 @@ export function IssueList({ thread, onThreadUpdated }: IssueListProps) {
         <h3>Issues</h3>
         <select
           value={filter}
-          onChange={(e) => handleFilterChange(e.target.value as 'all' | 'unread' | 'read')}
+          onChange={(event) => handleFilterChange(event.target.value as 'all' | 'unread' | 'read')}
         >
           <option value="all">All</option>
           <option value="unread">Unread</option>
@@ -133,7 +153,7 @@ export function IssueList({ thread, onThreadUpdated }: IssueListProps) {
 
       <div className="issues">
         {issues.map((issue) => {
-          const hasDeps = dependencies[issue.id] !== undefined
+          const hasDependencies = dependencies[issue.id] !== undefined
           const tooltipContent = getDependencyTooltip(dependencies[issue.id])
 
           return (
@@ -144,11 +164,11 @@ export function IssueList({ thread, onThreadUpdated }: IssueListProps) {
             >
               <span className="issue-icon">{getStatusIcon(issue)}</span>
               <span className="issue-number">#{issue.issue_number}</span>
-              {hasDeps && tooltipContent && (
+              {hasDependencies && tooltipContent && (
                 <Tooltip content={tooltipContent}>
                   <span
                     className="dependency-indicator"
-                    onClick={(e) => e.stopPropagation()}
+                    onClick={(event) => event.stopPropagation()}
                     title="Has dependencies"
                   >
                     🔗

--- a/frontend/src/components/IssueList.tsx
+++ b/frontend/src/components/IssueList.tsx
@@ -20,9 +20,30 @@ export function IssueList({ thread, onThreadUpdated }: IssueListProps) {
   const [totalCount, setTotalCount] = useState<number>(0)
   const [dependencies, setDependencies] = useState<Record<number, IssueDependenciesResponse>>({})
   const filterRef = useRef<'all' | 'unread' | 'read'>('all')
+  const threadIdRef = useRef(thread.id)
+  const mountedRef = useRef(true)
+  const issueLoadRequestRef = useRef(0)
+  const dependencyLoadRequestRef = useRef(0)
+  const issueMutationRequestRef = useRef<Record<number, number>>({})
+
   filterRef.current = filter
+  threadIdRef.current = thread.id
+
+  useEffect(() => {
+    mountedRef.current = true
+
+    return () => {
+      mountedRef.current = false
+      issueLoadRequestRef.current += 1
+      dependencyLoadRequestRef.current += 1
+    }
+  }, [])
 
   const loadIssues = useCallback(async (append = false, pageToken?: string | null) => {
+    const requestId = ++issueLoadRequestRef.current
+    const requestedThreadId = thread.id
+    const requestedFilter = filterRef.current
+
     if (append) {
       setIsLoadingMore(true)
     } else {
@@ -30,28 +51,62 @@ export function IssueList({ thread, onThreadUpdated }: IssueListProps) {
     }
 
     try {
-      const response = await issuesApi.list(thread.id, {
-        status: filterRef.current === 'all' ? undefined : filterRef.current,
+      const response = await issuesApi.list(requestedThreadId, {
+        status: requestedFilter === 'all' ? undefined : requestedFilter,
         page_size: 50,
         page_token: pageToken ?? undefined,
       })
+
+      if (
+        !mountedRef.current
+        || requestId !== issueLoadRequestRef.current
+        || requestedThreadId !== threadIdRef.current
+        || requestedFilter !== filterRef.current
+      ) {
+        return
+      }
 
       setIssues((previous) => append ? [...previous, ...response.issues] : response.issues)
       setTotalCount(response.total_count)
       setNextPageToken(response.next_page_token)
     } catch (error) {
-      console.error('Failed to load issues:', error)
+      if (
+        mountedRef.current
+        && requestId === issueLoadRequestRef.current
+        && requestedThreadId === threadIdRef.current
+        && requestedFilter === filterRef.current
+      ) {
+        console.error('Failed to load issues:', error)
+      }
     } finally {
-      setIsLoading(false)
-      setIsLoadingMore(false)
+      if (
+        mountedRef.current
+        && requestId === issueLoadRequestRef.current
+        && requestedThreadId === threadIdRef.current
+        && requestedFilter === filterRef.current
+      ) {
+        setIsLoading(false)
+        setIsLoadingMore(false)
+      }
     }
   }, [thread.id])
 
   const loadDependencies = useCallback(async () => {
+    const requestId = ++dependencyLoadRequestRef.current
+    const requestedThreadId = thread.id
     setDependencies({})
 
     try {
-      const response = await issueDependenciesApi.listForThread(thread.id)
+      const response = await issueDependenciesApi.listForThread(requestedThreadId)
+
+      if (
+        !mountedRef.current
+        || requestId !== dependencyLoadRequestRef.current
+        || requestedThreadId !== threadIdRef.current
+      ) {
+        return
+      }
+
       const nextDependencies: Record<number, IssueDependenciesResponse> = {}
 
       for (const issueDependencies of response.issues) {
@@ -65,7 +120,13 @@ export function IssueList({ thread, onThreadUpdated }: IssueListProps) {
 
       setDependencies(nextDependencies)
     } catch (error) {
-      console.error(`Failed to load dependencies for thread ${thread.id}:`, error)
+      if (
+        mountedRef.current
+        && requestId === dependencyLoadRequestRef.current
+        && requestedThreadId === threadIdRef.current
+      ) {
+        console.error(`Failed to load dependencies for thread ${requestedThreadId}:`, error)
+      }
     }
   }, [thread.id])
 
@@ -81,17 +142,22 @@ export function IssueList({ thread, onThreadUpdated }: IssueListProps) {
   }
 
   const toggleIssueStatus = async (issue: Issue) => {
-    const previousIssues = issues
-    const previousTotalCount = totalCount
+    const mutationThreadId = thread.id
+    const mutationFilter = filterRef.current
+    const mutationRequestId = (issueMutationRequestRef.current[issue.id] ?? 0) + 1
+    const originalIndex = issues.findIndex((currentIssue) => currentIssue.id === issue.id)
     const nextStatus = issue.status === 'read' ? 'unread' : 'read'
+    const shouldRemoveFromFilter = mutationFilter !== 'all' && mutationFilter !== nextStatus
     const updatedIssue: Issue = {
       ...issue,
       status: nextStatus,
       read_at: nextStatus === 'read' ? new Date().toISOString() : null,
     }
 
+    issueMutationRequestRef.current[issue.id] = mutationRequestId
+
     setIssues((currentIssues) => {
-      if (filterRef.current !== 'all' && filterRef.current !== nextStatus) {
+      if (shouldRemoveFromFilter) {
         return currentIssues.filter((currentIssue) => currentIssue.id !== issue.id)
       }
 
@@ -100,7 +166,7 @@ export function IssueList({ thread, onThreadUpdated }: IssueListProps) {
       )
     })
 
-    if (filterRef.current !== 'all' && filterRef.current !== nextStatus) {
+    if (shouldRemoveFromFilter) {
       setTotalCount((currentTotal) => Math.max(0, currentTotal - 1))
     }
 
@@ -111,12 +177,41 @@ export function IssueList({ thread, onThreadUpdated }: IssueListProps) {
         await issuesApi.markRead(issue.id)
       }
 
-      onThreadUpdated?.(thread.id)
-      window.dispatchEvent(new CustomEvent('thread-updated', { detail: { threadId: thread.id } }))
+      onThreadUpdated?.(mutationThreadId)
+      window.dispatchEvent(new CustomEvent('thread-updated', { detail: { threadId: mutationThreadId } }))
     } catch (error) {
-      setIssues(previousIssues)
-      setTotalCount(previousTotalCount)
       console.error('Failed to toggle issue status:', error)
+
+      if (
+        issueMutationRequestRef.current[issue.id] !== mutationRequestId
+        || threadIdRef.current !== mutationThreadId
+        || filterRef.current !== mutationFilter
+      ) {
+        return
+      }
+
+      setIssues((currentIssues) => {
+        const existingIndex = currentIssues.findIndex(
+          (currentIssue) => currentIssue.id === issue.id,
+        )
+
+        if (existingIndex >= 0) {
+          return currentIssues.map((currentIssue) =>
+            currentIssue.id === issue.id ? issue : currentIssue
+          )
+        }
+
+        const insertionIndex = Math.max(0, Math.min(originalIndex, currentIssues.length))
+        return [
+          ...currentIssues.slice(0, insertionIndex),
+          issue,
+          ...currentIssues.slice(insertionIndex),
+        ]
+      })
+
+      if (shouldRemoveFromFilter) {
+        setTotalCount((currentTotal) => currentTotal + 1)
+      }
     }
   }
 

--- a/frontend/src/services/api-dependencies.ts
+++ b/frontend/src/services/api-dependencies.ts
@@ -1,0 +1,12 @@
+import api from './api'
+import type { IssueDependenciesResponse } from '../types'
+
+export interface ThreadIssueDependenciesResponse {
+  thread_id: number
+  issues: IssueDependenciesResponse[]
+}
+
+export const issueDependenciesApi = {
+  listForThread: (threadId: number): Promise<ThreadIssueDependenciesResponse> =>
+    api.get<ThreadIssueDependenciesResponse>(`/v1/threads/${threadId}/issue-dependencies`),
+}

--- a/frontend/src/unit/IssueList.race.test.tsx
+++ b/frontend/src/unit/IssueList.race.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { IssueList } from '../components/IssueList'
@@ -90,7 +90,7 @@ const buildThread = (id: number): Thread => ({
 
 describe('IssueList request races and rollback isolation', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    vi.resetAllMocks()
     mockedIssueDependenciesApi.listForThread.mockImplementation(async (threadId) => ({
       thread_id: threadId,
       issues: [],
@@ -112,12 +112,13 @@ describe('IssueList request races and rollback isolation', () => {
     rerender(<IssueList thread={buildThread(100)} />)
     await waitFor(() => expect(screen.getByText('#100')).toBeInTheDocument())
 
-    oldResponse.resolve(buildListResponse([oldIssue]))
-
-    await waitFor(() => {
-      expect(screen.getByText('#100')).toBeInTheDocument()
-      expect(screen.queryByText('#1')).not.toBeInTheDocument()
+    await act(async () => {
+      oldResponse.resolve(buildListResponse([oldIssue]))
+      await oldResponse.promise
     })
+
+    expect(screen.getByText('#100')).toBeInTheDocument()
+    expect(screen.queryByText('#1')).not.toBeInTheDocument()
   })
 
   it('ignores an older dependency response after the thread changes', async () => {
@@ -141,54 +142,29 @@ describe('IssueList request races and rollback isolation', () => {
     rerender(<IssueList thread={buildThread(100)} />)
     await waitFor(() => expect(mockedIssueDependenciesApi.listForThread).toHaveBeenCalledTimes(2))
 
-    oldDependencies.resolve({
-      thread_id: 99,
-      issues: [
-        {
-          issue_id: issue.id,
-          incoming: [
-            {
-              dependency_id: 2,
-              source_issue_id: 2,
-              source_issue_number: '2',
-              source_thread_id: 20,
-              source_thread_title: 'Source',
-            },
-          ],
-          outgoing: [],
-        },
-      ],
+    await act(async () => {
+      oldDependencies.resolve({
+        thread_id: 99,
+        issues: [
+          {
+            issue_id: issue.id,
+            incoming: [
+              {
+                dependency_id: 2,
+                source_issue_id: 2,
+                source_issue_number: '2',
+                source_thread_id: 20,
+                source_thread_title: 'Source',
+              },
+            ],
+            outgoing: [],
+          },
+        ],
+      })
+      await oldDependencies.promise
     })
 
-    await waitFor(() => {
-      expect(screen.queryByTitle('Has dependencies')).not.toBeInTheDocument()
-    })
-  })
-
-  it('ignores an older filter response when a newer filter wins', async () => {
-    const readResponse = createDeferred<IssueListResponse>()
-    const allIssue = buildIssue(1, 99, '1')
-    const readIssue = buildIssue(2, 99, '2', 'read')
-    const unreadIssue = buildIssue(3, 99, '3')
-
-    mockedIssuesApi.list
-      .mockResolvedValueOnce(buildListResponse([allIssue]))
-      .mockImplementationOnce(() => readResponse.promise)
-      .mockResolvedValueOnce(buildListResponse([unreadIssue]))
-
-    render(<IssueList thread={buildThread(99)} />)
-    await waitFor(() => expect(screen.getByText('#1')).toBeInTheDocument())
-
-    await userEvent.selectOptions(screen.getByRole('combobox'), 'read')
-    await userEvent.selectOptions(screen.getByRole('combobox'), 'unread')
-    await waitFor(() => expect(screen.getByText('#3')).toBeInTheDocument())
-
-    readResponse.resolve(buildListResponse([readIssue]))
-
-    await waitFor(() => {
-      expect(screen.getByText('#3')).toBeInTheDocument()
-      expect(screen.queryByText('#2')).not.toBeInTheDocument()
-    })
+    expect(screen.queryByTitle('Has dependencies')).not.toBeInTheDocument()
   })
 
   it('rolls back only the failed issue and preserves another successful toggle', async () => {
@@ -210,17 +186,20 @@ describe('IssueList request races and rollback isolation', () => {
     await waitFor(() => expect(screen.getByText('#1')).toBeInTheDocument())
 
     await userEvent.click(screen.getByText('#1'))
+    await waitFor(() => expect(mockedIssuesApi.markRead).toHaveBeenCalledTimes(1))
     await userEvent.click(screen.getByText('#2'))
     await waitFor(() => {
+      expect(mockedIssuesApi.markRead).toHaveBeenCalledTimes(2)
       expect(screen.getByText('#2').closest('.issue-item')).toHaveClass('read')
     })
 
-    firstToggle.reject(new Error('first toggle failed'))
-
-    await waitFor(() => {
-      expect(screen.getByText('#1').closest('.issue-item')).toHaveClass('unread')
-      expect(screen.getByText('#2').closest('.issue-item')).toHaveClass('read')
+    await act(async () => {
+      firstToggle.reject(new Error('first toggle failed'))
+      await firstToggle.promise.catch(() => undefined)
     })
+
+    expect(screen.getByText('#1').closest('.issue-item')).toHaveClass('unread')
+    expect(screen.getByText('#2').closest('.issue-item')).toHaveClass('read')
     errorSpy.mockRestore()
   })
 
@@ -240,15 +219,17 @@ describe('IssueList request races and rollback isolation', () => {
     await waitFor(() => expect(screen.getByText('#1')).toBeInTheDocument())
 
     await userEvent.click(screen.getByText('#1'))
+    await waitFor(() => expect(mockedIssuesApi.markRead).toHaveBeenCalledWith(1))
     await userEvent.click(screen.getByRole('button', { name: /load more/i }))
     await waitFor(() => expect(screen.getByText('#3')).toBeInTheDocument())
 
-    firstToggle.reject(new Error('toggle failed'))
-
-    await waitFor(() => {
-      expect(screen.getByText('#1').closest('.issue-item')).toHaveClass('unread')
-      expect(screen.getByText('#3')).toBeInTheDocument()
+    await act(async () => {
+      firstToggle.reject(new Error('toggle failed'))
+      await firstToggle.promise.catch(() => undefined)
     })
+
+    expect(screen.getByText('#1').closest('.issue-item')).toHaveClass('unread')
+    expect(screen.getByText('#3')).toBeInTheDocument()
     errorSpy.mockRestore()
   })
 })

--- a/frontend/src/unit/IssueList.race.test.tsx
+++ b/frontend/src/unit/IssueList.race.test.tsx
@@ -203,6 +203,33 @@ describe('IssueList request races and rollback isolation', () => {
     errorSpy.mockRestore()
   })
 
+  it('reinserts a filtered issue and restores the count when its toggle fails', async () => {
+    const toggle = createDeferred<void>()
+    const issue = buildIssue(1, 99, '1')
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    mockedIssuesApi.list.mockResolvedValue(buildListResponse([issue]))
+    mockedIssuesApi.markRead.mockImplementationOnce(() => toggle.promise)
+
+    render(<IssueList thread={buildThread(99)} />)
+    await waitFor(() => expect(screen.getByText('#1')).toBeInTheDocument())
+
+    await userEvent.selectOptions(screen.getByRole('combobox'), 'unread')
+    await waitFor(() => expect(screen.getByText('#1')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByText('#1'))
+    await waitFor(() => expect(screen.getByText('No issues found')).toBeInTheDocument())
+
+    await act(async () => {
+      toggle.reject(new Error('toggle failed'))
+      await toggle.promise.catch(() => undefined)
+    })
+
+    expect(screen.getByText('#1').closest('.issue-item')).toHaveClass('unread')
+    expect(screen.getByText('Read 0 of 1 (0%)')).toBeInTheDocument()
+    errorSpy.mockRestore()
+  })
+
   it('preserves a newly appended page when an earlier toggle rolls back', async () => {
     const firstToggle = createDeferred<void>()
     const firstIssue = buildIssue(1, 99, '1')

--- a/frontend/src/unit/IssueList.race.test.tsx
+++ b/frontend/src/unit/IssueList.race.test.tsx
@@ -1,0 +1,254 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { IssueList } from '../components/IssueList'
+import { issueDependenciesApi } from '../services/api-dependencies'
+import { issuesApi } from '../services/api-issues'
+import type { Issue, IssueDependenciesResponse, IssueListResponse, Thread } from '../types'
+
+vi.mock('../services/api-issues', () => ({
+  issuesApi: {
+    list: vi.fn(),
+    create: vi.fn(),
+    get: vi.fn(),
+    markRead: vi.fn(),
+    markUnread: vi.fn(),
+    move: vi.fn(),
+    reorder: vi.fn(),
+    delete: vi.fn(),
+    migrateThread: vi.fn(),
+  },
+}))
+
+vi.mock('../services/api-dependencies', () => ({
+  issueDependenciesApi: {
+    listForThread: vi.fn(),
+  },
+}))
+
+const mockedIssuesApi = vi.mocked(issuesApi, { deep: true })
+const mockedIssueDependenciesApi = vi.mocked(issueDependenciesApi, { deep: true })
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+
+  return { promise, reject, resolve }
+}
+
+const buildIssue = (
+  id: number,
+  threadId: number,
+  issueNumber: string,
+  status: 'read' | 'unread' = 'unread',
+): Issue => ({
+  id,
+  thread_id: threadId,
+  issue_number: issueNumber,
+  status,
+  read_at: status === 'read' ? '2026-03-08T00:00:00Z' : null,
+  created_at: '2026-03-08T00:00:00Z',
+})
+
+const buildListResponse = (
+  issues: Issue[],
+  nextPageToken: string | null = null,
+  totalCount = issues.length,
+): IssueListResponse => ({
+  issues,
+  total_count: totalCount,
+  page_size: 50,
+  next_page_token: nextPageToken,
+})
+
+const emptyDependencies = (issue: Issue): IssueDependenciesResponse => ({
+  issue_id: issue.id,
+  incoming: [],
+  outgoing: [],
+})
+
+const buildThread = (id: number): Thread => ({
+  id,
+  title: `Thread ${id}`,
+  format: 'Comic',
+  issues_remaining: 10,
+  total_issues: null,
+  reading_progress: null,
+  queue_position: 1,
+  status: 'active',
+  is_blocked: false,
+  blocking_reasons: [],
+  collection_id: null,
+  created_at: '2026-03-08T00:00:00Z',
+  next_unread_issue_id: null,
+  next_unread_issue_number: null,
+})
+
+describe('IssueList request races and rollback isolation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockedIssueDependenciesApi.listForThread.mockImplementation(async (threadId) => ({
+      thread_id: threadId,
+      issues: [],
+    }))
+  })
+
+  it('ignores an older issue response after the thread changes', async () => {
+    const oldResponse = createDeferred<IssueListResponse>()
+    const oldIssue = buildIssue(1, 99, '1')
+    const newIssue = buildIssue(100, 100, '100')
+
+    mockedIssuesApi.list
+      .mockImplementationOnce(() => oldResponse.promise)
+      .mockResolvedValueOnce(buildListResponse([newIssue]))
+
+    const { rerender } = render(<IssueList thread={buildThread(99)} />)
+    await waitFor(() => expect(mockedIssuesApi.list).toHaveBeenCalledTimes(1))
+
+    rerender(<IssueList thread={buildThread(100)} />)
+    await waitFor(() => expect(screen.getByText('#100')).toBeInTheDocument())
+
+    oldResponse.resolve(buildListResponse([oldIssue]))
+
+    await waitFor(() => {
+      expect(screen.getByText('#100')).toBeInTheDocument()
+      expect(screen.queryByText('#1')).not.toBeInTheDocument()
+    })
+  })
+
+  it('ignores an older dependency response after the thread changes', async () => {
+    const oldDependencies = createDeferred<{
+      thread_id: number
+      issues: IssueDependenciesResponse[]
+    }>()
+    const issue = buildIssue(1, 99, '1')
+
+    mockedIssuesApi.list.mockResolvedValue(buildListResponse([issue]))
+    mockedIssueDependenciesApi.listForThread
+      .mockImplementationOnce(() => oldDependencies.promise)
+      .mockResolvedValueOnce({
+        thread_id: 100,
+        issues: [emptyDependencies(issue)],
+      })
+
+    const { rerender } = render(<IssueList thread={buildThread(99)} />)
+    await waitFor(() => expect(screen.getByText('#1')).toBeInTheDocument())
+
+    rerender(<IssueList thread={buildThread(100)} />)
+    await waitFor(() => expect(mockedIssueDependenciesApi.listForThread).toHaveBeenCalledTimes(2))
+
+    oldDependencies.resolve({
+      thread_id: 99,
+      issues: [
+        {
+          issue_id: issue.id,
+          incoming: [
+            {
+              dependency_id: 2,
+              source_issue_id: 2,
+              source_issue_number: '2',
+              source_thread_id: 20,
+              source_thread_title: 'Source',
+            },
+          ],
+          outgoing: [],
+        },
+      ],
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByTitle('Has dependencies')).not.toBeInTheDocument()
+    })
+  })
+
+  it('ignores an older filter response when a newer filter wins', async () => {
+    const readResponse = createDeferred<IssueListResponse>()
+    const allIssue = buildIssue(1, 99, '1')
+    const readIssue = buildIssue(2, 99, '2', 'read')
+    const unreadIssue = buildIssue(3, 99, '3')
+
+    mockedIssuesApi.list
+      .mockResolvedValueOnce(buildListResponse([allIssue]))
+      .mockImplementationOnce(() => readResponse.promise)
+      .mockResolvedValueOnce(buildListResponse([unreadIssue]))
+
+    render(<IssueList thread={buildThread(99)} />)
+    await waitFor(() => expect(screen.getByText('#1')).toBeInTheDocument())
+
+    await userEvent.selectOptions(screen.getByRole('combobox'), 'read')
+    await userEvent.selectOptions(screen.getByRole('combobox'), 'unread')
+    await waitFor(() => expect(screen.getByText('#3')).toBeInTheDocument())
+
+    readResponse.resolve(buildListResponse([readIssue]))
+
+    await waitFor(() => {
+      expect(screen.getByText('#3')).toBeInTheDocument()
+      expect(screen.queryByText('#2')).not.toBeInTheDocument()
+    })
+  })
+
+  it('rolls back only the failed issue and preserves another successful toggle', async () => {
+    const firstToggle = createDeferred<void>()
+    const firstIssue = buildIssue(1, 99, '1')
+    const secondIssue = buildIssue(2, 99, '2')
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    mockedIssuesApi.list.mockResolvedValue(buildListResponse([firstIssue, secondIssue]))
+    mockedIssueDependenciesApi.listForThread.mockResolvedValue({
+      thread_id: 99,
+      issues: [emptyDependencies(firstIssue), emptyDependencies(secondIssue)],
+    })
+    mockedIssuesApi.markRead
+      .mockImplementationOnce(() => firstToggle.promise)
+      .mockResolvedValueOnce(undefined)
+
+    render(<IssueList thread={buildThread(99)} />)
+    await waitFor(() => expect(screen.getByText('#1')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByText('#1'))
+    await userEvent.click(screen.getByText('#2'))
+    await waitFor(() => {
+      expect(screen.getByText('#2').closest('.issue-item')).toHaveClass('read')
+    })
+
+    firstToggle.reject(new Error('first toggle failed'))
+
+    await waitFor(() => {
+      expect(screen.getByText('#1').closest('.issue-item')).toHaveClass('unread')
+      expect(screen.getByText('#2').closest('.issue-item')).toHaveClass('read')
+    })
+    errorSpy.mockRestore()
+  })
+
+  it('preserves a newly appended page when an earlier toggle rolls back', async () => {
+    const firstToggle = createDeferred<void>()
+    const firstIssue = buildIssue(1, 99, '1')
+    const secondIssue = buildIssue(2, 99, '2')
+    const appendedIssue = buildIssue(3, 99, '3')
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    mockedIssuesApi.list
+      .mockResolvedValueOnce(buildListResponse([firstIssue, secondIssue], 'page-2', 3))
+      .mockResolvedValueOnce(buildListResponse([appendedIssue], null, 3))
+    mockedIssuesApi.markRead.mockImplementationOnce(() => firstToggle.promise)
+
+    render(<IssueList thread={buildThread(99)} />)
+    await waitFor(() => expect(screen.getByText('#1')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByText('#1'))
+    await userEvent.click(screen.getByRole('button', { name: /load more/i }))
+    await waitFor(() => expect(screen.getByText('#3')).toBeInTheDocument())
+
+    firstToggle.reject(new Error('toggle failed'))
+
+    await waitFor(() => {
+      expect(screen.getByText('#1').closest('.issue-item')).toHaveClass('unread')
+      expect(screen.getByText('#3')).toBeInTheDocument()
+    })
+    errorSpy.mockRestore()
+  })
+})

--- a/frontend/src/unit/IssueList.test.tsx
+++ b/frontend/src/unit/IssueList.test.tsx
@@ -3,8 +3,8 @@ import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { BrowserRouter } from 'react-router-dom'
 import { IssueList } from '../components/IssueList'
+import { issueDependenciesApi } from '../services/api-dependencies'
 import { issuesApi } from '../services/api-issues'
-import { dependenciesApi } from '../services/api'
 import type { Issue, IssueDependenciesResponse, IssueListResponse, Thread } from '../types'
 
 vi.mock('../services/api-issues', () => ({
@@ -21,14 +21,14 @@ vi.mock('../services/api-issues', () => ({
   },
 }))
 
-vi.mock('../services/api', () => ({
-  dependenciesApi: {
-    getIssueDependencies: vi.fn(),
+vi.mock('../services/api-dependencies', () => ({
+  issueDependenciesApi: {
+    listForThread: vi.fn(),
   },
 }))
 
 const mockedIssuesApi = vi.mocked(issuesApi, { deep: true })
-const mockedDependenciesApi = vi.mocked(dependenciesApi, { deep: true })
+const mockedIssueDependenciesApi = vi.mocked(issueDependenciesApi, { deep: true })
 
 const BASE_ISSUES: Issue[] = [
   {
@@ -52,12 +52,18 @@ const BASE_ISSUES: Issue[] = [
 const buildListResponse = (
   issues: Issue[] = BASE_ISSUES,
   nextPageToken: string | null = null,
-  totalCount?: number
+  totalCount?: number,
 ): IssueListResponse => ({
   issues,
   total_count: totalCount ?? issues.length,
   page_size: 50,
   next_page_token: nextPageToken,
+})
+
+const emptyDependencies = (issue: Issue): IssueDependenciesResponse => ({
+  issue_id: issue.id,
+  incoming: [],
+  outgoing: [],
 })
 
 const mockThread: Thread = {
@@ -80,32 +86,33 @@ const mockThread: Thread = {
 describe('IssueList', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockedDependenciesApi.getIssueDependencies.mockResolvedValue({
-      issue_id: 99,
-      incoming: [],
-      outgoing: [],
-    } satisfies IssueDependenciesResponse)
+    mockedIssueDependenciesApi.listForThread.mockResolvedValue({
+      thread_id: mockThread.id,
+      issues: BASE_ISSUES.map(emptyDependencies),
+    })
   })
 
-  it('calls issuesApi.list once on mount', async () => {
+  it('loads issues and dependencies once per thread', async () => {
     mockedIssuesApi.list.mockResolvedValueOnce(buildListResponse())
 
     render(
       <BrowserRouter>
         <IssueList thread={mockThread} />
-      </BrowserRouter>
+      </BrowserRouter>,
     )
 
     await waitFor(() => {
       expect(mockedIssuesApi.list).toHaveBeenCalledTimes(1)
+      expect(mockedIssueDependenciesApi.listForThread).toHaveBeenCalledTimes(1)
     })
     expect(mockedIssuesApi.list).toHaveBeenCalledWith(mockThread.id, {
       page_size: 50,
       status: undefined,
     })
+    expect(mockedIssueDependenciesApi.listForThread).toHaveBeenCalledWith(mockThread.id)
   })
 
-  it('calls issuesApi.list again when "Load more" is clicked', async () => {
+  it('loads another issue page without refetching thread dependencies', async () => {
     const firstPage = buildListResponse(BASE_ISSUES, 'page-2', 4)
     const secondPage = buildListResponse([
       {
@@ -133,63 +140,46 @@ describe('IssueList', () => {
     render(
       <BrowserRouter>
         <IssueList thread={mockThread} />
-      </BrowserRouter>
+      </BrowserRouter>,
     )
 
-    await waitFor(() => {
-      expect(mockedIssuesApi.list).toHaveBeenCalledTimes(1)
-    })
+    await waitFor(() => expect(mockedIssuesApi.list).toHaveBeenCalledTimes(1))
+    await userEvent.click(screen.getByRole('button', { name: /load more/i }))
 
-    const loadMoreButton = screen.getByRole('button', { name: /load more/i })
-    await userEvent.click(loadMoreButton)
-
-    await waitFor(() => {
-      expect(mockedIssuesApi.list).toHaveBeenCalledTimes(2)
-    })
+    await waitFor(() => expect(mockedIssuesApi.list).toHaveBeenCalledTimes(2))
     expect(mockedIssuesApi.list).toHaveBeenNthCalledWith(2, mockThread.id, {
       page_size: 50,
       status: undefined,
       page_token: 'page-2',
     })
+    expect(mockedIssueDependenciesApi.listForThread).toHaveBeenCalledTimes(1)
   })
 
-  it('handles filter changes with fresh fetch', async () => {
-    const firstPage = buildListResponse(BASE_ISSUES, null, 2)
-    const filteredPage = buildListResponse([
-      {
-        id: 2,
-        thread_id: 99,
-        issue_number: '2',
-        status: 'read',
-        read_at: '2026-03-08T00:00:00Z',
-        created_at: '2026-03-08T00:00:00Z',
-      },
-    ])
-
+  it('handles filter changes with a fresh issue fetch only', async () => {
+    const filteredIssue: Issue = {
+      ...BASE_ISSUES[1],
+      status: 'read',
+      read_at: '2026-03-08T00:00:00Z',
+    }
     mockedIssuesApi.list
-      .mockResolvedValueOnce(firstPage)
-      .mockResolvedValueOnce(filteredPage)
+      .mockResolvedValueOnce(buildListResponse(BASE_ISSUES))
+      .mockResolvedValueOnce(buildListResponse([filteredIssue]))
 
     render(
       <BrowserRouter>
         <IssueList thread={mockThread} />
-      </BrowserRouter>
+      </BrowserRouter>,
     )
 
-    await waitFor(() => {
-      expect(mockedIssuesApi.list).toHaveBeenCalledTimes(1)
-    })
+    await waitFor(() => expect(mockedIssuesApi.list).toHaveBeenCalledTimes(1))
+    await userEvent.selectOptions(screen.getByRole('combobox'), 'read')
 
-    const filterSelect = screen.getByRole('combobox')
-    await userEvent.selectOptions(filterSelect, 'read')
-
-    await waitFor(() => {
-      expect(mockedIssuesApi.list).toHaveBeenCalledTimes(2)
-    })
+    await waitFor(() => expect(mockedIssuesApi.list).toHaveBeenCalledTimes(2))
     expect(mockedIssuesApi.list).toHaveBeenNthCalledWith(2, mockThread.id, {
       page_size: 50,
       status: 'read',
     })
+    expect(mockedIssueDependenciesApi.listForThread).toHaveBeenCalledTimes(1)
   })
 
   it('renders empty and loading failures without crashing', async () => {
@@ -198,52 +188,134 @@ describe('IssueList', () => {
     await waitFor(() => expect(screen.getByText('No issues found')).toBeInTheDocument())
 
     mockedIssuesApi.list.mockRejectedValueOnce(new Error('load failed'))
+    mockedIssueDependenciesApi.listForThread.mockResolvedValueOnce({
+      thread_id: 100,
+      issues: [],
+    })
     rerender(<IssueList thread={{ ...mockThread, id: 100 }} />)
     await waitFor(() => expect(screen.getByText('No issues found')).toBeInTheDocument())
   })
 
-  it('toggles read and unread issues, shows dependencies, and handles dependency errors', async () => {
+  it('toggles local status without reloading issues or dependencies', async () => {
     const onThreadUpdated = vi.fn()
-    const readIssue = { ...BASE_ISSUES[0], status: 'read' as const, read_at: '2026-03-09T00:00:00Z' }
-    mockedIssuesApi.list.mockResolvedValue(buildListResponse([readIssue, { ...BASE_ISSUES[1], id: 3 }]))
-    mockedDependenciesApi.getIssueDependencies
-      .mockResolvedValueOnce({ issue_id: 1, incoming: [{ dependency_id: 2, source_issue_id: 2, source_issue_number: '2', source_thread_id: 20, source_thread_title: 'Source' }], outgoing: [] })
-      .mockRejectedValueOnce(new Error('dependency failed'))
+    const readIssue: Issue = {
+      ...BASE_ISSUES[0],
+      status: 'read',
+      read_at: '2026-03-09T00:00:00Z',
+    }
+    const unreadIssue = { ...BASE_ISSUES[1], id: 3 }
+    mockedIssuesApi.list.mockResolvedValue(buildListResponse([readIssue, unreadIssue]))
+    mockedIssueDependenciesApi.listForThread.mockResolvedValue({
+      thread_id: mockThread.id,
+      issues: [
+        {
+          issue_id: readIssue.id,
+          incoming: [
+            {
+              dependency_id: 2,
+              source_issue_id: 2,
+              source_issue_number: '2',
+              source_thread_id: 20,
+              source_thread_title: 'Source',
+            },
+          ],
+          outgoing: [],
+        },
+        emptyDependencies(unreadIssue),
+      ],
+    })
     mockedIssuesApi.markUnread.mockResolvedValue(undefined)
     mockedIssuesApi.markRead.mockResolvedValue(undefined)
-    render(<IssueList thread={{ ...mockThread, next_unread_issue_id: 3 }} onThreadUpdated={onThreadUpdated} />)
+
+    render(
+      <IssueList
+        thread={{ ...mockThread, next_unread_issue_id: 3 }}
+        onThreadUpdated={onThreadUpdated}
+      />,
+    )
+
     await waitFor(() => expect(screen.getByText('#1')).toBeInTheDocument())
     expect(screen.getByTitle('Has dependencies')).toBeInTheDocument()
     await userEvent.click(screen.getByTitle('Has dependencies'))
     expect(mockedIssuesApi.markUnread).not.toHaveBeenCalled()
-    const items = screen.getAllByText(/#\d/)
-    await userEvent.click(items[0]!)
-    expect(mockedIssuesApi.markUnread).toHaveBeenCalledWith(1)
-    await waitFor(() => expect(onThreadUpdated).toHaveBeenCalledWith(99))
+
+    await userEvent.click(screen.getByText('#1'))
+    await waitFor(() => expect(mockedIssuesApi.markUnread).toHaveBeenCalledWith(1))
+    expect(onThreadUpdated).toHaveBeenCalledWith(99)
+
     await userEvent.click(screen.getByText('#2'))
-    expect(mockedIssuesApi.markRead).toHaveBeenCalledWith(3)
+    await waitFor(() => expect(mockedIssuesApi.markRead).toHaveBeenCalledWith(3))
+    expect(mockedIssuesApi.list).toHaveBeenCalledTimes(1)
+    expect(mockedIssueDependenciesApi.listForThread).toHaveBeenCalledTimes(1)
   })
 
-  it('keeps the list usable when a status toggle fails', async () => {
+  it('rolls back an optimistic status toggle when the request fails', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     mockedIssuesApi.list.mockResolvedValue(buildListResponse(BASE_ISSUES))
     mockedIssuesApi.markRead.mockRejectedValueOnce(new Error('toggle failed'))
+
     render(<IssueList thread={mockThread} />)
     await waitFor(() => expect(screen.getByText('#1')).toBeInTheDocument())
     await userEvent.click(screen.getByText('#1'))
-    await waitFor(() => expect(errorSpy).toHaveBeenCalledWith('Failed to toggle issue status:', expect.any(Error)))
+
+    await waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Failed to toggle issue status:',
+        expect.any(Error),
+      )
+      expect(screen.getByText('#1').closest('.issue-item')).toHaveClass('unread')
+    })
     errorSpy.mockRestore()
   })
 
-  it('handles zero-count progress, outgoing dependencies, and read dates without a callback', async () => {
-    mockedIssuesApi.list.mockResolvedValue(buildListResponse([
-      { ...BASE_ISSUES[0], status: 'read', read_at: '2026-03-10T00:00:00Z' },
-    ], null, 1))
-    mockedDependenciesApi.getIssueDependencies.mockResolvedValue({
-      issue_id: 1,
-      incoming: [],
-      outgoing: [{ dependency_id: 3, source_issue_id: 4, source_issue_number: '4', source_thread_id: 5, source_thread_title: 'Next' }],
+  it('removes a toggled issue from a filtered list without refetching', async () => {
+    const readIssue: Issue = {
+      ...BASE_ISSUES[0],
+      status: 'read',
+      read_at: '2026-03-10T00:00:00Z',
+    }
+    mockedIssuesApi.list
+      .mockResolvedValueOnce(buildListResponse(BASE_ISSUES))
+      .mockResolvedValueOnce(buildListResponse([readIssue], null, 1))
+    mockedIssuesApi.markUnread.mockResolvedValue(undefined)
+
+    render(<IssueList thread={mockThread} />)
+    await waitFor(() => expect(screen.getByText('#1')).toBeInTheDocument())
+    await userEvent.selectOptions(screen.getByRole('combobox'), 'read')
+    await waitFor(() => expect(screen.getByText(/Read 1 of 1 \(100%\)/)).toBeInTheDocument())
+
+    await userEvent.click(screen.getByText('#1'))
+    await waitFor(() => expect(screen.getByText('No issues found')).toBeInTheDocument())
+    expect(mockedIssuesApi.list).toHaveBeenCalledTimes(2)
+    expect(mockedIssueDependenciesApi.listForThread).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders outgoing dependencies and read dates without a callback', async () => {
+    const readIssue: Issue = {
+      ...BASE_ISSUES[0],
+      status: 'read',
+      read_at: '2026-03-10T00:00:00Z',
+    }
+    mockedIssuesApi.list.mockResolvedValue(buildListResponse([readIssue], null, 1))
+    mockedIssueDependenciesApi.listForThread.mockResolvedValue({
+      thread_id: mockThread.id,
+      issues: [
+        {
+          issue_id: readIssue.id,
+          incoming: [],
+          outgoing: [
+            {
+              dependency_id: 3,
+              source_issue_id: 4,
+              source_issue_number: '4',
+              source_thread_id: 5,
+              source_thread_title: 'Next',
+            },
+          ],
+        },
+      ],
     })
+    mockedIssuesApi.markUnread.mockResolvedValue(undefined)
 
     render(<IssueList thread={{ ...mockThread, next_unread_issue_id: 999 }} />)
 
@@ -254,18 +326,50 @@ describe('IssueList', () => {
     expect(mockedIssuesApi.markUnread).toHaveBeenCalledWith(1)
   })
 
-  it('removes stale dependency indicators when a later response is empty', async () => {
+  it('clears stale dependency indicators when the thread changes', async () => {
     const issue = BASE_ISSUES[0]
     mockedIssuesApi.list.mockResolvedValue(buildListResponse([issue]))
-    mockedDependenciesApi.getIssueDependencies.mockResolvedValueOnce({
-      issue_id: issue.id,
-      incoming: [{ dependency_id: 2, source_issue_id: 2, source_issue_number: '2', source_thread_id: 20, source_thread_title: 'Source' }],
-      outgoing: [],
-    }).mockResolvedValueOnce({ issue_id: issue.id, incoming: [], outgoing: [] })
+    mockedIssueDependenciesApi.listForThread
+      .mockResolvedValueOnce({
+        thread_id: mockThread.id,
+        issues: [
+          {
+            issue_id: issue.id,
+            incoming: [
+              {
+                dependency_id: 2,
+                source_issue_id: 2,
+                source_issue_number: '2',
+                source_thread_id: 20,
+                source_thread_title: 'Source',
+              },
+            ],
+            outgoing: [],
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ thread_id: 100, issues: [emptyDependencies(issue)] })
+
     const { rerender } = render(<IssueList thread={mockThread} />)
     await waitFor(() => expect(screen.getByTitle('Has dependencies')).toBeInTheDocument())
+
     rerender(<IssueList thread={{ ...mockThread, id: 100 }} />)
-    mockedIssuesApi.list.mockResolvedValue(buildListResponse([issue]))
     await waitFor(() => expect(screen.queryByTitle('Has dependencies')).not.toBeInTheDocument())
+  })
+
+  it('keeps issues usable when batched dependency loading fails', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockedIssuesApi.list.mockResolvedValue(buildListResponse(BASE_ISSUES))
+    mockedIssueDependenciesApi.listForThread.mockRejectedValueOnce(new Error('dependency failed'))
+
+    render(<IssueList thread={mockThread} />)
+
+    await waitFor(() => expect(screen.getByText('#1')).toBeInTheDocument())
+    expect(screen.queryByTitle('Has dependencies')).not.toBeInTheDocument()
+    expect(errorSpy).toHaveBeenCalledWith(
+      `Failed to load dependencies for thread ${mockThread.id}:`,
+      expect.any(Error),
+    )
+    errorSpy.mockRestore()
   })
 })

--- a/tests/test_issue_dependency_batch_api.py
+++ b/tests/test_issue_dependency_batch_api.py
@@ -1,0 +1,139 @@
+"""Tests for batched issue dependency retrieval."""
+
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import select
+
+from app.models import Dependency, Issue, Thread, User
+
+
+@pytest.mark.asyncio
+async def test_list_thread_issue_dependencies_batches_edges(
+    auth_client,
+    async_db,
+    test_username,
+):
+    """One request should return populated and empty issue dependency payloads."""
+    user_result = await async_db.execute(select(User).where(User.username == test_username))
+    user = user_result.scalar_one()
+
+    source_thread = Thread(
+        title="Batch Source",
+        format="Comic",
+        issues_remaining=2,
+        queue_position=1,
+        status="active",
+        user_id=user.id,
+        total_issues=2,
+    )
+    target_thread = Thread(
+        title="Batch Target",
+        format="Comic",
+        issues_remaining=1,
+        queue_position=2,
+        status="active",
+        user_id=user.id,
+        total_issues=1,
+    )
+    async_db.add_all([source_thread, target_thread])
+    await async_db.flush()
+
+    source_issue = Issue(
+        thread_id=source_thread.id,
+        issue_number="1",
+        position=1,
+        status="unread",
+    )
+    empty_issue = Issue(
+        thread_id=source_thread.id,
+        issue_number="2",
+        position=2,
+        status="unread",
+    )
+    target_issue = Issue(
+        thread_id=target_thread.id,
+        issue_number="1",
+        position=1,
+        status="unread",
+    )
+    async_db.add_all([source_issue, empty_issue, target_issue])
+    await async_db.flush()
+
+    source_thread.next_unread_issue_id = source_issue.id
+    target_thread.next_unread_issue_id = target_issue.id
+    dependency = Dependency(
+        source_issue_id=source_issue.id,
+        target_issue_id=target_issue.id,
+    )
+    async_db.add(dependency)
+    await async_db.commit()
+
+    response = await auth_client.get(
+        f"/api/v1/threads/{source_thread.id}/issue-dependencies"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["thread_id"] == source_thread.id
+    assert [item["issue_id"] for item in payload["issues"]] == [
+        source_issue.id,
+        empty_issue.id,
+    ]
+
+    source_payload = payload["issues"][0]
+    assert source_payload["incoming"] == []
+    assert source_payload["outgoing"] == [
+        {
+            "dependency_id": dependency.id,
+            "source_issue_id": target_issue.id,
+            "source_issue_number": "1",
+            "source_thread_id": target_thread.id,
+            "source_thread_title": "Batch Target",
+        }
+    ]
+    assert payload["issues"][1] == {
+        "issue_id": empty_issue.id,
+        "incoming": [],
+        "outgoing": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_thread_issue_dependencies_enforces_ownership(
+    auth_client,
+    async_db,
+):
+    """The batch endpoint should not expose another user's thread."""
+    outsider = User(username="batch_dependency_outsider", created_at=datetime.now(UTC))
+    async_db.add(outsider)
+    await async_db.flush()
+
+    outsider_thread = Thread(
+        title="Private Batch",
+        format="Comic",
+        issues_remaining=1,
+        queue_position=1,
+        status="active",
+        user_id=outsider.id,
+        total_issues=1,
+    )
+    async_db.add(outsider_thread)
+    await async_db.flush()
+
+    outsider_issue = Issue(
+        thread_id=outsider_thread.id,
+        issue_number="1",
+        position=1,
+        status="unread",
+    )
+    async_db.add(outsider_issue)
+    await async_db.flush()
+    outsider_thread.next_unread_issue_id = outsider_issue.id
+    await async_db.commit()
+
+    response = await auth_client.get(
+        f"/api/v1/threads/{outsider_thread.id}/issue-dependencies"
+    )
+
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary

- Replace the issue list's one-request-per-issue dependency loading with one thread-level batch endpoint.
- Return empty dependency entries as part of the complete batch response so the frontend never needs fallback lookups.
- Update issue read/unread state optimistically and roll it back on failure instead of refetching the full issue page and every dependency.
- Keep dependency data stable across pagination and filter changes.
- Add backend ownership/response coverage and update the IssueList unit suite for request-count regressions.

## Production profile root cause

The attached production HAR showed 71 calls to `/api/v1/issues/{id}/dependencies`, all returning empty dependency arrays. Those calls represented 36% of API requests and roughly 46% of cumulative API time in the recording. Toggling an issue then repeated the issue-list and dependency request wave.

After this change, opening a thread performs one issue-list request plus one dependency-batch request. Marking an issue read or unread performs only the mutation and the existing parent-thread notification.

## Validation status

I reviewed the changed paths and added regression coverage, but I could not execute the repository's local verification suite from this connector-only environment. In particular, I could not run the required local Chromium, Firefox, and WebKit E2E suite before opening the PR. The PR is ready for review, but it should not be merged until the repository checks and required local verification are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a batched dependency view for all issues in a thread, including incoming and outgoing relationships.
  * Dependency results now include issues with no dependencies and handle empty threads.
* **Improvements**
  * Reduced dependency loading to one request per thread.
  * Issue status changes now update immediately, remove filtered items when appropriate, and restore prior state if saving fails.
* **Bug Fixes**
  * Improved dependency refresh behavior when switching threads and handling load failures.
* **Tests**
  * Added coverage for dependency access control, empty results, status updates, filtering, and pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->