### PR TITLE
Restore production slow-request observability and document missing Server-Timing (#678)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -51,6 +51,60 @@ from app.middleware.request_logging import add_request_logging_middleware
 
 logger = logging.getLogger(__name__)
 
+
+def _default_log_level(environment: str) -> int:
+    """Resolve the default root log level for an environment.
+
+    Production defaults to WARNING so structured slow-request and client-error
+    warnings reach deployment logs. Set ``LOG_LEVEL`` to raise or lower it.
+
+    Args:
+        environment: Current application environment.
+
+    Returns:
+        The default root logging level for the environment.
+    """
+    env_level_map: dict[str, int] = {
+        "production": logging.WARNING,
+        "staging": logging.WARNING,
+        "development": logging.DEBUG,
+        "test": logging.WARNING,
+    }
+    return env_level_map.get(environment, logging.WARNING)
+
+
+def _resolve_log_level(environment: str) -> int:
+    """Resolve the effective root log level, honoring a ``LOG_LEVEL`` override.
+
+    Args:
+        environment: Current application environment.
+
+    Returns:
+        The root logging level to configure.
+    """
+    requested_level = os.getenv("LOG_LEVEL")
+    if requested_level:
+        return logging.getLevelNamesMapping().get(
+            requested_level.upper(),
+            _default_log_level(environment),
+        )
+    return _default_log_level(environment)
+
+
+def _configure_logging(environment: str) -> None:
+    """Configure root logging unless a handler is already installed.
+
+    Uvicorn leaves the root logger without handlers, so this path runs in
+    production. ``basicConfig`` is a no-op when handlers already exist.
+
+    Args:
+        environment: Current application environment.
+    """
+    if logging.getLogger().hasHandlers():
+        return
+    logging.basicConfig(level=_resolve_log_level(environment))
+
+
 # Log database URL at startup (with password redacted)
 _db_settings = get_database_settings()
 _redacted_url = make_url(_db_settings.database_url).render_as_string(hide_password=True)
@@ -67,22 +121,7 @@ def create_app(*, serve_frontend: bool = True) -> FastAPI:
     """
     app_settings = get_app_settings()
 
-    if not logging.getLogger().hasHandlers():
-        requested_level = os.getenv("LOG_LEVEL")
-        env_level_map: dict[str, int] = {
-            "production": logging.ERROR,
-            "staging": logging.WARNING,
-            "development": logging.DEBUG,
-            "test": logging.WARNING,
-        }
-        default_level = env_level_map.get(app_settings.environment, logging.WARNING)
-
-        if requested_level:
-            level = logging.getLevelNamesMapping().get(requested_level.upper(), default_level)
-        else:
-            level = default_level
-
-        logging.basicConfig(level=level)
+    _configure_logging(app_settings.environment)
 
     app = FastAPI(
         title="Dice-Driven Comic Tracker",

--- a/docs/PRODUCTION_PROFILE.md
+++ b/docs/PRODUCTION_PROFILE.md
@@ -88,18 +88,19 @@ Each run attaches `production-profile.json` with:
 
 The report is evidence, not a synthetic pass badge. A large drop in request count is expected when fan-out is removed, but a tiny request count or small-account guard failure means the profile is no longer representative.
 
-## Vercel strips the `Server-Timing` response header
+## `Server-Timing` is absent from the current Vercel deployment
 
-Proven against the live production deployment (`https://comic-pile.vercel.app/health`) and the local container path:
+Observed against the live production deployment (`https://comic-pile.vercel.app/health`) and the local container path:
 
 - Running the same middleware over real HTTP locally returns all four headers: `X-Request-ID`, `X-App-Cache`, `X-App-DB-Queries`, and `Server-Timing`.
-- Through Vercel's container-deployment proxy, `X-Request-ID`, `X-App-Cache`, and `X-App-DB-Queries` are present but `Server-Timing` is absent.
-- Vercel's documented deployment response headers cover only system headers (`x-vercel-cache`, `x-vercel-id`, `cache-control`, etc.); `Server-Timing` is stripped by the platform proxy for container deployments.
+- Responses observed through the current Vercel container deployment include `X-Request-ID`, `X-App-Cache`, and `X-App-DB-Queries`, but not `Server-Timing`.
+- This proves a deployment-path discrepancy, but the precise layer removing or suppressing `Server-Timing` has not been isolated. Vercel's documented system response headers are not an allowlist for application-defined headers.
 
 Consequences for the production profile report:
 
-- `serverTiming` is `null` for every record captured against a Vercel deployment. This is expected platform behavior, not a missing report field.
-- Timing and diagnostics evidence is still available from the per-request `X-Request-ID`, `X-App-DB-Queries`, and `X-App-Cache` headers, from the structured `Slow HTTP request` warning logs, and from Vercel runtime logs (request `x-vercel-id`, invocation timings).
+- `serverTiming` is currently expected to be `null` for records captured against this deployment. Treat that as an observed limitation of the current deployment path, not a permanent or documented Vercel platform guarantee.
+- Timing and diagnostics evidence remains available from the per-request `X-Request-ID`, `X-App-DB-Queries`, and `X-App-Cache` headers, from the structured `Slow HTTP request` warning logs, and from Vercel runtime logs such as request `x-vercel-id` and invocation timing information.
+- A preview-deployment comparison or origin-versus-proxy capture is still required before attributing the missing header to a specific Vercel proxy layer.
 
 ## Production slow-request warnings are enabled
 

--- a/docs/PRODUCTION_PROFILE.md
+++ b/docs/PRODUCTION_PROFILE.md
@@ -87,3 +87,26 @@ Each run attaches `production-profile.json` with:
 - duplicate GET bursts, transport failures, and slow responses.
 
 The report is evidence, not a synthetic pass badge. A large drop in request count is expected when fan-out is removed, but a tiny request count or small-account guard failure means the profile is no longer representative.
+
+## Vercel strips the `Server-Timing` response header
+
+Proven against the live production deployment (`https://comic-pile.vercel.app/health`) and the local container path:
+
+- Running the same middleware over real HTTP locally returns all four headers: `X-Request-ID`, `X-App-Cache`, `X-App-DB-Queries`, and `Server-Timing`.
+- Through Vercel's container-deployment proxy, `X-Request-ID`, `X-App-Cache`, and `X-App-DB-Queries` are present but `Server-Timing` is absent.
+- Vercel's documented deployment response headers cover only system headers (`x-vercel-cache`, `x-vercel-id`, `cache-control`, etc.); `Server-Timing` is stripped by the platform proxy for container deployments.
+
+Consequences for the production profile report:
+
+- `serverTiming` is `null` for every record captured against a Vercel deployment. This is expected platform behavior, not a missing report field.
+- Timing and diagnostics evidence is still available from the per-request `X-Request-ID`, `X-App-DB-Queries`, and `X-App-Cache` headers, from the structured `Slow HTTP request` warning logs, and from Vercel runtime logs (request `x-vercel-id`, invocation timings).
+
+## Production slow-request warnings are enabled
+
+The middleware emits `Slow HTTP request` and `Client Error` warnings at WARNING level. Production defaults to WARNING (not ERROR) so these structured records reach Vercel runtime logs. Operators may still set `LOG_LEVEL` to raise (e.g. `ERROR`) or lower (e.g. `INFO`/`DEBUG`) verbosity. Verify slow-request logging locally with:
+
+```bash
+SLOW_REQUEST_THRESHOLD_MS=1 .venv/bin/python -m uvicorn app.main:app --port 9000
+```
+
+then exercise a slow endpoint and look for `Slow HTTP request` in the server output.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -78,7 +78,7 @@
 - Interactive indicators have clear visual affordances (cursor-help, dashed borders)
 - Tooltips explain what each value means and whether/how it can be changed
 - Screen readers can read each indicator's label and value via aria-label attributes
-- Users can view contextual explanations on hover, focus, or tap
+- No layout changes to the roll page — tooltips fit within existing header space
 
 **Dependency Notes Feature (#364)**
 - Added optional `note` field to Dependency model (VARCHAR 255)
@@ -86,7 +86,7 @@
 - Notes validate max 255 characters; returns 422 if exceeded
 - Updated DependencyResponse schema to include `note: str | None`
 - Added inline note editing in DependencyBuilder modal component
-- Shows "Add note" link when empty, displays note with "Edit note" button
+- Shows "Add note" link when empty, displays note with "Edit note" button when present
 - Notes are deleted with their dependency (not preserved on re-add)
 
 **Dependency Reading Order (Issue #371)**
@@ -104,7 +104,7 @@
 - Distinguishes between no threads and threads blocked/snoozed; includes actionable CTAs.
 - Adds quick navigation to thread creation flow via the Roll empty state (Add Thread) and a path to the queue (Go to Queue).
 - Mobile-friendly touch targets for new CTAs and improved accessibility.
-- No regression for users with eligible threads; empty state disappears once they become available.
+- No regression for users with eligible threads; empty state disappears once threads are available.
 
 **Accessibility Improvements (#220)**
 - Added `aria-label="Roll pool collection"` to ThreadPool container for screen reader support
@@ -112,7 +112,7 @@
 - Implemented focus trap in Modal component to keep focus within dialog
 - Added focus return to trigger element on Modal close
 - Fixed ESLint warnings for React hook dependencies in RollPage
-- Fixed touch targets in IssueToggleList to be at least 44px on mobile accessibility (#358)
+- Fixed touch targets in IssueToggleList to be at least 44px for mobile accessibility (#358)
 
 **Documentation Updates (#220)**
 - README.md: Added prominent async-only PostgreSQL warning and guidance
@@ -155,7 +155,7 @@
 **Collections**
 - Success toast notification now appears after creating a collection
 - Toast includes collection name and auto-dismisses after 5 seconds
-- No success message shown on validation or error
+- No success message shown on validation or network errors
 
 **Developer Tools**
 - Added `GET /api/v1/threads/{thread_id}/dependency-order-check` endpoint to detect conflicts between dependency-implied reading order and issue position order
@@ -173,7 +173,7 @@
 
 **Issue Number Correction**
 - Added edit icon next to issue number in rating view
-- Quick correction dialog allows adjusting current issue without leaving rating page
+- Quick correction dialog allows adjusting current issue without leaving the rating page
 - +/- buttons for easy issue number adjustment
 - Validates issue number is within valid range (1 to total issues)
 - Updates thread's issue tracking state automatically
@@ -202,6 +202,7 @@
 **Validation & Error Handling**
 - Snooze at d20 max pool size now shows feedback message
 - Manual die selection persists when rolling into snoozed threads
+- Improved feedback when rolled die exceeds pool size
 - Collection filter now available on roll API and get_roll_pool endpoint
 - Validation prevents rating threads with 0 issues remaining
 - Config validation errors now raise ValueError instead of silent fallback
@@ -236,7 +237,7 @@
 **Mobile UX Redesign (Complete)**
 - Complete mobile UI overhaul with responsive design improvements
 - Touch-optimized interface across all major screens
-- Mobile-specific navigation patterns
+- Mobile-specific navigation and interaction patterns
 
 **Dependency Blocking**
 - Fixed dependency blocking to only block when next unread issue has unread prerequisite
@@ -255,6 +256,7 @@
 
 **CI & Infrastructure**
 - Updated CI setup actions for improved reliability
+- Added utility scripts for development workflow
 
 ## 2026-03-14
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,7 @@
 **Production request observability (#678)**
 
 - Production now defaults to WARNING root log level instead of ERROR, so structured `Slow HTTP request` and `Client Error` warnings reach deployment logs (previously suppressed).
-- Documented that Vercel strips the `Server-Timing` response header for container deployments while passing custom `X-*` headers through; timing evidence should be read from `X-Request-ID`, `X-App-DB-Queries`, `X-App-Cache`, runtime logs, and the structured slow-request warnings.
+- Documented that `Server-Timing` is emitted locally but absent from responses observed through the current Vercel deployment; the precise removal layer remains unisolated, so timing evidence should currently be read from `X-Request-ID`, `X-App-DB-Queries`, `X-App-Cache`, runtime logs, and the structured slow-request warnings.
 - Added regression coverage for log-level resolution and slow-request warning emission.
 
 ## 2026-07-24
@@ -78,7 +78,7 @@
 - Interactive indicators have clear visual affordances (cursor-help, dashed borders)
 - Tooltips explain what each value means and whether/how it can be changed
 - Screen readers can read each indicator's label and value via aria-label attributes
-- No layout changes to the roll page — tooltips fit within existing header space
+- Users can view contextual explanations on hover, focus, or tap
 
 **Dependency Notes Feature (#364)**
 - Added optional `note` field to Dependency model (VARCHAR 255)
@@ -86,7 +86,7 @@
 - Notes validate max 255 characters; returns 422 if exceeded
 - Updated DependencyResponse schema to include `note: str | None`
 - Added inline note editing in DependencyBuilder modal component
-- Shows "Add note" link when empty, displays note with "Edit note" button when present
+- Shows "Add note" link when empty, displays note with "Edit note" button
 - Notes are deleted with their dependency (not preserved on re-add)
 
 **Dependency Reading Order (Issue #371)**
@@ -104,7 +104,7 @@
 - Distinguishes between no threads and threads blocked/snoozed; includes actionable CTAs.
 - Adds quick navigation to thread creation flow via the Roll empty state (Add Thread) and a path to the queue (Go to Queue).
 - Mobile-friendly touch targets for new CTAs and improved accessibility.
-- No regression for users with eligible threads; empty state disappears once threads are available.
+- No regression for users with eligible threads; empty state disappears once they become available.
 
 **Accessibility Improvements (#220)**
 - Added `aria-label="Roll pool collection"` to ThreadPool container for screen reader support
@@ -112,7 +112,7 @@
 - Implemented focus trap in Modal component to keep focus within dialog
 - Added focus return to trigger element on Modal close
 - Fixed ESLint warnings for React hook dependencies in RollPage
-- Fixed touch targets in IssueToggleList to be at least 44px for mobile accessibility (#358)
+- Fixed touch targets in IssueToggleList to be at least 44px on mobile accessibility (#358)
 
 **Documentation Updates (#220)**
 - README.md: Added prominent async-only PostgreSQL warning and guidance
@@ -155,7 +155,7 @@
 **Collections**
 - Success toast notification now appears after creating a collection
 - Toast includes collection name and auto-dismisses after 5 seconds
-- No success message shown on validation or network errors
+- No success message shown on validation or error
 
 **Developer Tools**
 - Added `GET /api/v1/threads/{thread_id}/dependency-order-check` endpoint to detect conflicts between dependency-implied reading order and issue position order
@@ -173,7 +173,7 @@
 
 **Issue Number Correction**
 - Added edit icon next to issue number in rating view
-- Quick correction dialog allows adjusting current issue without leaving the rating page
+- Quick correction dialog allows adjusting current issue without leaving rating page
 - +/- buttons for easy issue number adjustment
 - Validates issue number is within valid range (1 to total issues)
 - Updates thread's issue tracking state automatically
@@ -202,7 +202,6 @@
 **Validation & Error Handling**
 - Snooze at d20 max pool size now shows feedback message
 - Manual die selection persists when rolling into snoozed threads
-- Improved feedback when rolled die exceeds pool size
 - Collection filter now available on roll API and get_roll_pool endpoint
 - Validation prevents rating threads with 0 issues remaining
 - Config validation errors now raise ValueError instead of silent fallback
@@ -237,7 +236,7 @@
 **Mobile UX Redesign (Complete)**
 - Complete mobile UI overhaul with responsive design improvements
 - Touch-optimized interface across all major screens
-- Mobile-specific navigation and interaction patterns
+- Mobile-specific navigation patterns
 
 **Dependency Blocking**
 - Fixed dependency blocking to only block when next unread issue has unread prerequisite
@@ -256,7 +255,6 @@
 
 **CI & Infrastructure**
 - Updated CI setup actions for improved reliability
-- Added utility scripts for development workflow
 
 ## 2026-03-14
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-08-01
+
+**Production request observability (#678)**
+
+- Production now defaults to WARNING root log level instead of ERROR, so structured `Slow HTTP request` and `Client Error` warnings reach deployment logs (previously suppressed).
+- Documented that Vercel strips the `Server-Timing` response header for container deployments while passing custom `X-*` headers through; timing evidence should be read from `X-Request-ID`, `X-App-DB-Queries`, `X-App-Cache`, runtime logs, and the structured slow-request warnings.
+- Added regression coverage for log-level resolution and slow-request warning emission.
+
 ## 2026-07-24
 
 **Incremental session history (#608)**

--- a/tests/test_request_logging_observability.py
+++ b/tests/test_request_logging_observability.py
@@ -1,0 +1,132 @@
+"""Regression coverage for production request observability.
+
+Issue #678: production was missing ``Server-Timing`` on Vercel (stripped by the
+platform proxy for container deployments) and no structured slow-request
+warnings were reaching deployment logs because the production default root log
+level (``ERROR``) suppressed WARNING-level records.
+"""
+
+import asyncio
+import logging
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.main import _configure_logging, _default_log_level, _resolve_log_level
+from app.middleware.request_logging import add_request_logging_middleware
+
+
+def test_production_default_log_level_does_not_suppress_warnings() -> None:
+    """Production should default to WARNING so slow-request logs are emitted."""
+    assert _default_log_level("production") == logging.WARNING
+
+
+def test_default_log_levels_match_environment_intent() -> None:
+    """Each environment should retain its documented default verbosity."""
+    assert _default_log_level("staging") == logging.WARNING
+    assert _default_log_level("development") == logging.DEBUG
+    assert _default_log_level("test") == logging.WARNING
+    assert _default_log_level("unknown-environment") == logging.WARNING
+
+
+def test_production_log_level_resolution_without_override(monkeypatch) -> None:
+    """Production without LOG_LEVEL resolves to WARNING after the fix."""
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    assert _resolve_log_level("production") == logging.WARNING
+
+
+def test_log_level_override_is_honored(monkeypatch) -> None:
+    """An explicit LOG_LEVEL should override the production default."""
+    monkeypatch.setenv("LOG_LEVEL", "ERROR")
+    assert _resolve_log_level("production") == logging.ERROR
+
+
+def test_invalid_log_level_falls_back_to_environment_default(monkeypatch) -> None:
+    """An unrecognized LOG_LEVEL should fall back to the environment default."""
+    monkeypatch.setenv("LOG_LEVEL", "not-a-level")
+    assert _resolve_log_level("production") == logging.WARNING
+
+
+def test_configure_logging_sets_production_level_when_no_handlers(monkeypatch) -> None:
+    """Uvicorn leaves the root logger handlerless, so the production level applies."""
+    root = logging.getLogger()
+    original_handlers = root.handlers[:]
+    original_level = root.level
+    monkeypatch.setattr(root, "hasHandlers", lambda: False)
+    try:
+        root.handlers.clear()
+        _configure_logging("production")
+        assert root.level == logging.WARNING
+    finally:
+        root.handlers[:] = original_handlers
+        root.setLevel(original_level)
+
+
+def _find_slow_request_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [
+        record
+        for record in caplog.records
+        if record.name == "app.middleware.request_logging"
+        and record.getMessage().startswith("Slow HTTP request:")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_middleware_emits_structured_slow_request_warning(
+    monkeypatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Requests past the threshold should produce a WARNING with diagnostics extras."""
+    monkeypatch.setenv("SLOW_REQUEST_THRESHOLD_MS", "1")
+    app = FastAPI()
+    add_request_logging_middleware(app, "test")
+
+    @app.get("/slow")
+    async def slow_route() -> dict[str, str]:
+        """Return after sleeping well past the configured threshold."""
+        await asyncio.sleep(0.05)
+        return {"status": "ok"}
+
+    caplog.set_level(logging.WARNING, logger="app.middleware.request_logging")
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/slow")
+        assert response.status_code == 200
+
+    records = _find_slow_request_records(caplog)
+    assert len(records) == 1
+    record = records[0]
+    assert record.levelno == logging.WARNING
+    assert "GET /slow completed in" in record.getMessage()
+    assert len(record.__dict__["request_id"]) == 32
+    assert record.__dict__["method"] == "GET"
+    assert record.__dict__["path"] == "/slow"
+    assert record.__dict__["status_code"] == 200
+    assert record.__dict__["database_queries"] == 0
+
+
+@pytest.mark.asyncio
+async def test_middleware_does_not_warn_below_threshold(
+    monkeypatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Requests under the threshold should not emit a slow-request warning."""
+    monkeypatch.setenv("SLOW_REQUEST_THRESHOLD_MS", "100000")
+    app = FastAPI()
+    add_request_logging_middleware(app, "test")
+
+    @app.get("/fast")
+    async def fast_route() -> dict[str, str]:
+        """Return immediately."""
+        return {"status": "ok"}
+
+    caplog.set_level(logging.WARNING, logger="app.middleware.request_logging")
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/fast")
+        assert response.status_code == 200
+
+    assert _find_slow_request_records(caplog) == []

--- a/tests/test_request_logging_observability.py
+++ b/tests/test_request_logging_observability.py
@@ -30,25 +30,25 @@ def test_default_log_levels_match_environment_intent() -> None:
     assert _default_log_level("unknown-environment") == logging.WARNING
 
 
-def test_production_log_level_resolution_without_override(monkeypatch) -> None:
+def test_production_log_level_resolution_without_override(monkeypatch: pytest.MonkeyPatch) -> None:
     """Production without LOG_LEVEL resolves to WARNING after the fix."""
     monkeypatch.delenv("LOG_LEVEL", raising=False)
     assert _resolve_log_level("production") == logging.WARNING
 
 
-def test_log_level_override_is_honored(monkeypatch) -> None:
+def test_log_level_override_is_honored(monkeypatch: pytest.MonkeyPatch) -> None:
     """An explicit LOG_LEVEL should override the production default."""
     monkeypatch.setenv("LOG_LEVEL", "ERROR")
     assert _resolve_log_level("production") == logging.ERROR
 
 
-def test_invalid_log_level_falls_back_to_environment_default(monkeypatch) -> None:
+def test_invalid_log_level_falls_back_to_environment_default(monkeypatch: pytest.MonkeyPatch) -> None:
     """An unrecognized LOG_LEVEL should fall back to the environment default."""
     monkeypatch.setenv("LOG_LEVEL", "not-a-level")
     assert _resolve_log_level("production") == logging.WARNING
 
 
-def test_configure_logging_sets_production_level_when_no_handlers(monkeypatch) -> None:
+def test_configure_logging_sets_production_level_when_no_handlers(monkeypatch: pytest.MonkeyPatch) -> None:
     """Uvicorn leaves the root logger handlerless, so the production level applies."""
     root = logging.getLogger()
     original_handlers = root.handlers[:]
@@ -74,7 +74,7 @@ def _find_slow_request_records(caplog: pytest.LogCaptureFixture) -> list[logging
 
 @pytest.mark.asyncio
 async def test_middleware_emits_structured_slow_request_warning(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Requests past the threshold should produce a WARNING with diagnostics extras."""
@@ -109,7 +109,7 @@ async def test_middleware_emits_structured_slow_request_warning(
 
 @pytest.mark.asyncio
 async def test_middleware_does_not_warn_below_threshold(
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Requests under the threshold should not emit a slow-request warning."""
@@ -130,3 +130,35 @@ async def test_middleware_does_not_warn_below_threshold(
         assert response.status_code == 200
 
     assert _find_slow_request_records(caplog) == []
+
+
+@pytest.mark.asyncio
+async def test_middleware_emits_structured_client_error_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """4xx responses should produce a WARNING with Client Error message."""
+    app = FastAPI()
+    add_request_logging_middleware(app, "test")
+
+    @app.get("/existing")
+    async def existing_route() -> dict[str, str]:
+        """Return a normal response."""
+        return {"status": "ok"}
+
+    caplog.set_level(logging.WARNING, logger="app.middleware.request_logging")
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/nonexistent")
+        assert response.status_code == 404
+
+    client_error_records = [
+        record
+        for record in caplog.records
+        if record.name == "app.middleware.request_logging"
+        and record.getMessage().startswith("Client Error:")
+    ]
+    assert len(client_error_records) == 1
+    record = client_error_records[0]
+    assert record.levelno == logging.WARNING
+    assert "GET /nonexistent - 404" in record.getMessage()


### PR DESCRIPTION
## What changed

Investigation and fix for missing `Server-Timing` and slow-request logs on Vercel production (#678).

### Observed deployment discrepancy: `Server-Timing` is missing
- Live production (`https://comic-pile.vercel.app/health`) returns `X-Request-ID`, `X-App-Cache`, and `X-App-DB-Queries`, but not `Server-Timing`.
- The same middleware run over real HTTP locally returns all four headers (`Server-Timing: app;dur=...`).
- This proves a discrepancy along the deployment path, but it does not isolate the precise layer removing or suppressing `Server-Timing`. Vercel's documented system response headers are not an allowlist for application-defined headers.
- Production profiling now treats `Server-Timing` as unavailable on the current deployment without claiming a permanent or documented Vercel platform restriction.

### Root cause fixed: production default log level suppressed WARNING logs
- `create_app` set the production default root log level to `ERROR`, so the WARNING-level `Slow HTTP request` and `Client Error` structured logs were filtered out before reaching deployment logs.
- Reproduced under uvicorn with `ENVIRONMENT=production`: `ROOT_LEVEL=ERROR`, with no warning emitted for a request 50× over threshold.
- Fixed by defaulting production to `WARNING` (matching staging). Operators can still raise or lower verbosity via `LOG_LEVEL`.

## Why it changed
The observability added in #674 (`Server-Timing`, request IDs, cache/DB counters, and slow-request warnings) is the evidence base for the #687 performance campaign. The timing header is absent on the current deployment and the warning logs were suppressed, making cold-path latency analysis incomplete.

## Files / components affected
- `app/main.py` extracts `_default_log_level`, `_resolve_log_level`, and `_configure_logging`; production now defaults to WARNING.
- `tests/test_request_logging_observability.py` adds regression coverage for log-level resolution, slow-request warning emission and non-emission, handlerless configuration, and the client-error warning path.
- `docs/PRODUCTION_PROFILE.md` documents the observed `Server-Timing` discrepancy, its current impact, and the remaining uncertainty.
- `docs/changelog.md` adds a dated entry.

## Acceptance criteria satisfied
- Confirmed `Server-Timing` exists locally and is absent from the current production deployment.
- Documented that the precise removal layer remains unisolated rather than attributing it permanently to Vercel's proxy.
- Confirmed and fixed the logging configuration that suppressed slow-request warnings.
- Added regression coverage for the proven behavior.
- No production-profile budgets were weakened; the Axios timeout is unchanged; this remains separate from #677.

## Tests and commands run
- `pytest tests/test_request_logging_observability.py tests/test_request_logging_sanitization.py tests/test_performance_diagnostics.py` — 15 passed.
- Full suite `pytest` (with `.env.test`) — **759 passed**, coverage 97% (≥94% gate).
- `ruff check .` — pass; `ty check --error-on-warning` (app + test) — pass; `bash scripts/lint.sh --staged` — pass.
- Production reproduction via curl: custom `X-*` diagnostics present, `Server-Timing` absent; local uvicorn: all four headers present.

## Before / after evidence
Slow-request warning under uvicorn, `ENVIRONMENT=production`, `SLOW_REQUEST_THRESHOLD_MS=1`, route sleeping 50 ms:
- Before: `ROOT_LEVEL=ERROR` and no `Slow HTTP request` log line.
- After: `ROOT_LEVEL=WARNING` and `WARNING:app.middleware.request_logging:Slow HTTP request: GET /slow completed in 52.18 ms`.

## Known limitations
- `Server-Timing` remains absent from responses observed through the current Vercel deployment. Timing evidence currently comes from `X-Request-ID`, `X-App-DB-Queries`, `X-App-Cache`, structured slow-request warnings, and runtime logs.
- A preview-deployment comparison or origin-versus-proxy capture is still needed to attribute the missing header to a specific deployment layer.

Closes: #678


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Production logging now surfaces warning-level events by default, including slow requests and client errors.
  - Supported `LOG_LEVEL` settings can customize logging behavior, with invalid values safely falling back to defaults.
  - Request warnings include structured diagnostic details to support troubleshooting.

- **Documentation**
  - Clarified which diagnostic headers and timing information are available in production deployments.
  - Added guidance for interpreting production logs and verifying logging behavior locally.

- **Tests**
  - Added coverage for logging defaults, overrides, invalid settings, and slow-request warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->