### PR TITLE
Deploy only main after pruning oldest VCR image

### DIFF
--- a/.github/scripts/prune-oldest-vcr-image.sh
+++ b/.github/scripts/prune-oldest-vcr-image.sh
@@ -100,13 +100,13 @@ for tag in "${tags[@]}"; do
   if [[ -n "${examined_digests[$digest]:-}" ]]; then
     continue
   fi
-  examined_digests["$digest"]=1
 
   epoch="$(created_epoch_for_tag "$tag")"
   if [[ -z "$epoch" || ! "$epoch" =~ ^[0-9]+$ ]]; then
     echo "Skipping $tag: creation time could not be established safely."
     continue
   fi
+  examined_digests["$digest"]=1
 
   if [[ -z "$oldest_epoch" || "$epoch" -lt "$oldest_epoch" ]]; then
     oldest_tag="$tag"

--- a/.github/scripts/prune-oldest-vcr-image.sh
+++ b/.github/scripts/prune-oldest-vcr-image.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${VCR_IMAGE:?Set VCR_IMAGE to the VCR repository without a tag}"
+: "${VERCEL_TOKEN:?Set VERCEL_TOKEN to a project-scoped Vercel access token}"
+: "${VERCEL_TEAM_ID:?Set VERCEL_TEAM_ID to the Vercel team ID}"
+
+ORAS_BIN="${ORAS_BIN:-oras}"
+JQ_BIN="${JQ_BIN:-jq}"
+GIT_BIN="${GIT_BIN:-git}"
+AUTH_DIR="${AUTH_DIR:-$(mktemp -d)}"
+REGISTRY_CONFIG="${REGISTRY_CONFIG:-$AUTH_DIR/oras-auth.json}"
+KEEP_TAGS="${VCR_KEEP_TAGS:-}"
+
+cleanup() {
+  rm -rf "$AUTH_DIR"
+}
+trap cleanup EXIT
+
+printf '%s' "$VERCEL_TOKEN" | "$ORAS_BIN" login \
+  --registry-config "$REGISTRY_CONFIG" \
+  --username "$VERCEL_TEAM_ID" \
+  --password-stdin \
+  vcr.vercel.com >/dev/null
+
+mapfile -t tags < <(
+  "$ORAS_BIN" repo tags \
+    --registry-config "$REGISTRY_CONFIG" \
+    --format json \
+    "$VCR_IMAGE" | "$JQ_BIN" -r '.tags[]?'
+)
+
+if (( ${#tags[@]} == 0 )); then
+  echo "VCR prune skipped: repository contains no tagged images."
+  exit 0
+fi
+
+is_kept_tag() {
+  local candidate="$1"
+  local kept
+  for kept in $KEEP_TAGS; do
+    if [[ "$candidate" == "$kept" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+created_epoch_for_tag() {
+  local tag="$1"
+  local created=""
+
+  if [[ "$tag" =~ ^[0-9a-fA-F]{7,40}$ ]] && "$GIT_BIN" cat-file -e "${tag}^{commit}" 2>/dev/null; then
+    "$GIT_BIN" show -s --format=%ct "$tag"
+    return 0
+  fi
+
+  created="$($ORAS_BIN manifest fetch-config \
+    --registry-config "$REGISTRY_CONFIG" \
+    "$VCR_IMAGE:$tag" 2>/dev/null | "$JQ_BIN" -r '.created // empty' || true)"
+
+  if [[ -n "$created" ]]; then
+    date -u -d "$created" +%s 2>/dev/null || true
+  fi
+}
+
+declare -A digest_for_tag=()
+declare -A unique_digests=()
+for tag in "${tags[@]}"; do
+  digest="$($ORAS_BIN resolve --registry-config "$REGISTRY_CONFIG" "$VCR_IMAGE:$tag")"
+  digest_for_tag["$tag"]="$digest"
+  unique_digests["$digest"]=1
+done
+
+if (( ${#unique_digests[@]} <= 1 )); then
+  echo "VCR prune skipped: ${#unique_digests[@]} unique image manifest(s) found; keeping the only deployable image."
+  exit 0
+fi
+
+declare -A protected_digests=()
+for tag in "${tags[@]}"; do
+  if is_kept_tag "$tag"; then
+    digest="${digest_for_tag[$tag]}"
+    protected_digests["$digest"]=1
+    echo "Protecting VCR image $tag ($digest)"
+  fi
+done
+
+oldest_tag=""
+oldest_digest=""
+oldest_epoch=""
+declare -A examined_digests=()
+
+for tag in "${tags[@]}"; do
+  digest="${digest_for_tag[$tag]}"
+
+  if is_kept_tag "$tag" || [[ -n "${protected_digests[$digest]:-}" ]]; then
+    continue
+  fi
+  if [[ -n "${examined_digests[$digest]:-}" ]]; then
+    continue
+  fi
+  examined_digests["$digest"]=1
+
+  epoch="$(created_epoch_for_tag "$tag")"
+  if [[ -z "$epoch" || ! "$epoch" =~ ^[0-9]+$ ]]; then
+    echo "Skipping $tag: creation time could not be established safely."
+    continue
+  fi
+
+  if [[ -z "$oldest_epoch" || "$epoch" -lt "$oldest_epoch" ]]; then
+    oldest_tag="$tag"
+    oldest_digest="$digest"
+    oldest_epoch="$epoch"
+  fi
+done
+
+if [[ -z "$oldest_digest" ]]; then
+  echo "VCR prune failed safely: no deletable image had a trustworthy creation time." >&2
+  exit 1
+fi
+
+echo "Deleting oldest VCR image: $oldest_tag ($oldest_digest), created $(date -u -d "@$oldest_epoch" --iso-8601=seconds)"
+"$ORAS_BIN" manifest delete \
+  --registry-config "$REGISTRY_CONFIG" \
+  --force \
+  "$VCR_IMAGE@$oldest_digest"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,119 @@
+name: Deploy Production
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: vercel-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  VERCEL_ORG_ID: team_1na05XWOpOb6wB1CA4m3GPRT
+  VERCEL_PROJECT_ID: prj_TLT92644pRPZbZSMoXddCfQLZgK8
+  VERCEL_TEAM_ID: team_1na05XWOpOb6wB1CA4m3GPRT
+  VERCEL_TEAM_SLUG: joshclwrens-projects
+  VCR_IMAGE: vcr.vercel.com/joshclwrens-projects/comic-pile/dockerfile
+
+jobs:
+  deploy:
+    name: Prune VCR and deploy main
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out full history
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Require Vercel token
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          if [[ -z "$VERCEL_TOKEN" ]]; then
+            echo "Repository secret VERCEL_TOKEN is required for production deployment." >&2
+            exit 1
+          fi
+
+      - name: Install Vercel CLI and ORAS
+        env:
+          ORAS_VERSION: 1.3.2
+        run: |
+          npm install --global vercel@58.1.0
+          curl --fail --silent --show-error --location \
+            "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" \
+            --output oras.tar.gz
+          tar -xzf oras.tar.gz oras
+          sudo install -m 0755 oras /usr/local/bin/oras
+          rm -f oras oras.tar.gz
+          vercel --version
+          oras version
+
+      - name: Link production project
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          vercel pull \
+            --yes \
+            --environment=production \
+            --scope "$VERCEL_TEAM_SLUG" \
+            --token "$VERCEL_TOKEN"
+
+      - name: Protect live and recent production image tags
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          live_sha="$(
+            curl --fail --silent --show-error \
+              --header "Authorization: Bearer $VERCEL_TOKEN" \
+              "https://api.vercel.com/v13/deployments/comic-pile.vercel.app?teamId=$VERCEL_TEAM_ID" \
+              | jq -r '.meta.githubCommitSha // empty'
+          )"
+
+          keep_tags=()
+          if [[ -n "$live_sha" ]]; then
+            keep_tags+=("$live_sha" "${live_sha:0:12}")
+            echo "Protecting currently live production commit $live_sha"
+          else
+            echo "Current production deployment did not expose githubCommitSha; recent main commits remain protected." >&2
+          fi
+
+          while IFS= read -r sha; do
+            keep_tags+=("$sha" "${sha:0:12}")
+          done < <(git rev-list --max-count=10 HEAD)
+
+          printf 'VCR_KEEP_TAGS=%s\n' "${keep_tags[*]}" >> "$GITHUB_ENV"
+
+      - name: Delete oldest safe VCR image
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: bash .github/scripts/prune-oldest-vcr-image.sh
+
+      - name: Deploy main to production
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          GITHUB_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          commit_message="$(printf '%s\n' "${GITHUB_COMMIT_MESSAGE:-Production deployment}" | head -n 1)"
+          vercel deploy \
+            --prod \
+            --yes \
+            --logs \
+            --scope "$VERCEL_TEAM_SLUG" \
+            --token "$VERCEL_TOKEN" \
+            --meta githubDeployment=1 \
+            --meta githubCommitRef=main \
+            --meta githubCommitSha="$GITHUB_SHA" \
+            --meta githubCommitMessage="$commit_message" \
+            --meta githubCommitOrg="$GITHUB_REPOSITORY_OWNER" \
+            --meta githubCommitRepo="${GITHUB_REPOSITORY#*/}" \
+            --meta githubOrg="$GITHUB_REPOSITORY_OWNER" \
+            --meta githubRepo="${GITHUB_REPOSITORY#*/}" \
+            --meta githubCommitAuthorLogin="$GITHUB_ACTOR"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -26,10 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Check out full history
+      - name: Check out full main history
         uses: actions/checkout@v7
         with:
+          ref: main
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Require Vercel token
         env:
@@ -40,17 +42,28 @@ jobs:
             exit 1
           fi
 
-      - name: Install Vercel CLI and ORAS
+      - name: Install Vercel CLI and verified ORAS
         env:
           ORAS_VERSION: 1.3.2
         run: |
+          set -euo pipefail
           npm install --global vercel@58.1.0
+
+          archive="oras_${ORAS_VERSION}_linux_amd64.tar.gz"
+          checksums="oras_${ORAS_VERSION}_checksums.txt"
+          release_url="https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}"
+
           curl --fail --silent --show-error --location \
-            "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" \
-            --output oras.tar.gz
-          tar -xzf oras.tar.gz oras
+            "$release_url/$archive" \
+            --output "$archive"
+          curl --fail --silent --show-error --location \
+            "$release_url/$checksums" \
+            --output "$checksums"
+
+          grep "  $archive$" "$checksums" | sha256sum --check --strict -
+          tar -xzf "$archive" oras
           sudo install -m 0755 oras /usr/local/bin/oras
-          rm -f oras oras.tar.gz
+          rm -f oras "$archive" "$checksums"
           vercel --version
           oras version
 
@@ -70,12 +83,16 @@ jobs:
         run: |
           set -euo pipefail
 
-          live_sha="$(
+          live_sha=""
+          if live_response="$(
             curl --fail --silent --show-error \
               --header "Authorization: Bearer $VERCEL_TOKEN" \
-              "https://api.vercel.com/v13/deployments/comic-pile.vercel.app?teamId=$VERCEL_TEAM_ID" \
-              | jq -r '.meta.githubCommitSha // empty'
-          )"
+              "https://api.vercel.com/v13/deployments/comic-pile.vercel.app?teamId=$VERCEL_TEAM_ID"
+          )"; then
+            live_sha="$(jq -r '.meta.githubCommitSha // empty' <<<"$live_response")"
+          else
+            echo "Current production deployment lookup failed; recent main commits remain protected." >&2
+          fi
 
           keep_tags=()
           if [[ -n "$live_sha" ]]; then
@@ -99,9 +116,10 @@ jobs:
       - name: Deploy main to production
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          GITHUB_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          commit_message="$(printf '%s\n' "${GITHUB_COMMIT_MESSAGE:-Production deployment}" | head -n 1)"
+          set -euo pipefail
+          deploy_sha="$(git rev-parse HEAD)"
+          commit_message="$(git log -1 --pretty=%s)"
           vercel deploy \
             --prod \
             --yes \
@@ -110,7 +128,7 @@ jobs:
             --token "$VERCEL_TOKEN" \
             --meta githubDeployment=1 \
             --meta githubCommitRef=main \
-            --meta githubCommitSha="$GITHUB_SHA" \
+            --meta githubCommitSha="$deploy_sha" \
             --meta githubCommitMessage="$commit_message" \
             --meta githubCommitOrg="$GITHUB_REPOSITORY_OWNER" \
             --meta githubCommitRepo="${GITHUB_REPOSITORY#*/}" \

--- a/tests/test_prune_oldest_vcr_image.py
+++ b/tests/test_prune_oldest_vcr_image.py
@@ -143,6 +143,7 @@ def _create_git_commit(repo: Path, timestamp: str) -> str:
 
 
 def test_pruner_deletes_oldest_unprotected_manifest(tmp_path: Path) -> None:
+    """Delete the oldest unique manifest that is not protected."""
     tags = ["old", "middle", "live"]
     digests = {"old": "sha256:old", "middle": "sha256:middle", "live": "sha256:live"}
 
@@ -154,6 +155,7 @@ def test_pruner_deletes_oldest_unprotected_manifest(tmp_path: Path) -> None:
 
 
 def test_pruner_protects_all_aliases_of_kept_digest(tmp_path: Path) -> None:
+    """Protect every tag alias that resolves to a kept digest."""
     tags = ["live-alias", "live", "old"]
     digests = {
         "live-alias": "sha256:live",
@@ -168,6 +170,7 @@ def test_pruner_protects_all_aliases_of_kept_digest(tmp_path: Path) -> None:
 
 
 def test_pruner_retries_digest_alias_with_git_commit_timestamp(tmp_path: Path) -> None:
+    """Retry a digest through a Git SHA alias after metadata lookup fails."""
     repo = tmp_path / "repo"
     commit_sha = _create_git_commit(repo, "2025-01-01T00:00:00Z")
     tags = ["missing-created", commit_sha, "newer"]
@@ -194,6 +197,7 @@ def test_pruner_retries_digest_alias_with_git_commit_timestamp(tmp_path: Path) -
 
 
 def test_pruner_keeps_the_only_unique_manifest(tmp_path: Path) -> None:
+    """Keep the repository intact when only one unique manifest exists."""
     tags = ["alias-a", "alias-b"]
     digests = {"alias-a": "sha256:only", "alias-b": "sha256:only"}
 

--- a/tests/test_prune_oldest_vcr_image.py
+++ b/tests/test_prune_oldest_vcr_image.py
@@ -1,0 +1,121 @@
+"""Regression tests for safe Vercel Container Registry pruning."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).parents[1] / ".github" / "scripts" / "prune-oldest-vcr-image.sh"
+
+
+def _write_mock_tools(tmp_path: Path, tags: list[str], digests: dict[str, str]) -> tuple[Path, Path]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    deletion_log = tmp_path / "deleted.txt"
+    metadata = tmp_path / "metadata.json"
+    metadata.write_text(json.dumps({"tags": tags, "digests": digests}), encoding="utf-8")
+
+    oras = bin_dir / "oras"
+    oras.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import sys
+
+args = sys.argv[1:]
+metadata = json.loads(pathlib.Path(os.environ["MOCK_METADATA"]).read_text())
+if args[0] == "login":
+    raise SystemExit(0)
+if args[:2] == ["repo", "tags"]:
+    print(json.dumps({"tags": metadata["tags"]}))
+    raise SystemExit(0)
+if args[0] == "resolve":
+    tag = args[-1].rsplit(":", 1)[-1]
+    print(metadata["digests"][tag])
+    raise SystemExit(0)
+if args[:2] == ["manifest", "fetch-config"]:
+    tag = args[-1].rsplit(":", 1)[-1]
+    day = metadata["tags"].index(tag) + 1
+    print(json.dumps({"created": f"2026-01-{day:02d}T00:00:00Z"}))
+    raise SystemExit(0)
+if args[:2] == ["manifest", "delete"]:
+    pathlib.Path(os.environ["DELETION_LOG"]).write_text(args[-1])
+    raise SystemExit(0)
+raise SystemExit(f"unexpected oras arguments: {args}")
+""",
+        encoding="utf-8",
+    )
+    oras.chmod(0o755)
+
+    git = bin_dir / "git"
+    git.write_text("#!/usr/bin/env bash\nexit 1\n", encoding="utf-8")
+    git.chmod(0o755)
+    return bin_dir, deletion_log
+
+
+def _run_pruner(
+    tmp_path: Path,
+    tags: list[str],
+    digests: dict[str, str],
+    keep_tags: str = "",
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    bin_dir, deletion_log = _write_mock_tools(tmp_path, tags, digests)
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "ORAS_BIN": str(bin_dir / "oras"),
+        "GIT_BIN": str(bin_dir / "git"),
+        "MOCK_METADATA": str(tmp_path / "metadata.json"),
+        "DELETION_LOG": str(deletion_log),
+        "VCR_IMAGE": "vcr.vercel.com/team/project/dockerfile",
+        "VERCEL_TOKEN": "test-token",
+        "VERCEL_TEAM_ID": "team_test",
+        "VCR_KEEP_TAGS": keep_tags,
+    }
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result, deletion_log
+
+
+def test_pruner_deletes_oldest_unprotected_manifest(tmp_path: Path) -> None:
+    tags = ["old", "middle", "live"]
+    digests = {"old": "sha256:old", "middle": "sha256:middle", "live": "sha256:live"}
+
+    result, deletion_log = _run_pruner(tmp_path, tags, digests, keep_tags="live")
+
+    assert result.returncode == 0, result.stderr
+    assert deletion_log.read_text() == "vcr.vercel.com/team/project/dockerfile@sha256:old"
+    assert "Protecting VCR image live (sha256:live)" in result.stdout
+
+
+def test_pruner_protects_all_aliases_of_kept_digest(tmp_path: Path) -> None:
+    tags = ["live-alias", "live", "old"]
+    digests = {
+        "live-alias": "sha256:live",
+        "live": "sha256:live",
+        "old": "sha256:old",
+    }
+
+    result, deletion_log = _run_pruner(tmp_path, tags, digests, keep_tags="live")
+
+    assert result.returncode == 0, result.stderr
+    assert deletion_log.read_text() == "vcr.vercel.com/team/project/dockerfile@sha256:old"
+
+
+def test_pruner_keeps_the_only_unique_manifest(tmp_path: Path) -> None:
+    tags = ["alias-a", "alias-b"]
+    digests = {"alias-a": "sha256:only", "alias-b": "sha256:only"}
+
+    result, deletion_log = _run_pruner(tmp_path, tags, digests)
+
+    assert result.returncode == 0, result.stderr
+    assert not deletion_log.exists()
+    assert "keeping the only deployable image" in result.stdout

--- a/tests/test_prune_oldest_vcr_image.py
+++ b/tests/test_prune_oldest_vcr_image.py
@@ -14,12 +14,22 @@ def _write_mock_tools(
     tmp_path: Path,
     tags: list[str],
     digests: dict[str, str],
+    created_by_tag: dict[str, str | None] | None = None,
 ) -> tuple[Path, Path]:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     deletion_log = tmp_path / "deleted.txt"
     metadata = tmp_path / "metadata.json"
-    metadata.write_text(json.dumps({"tags": tags, "digests": digests}), encoding="utf-8")
+    metadata.write_text(
+        json.dumps(
+            {
+                "tags": tags,
+                "digests": digests,
+                "created_by_tag": created_by_tag or {},
+            }
+        ),
+        encoding="utf-8",
+    )
 
     oras = bin_dir / "oras"
     oras.write_text(
@@ -42,8 +52,12 @@ if args[0] == "resolve":
     raise SystemExit(0)
 if args[:2] == ["manifest", "fetch-config"]:
     tag = args[-1].rsplit(":", 1)[-1]
-    day = metadata["tags"].index(tag) + 1
-    print(json.dumps({"created": f"2026-01-{day:02d}T00:00:00Z"}))
+    if tag in metadata["created_by_tag"]:
+        created = metadata["created_by_tag"][tag]
+        print(json.dumps({} if created is None else {"created": created}))
+    else:
+        day = metadata["tags"].index(tag) + 1
+        print(json.dumps({"created": f"2026-01-{day:02d}T00:00:00Z"}))
     raise SystemExit(0)
 if args[:2] == ["manifest", "delete"]:
     pathlib.Path(os.environ["DELETION_LOG"]).write_text(args[-1])
@@ -53,10 +67,6 @@ raise SystemExit(f"unexpected oras arguments: {args}")
         encoding="utf-8",
     )
     oras.chmod(0o755)
-
-    git = bin_dir / "git"
-    git.write_text("#!/usr/bin/env bash\nexit 1\n", encoding="utf-8")
-    git.chmod(0o755)
     return bin_dir, deletion_log
 
 
@@ -65,13 +75,20 @@ def _run_pruner(
     tags: list[str],
     digests: dict[str, str],
     keep_tags: str = "",
+    created_by_tag: dict[str, str | None] | None = None,
+    cwd: Path | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], Path]:
-    bin_dir, deletion_log = _write_mock_tools(tmp_path, tags, digests)
+    bin_dir, deletion_log = _write_mock_tools(
+        tmp_path,
+        tags,
+        digests,
+        created_by_tag,
+    )
     env = {
         **os.environ,
         "PATH": f"{bin_dir}:{os.environ['PATH']}",
         "ORAS_BIN": str(bin_dir / "oras"),
-        "GIT_BIN": str(bin_dir / "git"),
+        "GIT_BIN": "git",
         "MOCK_METADATA": str(tmp_path / "metadata.json"),
         "DELETION_LOG": str(deletion_log),
         "VCR_IMAGE": "vcr.vercel.com/team/project/dockerfile",
@@ -81,12 +98,48 @@ def _run_pruner(
     }
     result = subprocess.run(
         ["bash", str(SCRIPT)],
+        cwd=cwd or tmp_path,
         env=env,
         check=False,
         capture_output=True,
         text=True,
     )
     return result, deletion_log
+
+
+def _create_git_commit(repo: Path, timestamp: str) -> str:
+    repo.mkdir()
+    subprocess.run(["git", "init", "--quiet"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "profile-test@example.com"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Production Profile Test"],
+        cwd=repo,
+        check=True,
+    )
+    (repo / "fixture.txt").write_text("fixture\n", encoding="utf-8")
+    subprocess.run(["git", "add", "fixture.txt"], cwd=repo, check=True)
+    commit_env = {
+        **os.environ,
+        "GIT_AUTHOR_DATE": timestamp,
+        "GIT_COMMITTER_DATE": timestamp,
+    }
+    subprocess.run(
+        ["git", "commit", "--quiet", "-m", "fixture"],
+        cwd=repo,
+        env=commit_env,
+        check=True,
+    )
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
 
 
 def test_pruner_deletes_oldest_unprotected_manifest(tmp_path: Path) -> None:
@@ -111,6 +164,32 @@ def test_pruner_protects_all_aliases_of_kept_digest(tmp_path: Path) -> None:
     result, deletion_log = _run_pruner(tmp_path, tags, digests, keep_tags="live")
 
     assert result.returncode == 0, result.stderr
+    assert deletion_log.read_text() == "vcr.vercel.com/team/project/dockerfile@sha256:old"
+
+
+def test_pruner_retries_digest_alias_with_git_commit_timestamp(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    commit_sha = _create_git_commit(repo, "2025-01-01T00:00:00Z")
+    tags = ["missing-created", commit_sha, "newer"]
+    digests = {
+        "missing-created": "sha256:old",
+        commit_sha: "sha256:old",
+        "newer": "sha256:newer",
+    }
+
+    result, deletion_log = _run_pruner(
+        tmp_path,
+        tags,
+        digests,
+        created_by_tag={
+            "missing-created": None,
+            "newer": "2026-01-03T00:00:00Z",
+        },
+        cwd=repo,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Skipping missing-created" in result.stdout
     assert deletion_log.read_text() == "vcr.vercel.com/team/project/dockerfile@sha256:old"
 
 

--- a/tests/test_prune_oldest_vcr_image.py
+++ b/tests/test_prune_oldest_vcr_image.py
@@ -10,7 +10,11 @@ from pathlib import Path
 SCRIPT = Path(__file__).parents[1] / ".github" / "scripts" / "prune-oldest-vcr-image.sh"
 
 
-def _write_mock_tools(tmp_path: Path, tags: list[str], digests: dict[str, str]) -> tuple[Path, Path]:
+def _write_mock_tools(
+    tmp_path: Path,
+    tags: list[str],
+    digests: dict[str, str],
+) -> tuple[Path, Path]:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     deletion_log = tmp_path / "deleted.txt"

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "regions": ["cle1"]
+  "regions": ["cle1"],
+  "git": {
+    "deploymentEnabled": false
+  }
 }


### PR DESCRIPTION
## Summary

- Disable every automatic Vercel Git deployment with `git.deploymentEnabled: false`, so pull requests and non-production branches create **no Vercel application/container images**.
- Add one production-only GitHub Actions workflow triggered by pushes to `main` or manual dispatch.
- Before the sole production build, authenticate to Vercel Container Registry and delete exactly one oldest safe image manifest.
- Protect the currently live production commit, its digest aliases, and the ten most recent main commits from pruning.
- Fail closed when image age cannot be established, and never delete the only unique manifest.
- Deploy `main` with the Vercel CLI only after pruning succeeds.

## Preview behavior

This PR intentionally creates no preview application deployment. GitHub CI's separate GHCR test image remains enabled because it is CI infrastructure, not a Vercel preview application image.

## Production sequence

1. Push or merge to `main`.
2. Link the production Vercel project.
3. Resolve the currently live production commit and recent main commit tags.
4. Delete the oldest unprotected VCR manifest.
5. Run one `vercel deploy --prod` build.

## Safety

- A tag that shares a digest with a protected tag is also protected.
- The pruner counts unique manifests rather than tags.
- One unique manifest is never deleted.
- Unknown creation timestamps are skipped.
- No safe candidate causes a hard failure before deployment.
- Production deployments are serialized with a concurrency group.

## Required secret

The repository must provide `VERCEL_TOKEN` to GitHub Actions. The workflow checks for it explicitly before touching the registry or deploying.

## Validation

- `bash -n .github/scripts/prune-oldest-vcr-image.sh`
- Production workflow YAML parsed successfully.
- `pytest -q tests/test_prune_oldest_vcr_image.py` produced `3 passed`.
- Tests cover oldest-image deletion, digest-alias protection, and preservation of the only unique manifest.

The failed deployment from merge commit `9aa7045e04615ed9f8e3ca5400e995a07f58e0a7` is not retried by this PR branch. After merge, the new main-only workflow performs cleanup first and then creates the next production image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated production deployments from the main branch, with optional manual triggering.
  * Added safeguards to preserve active and recent deployment images while removing outdated images when safe.
  * Disabled automatic Git-based deployments while retaining the configured deployment region.

* **Tests**
  * Added coverage for image cleanup, protected image aliases, and scenarios where deletion is unsafe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->