### PR TITLE
Fix pnpm setup in production smoke job

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -155,7 +155,6 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.15.0
           run_install: false
 
       - name: Set up Node.js


### PR DESCRIPTION
## Summary

- remove the explicit pnpm version from `pnpm/action-setup`
- let the action use the repository's existing `packageManager` declaration
- keep the post-deploy Chromium smoke workflow unchanged otherwise

## Failure addressed

The first post-merge production smoke run failed during `Set up pnpm` because pnpm 10.15.0 was specified both in the workflow action input and in the root `package.json`. The action rejects multiple version sources before installing dependencies.

After merge, the next main deployment will exercise the corrected smoke job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the production deployment workflow to use the default pnpm setup configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->