### PR TITLE
Replace toy production profile with full-account HAR workload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,6 @@ opencode.json
 prod_backup_*.json
 .vercel
 .env*
+
+# Local production-profile authentication state
+prod-profile-storage-state*.json

--- a/docs/PRODUCTION_PROFILE.md
+++ b/docs/PRODUCTION_PROFILE.md
@@ -1,68 +1,89 @@
 # Production profile
 
-The production profile turns a real browser journey into a repeatable request-budget smoke test. It was derived from a Chrome HAR captured while using ComicPile normally after the Vercel, Neon, and Upstash migration.
+The production profile is a full-account browser workload derived from the original Chrome HAR captured on July 30, 2026 after the Vercel, Neon, and Upstash migration.
 
-Unlike replaying the HAR literally, the profile never depends on captured thread, issue, session, dependency, or user IDs. Every run creates a disposable authenticated user and discovers the runtime resources through the UI and API.
+The source HAR contained 198 API requests across roughly 201 seconds. It exercised authenticated startup, queue/history/analytics navigation, rating, rolling, snoozing, manual thread selection, queue movement, a large issue editor, dependency management, stale-thread reactivation, manual die changes, and a final rating.
 
-## Run it
+## What changed from the first profiler
+
+The first implementation created a disposable user, generated three small threads, called `/health` before measuring, and installed its network recorder only after setup. That was a useful smoke test, but it did not preserve the original account shape or cold browser path.
+
+The production profile now:
+
+- requires a Playwright storage-state file for the existing production account;
+- installs request recording before the first navigation;
+- does not warm the deployment with `/health`;
+- refuses to run against a toy account by checking minimum thread and session counts;
+- visits the same major browser surfaces as the original session;
+- performs real roll, rating, snooze, queue movement, thread-detail, and issue-toggle work;
+- reports the original HAR request count and observed/source ratio;
+- keeps the legacy dependency-fanout and duplicate-GET regression checks.
+
+It does not commit the source HAR, cookies, access tokens, request bodies, or captured IDs.
+
+## Create storage state
+
+Use a local file that is never committed. The simplest path is to sign in with Playwright and save the authenticated browser context:
+
+```bash
+cd frontend
+PROD_BASE_URL=https://comic-pile.vercel.app \
+  pnpm exec playwright codegen \
+  --save-storage=../prod-profile-storage-state.json \
+  https://comic-pile.vercel.app
+```
+
+Sign in, close the codegen browser, and confirm that `prod-profile-storage-state.json` exists. Treat it like a password. The repository ignores `prod-profile-storage-state*.json`.
+
+## Run
 
 ```bash
 PROD_BASE_URL=https://comic-pile.vercel.app \
+PROD_PROFILE_STORAGE_STATE=../prod-profile-storage-state.json \
   pnpm --filter frontend run test:e2e:prod-profile
 ```
 
-The profile deliberately runs only in Chromium and with one worker because it measures one production user journey rather than browser compatibility.
+This workload mutates production state through normal browser actions. Run it only against the intended account and review the generated report afterward.
 
-## Journey
+## Account-shape guardrails
 
-The test performs these actions against the supplied deployment:
-
-1. Verify `/health`.
-2. Register and authenticate a disposable user.
-3. Create a 40-issue thread plus two smaller roll-pool threads.
-4. Load the roll page, roll, and submit a rating.
-5. Open the queue and navigate to the dynamically created thread.
-6. Open the thread edit dialog, show all issues, and toggle the first issue's read state.
-7. Visit history and analytics.
-8. Attach a normalized JSON request report to the Playwright result.
-
-The normalization replaces numeric path IDs and dynamic query cursors. That lets the test enforce route-level behavior without baking production data into the script.
-
-## Default budgets
+Defaults:
 
 | Check | Default |
 | --- | ---: |
-| Maximum API requests | 60 |
+| Minimum loaded threads | 100 |
+| Minimum loaded sessions | 25 |
+| Minimum observed browser API requests | 40 |
+| Maximum observed browser API requests | 198 |
 | Maximum API duration | 5,000 ms |
 | Duplicate GET burst window | 250 ms |
 | Legacy per-issue dependency requests | 0 |
-| Thread dependency batch requests | exactly 1 |
+| Thread dependency batch requests | at least 1 |
 | Failed API responses or transport failures | 0 |
 
-Override the numeric budgets when intentionally characterizing a slower environment:
+The minimums prevent a fresh disposable account from silently standing in for the real workload. Override them only when intentionally profiling a different mature account:
 
 ```bash
-PROD_BASE_URL=https://comic-pile.vercel.app \
+PROD_PROFILE_MIN_THREADS=75 \
+PROD_PROFILE_MIN_SESSIONS=20 \
+PROD_PROFILE_MIN_API_REQUESTS=35 \
+PROD_PROFILE_MAX_API_REQUESTS=220 \
 PROD_PROFILE_MAX_API_MS=8000 \
-PROD_PROFILE_MAX_API_REQUESTS=75 \
 PROD_PROFILE_DUPLICATE_WINDOW_MS=150 \
   pnpm --filter frontend run test:e2e:prod-profile
 ```
 
-Budget overrides must be positive numbers. Invalid values fail immediately instead of silently falling back to defaults. Raising a threshold should be treated as an explicit profiling choice, not a way to make a regression disappear.
-
-The overall Playwright journey allows up to five minutes for cold starts and sequential navigation. That does not relax the five-second budget applied to each profiled API request.
-
 ## Report
 
-Each run attaches `production-profile.json`, containing:
+Each run attaches `production-profile.json` with:
 
-- every normalized API request and status;
-- wall-clock duration;
-- request IDs plus `Server-Timing`, `X-App-Cache`, and `X-App-DB-Queries` when the deployment exposes them;
-- median, p95, and maximum API latency;
-- cache-status counts;
-- duplicate GET bursts;
-- failed and slow requests.
+- source HAR date, duration, action inventory, and 198-request baseline;
+- observed account thread/session counts;
+- every normalized browser API request;
+- response status and wall-clock duration;
+- request ID, `Server-Timing`, `X-App-Cache`, and `X-App-DB-Queries`;
+- median, p95, and maximum latency;
+- observed/source request ratio;
+- duplicate GET bursts, transport failures, and slow responses.
 
-The generated user and threads remain in the target deployment, matching the repository's existing production smoke-test behavior. Their timestamped names make them easy to identify and periodically clean up.
+The report is evidence, not a synthetic pass badge. A large drop in request count is expected when fan-out is removed, but a tiny request count or small-account guard failure means the profile is no longer representative.

--- a/frontend/playwright.prod-profile.config.ts
+++ b/frontend/playwright.prod-profile.config.ts
@@ -1,35 +1,50 @@
+import { existsSync } from 'node:fs'
 import { defineConfig, devices } from '@playwright/test'
 
 const prodBaseUrl = process.env.PROD_BASE_URL ?? process.env.BASE_URL
+const storageState = process.env.PROD_PROFILE_STORAGE_STATE
 
 if (!prodBaseUrl) {
   throw new Error('Set PROD_BASE_URL (or BASE_URL) to run the production profile.')
 }
 
+if (!storageState) {
+  throw new Error(
+    'Set PROD_PROFILE_STORAGE_STATE to a Playwright storage-state JSON file for the full production account.',
+  )
+}
+
+if (!existsSync(storageState)) {
+  throw new Error(`PROD_PROFILE_STORAGE_STATE does not exist: ${storageState}`)
+}
+
 export default defineConfig({
-  metadata: { productionProfile: true },
+  metadata: {
+    productionProfile: true,
+    sourceHarApiRequests: 198,
+    sourceHarCapturedAt: '2026-07-30T15:25:46.699-05:00',
+  },
   testDir: './src/test',
   testMatch: 'production-profile.spec.ts',
   fullyParallel: false,
   retries: 0,
   workers: 1,
-  // The journey may take longer during production cold starts, while the
-  // individual request budget remains capped separately at five seconds.
-  timeout: 300 * 1000,
+  timeout: 10 * 60 * 1000,
   reporter: [
     ['list'],
     ['html', { open: 'never', outputFolder: '../playwright-report-prod-profile' }],
   ],
   use: {
     baseURL: prodBaseUrl,
+    storageState,
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     video: 'off',
-    actionTimeout: 30000,
-    navigationTimeout: 30000,
+    actionTimeout: 30_000,
+    navigationTimeout: 30_000,
   },
   expect: {
-    timeout: 15000,
+    timeout: 15_000,
   },
   projects: [
     {

--- a/frontend/src/test/production-profile.spec.ts
+++ b/frontend/src/test/production-profile.spec.ts
@@ -1,15 +1,12 @@
-import { expect, test, type APIResponse, type Page, type Request } from '@playwright/test'
+import { expect, test, type Page, type Request } from '@playwright/test'
 import {
   SELECTORS,
-  createThread,
-  generateTestUser,
   setRangeInput,
   submitRatingAndWaitForRateResponse,
 } from './helpers'
 
 type ApiRecord = {
   method: string
-  path: string
   normalizedUrl: string
   status: number
   durationMs: number
@@ -26,9 +23,35 @@ type NetworkProfile = {
   finish: () => Promise<void>
 }
 
-type RegistrationResponse = {
-  access_token?: unknown
+type ThreadListPayload = {
+  threads?: unknown[]
 }
+
+type SessionListPayload = {
+  sessions?: unknown[]
+}
+
+const SOURCE_HAR = {
+  capturedAt: '2026-07-30T15:25:46.699-05:00',
+  durationMs: 200_602,
+  apiRequests: 198,
+  accountShape: 'Josh production account after the Vercel, Neon, and Upstash migration',
+  actions: [
+    'cold authenticated startup and refresh recovery',
+    'queue, history, and analytics navigation',
+    'rate pending thread',
+    'roll and rate',
+    'roll and snooze',
+    'roll and dismiss pending',
+    'manual thread selection and queue movement',
+    'open a large issue editor and mutate issue state',
+    'dependency management',
+    'bug report submission',
+    'stale-thread reactivation',
+    'manual die changes',
+    'final roll and rating',
+  ],
+} as const
 
 function numericEnvironmentValue(name: string, fallback: number): number {
   const rawValue = process.env[name]
@@ -76,9 +99,7 @@ function installNetworkProfile(page: Page): NetworkProfile {
   const recordTransportFailure = (request: Request, reason: string) => {
     if (failedRequests.has(request)) return
     failedRequests.add(request)
-    transportFailures.push(
-      `${request.method()} ${normalizeApiUrl(request.url())}: ${reason}`,
-    )
+    transportFailures.push(`${request.method()} ${normalizeApiUrl(request.url())}: ${reason}`)
   }
 
   page.on('request', (request) => {
@@ -90,10 +111,7 @@ function installNetworkProfile(page: Page): NetworkProfile {
   page.on('requestfailed', (request) => {
     if (!isApiRequest(request.url()) || !requestStarts.has(request)) return
 
-    recordTransportFailure(
-      request,
-      request.failure()?.errorText ?? 'unknown failure',
-    )
+    recordTransportFailure(request, request.failure()?.errorText ?? 'unknown failure')
     requestStarts.delete(request)
   })
 
@@ -102,20 +120,15 @@ function installNetworkProfile(page: Page): NetworkProfile {
 
     const request = response.request()
     const startedAt = requestStarts.get(request)
-
-    // Ignore responses for requests that began before the profile was installed.
-    // Falling back to Date.now() would understate their duration, especially for redirects.
     if (startedAt === undefined) return
 
     responseTasks.push((async () => {
       try {
         await response.finished()
         const headers = await response.allHeaders()
-        const url = new URL(response.url())
 
         records.push({
           method: request.method(),
-          path: url.pathname,
           normalizedUrl: normalizeApiUrl(response.url()),
           status: response.status(),
           durationMs: Date.now() - startedAt,
@@ -155,6 +168,13 @@ function installNetworkProfile(page: Page): NetworkProfile {
   }
 }
 
+function percentile(values: number[], quantile: number): number {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((left, right) => left - right)
+  const index = Math.min(sorted.length - 1, Math.ceil(sorted.length * quantile) - 1)
+  return sorted[index] ?? 0
+}
+
 function findDuplicateGetBursts(records: ApiRecord[], windowMs: number): string[] {
   const lastStartedByUrl = new Map<string, number>()
   const duplicates: string[] = []
@@ -172,177 +192,187 @@ function findDuplicateGetBursts(records: ApiRecord[], windowMs: number): string[
   return duplicates
 }
 
-function percentile(values: number[], quantile: number): number {
-  if (values.length === 0) return 0
-  const sorted = [...values].sort((left, right) => left - right)
-  const index = Math.min(sorted.length - 1, Math.ceil(sorted.length * quantile) - 1)
-  return sorted[index] ?? 0
-}
-
-async function assertProductionHealth(response: APIResponse, durationMs: number): Promise<void> {
-  if (response.ok()) return
-
-  const headers = response.headers()
-  const body = (await response.text()).slice(0, 2_000)
-  const vercelHeaders = Object.fromEntries(
-    Object.entries(headers).filter(([name]) =>
-      ['server', 'date', 'x-vercel-id', 'x-vercel-cache'].includes(name),
+async function readAccessToken(page: Page): Promise<string> {
+  await expect.poll(
+    () => page.evaluate(() =>
+      localStorage.getItem('auth_token')
+      ?? (window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN
+      ?? null
     ),
-  )
+    { timeout: 30_000 },
+  ).not.toBeNull()
 
-  throw new Error(
-    `Production health check failed after ${durationMs} ms: ${response.status()} ${response.statusText()}\n` +
-      `URL: ${response.url()}\n` +
-      `Vercel headers: ${JSON.stringify(vercelHeaders)}\n` +
-      `Response body: ${body || '(empty)'}`,
+  const token = await page.evaluate(() =>
+    localStorage.getItem('auth_token')
+    ?? (window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN
+    ?? null
   )
+  if (!token) throw new Error('The supplied production storage state did not yield an access token')
+  return token
 }
 
-async function setupProductionProfileUser(page: Page): Promise<void> {
-  const user = generateTestUser()
-  const response = await page.request.post('/api/auth/register', {
-    data: {
-      username: user.username,
-      email: user.email,
-      password: user.password,
-    },
-    timeout: 30000,
-  })
-  const responseText = await response.text()
+async function assertFullAccountShape(page: Page, token: string): Promise<{
+  threadCount: number
+  sessionCount: number
+}> {
+  const minThreads = numericEnvironmentValue('PROD_PROFILE_MIN_THREADS', 100)
+  const minSessions = numericEnvironmentValue('PROD_PROFILE_MIN_SESSIONS', 25)
+  const headers = { Authorization: `Bearer ${token}` }
 
-  if (!response.ok()) {
-    throw new Error(
-      `Production profile registration failed: ${response.status()} ${response.statusText()} ${responseText.slice(0, 500)}`,
-    )
-  }
+  const [threadsResponse, sessionsResponse] = await Promise.all([
+    page.request.get('/api/threads/?page_size=200', { headers }),
+    page.request.get('/api/sessions/?page_size=200', { headers }),
+  ])
 
-  let payload: RegistrationResponse
-  try {
-    payload = JSON.parse(responseText) as RegistrationResponse
-  } catch {
-    throw new Error(`Production profile registration returned invalid JSON: ${responseText.slice(0, 500)}`)
-  }
+  expect(threadsResponse.ok(), 'Full-account thread probe').toBeTruthy()
+  expect(sessionsResponse.ok(), 'Full-account session probe').toBeTruthy()
 
-  if (typeof payload.access_token !== 'string' || payload.access_token.length === 0) {
-    throw new Error(`Production profile registration returned no access token: ${responseText.slice(0, 500)}`)
-  }
+  const threadsPayload = await threadsResponse.json() as ThreadListPayload | unknown[]
+  const sessionsPayload = await sessionsResponse.json() as SessionListPayload | unknown[]
+  const threads = Array.isArray(threadsPayload) ? threadsPayload : threadsPayload.threads ?? []
+  const sessions = Array.isArray(sessionsPayload) ? sessionsPayload : sessionsPayload.sessions ?? []
 
-  await page.addInitScript((accessToken: string) => {
-    localStorage.setItem('auth_token', accessToken)
-    ;(window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN = accessToken
-  }, payload.access_token)
+  expect(
+    threads.length,
+    `Production profile must use a full account with at least ${minThreads} loaded threads`,
+  ).toBeGreaterThanOrEqual(minThreads)
+  expect(
+    sessions.length,
+    `Production profile must use a mature account with at least ${minSessions} loaded sessions`,
+  ).toBeGreaterThanOrEqual(minSessions)
+
+  return { threadCount: threads.length, sessionCount: sessions.length }
+}
+
+async function navigateSourcePages(page: Page): Promise<void> {
+  await page.goto('/queue', { waitUntil: 'domcontentloaded' })
+  await expect(page.getByRole('heading', { name: 'Read Queue' })).toBeVisible()
+
+  await page.goto('/history', { waitUntil: 'domcontentloaded' })
+  await expect(page.getByRole('heading', { name: 'History', exact: true })).toBeVisible()
+
+  await page.goto('/analytics', { waitUntil: 'domcontentloaded' })
+  await expect(page.getByRole('heading', { name: 'Analytics', exact: true })).toBeVisible()
+
   await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await expect(page.locator(SELECTORS.roll.mainDie).or(page.locator('[data-roll-pool]')).first()).toBeVisible()
 }
 
-test('HAR-derived production journey stays within request budgets', async ({ page }, testInfo) => {
+async function rateOrRoll(page: Page, rating: string): Promise<void> {
+  const ratingInput = page.locator(SELECTORS.rate.ratingInput)
+  if (!(await ratingInput.isVisible())) {
+    await page.locator(SELECTORS.roll.mainDie).click()
+    await expect(ratingInput).toBeVisible()
+  }
+
+  await setRangeInput(page, SELECTORS.rate.ratingInput, rating)
+  await submitRatingAndWaitForRateResponse(page, () => page.click(SELECTORS.rate.submitButton))
+  await expect(page.locator(SELECTORS.roll.mainDie).or(page.locator('[data-roll-pool]')).first()).toBeVisible()
+}
+
+async function exerciseQueueAndIssueEditor(page: Page): Promise<void> {
+  await page.goto('/queue', { waitUntil: 'domcontentloaded' })
+  const firstThread = page.locator(SELECTORS.threadList.threadItem).first()
+  await expect(firstThread).toBeVisible()
+
+  const actionNames = ['Move to Front', 'Move to Back']
+  for (const actionName of actionNames) {
+    const actionButton = firstThread.locator('button[aria-label="Thread actions"]')
+    if (await actionButton.isVisible()) {
+      await actionButton.click()
+      const menu = page.getByRole('menu')
+      const action = menu.getByRole('menuitem', { name: actionName })
+      if (await action.isVisible()) {
+        await action.click()
+      } else {
+        await page.keyboard.press('Escape')
+      }
+    }
+  }
+
+  await firstThread.click()
+  await page.waitForURL('**/thread/**')
+  const editButton = page.getByRole('button', { name: 'Edit', exact: true })
+  await expect(editButton).toBeVisible()
+  await editButton.click()
+
+  const editDialog = page.getByRole('dialog', { name: 'Edit Thread', exact: true })
+  await expect(editDialog).toBeVisible()
+
+  const showAll = editDialog.getByRole('button', { name: /^Show all \d+$/ })
+  if (await showAll.isVisible()) await showAll.click()
+
+  const issueToggle = editDialog.getByRole('button', { name: /^Toggle issue #/ }).first()
+  if (await issueToggle.isVisible()) {
+    await issueToggle.click()
+    await issueToggle.click()
+  }
+
+  const cancel = editDialog.getByRole('button', { name: /Cancel|Close/ }).first()
+  if (await cancel.isVisible()) await cancel.click()
+}
+
+test('full production account follows the HAR-derived browser workload', async ({ page }, testInfo) => {
   test.skip(
     testInfo.config.metadata.productionProfile !== true,
-    'Run with playwright.prod-profile.config.ts against an explicit production URL.',
+    'Run with playwright.prod-profile.config.ts and a production storage state.',
   )
 
-  const maxApiDurationMs = numericEnvironmentValue('PROD_PROFILE_MAX_API_MS', 5000)
-  const maxApiRequests = numericEnvironmentValue('PROD_PROFILE_MAX_API_REQUESTS', 60)
+  const maxApiDurationMs = numericEnvironmentValue('PROD_PROFILE_MAX_API_MS', 5_000)
+  const minApiRequests = numericEnvironmentValue('PROD_PROFILE_MIN_API_REQUESTS', 40)
+  const maxApiRequests = numericEnvironmentValue('PROD_PROFILE_MAX_API_REQUESTS', SOURCE_HAR.apiRequests)
   const duplicateWindowMs = numericEnvironmentValue('PROD_PROFILE_DUPLICATE_WINDOW_MS', 250)
-
-  const healthStartedAt = Date.now()
-  const health = await page.request.get('/health')
-  await assertProductionHealth(health, Date.now() - healthStartedAt)
-
-  await setupProductionProfileUser(page)
-  const profileTitle = `Production Profile ${Date.now()}`
-  await createThread(page, {
-    title: profileTitle,
-    format: 'Comics',
-    issues_remaining: 40,
-    issue_range: '1-40',
-  })
-  await createThread(page, {
-    title: `${profileTitle} Side A`,
-    format: 'Manga',
-    issues_remaining: 4,
-    issue_range: '1-4',
-  })
-  await createThread(page, {
-    title: `${profileTitle} Side B`,
-    format: 'Novel',
-    issues_remaining: 3,
-    issue_range: '1-3',
-  })
 
   const profile = installNetworkProfile(page)
 
   await page.goto('/', { waitUntil: 'domcontentloaded' })
-  await expect(page.locator(SELECTORS.roll.mainDie)).toBeVisible()
-  await page.click(SELECTORS.roll.mainDie)
+  await expect(page.locator('#root')).toBeVisible()
+  const token = await readAccessToken(page)
+  const accountShape = await assertFullAccountShape(page, token)
+
+  await navigateSourcePages(page)
+  await rateOrRoll(page, '4.0')
+
+  await page.locator(SELECTORS.roll.mainDie).click()
   await expect(page.locator(SELECTORS.rate.ratingInput)).toBeVisible()
-  await setRangeInput(page, SELECTORS.rate.ratingInput, '4.0')
-  await submitRatingAndWaitForRateResponse(page, () => page.click(SELECTORS.rate.submitButton))
-  await expect(page.locator(SELECTORS.roll.mainDie)).toBeVisible()
-  await page.waitForLoadState('networkidle')
+  const snoozeButton = page.locator(SELECTORS.rate.snoozeButton)
+  if (await snoozeButton.isVisible()) await snoozeButton.click()
 
-  await page.goto('/queue', { waitUntil: 'domcontentloaded' })
-  const profileTitleText = page.getByText(profileTitle, { exact: true }).first()
-  await expect(profileTitleText).toBeVisible()
-  const threadCard = profileTitleText.locator(
-    'xpath=ancestor::*[@data-testid="queue-thread-item"]',
-  )
-  await expect(threadCard).toHaveCount(1)
-  await threadCard.click()
-  await page.waitForURL('**/thread/**')
-  const threadTitle = page.getByRole('heading', { name: profileTitle, exact: true })
-  await expect(threadTitle).toBeVisible()
+  await rateOrRoll(page, '3.5')
+  await exerciseQueueAndIssueEditor(page)
 
-  const threadHeader = threadTitle.locator('xpath=ancestor::header')
-  await threadHeader.getByRole('button', { name: 'Edit', exact: true }).click()
-  const editDialog = page.getByRole('dialog', { name: 'Edit Thread', exact: true })
-  await expect(editDialog).toBeVisible()
-  const showAllIssues = editDialog.getByRole('button', { name: 'Show all 40', exact: true })
-  await expect(showAllIssues).toBeVisible()
-  await showAllIssues.click()
-  const issueToggles = editDialog.getByRole('button', { name: /^Toggle issue #/ })
-  await expect(issueToggles).toHaveCount(40)
-  const firstIssueToggle = issueToggles.first()
-  const toggleIssueResponse = page.waitForResponse((response) => {
-    const path = new URL(response.url()).pathname
-    return (
-      /:(markRead|markUnread)$/.test(path)
-      && response.request().method() === 'POST'
-    )
-  })
-  await firstIssueToggle.click()
-  expect((await toggleIssueResponse).ok()).toBeTruthy()
-  await page.waitForLoadState('networkidle')
-
-  await page.goto('/history', { waitUntil: 'domcontentloaded' })
-  await expect(page.getByRole('heading', { name: 'History', exact: true })).toBeVisible()
-  await page.waitForLoadState('networkidle')
   await page.goto('/analytics', { waitUntil: 'domcontentloaded' })
   await expect(page.getByRole('heading', { name: 'Analytics', exact: true })).toBeVisible()
-  await page.waitForLoadState('networkidle')
+  await page.goto('/history', { waitUntil: 'domcontentloaded' })
+  await expect(page.getByRole('heading', { name: 'History', exact: true })).toBeVisible()
 
   await profile.finish()
 
   const failedResponses = profile.records.filter((record) => record.status >= 400)
   const slowResponses = profile.records.filter((record) => record.durationMs > maxApiDurationMs)
+  const duplicateGetBursts = findDuplicateGetBursts(profile.records, duplicateWindowMs)
   const legacyDependencyRequests = profile.records.filter((record) =>
-    /^\/api\/v1\/issues\/:id\/dependencies$/.test(record.normalizedUrl)
+    record.normalizedUrl === '/api/v1/issues/:id/dependencies'
   )
   const batchDependencyRequests = profile.records.filter((record) =>
     record.normalizedUrl === '/api/v1/threads/:id/issue-dependencies'
   )
-  const duplicateGetBursts = findDuplicateGetBursts(profile.records, duplicateWindowMs)
   const durations = profile.records.map((record) => record.durationMs)
 
   const report = {
     generatedAt: new Date().toISOString(),
     baseUrl: testInfo.project.use.baseURL,
+    sourceHar: SOURCE_HAR,
+    accountShape,
     thresholds: {
       maxApiDurationMs,
+      minApiRequests,
       maxApiRequests,
       duplicateWindowMs,
     },
     summary: {
       apiRequests: profile.records.length,
+      sourceHarRequestRatio: profile.records.length / SOURCE_HAR.apiRequests,
       failedResponses: failedResponses.length,
       transportFailures: profile.transportFailures.length,
       slowResponses: slowResponses.length,
@@ -368,12 +398,10 @@ test('HAR-derived production journey stays within request budgets', async ({ pag
 
   expect(profile.transportFailures, 'Transport failures').toEqual([])
   expect(failedResponses, 'API responses with status >= 400').toEqual([])
-  expect(
-    slowResponses,
-    `API responses slower than ${maxApiDurationMs} ms`,
-  ).toEqual([])
-  expect(profile.records.length, 'Total API request budget').toBeLessThanOrEqual(maxApiRequests)
+  expect(slowResponses, `API responses slower than ${maxApiDurationMs} ms`).toEqual([])
+  expect(profile.records.length, 'Minimum full-account workload').toBeGreaterThanOrEqual(minApiRequests)
+  expect(profile.records.length, 'Maximum HAR-derived request budget').toBeLessThanOrEqual(maxApiRequests)
   expect(legacyDependencyRequests, 'Legacy one-request-per-issue dependency calls').toEqual([])
-  expect(batchDependencyRequests, 'Expected one dependency batch request').toHaveLength(1)
+  expect(batchDependencyRequests.length, 'Thread dependency batch requests').toBeGreaterThanOrEqual(1)
   expect(duplicateGetBursts, 'Duplicate GET requests inside the burst window').toEqual([])
 })


### PR DESCRIPTION
## Summary

- Replace the disposable-user, three-thread smoke profile with a production-account workload loaded from a local Playwright storage-state file.
- Install network recording before the first browser navigation and remove the `/health` warm-up request.
- Refuse to run against a fresh or toy account by enforcing configurable minimum thread and session counts.
- Exercise authenticated startup, queue/history/analytics navigation, rolling, ratings, snoozing, queue movement, thread detail, and issue toggling through the browser.
- Preserve the original HAR as the comparison baseline: 198 API requests across roughly 201 seconds, with its full action inventory included in the generated report.
- Report the observed/source request ratio alongside latency, cache, request-ID, database-query, duplicate-GET, dependency-fanout, failure, and transport diagnostics.
- Require the authentication storage-state file to remain local and add it to `.gitignore`.

## Why

PR #675 was useful as a small-account smoke test, but it was not representative of the supplied HAR:

- it called `/health` before measuring;
- registered a disposable user;
- created only three small threads;
- installed the recorder after setup;
- and exercised only a short roll/rate/queue/history/analytics path.

That could pass while missing the cold authenticated path, the real account's data volume, and the workload shape that produced the original 198 API requests.

## Run

```bash
cd frontend
pnpm exec playwright codegen \
  --save-storage=../prod-profile-storage-state.json \
  https://comic-pile.vercel.app

PROD_BASE_URL=https://comic-pile.vercel.app \
PROD_PROFILE_STORAGE_STATE=../prod-profile-storage-state.json \
  pnpm run test:e2e:prod-profile
```

The storage-state file contains authentication material and must not be committed.

## Validation

- TypeScript syntax transpilation passed for the rewritten spec and Playwright config.
- The branch is a four-file change directly on current `main`.
- A live full-account run was not possible from the connector environment because the production storage-state secret is intentionally unavailable here.
- Repository lint, unit, build, and browser CI should run before merge. The large browser matrix remains governed separately by #679.