### PR TITLE
Add request, database, and cache diagnostics

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -2,14 +2,16 @@
 
 import logging
 import os
+import time
 from collections.abc import AsyncIterator
 
-from sqlalchemy import text
+from sqlalchemy import event, text
 from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase
 
 from app.config import get_database_settings
+from app.performance_diagnostics import record_database_query
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +48,37 @@ async_engine = create_async_engine(
     pool_timeout=30,
     pool_pre_ping=True,
 )
+
+
+@event.listens_for(async_engine.sync_engine, "before_cursor_execute")
+def _before_cursor_execute(
+    connection: object,
+    cursor: object,
+    statement: str,
+    parameters: object,
+    context: object,
+    executemany: bool,
+) -> None:
+    """Start timing a SQL statement after a connection has been acquired."""
+    del connection, cursor, statement, parameters, executemany
+    setattr(context, "_comic_pile_query_started_at", time.perf_counter())
+
+
+@event.listens_for(async_engine.sync_engine, "after_cursor_execute")
+def _after_cursor_execute(
+    connection: object,
+    cursor: object,
+    statement: str,
+    parameters: object,
+    context: object,
+    executemany: bool,
+) -> None:
+    """Record SQL execution time in the active request diagnostics context."""
+    del connection, cursor, statement, parameters, executemany
+    started_at = getattr(context, "_comic_pile_query_started_at", None)
+    if isinstance(started_at, float):
+        record_database_query((time.perf_counter() - started_at) * 1000)
+
 
 AsyncSessionLocal = async_sessionmaker(
     async_engine,

--- a/app/database.py
+++ b/app/database.py
@@ -61,7 +61,7 @@ def _before_cursor_execute(
 ) -> None:
     """Start timing a SQL statement after a connection has been acquired."""
     del connection, cursor, statement, parameters, executemany
-    setattr(context, "_comic_pile_query_started_at", time.perf_counter())
+    vars(context)["_comic_pile_query_started_at"] = time.perf_counter()
 
 
 @event.listens_for(async_engine.sync_engine, "after_cursor_execute")
@@ -75,7 +75,7 @@ def _after_cursor_execute(
 ) -> None:
     """Record SQL execution time in the active request diagnostics context."""
     del connection, cursor, statement, parameters, executemany
-    started_at = getattr(context, "_comic_pile_query_started_at", None)
+    started_at = vars(context).get("_comic_pile_query_started_at")
     if isinstance(started_at, float):
         record_database_query((time.perf_counter() - started_at) * 1000)
 

--- a/app/middleware/request_logging.py
+++ b/app/middleware/request_logging.py
@@ -1,20 +1,32 @@
-"""Request logging and request-body redaction middleware.
+"""Request logging, redaction, and lightweight performance diagnostics.
 
 Provides helpers for safely reading and redacting request bodies before they
-are written to logs, plus the error-only HTTP middleware that records every
-request with a status code >= 400.
+are written to logs. The HTTP middleware also emits request IDs, Server-Timing
+metrics, cache outcomes, database query counts, slow-request logs, and the
+existing error logs.
 """
 
 import json
 import logging
+import os
 import time
+import uuid
 from datetime import UTC, datetime
 
 from fastapi import FastAPI, Request
 
+from app.cache import cache
+from app.performance_diagnostics import (
+    begin_request_diagnostics,
+    end_request_diagnostics,
+    get_request_diagnostics,
+    install_cache_instrumentation,
+)
+
 logger = logging.getLogger(__name__)
 
 MAX_LOG_BODY_SIZE = 1000
+_DEFAULT_SLOW_REQUEST_THRESHOLD_MS = 1000.0
 
 
 def contains_sensitive_keys(body_json: dict | list) -> bool:
@@ -89,7 +101,6 @@ async def _safe_get_request_body(request: Request) -> str | dict | None:
                 return body.decode("utf-8", errors="replace")
             return f"[BINARY DATA: {len(body)} bytes]"
     except (OSError, RuntimeError, TimeoutError) as e:
-        # Catch I/O errors (body already consumed, network issues), RuntimeError from Starlette, and timeouts
         logger.debug(f"Failed to read request body: {e}")
         return None
 
@@ -128,55 +139,87 @@ def sanitize_for_logging(log_data: dict[str, object], environment: str) -> dict[
     if environment not in ("production", "staging"):
         return log_data
 
-    # Avoid leaking potentially sensitive request context.
     trimmed = dict(log_data)
     for key in ("request_body", "query_params", "session_id", "body"):
         trimmed.pop(key, None)
     return trimmed
 
 
-def add_request_logging_middleware(app: FastAPI, environment: str) -> None:
-    """Register the error-only request logging middleware on the app.
+def _slow_request_threshold_ms() -> float:
+    """Resolve the threshold for structured slow-request warnings."""
+    raw_value = os.getenv("SLOW_REQUEST_THRESHOLD_MS")
+    if raw_value is None:
+        return _DEFAULT_SLOW_REQUEST_THRESHOLD_MS
 
-    The middleware records every request whose response status code is >= 400,
-    attaching redacted request context (body, headers, query params) in
-    non-production environments.
+    try:
+        parsed = float(raw_value)
+    except ValueError:
+        return _DEFAULT_SLOW_REQUEST_THRESHOLD_MS
+    return parsed if parsed > 0 else _DEFAULT_SLOW_REQUEST_THRESHOLD_MS
+
+
+def _server_timing_header(total_ms: float) -> str:
+    """Build the Server-Timing header from the active diagnostics snapshot."""
+    diagnostics = get_request_diagnostics()
+    metrics = [f"app;dur={total_ms:.2f}"]
+
+    if diagnostics.database_queries:
+        metrics.append(
+            f'db;dur={diagnostics.database_time_ms:.2f};desc="{diagnostics.database_queries} queries"'
+        )
+    if diagnostics.cache_calls:
+        metrics.append(
+            f'cache;dur={diagnostics.cache_time_ms:.2f};desc="{diagnostics.cache_status}"'
+        )
+    return ", ".join(metrics)
+
+
+def add_request_logging_middleware(app: FastAPI, environment: str) -> None:
+    """Register request diagnostics and error logging middleware.
 
     Args:
         app: FastAPI application instance to wire the middleware onto.
         environment: Current application environment.
     """
+    install_cache_instrumentation(cache)
 
     @app.middleware("http")
     async def log_errors_middleware(request: Request, call_next):
-        """Log all requests with status codes >= 400.
+        """Add diagnostics headers and log slow or failed requests."""
+        started_at = time.perf_counter()
+        request_id = uuid.uuid4().hex
+        diagnostics_token = begin_request_diagnostics()
+        request.state.request_id = request_id
 
-        Args:
-            request: FastAPI request object.
-            call_next: Next middleware/route handler.
+        try:
+            if environment != "production":
+                body = await _safe_get_request_body(request)
+                if body:
+                    request.state.request_body = body
 
-        Returns:
-            HTTP response from the next handler.
-        """
-        start_time = time.time()
+            response = await call_next(request)
+            process_time_ms = (time.perf_counter() - started_at) * 1000
+            status_code = response.status_code
+            diagnostics = get_request_diagnostics()
 
-        if environment != "production":
-            body = await _safe_get_request_body(request)
-            if body:
-                request.state.request_body = body
+            response.headers["X-Request-ID"] = request_id
+            response.headers["X-App-Cache"] = diagnostics.cache_status
+            response.headers["X-App-DB-Queries"] = str(diagnostics.database_queries)
+            response.headers["Server-Timing"] = _server_timing_header(process_time_ms)
 
-        response = await call_next(request)
-        process_time = time.time() - start_time
-        status_code = response.status_code
-
-        if status_code >= 400:
             log_data = {
                 "timestamp": datetime.now(UTC).isoformat(),
+                "request_id": request_id,
                 "method": request.method,
                 "path": request.url.path,
                 "query_params": str(request.url.query) if request.url.query else None,
                 "status_code": status_code,
-                "process_time_ms": round(process_time * 1000, 2),
+                "process_time_ms": round(process_time_ms, 2),
+                "database_queries": diagnostics.database_queries,
+                "database_time_ms": round(diagnostics.database_time_ms, 2),
+                "cache_status": diagnostics.cache_status,
+                "cache_calls": diagnostics.cache_calls,
+                "cache_time_ms": round(diagnostics.cache_time_ms, 2),
                 "client_host": request.client.host if request.client else None,
                 "user_agent": request.headers.get("user-agent"),
                 "headers": redact_headers(dict(request.headers)),
@@ -196,10 +239,20 @@ def add_request_logging_middleware(app: FastAPI, environment: str) -> None:
                     f"API Error: {request.method} {request.url.path} - {status_code}",
                     extra={**log_data, "level": "ERROR"},
                 )
-            else:
+            elif status_code >= 400:
                 logger.warning(
                     f"Client Error: {request.method} {request.url.path} - {status_code}",
                     extra={**log_data, "level": "WARNING"},
                 )
+            elif process_time_ms >= _slow_request_threshold_ms():
+                logger.warning(
+                    "Slow HTTP request: %s %s completed in %.2f ms",
+                    request.method,
+                    request.url.path,
+                    process_time_ms,
+                    extra={**log_data, "level": "WARNING"},
+                )
 
-        return response
+            return response
+        finally:
+            end_request_diagnostics(diagnostics_token)

--- a/app/performance_diagnostics.py
+++ b/app/performance_diagnostics.py
@@ -1,0 +1,252 @@
+"""Per-request performance diagnostics for database and cache activity."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from collections.abc import Awaitable
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+from typing import Literal, TypeVar
+
+from app.cache import UpstashCache
+
+logger = logging.getLogger(__name__)
+
+CacheOutcome = Literal["hit", "miss", "write", "bypass", "timeout", "error"]
+T = TypeVar("T")
+_DEFAULT_CACHE_OPERATION_TIMEOUT_SECONDS = 2.0
+
+
+@dataclass
+class RequestDiagnostics:
+    """Mutable counters collected during one HTTP request."""
+
+    cache_calls: int = 0
+    cache_hits: int = 0
+    cache_misses: int = 0
+    cache_writes: int = 0
+    cache_bypasses: int = 0
+    cache_timeouts: int = 0
+    cache_errors: int = 0
+    cache_time_ms: float = 0.0
+    database_queries: int = 0
+    database_time_ms: float = 0.0
+
+    @property
+    def cache_status(self) -> str:
+        """Return a compact aggregate cache status for response headers."""
+        if self.cache_calls == 0:
+            return "not-used"
+        if self.cache_timeouts:
+            return "timeout"
+        if self.cache_errors:
+            return "error"
+        if self.cache_hits and self.cache_misses:
+            return "mixed"
+        if self.cache_hits:
+            return "hit"
+        if self.cache_misses:
+            return "miss"
+        if self.cache_writes:
+            return "write"
+        if self.cache_bypasses:
+            return "bypass"
+        return "unknown"
+
+
+_request_diagnostics: ContextVar[RequestDiagnostics | None] = ContextVar(
+    "request_diagnostics",
+    default=None,
+)
+
+
+def begin_request_diagnostics() -> Token[RequestDiagnostics | None]:
+    """Start a fresh diagnostics context for the current request."""
+    return _request_diagnostics.set(RequestDiagnostics())
+
+
+def end_request_diagnostics(token: Token[RequestDiagnostics | None]) -> None:
+    """Restore the diagnostics context that preceded the current request."""
+    _request_diagnostics.reset(token)
+
+
+def get_request_diagnostics() -> RequestDiagnostics:
+    """Return the active diagnostics object or an empty detached snapshot."""
+    return _request_diagnostics.get() or RequestDiagnostics()
+
+
+def record_database_query(duration_ms: float) -> None:
+    """Record one completed SQL query in the active request context."""
+    diagnostics = _request_diagnostics.get()
+    if diagnostics is None:
+        return
+    diagnostics.database_queries += 1
+    diagnostics.database_time_ms += duration_ms
+
+
+def record_cache_operation(outcome: CacheOutcome, duration_ms: float) -> None:
+    """Record one cache operation and its result in the active request context."""
+    diagnostics = _request_diagnostics.get()
+    if diagnostics is None:
+        return
+
+    diagnostics.cache_calls += 1
+    diagnostics.cache_time_ms += duration_ms
+
+    if outcome == "hit":
+        diagnostics.cache_hits += 1
+    elif outcome == "miss":
+        diagnostics.cache_misses += 1
+    elif outcome == "write":
+        diagnostics.cache_writes += 1
+    elif outcome == "bypass":
+        diagnostics.cache_bypasses += 1
+    elif outcome == "timeout":
+        diagnostics.cache_timeouts += 1
+    else:
+        diagnostics.cache_errors += 1
+
+
+def _cache_operation_timeout_seconds() -> float:
+    """Resolve the fail-open cache operation timeout from the environment."""
+    raw_value = os.getenv("CACHE_OPERATION_TIMEOUT_SECONDS")
+    if raw_value is None:
+        return _DEFAULT_CACHE_OPERATION_TIMEOUT_SECONDS
+
+    try:
+        parsed = float(raw_value)
+    except ValueError:
+        logger.warning(
+            "Invalid CACHE_OPERATION_TIMEOUT_SECONDS=%r; using %.1f seconds",
+            raw_value,
+            _DEFAULT_CACHE_OPERATION_TIMEOUT_SECONDS,
+        )
+        return _DEFAULT_CACHE_OPERATION_TIMEOUT_SECONDS
+
+    if parsed <= 0:
+        logger.warning(
+            "CACHE_OPERATION_TIMEOUT_SECONDS must be positive; using %.1f seconds",
+            _DEFAULT_CACHE_OPERATION_TIMEOUT_SECONDS,
+        )
+        return _DEFAULT_CACHE_OPERATION_TIMEOUT_SECONDS
+    return parsed
+
+
+def _record_cache_timeout_failure(cache: UpstashCache) -> None:
+    """Feed wrapper-level timeouts into the cache circuit breaker when available."""
+    breaker = getattr(cache, "_circuit_breaker", None)
+    record_failure = getattr(breaker, "record_failure", None)
+    if callable(record_failure):
+        record_failure()
+
+
+async def _await_cache_operation(
+    operation: str,
+    awaitable: Awaitable[T],
+    fallback: T,
+) -> tuple[T, bool]:
+    """Await a cache operation with a fail-open timeout."""
+    started_at = time.perf_counter()
+    try:
+        async with asyncio.timeout(_cache_operation_timeout_seconds()):
+            return await awaitable, False
+    except TimeoutError:
+        duration_ms = (time.perf_counter() - started_at) * 1000
+        record_cache_operation("timeout", duration_ms)
+        logger.warning(
+            "Cache %s timed out after %.2f ms; falling back",
+            operation,
+            duration_ms,
+        )
+        return fallback, True
+
+
+def install_cache_instrumentation(cache: UpstashCache) -> None:
+    """Wrap cache operations with timing, outcomes, and a fail-open timeout."""
+    if getattr(cache, "_performance_instrumented", False):
+        return
+
+    original_get = cache.get
+    original_set = cache.set
+    original_delete = cache.delete
+    original_clear_pattern = cache.clear_pattern
+
+    async def instrumented_get(key: str) -> object | None:
+        initialized = cache.is_initialized
+        started_at = time.perf_counter()
+        result, timed_out = await _await_cache_operation("get", original_get(key), None)
+        if timed_out:
+            _record_cache_timeout_failure(cache)
+            return None
+
+        duration_ms = (time.perf_counter() - started_at) * 1000
+        if not initialized:
+            record_cache_operation("bypass", duration_ms)
+        elif result is None:
+            record_cache_operation("miss", duration_ms)
+        else:
+            record_cache_operation("hit", duration_ms)
+        return result
+
+    async def instrumented_set(key: str, value: object, ttl: int | None = None) -> bool:
+        initialized = cache.is_initialized
+        started_at = time.perf_counter()
+        result, timed_out = await _await_cache_operation(
+            "set",
+            original_set(key, value, ttl),
+            False,
+        )
+        if timed_out:
+            _record_cache_timeout_failure(cache)
+            return False
+
+        duration_ms = (time.perf_counter() - started_at) * 1000
+        if not initialized:
+            record_cache_operation("bypass", duration_ms)
+        else:
+            record_cache_operation("write" if result else "error", duration_ms)
+        return result
+
+    async def instrumented_delete(key: str) -> bool:
+        initialized = cache.is_initialized
+        started_at = time.perf_counter()
+        result, timed_out = await _await_cache_operation(
+            "delete",
+            original_delete(key),
+            False,
+        )
+        if timed_out:
+            _record_cache_timeout_failure(cache)
+            return False
+
+        duration_ms = (time.perf_counter() - started_at) * 1000
+        if not initialized:
+            record_cache_operation("bypass", duration_ms)
+        else:
+            record_cache_operation("write" if result else "error", duration_ms)
+        return result
+
+    async def instrumented_clear_pattern(pattern: str) -> int:
+        initialized = cache.is_initialized
+        started_at = time.perf_counter()
+        result, timed_out = await _await_cache_operation(
+            "clear_pattern",
+            original_clear_pattern(pattern),
+            0,
+        )
+        if timed_out:
+            _record_cache_timeout_failure(cache)
+            return 0
+
+        duration_ms = (time.perf_counter() - started_at) * 1000
+        record_cache_operation("write" if initialized else "bypass", duration_ms)
+        return result
+
+    setattr(cache, "get", instrumented_get)
+    setattr(cache, "set", instrumented_set)
+    setattr(cache, "delete", instrumented_delete)
+    setattr(cache, "clear_pattern", instrumented_clear_pattern)
+    setattr(cache, "_performance_instrumented", True)

--- a/app/performance_diagnostics.py
+++ b/app/performance_diagnostics.py
@@ -9,14 +9,13 @@ import time
 from collections.abc import Awaitable
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
-from typing import Literal, TypeVar
+from typing import Literal
 
 from app.cache import UpstashCache
 
 logger = logging.getLogger(__name__)
 
 CacheOutcome = Literal["hit", "miss", "write", "bypass", "timeout", "error"]
-T = TypeVar("T")
 _DEFAULT_CACHE_OPERATION_TIMEOUT_SECONDS = 2.0
 
 
@@ -143,7 +142,7 @@ def _record_cache_timeout_failure(cache: UpstashCache) -> None:
         record_failure()
 
 
-async def _await_cache_operation(
+async def _await_cache_operation[T](
     operation: str,
     awaitable: Awaitable[T],
     fallback: T,
@@ -245,8 +244,12 @@ def install_cache_instrumentation(cache: UpstashCache) -> None:
         record_cache_operation("write" if initialized else "bypass", duration_ms)
         return result
 
-    setattr(cache, "get", instrumented_get)
-    setattr(cache, "set", instrumented_set)
-    setattr(cache, "delete", instrumented_delete)
-    setattr(cache, "clear_pattern", instrumented_clear_pattern)
-    setattr(cache, "_performance_instrumented", True)
+    vars(cache).update(
+        {
+            "get": instrumented_get,
+            "set": instrumented_set,
+            "delete": instrumented_delete,
+            "clear_pattern": instrumented_clear_pattern,
+            "_performance_instrumented": True,
+        }
+    )

--- a/tests/test_performance_diagnostics.py
+++ b/tests/test_performance_diagnostics.py
@@ -27,6 +27,7 @@ async def test_request_middleware_emits_performance_headers() -> None:
 
     @app.get("/diagnostics")
     async def diagnostics_route() -> dict[str, str]:
+        """Return a response after recording synthetic request activity."""
         record_cache_operation("hit", 12.5)
         record_database_query(8.25)
         return {"status": "ok"}

--- a/tests/test_performance_diagnostics.py
+++ b/tests/test_performance_diagnostics.py
@@ -1,0 +1,124 @@
+"""Tests for request, database, and cache performance diagnostics."""
+
+import asyncio
+from typing import cast
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.cache import UpstashCache
+from app.middleware.request_logging import add_request_logging_middleware
+from app.performance_diagnostics import (
+    begin_request_diagnostics,
+    end_request_diagnostics,
+    get_request_diagnostics,
+    install_cache_instrumentation,
+    record_cache_operation,
+    record_database_query,
+)
+
+
+@pytest.mark.asyncio
+async def test_request_middleware_emits_performance_headers() -> None:
+    """Responses should expose a request ID and timing breakdown."""
+    app = FastAPI()
+    add_request_logging_middleware(app, "test")
+
+    @app.get("/diagnostics")
+    async def diagnostics_route() -> dict[str, str]:
+        record_cache_operation("hit", 12.5)
+        record_database_query(8.25)
+        return {"status": "ok"}
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/diagnostics")
+
+    assert response.status_code == 200
+    assert len(response.headers["x-request-id"]) == 32
+    assert response.headers["x-app-cache"] == "hit"
+    assert response.headers["x-app-db-queries"] == "1"
+    server_timing = response.headers["server-timing"]
+    assert "app;dur=" in server_timing
+    assert 'db;dur=8.25;desc="1 queries"' in server_timing
+    assert 'cache;dur=12.50;desc="hit"' in server_timing
+
+
+def test_diagnostics_aggregate_mixed_cache_activity() -> None:
+    """A request with cache hits and misses should report a mixed result."""
+    token = begin_request_diagnostics()
+    try:
+        record_cache_operation("hit", 2.0)
+        record_cache_operation("miss", 3.0)
+        record_database_query(4.0)
+        diagnostics = get_request_diagnostics()
+
+        assert diagnostics.cache_status == "mixed"
+        assert diagnostics.cache_calls == 2
+        assert diagnostics.cache_time_ms == 5.0
+        assert diagnostics.database_queries == 1
+        assert diagnostics.database_time_ms == 4.0
+    finally:
+        end_request_diagnostics(token)
+
+
+class _FakeCircuitBreaker:
+    """Minimal circuit breaker used by the cache timeout test."""
+
+    def __init__(self) -> None:
+        self.failures = 0
+
+    def record_failure(self) -> None:
+        """Record one wrapper-level timeout."""
+        self.failures += 1
+
+
+class _SlowCache:
+    """Cache-shaped object whose reads exceed the configured timeout."""
+
+    def __init__(self) -> None:
+        self.is_initialized = True
+        self._circuit_breaker = _FakeCircuitBreaker()
+
+    async def get(self, key: str) -> object | None:
+        """Return too slowly for the timeout wrapper."""
+        del key
+        await asyncio.sleep(0.05)
+        return {"cached": True}
+
+    async def set(self, key: str, value: object, ttl: int | None = None) -> bool:
+        """Pretend to write successfully."""
+        del key, value, ttl
+        return True
+
+    async def delete(self, key: str) -> bool:
+        """Pretend to delete successfully."""
+        del key
+        return True
+
+    async def clear_pattern(self, pattern: str) -> int:
+        """Pretend to clear one key."""
+        del pattern
+        return 1
+
+
+@pytest.mark.asyncio
+async def test_cache_timeout_fails_open_and_records_failure(monkeypatch) -> None:
+    """A stalled cache read should return a miss rather than delaying the request."""
+    monkeypatch.setenv("CACHE_OPERATION_TIMEOUT_SECONDS", "0.001")
+    fake_cache = _SlowCache()
+    cache = cast(UpstashCache, fake_cache)
+    install_cache_instrumentation(cache)
+
+    token = begin_request_diagnostics()
+    try:
+        result = await cache.get("slow-key")
+        diagnostics = get_request_diagnostics()
+    finally:
+        end_request_diagnostics(token)
+
+    assert result is None
+    assert diagnostics.cache_status == "timeout"
+    assert diagnostics.cache_timeouts == 1
+    assert fake_cache._circuit_breaker.failures == 1

--- a/tests/test_performance_diagnostics.py
+++ b/tests/test_performance_diagnostics.py
@@ -6,8 +6,10 @@ from typing import cast
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
 
 from app.cache import UpstashCache
+from app.database import AsyncSessionLocal
 from app.middleware.request_logging import add_request_logging_middleware
 from app.performance_diagnostics import (
     begin_request_diagnostics,
@@ -44,6 +46,21 @@ async def test_request_middleware_emits_performance_headers() -> None:
     assert "app;dur=" in server_timing
     assert 'db;dur=8.25;desc="1 queries"' in server_timing
     assert 'cache;dur=12.50;desc="hit"' in server_timing
+
+
+@pytest.mark.asyncio
+async def test_database_events_record_a_real_async_query() -> None:
+    """SQLAlchemy execution events should update the active request context."""
+    token = begin_request_diagnostics()
+    try:
+        async with AsyncSessionLocal() as session:
+            await session.execute(text("SELECT 1"))
+        diagnostics = get_request_diagnostics()
+    finally:
+        end_request_diagnostics(token)
+
+    assert diagnostics.database_queries >= 1
+    assert diagnostics.database_time_ms >= 0
 
 
 def test_diagnostics_aggregate_mixed_cache_activity() -> None:


### PR DESCRIPTION
## Summary

- Add a unique `X-Request-ID` to every response.
- Emit `Server-Timing` metrics for total application time, SQL execution time/query count, and Redis time/outcome.
- Emit compact `X-App-Cache` and `X-App-DB-Queries` headers so a HAR can distinguish cache hits, misses, bypasses, and timeouts.
- Log successful requests that exceed `SLOW_REQUEST_THRESHOLD_MS` with the same request ID and timing breakdown.
- Fail open when any individual Redis operation exceeds `CACHE_OPERATION_TIMEOUT_SECONDS` instead of allowing a cache call to consume most of the frontend's ten-second request timeout.
- Feed wrapper-level cache timeouts into the existing Redis circuit breaker.
- Add focused middleware, aggregation, and timeout regression tests.

## Production profile root cause

The production HAR contained several unrelated requests clustered around 7.3 to 8.0 seconds. The browser spent virtually all of that time waiting for the first byte, but the HAR could not tell whether each stall came from Redis, SQL execution, connection-pool wait, or application work.

This PR makes the next HAR self-describing. SQL timing is measured after a connection is acquired, so a large gap between total application time and the reported SQL/cache time is also useful evidence of pool wait or other application work.

Defaults:

- `CACHE_OPERATION_TIMEOUT_SECONDS=2.0`
- `SLOW_REQUEST_THRESHOLD_MS=1000`

Both are optional environment overrides.

## Validation status

I reviewed the changed paths and added regression coverage, but I could not execute the repository's local verification suite from this connector-only environment. In particular, I could not run the required local Chromium, Firefox, and WebKit E2E suite before opening the PR. The PR is ready for review, but it should not be merged until the repository checks and required local verification are green.