### PR TITLE
Coalesce duplicate frontend GET bursts

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { SessionProvider } from './contexts/SessionContext'
 import { ToastProvider } from './contexts/ToastProvider'
+import './services/api-read-coalescing'
 import './index.css'
 import App from './App'
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,9 +2,11 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { SessionProvider } from './contexts/SessionContext'
 import { ToastProvider } from './contexts/ToastProvider'
-import './services/api-read-coalescing'
+import { installApiReadCoalescing } from './services/api-read-coalescing'
 import './index.css'
 import App from './App'
+
+installApiReadCoalescing()
 
 const rootElement = document.getElementById('root')
 

--- a/frontend/src/services/api-read-coalescing.ts
+++ b/frontend/src/services/api-read-coalescing.ts
@@ -4,7 +4,13 @@ import {
   threadsApi,
 } from './api'
 
-const inFlightReads = new Map<string, Promise<unknown>>()
+type InFlightRead = {
+  request: Promise<unknown>
+  startedAt: number
+}
+
+const COALESCE_BURST_WINDOW_MS = 250
+const inFlightReads = new Map<string, InFlightRead>()
 let installed = false
 
 function stableSerialize(value: unknown): string {
@@ -19,14 +25,20 @@ function stableSerialize(value: unknown): string {
 }
 
 export function coalesceRead<T>(key: string, loader: () => Promise<T>): Promise<T> {
+  const startedAt = Date.now()
   const existing = inFlightReads.get(key)
-  if (existing) return existing as Promise<T>
+  if (
+    existing
+    && startedAt - existing.startedAt <= COALESCE_BURST_WINDOW_MS
+  ) {
+    return existing.request as Promise<T>
+  }
 
   const request = loader()
-  inFlightReads.set(key, request)
+  inFlightReads.set(key, { request, startedAt })
 
   const removeRequest = () => {
-    if (inFlightReads.get(key) === request) {
+    if (inFlightReads.get(key)?.request === request) {
       inFlightReads.delete(key)
     }
   }

--- a/frontend/src/services/api-read-coalescing.ts
+++ b/frontend/src/services/api-read-coalescing.ts
@@ -69,5 +69,3 @@ export function installApiReadCoalescing(): void {
       () => originalCurrentSession(...args),
     )) as typeof sessionApi.getCurrent
 }
-
-installApiReadCoalescing()

--- a/frontend/src/services/api-read-coalescing.ts
+++ b/frontend/src/services/api-read-coalescing.ts
@@ -1,0 +1,73 @@
+import {
+  getAccessToken,
+  sessionApi,
+  threadsApi,
+} from './api'
+
+const inFlightReads = new Map<string, Promise<unknown>>()
+let installed = false
+
+function stableSerialize(value: unknown): string {
+  if (value === undefined) return 'undefined'
+  if (value === null || typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map(stableSerialize).join(',')}]`
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableSerialize(entryValue)}`)
+  return `{${entries.join(',')}}`
+}
+
+export function coalesceRead<T>(key: string, loader: () => Promise<T>): Promise<T> {
+  const existing = inFlightReads.get(key)
+  if (existing) return existing as Promise<T>
+
+  const request = loader()
+  inFlightReads.set(key, request)
+
+  const removeRequest = () => {
+    if (inFlightReads.get(key) === request) {
+      inFlightReads.delete(key)
+    }
+  }
+  void request.then(removeRequest, removeRequest)
+
+  return request
+}
+
+export function clearCoalescedReads(): void {
+  inFlightReads.clear()
+}
+
+function requestKey(operation: string, args: readonly unknown[]): string {
+  return `${getAccessToken() ?? 'anonymous'}:${operation}:${stableSerialize(args)}`
+}
+
+export function installApiReadCoalescing(): void {
+  if (installed) return
+  installed = true
+
+  const originalThreadsList = threadsApi.list.bind(threadsApi)
+  const originalStaleThreads = threadsApi.listStale.bind(threadsApi)
+  const originalCurrentSession = sessionApi.getCurrent.bind(sessionApi)
+
+  threadsApi.list = ((...args: Parameters<typeof originalThreadsList>) =>
+    coalesceRead(
+      requestKey('threads.list', args),
+      () => originalThreadsList(...args),
+    )) as typeof threadsApi.list
+
+  threadsApi.listStale = ((...args: Parameters<typeof originalStaleThreads>) =>
+    coalesceRead(
+      requestKey('threads.listStale', args),
+      () => originalStaleThreads(...args),
+    )) as typeof threadsApi.listStale
+
+  sessionApi.getCurrent = ((...args: Parameters<typeof originalCurrentSession>) =>
+    coalesceRead(
+      requestKey('session.getCurrent', args),
+      () => originalCurrentSession(...args),
+    )) as typeof sessionApi.getCurrent
+}
+
+installApiReadCoalescing()

--- a/frontend/src/unit/api-read-coalescing.test.ts
+++ b/frontend/src/unit/api-read-coalescing.test.ts
@@ -73,6 +73,33 @@ describe('API read coalescing', () => {
     expect(apiMocks.listThreads).toHaveBeenCalledTimes(2)
   })
 
+  it('starts a fresh request when an older read is outside the burst window', async () => {
+    let now = 1000
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
+    const resolvers: Array<(value: ThreadListResponse) => void> = []
+    apiMocks.listThreads.mockImplementation(() =>
+      new Promise<ThreadListResponse>((resolve) => {
+        resolvers.push(resolve)
+      })
+    )
+
+    try {
+      const first = threadsApi.list({ page_size: 200 })
+      now += 251
+      const second = threadsApi.list({ page_size: 200 })
+
+      expect(first).not.toBe(second)
+      expect(apiMocks.listThreads).toHaveBeenCalledTimes(2)
+
+      for (const resolve of resolvers) {
+        resolve(emptyThreadResponse)
+      }
+      await Promise.all([first, second])
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+
   it('keeps request keys isolated by access token', async () => {
     const resolvers: Array<(value: ThreadListResponse) => void> = []
     apiMocks.listThreads.mockImplementation(() =>

--- a/frontend/src/unit/api-read-coalescing.test.ts
+++ b/frontend/src/unit/api-read-coalescing.test.ts
@@ -1,0 +1,100 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ThreadListResponse } from '../types'
+
+const apiMocks = vi.hoisted(() => ({
+  getAccessToken: vi.fn<() => string | null>(() => 'token-a'),
+  listThreads: vi.fn(),
+  listStaleThreads: vi.fn(),
+  getCurrentSession: vi.fn(),
+}))
+
+vi.mock('../services/api', () => ({
+  getAccessToken: apiMocks.getAccessToken,
+  threadsApi: {
+    list: apiMocks.listThreads,
+    listStale: apiMocks.listStaleThreads,
+  },
+  sessionApi: {
+    getCurrent: apiMocks.getCurrentSession,
+  },
+}))
+
+import { threadsApi } from '../services/api'
+import {
+  clearCoalescedReads,
+  coalesceRead,
+  installApiReadCoalescing,
+} from '../services/api-read-coalescing'
+
+const emptyThreadResponse: ThreadListResponse = {
+  threads: [],
+  total_count: 0,
+  page_size: 200,
+  next_page_token: null,
+}
+
+describe('API read coalescing', () => {
+  beforeAll(() => {
+    installApiReadCoalescing()
+  })
+
+  beforeEach(() => {
+    clearCoalescedReads()
+    vi.clearAllMocks()
+    apiMocks.getAccessToken.mockReturnValue('token-a')
+  })
+
+  it('shares an in-flight thread request with equivalent parameters', async () => {
+    let resolveRequest: ((value: ThreadListResponse) => void) | undefined
+    const request = new Promise<ThreadListResponse>((resolve) => {
+      resolveRequest = resolve
+    })
+    apiMocks.listThreads.mockReturnValue(request)
+
+    const first = threadsApi.list({ search: 'Batman', page_size: 200 })
+    const second = threadsApi.list({ page_size: 200, search: 'Batman' })
+
+    expect(first).toBe(second)
+    expect(apiMocks.listThreads).toHaveBeenCalledTimes(1)
+
+    resolveRequest?.(emptyThreadResponse)
+    await Promise.all([first, second])
+  })
+
+  it('starts a fresh request after the previous request settles', async () => {
+    apiMocks.listThreads.mockResolvedValue(emptyThreadResponse)
+
+    await threadsApi.list({ page_size: 200 })
+    await threadsApi.list({ page_size: 200 })
+
+    expect(apiMocks.listThreads).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not share reads across authenticated users', async () => {
+    let resolveRequest: ((value: ThreadListResponse) => void) | undefined
+    const request = new Promise<ThreadListResponse>((resolve) => {
+      resolveRequest = resolve
+    })
+    apiMocks.listThreads.mockReturnValue(request)
+
+    const first = threadsApi.list({ page_size: 200 })
+    apiMocks.getAccessToken.mockReturnValue('token-b')
+    const second = threadsApi.list({ page_size: 200 })
+
+    expect(first).not.toBe(second)
+    expect(apiMocks.listThreads).toHaveBeenCalledTimes(2)
+
+    resolveRequest?.(emptyThreadResponse)
+    await Promise.all([first, second])
+  })
+
+  it('evicts a failed request so a retry can run', async () => {
+    const loader = vi.fn()
+      .mockRejectedValueOnce(new Error('temporary failure'))
+      .mockResolvedValueOnce('recovered')
+
+    await expect(coalesceRead('retryable', loader)).rejects.toThrow('temporary failure')
+    await expect(coalesceRead('retryable', loader)).resolves.toBe('recovered')
+    expect(loader).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/src/unit/api-read-coalescing.test.ts
+++ b/frontend/src/unit/api-read-coalescing.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { ThreadListResponse } from '../types'
+import type { SessionCurrent, ThreadListResponse } from '../types'
 
 const apiMocks = vi.hoisted(() => ({
   getAccessToken: vi.fn<() => string | null>(() => 'token-a'),
@@ -19,7 +19,7 @@ vi.mock('../services/api', () => ({
   },
 }))
 
-import { threadsApi } from '../services/api'
+import { sessionApi, threadsApi } from '../services/api'
 import {
   clearCoalescedReads,
   coalesceRead,
@@ -28,9 +28,12 @@ import {
 
 const emptyThreadResponse: ThreadListResponse = {
   threads: [],
-  total_count: 0,
-  page_size: 200,
   next_page_token: null,
+}
+
+const currentSession: SessionCurrent = {
+  id: 1,
+  current_die: 20,
 }
 
 describe('API read coalescing', () => {
@@ -89,6 +92,45 @@ describe('API read coalescing', () => {
       resolve(emptyThreadResponse)
     }
     await Promise.all([first, second])
+  })
+
+  it('coalesces stale-thread and current-session reads', async () => {
+    let resolveStaleThreads: ((value: []) => void) | undefined
+    let resolveCurrentSession: ((value: SessionCurrent) => void) | undefined
+    const staleThreadsRequest = new Promise<[]>((resolve) => {
+      resolveStaleThreads = resolve
+    })
+    const currentSessionRequest = new Promise<SessionCurrent>((resolve) => {
+      resolveCurrentSession = resolve
+    })
+    apiMocks.listStaleThreads.mockReturnValue(staleThreadsRequest)
+    apiMocks.getCurrentSession.mockReturnValue(currentSessionRequest)
+
+    const firstStale = threadsApi.listStale(45)
+    const secondStale = threadsApi.listStale(45)
+    const firstSession = sessionApi.getCurrent()
+    const secondSession = sessionApi.getCurrent()
+
+    expect(firstStale).toBe(secondStale)
+    expect(firstSession).toBe(secondSession)
+    expect(apiMocks.listStaleThreads).toHaveBeenCalledTimes(1)
+    expect(apiMocks.getCurrentSession).toHaveBeenCalledTimes(1)
+
+    resolveStaleThreads?.([])
+    resolveCurrentSession?.(currentSession)
+    await Promise.all([firstStale, secondStale, firstSession, secondSession])
+  })
+
+  it('does not wrap the API methods more than once', () => {
+    const installedThreadsList = threadsApi.list
+    const installedStaleThreads = threadsApi.listStale
+    const installedCurrentSession = sessionApi.getCurrent
+
+    installApiReadCoalescing()
+
+    expect(threadsApi.list).toBe(installedThreadsList)
+    expect(threadsApi.listStale).toBe(installedStaleThreads)
+    expect(sessionApi.getCurrent).toBe(installedCurrentSession)
   })
 
   it('evicts a failed request so a retry can run', async () => {

--- a/frontend/src/unit/api-read-coalescing.test.ts
+++ b/frontend/src/unit/api-read-coalescing.test.ts
@@ -70,12 +70,13 @@ describe('API read coalescing', () => {
     expect(apiMocks.listThreads).toHaveBeenCalledTimes(2)
   })
 
-  it('does not share reads across authenticated users', async () => {
-    let resolveRequest: ((value: ThreadListResponse) => void) | undefined
-    const request = new Promise<ThreadListResponse>((resolve) => {
-      resolveRequest = resolve
-    })
-    apiMocks.listThreads.mockReturnValue(request)
+  it('keeps request keys isolated by access token', async () => {
+    const resolvers: Array<(value: ThreadListResponse) => void> = []
+    apiMocks.listThreads.mockImplementation(() =>
+      new Promise<ThreadListResponse>((resolve) => {
+        resolvers.push(resolve)
+      })
+    )
 
     const first = threadsApi.list({ page_size: 200 })
     apiMocks.getAccessToken.mockReturnValue('token-b')
@@ -84,7 +85,9 @@ describe('API read coalescing', () => {
     expect(first).not.toBe(second)
     expect(apiMocks.listThreads).toHaveBeenCalledTimes(2)
 
-    resolveRequest?.(emptyThreadResponse)
+    for (const resolve of resolvers) {
+      resolve(emptyThreadResponse)
+    }
     await Promise.all([first, second])
   })
 


### PR DESCRIPTION
## Summary

- Coalesce identical reads for the thread list, stale-thread list, and current session only when they begin within the same 250 ms burst.
- Build stable request keys from operation arguments so equivalent parameter objects share the same short-lived in-flight promise.
- Include the active access token in the key so reads are never shared across authentication contexts.
- Stop coalescing against an older request after 250 ms, even if it is still pending, so a later mutation-driven refresh cannot become attached to a long-running pre-mutation read.
- Remove entries as soon as a request settles, successful or failed. This is request-burst coalescing, not response caching.
- Install the wrapper once during frontend startup.
- Add regression coverage for equivalent parameters, expired pending requests, post-settlement refetches, access-token isolation, all three wrapped APIs, installer idempotence, and failed-request retries.

## Production profile root cause

The production HAR repeatedly requested `/api/threads/`, `/api/sessions/current/`, and `/api/threads/stale`, sometimes in overlapping bursts. React Strict Mode, multiple hooks, navigation, or simultaneous refresh paths can independently ask for the same read before the first one finishes.

The 250 ms reuse ceiling is intentionally the same as the duplicate-burst threshold in #675. It removes immediate duplicate work without letting an unusually slow read monopolize later refreshes for its full lifetime.

## Validation status

The initial CI run exposed an invalid test fixture and branch coverage just below the repository's 94% gate. Those are fixed on the current head, along with the bounded-burst safeguard described above. Fresh CI and CodeRabbit review are required before merge.

I could not execute the repository's required local Chromium, Firefox, and WebKit E2E suite from the connector-only environment.