### PR TITLE
Rewrite queue repositioning to avoid O(n^2) scans and full reloads

### DIFF
--- a/comic_pile/queue.py
+++ b/comic_pile/queue.py
@@ -5,9 +5,9 @@ import logging
 import random
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import case, text, update
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.sql import select as sa_select
+from sqlalchemy.orm.attributes import set_committed_value
 
 from app.models import Thread
 
@@ -33,16 +33,14 @@ async def _acquire_queue_lock(user_id: int, db: AsyncSession) -> None:
     )
 
 
-async def _refresh_queue_positions(db: AsyncSession, user_id: int) -> None:
-    """Refresh ``queue_position`` on every cached Thread for *user_id*.
+def _sync_cached_queue_positions(db: AsyncSession, positions: dict[int, int]) -> None:
+    """Synchronize cached Thread objects without issuing per-object SELECTs."""
+    if not positions:
+        return
 
-    Core-level UPDATE statements bypass the ORM unit-of-work, so cached
-    ORM objects remain stale after a queue modification.  Refreshing only
-    the position column brings them in sync with the database.
-    """
     for obj in list(db.identity_map.values()):
-        if isinstance(obj, Thread) and obj.user_id == user_id:
-            await db.refresh(obj, attribute_names=["queue_position"])
+        if isinstance(obj, Thread) and obj.id in positions:
+            set_committed_value(obj, "queue_position", positions[obj.id])
 
 
 _MOVE_POSITION_SQL = text("""
@@ -57,22 +55,66 @@ _MOVE_POSITION_SQL = text("""
     UPDATE threads AS t
     SET queue_position = CASE
         WHEN t.id = :tid THEN :new_pos
-        WHEN (SELECT seq FROM target) < :new_pos THEN
-            CASE WHEN ranked.seq > (SELECT seq FROM target) AND ranked.seq <= :new_pos
+        WHEN target.seq < :new_pos THEN
+            CASE WHEN ranked.seq > target.seq AND ranked.seq <= :new_pos
                  THEN ranked.seq - 1 ELSE ranked.seq END
         ELSE
-            CASE WHEN ranked.seq >= :new_pos AND ranked.seq < (SELECT seq FROM target)
+            CASE WHEN ranked.seq >= :new_pos AND ranked.seq < target.seq
                  THEN ranked.seq + 1 ELSE ranked.seq END
     END
-    FROM ranked
+    FROM ranked, target
     WHERE t.id = ranked.id
+    RETURNING t.id, t.queue_position
+""")
+
+_MOVE_TO_BACK_SQL = text("""
+    WITH ranked AS (
+        SELECT id, row_number() OVER (ORDER BY queue_position, id) AS seq
+        FROM threads
+        WHERE user_id = :uid
+          AND queue_position >= 1
+          AND (status = 'active' OR id = :tid)
+    ),
+    target AS (
+        SELECT seq FROM ranked WHERE id = :tid
+    ),
+    bounds AS (
+        SELECT count(*) AS total FROM ranked
+    )
+    UPDATE threads AS t
+    SET queue_position = CASE
+        WHEN t.id = :tid THEN bounds.total
+        WHEN ranked.seq > target.seq THEN ranked.seq - 1
+        ELSE ranked.seq
+    END
+    FROM ranked, target, bounds
+    WHERE t.id = ranked.id
+    RETURNING t.id, t.queue_position
+""")
+
+_SHUFFLE_SQL = text("""
+    WITH shuffled AS (
+        SELECT thread_id, new_position
+        FROM unnest(
+            CAST(:thread_ids AS INTEGER[]),
+            CAST(:positions AS INTEGER[])
+        ) AS shuffled(thread_id, new_position)
+    )
+    UPDATE threads AS t
+    SET queue_position = shuffled.new_position
+    FROM shuffled
+    WHERE t.id = shuffled.thread_id
+      AND t.user_id = :uid
+      AND t.status = 'active'
+      AND t.queue_position >= 1
+    RETURNING t.id, t.queue_position
 """)
 
 
 async def move_to_front(
     thread_id: int, user_id: int, db: AsyncSession, commit: bool = True
 ) -> None:
-    """Move thread to front of queue.
+    """Move an active thread to the normalized front of its queue.
 
     Args:
         thread_id: Thread to move.
@@ -80,34 +122,15 @@ async def move_to_front(
         db: Async database session.
         commit: Whether to commit inside this helper.
     """
-    await _acquire_queue_lock(user_id, db)
-
-    result = await db.execute(
-        sa_select(Thread).where(Thread.id == thread_id).where(Thread.user_id == user_id)
-    )
-    target_thread = result.scalar_one_or_none()
-    if not target_thread:
-        return
-
-    original_position = target_thread.queue_position
-    if original_position == 1:
-        return
-
-    await db.execute(
-        update(Thread)
-        .where(Thread.user_id == user_id)
-        .where(Thread.status == "active")
-        .where(Thread.queue_position >= 1)
-        .where(Thread.queue_position < original_position)
-        .values(queue_position=Thread.queue_position + 1)
-    )
-    target_thread.queue_position = 1
-    if commit:
-        await db.commit()
+    await move_to_position(thread_id, user_id, 1, db, do_commit=commit)
 
 
 async def move_to_back(thread_id: int, user_id: int, db: AsyncSession, commit: bool = True) -> None:
-    """Move thread to back of queue.
+    """Move a thread behind the active queue while normalizing active positions.
+
+    The target is included even when it has just been marked completed, which
+    preserves the rating flow's behavior of compacting the remaining active
+    queue and placing the completed thread immediately after it.
 
     Args:
         thread_id: Thread to move.
@@ -118,52 +141,29 @@ async def move_to_back(thread_id: int, user_id: int, db: AsyncSession, commit: b
     await _acquire_queue_lock(user_id, db)
 
     result = await db.execute(
-        sa_select(Thread).where(Thread.id == thread_id).where(Thread.user_id == user_id)
+        _MOVE_TO_BACK_SQL,
+        {"uid": user_id, "tid": thread_id},
     )
-    target_thread = result.scalar_one_or_none()
-    if not target_thread:
-        return
+    positions = {row.id: row.queue_position for row in result.fetchall()}
+    _sync_cached_queue_positions(db, positions)
 
-    original_position = target_thread.queue_position
-
-    result = await db.execute(
-        sa_select(Thread.queue_position)
-        .where(Thread.user_id == user_id)
-        .where(Thread.status == "active")
-        .where(Thread.queue_position >= 1)
-        .order_by(Thread.queue_position.desc())
-        .limit(1)
-    )
-    max_position = result.scalar()
-
-    if max_position is None:
-        return
-
-    if original_position == max_position:
-        return
-
-    await db.execute(
-        update(Thread)
-        .where(Thread.user_id == user_id)
-        .where(Thread.status == "active")
-        .where(Thread.queue_position > original_position)
-        .values(queue_position=Thread.queue_position - 1)
-    )
-    target_thread.queue_position = max_position
     if commit:
         await db.commit()
 
 
 async def move_to_position(
-    thread_id: int, user_id: int, new_position: int, db: AsyncSession,
+    thread_id: int,
+    user_id: int,
+    new_position: int,
+    db: AsyncSession,
     do_commit: bool = True,
 ) -> None:
-    """Move thread to specific position.
+    """Move an active thread to a normalized sequential position.
 
-    Uses a single CASE-based UPDATE driven by a single linear scan of
-    active thread IDs — eliminating the previous O(n²) nested list scans
-    and the unconditional post-move full queue reload.  Gap / duplicate
-    positions are normalised to sequential 1..N in the same statement.
+    Uses a single CASE-based UPDATE driven by a window-function ranking.
+    Gap and duplicate normalization happens in the same statement as the move,
+    and returned positions synchronize cached ORM objects without N additional
+    database round trips.
 
     Args:
         thread_id: Thread to move.
@@ -172,7 +172,7 @@ async def move_to_position(
         db: Async database session.
         do_commit: Whether to commit inside this helper.
     """
-    logger.info(
+    logger.debug(
         "move_to_position ENTRY: thread_id=%d, user_id=%d, new_position=%d",
         thread_id,
         user_id,
@@ -181,9 +181,8 @@ async def move_to_position(
 
     await _acquire_queue_lock(user_id, db)
 
-    logger.debug("Retrieving thread %d for user %d", thread_id, user_id)
     result = await db.execute(
-        sa_select(Thread.id, Thread.queue_position, Thread.title, Thread.status)
+        select(Thread.id, Thread.queue_position, Thread.status)
         .where(Thread.id == thread_id)
         .where(Thread.user_id == user_id)
     )
@@ -191,43 +190,48 @@ async def move_to_position(
 
     if not row:
         logger.error("Thread %d not found for user %d", thread_id, user_id)
+        if do_commit:
+            await db.commit()
         return
 
-    thread_id_val, queue_position, title, status = row
-
-    logger.info(
-        "Thread found: id=%d, title='%s', "
-        "user_id=%d, current_position=%d, "
-        "status='%s'",
+    thread_id_val, queue_position, status = row
+    logger.debug(
+        "Thread found: id=%d, user_id=%d, current_position=%d, status='%s'",
         thread_id_val,
-        title,
         user_id,
         queue_position,
         status,
     )
 
-    old_position = queue_position
-    logger.info("Current thread position: %d", old_position)
+    if status != "active" or queue_position < 1:
+        logger.debug("Thread %d is not in the active queue", thread_id)
+        if do_commit:
+            await db.commit()
+        return
 
     result = await db.execute(
-        sa_select(Thread.id)
-        .where(Thread.user_id == user_id)
-        .where(Thread.status == "active")
-        .where(Thread.queue_position >= 1)
-        .order_by(Thread.queue_position, Thread.id)
+        text(
+            """
+            SELECT
+                count(*)::integer AS total,
+                count(*) FILTER (
+                    WHERE queue_position < :queue_position
+                       OR (queue_position = :queue_position AND id <= :tid)
+                )::integer AS seq
+            FROM threads
+            WHERE user_id = :uid
+              AND status = 'active'
+              AND queue_position >= 1
+            """
+        ),
+        {
+            "uid": user_id,
+            "tid": thread_id,
+            "queue_position": queue_position,
+        },
     )
-    active_ids = [row[0] for row in result.fetchall()]
-
-    thread_count = len(active_ids)
-    logger.info("Active thread count: %d", thread_count)
-
-    old_seq = next(
-        (i + 1 for i, tid in enumerate(active_ids) if tid == thread_id), 0
-    )
-
-    if old_seq == 0:
-        logger.error("Target thread %d not found in active threads list", thread_id)
-        return
+    thread_count, old_seq = result.one()
+    logger.debug("Active thread count: %d", thread_count)
 
     if new_position < 1:
         raise ValueError(f"Position must be at least 1, got {new_position}")
@@ -237,36 +241,28 @@ async def move_to_position(
             f"Position {new_position} is out of range. Maximum position is {thread_count}."
         )
 
-    logger.info("Final target position: %d (original: %d)", new_position, old_position)
+    logger.debug(
+        "Moving thread %d from sequential position %d to %d",
+        thread_id,
+        old_seq,
+        new_position,
+    )
 
-    if old_seq == new_position:
-        logger.info(
-            "Thread %d already at sequential position %d, no movement needed",
-            thread_id,
-            new_position,
-        )
-        return
-
-    await db.execute(
+    result = await db.execute(
         _MOVE_POSITION_SQL,
         {"uid": user_id, "tid": thread_id, "new_pos": new_position},
     )
-
-    await _refresh_queue_positions(db, user_id)
-
-    logger.debug("Committing database transaction")
-    if do_commit:
-        await db.commit()
-
-    logger.info("move_to_position SUCCESS: thread %d moved to position %d", thread_id, new_position)
+    positions = {row.id: row.queue_position for row in result.fetchall()}
+    _sync_cached_queue_positions(db, positions)
 
     if logger.isEnabledFor(logging.DEBUG):
         logger.debug("Final queue state after operation:")
         result = await db.execute(
-            sa_select(Thread)
+            select(Thread)
             .where(Thread.user_id == user_id)
+            .where(Thread.status == "active")
             .where(Thread.queue_position >= 1)
-            .order_by(Thread.queue_position)
+            .order_by(Thread.queue_position, Thread.id)
         )
         final_queue = result.scalars().all()
 
@@ -277,6 +273,15 @@ async def move_to_position(
                 thread.id,
                 thread.title[:50],
             )
+
+    if do_commit:
+        await db.commit()
+
+    logger.debug(
+        "move_to_position SUCCESS: thread %d moved to position %d",
+        thread_id,
+        new_position,
+    )
 
 
 async def move_to_safe_position(
@@ -294,18 +299,9 @@ async def move_to_safe_position(
     pool while keeping it realistically reachable.
 
     The roll pool (``get_roll_pool``) excludes blocked threads, so the target
-    position must be computed by counting non-blocked threads — not raw queue
-    positions.  This fixes a bug (#597) where blocked threads inflated the
-    ``queue_position`` values but were excluded from the roll pool, causing
-    the rated thread to remain selectable.
-
-    Example (die=d6, no blocked threads):
-        Position 1-6: rollable pool
-        Rated thread -> position 7
-
-    Example (die=d6, 10 blocked threads interspersed in positions 3-12):
-        Rollable pool: positions 1, 2, 13, 14, ... (blocked skipped)
-        Rated thread -> placed after the 6th non-blocked thread
+    position must be computed by counting non-blocked threads, not raw queue
+    positions. The queue lock covers both this calculation and the subsequent
+    move so a concurrent reorder cannot invalidate the target rank.
 
     Args:
         thread_id: Thread to reposition.
@@ -315,14 +311,16 @@ async def move_to_safe_position(
         excluded_thread_ids: Thread IDs excluded from the current roll pool,
             such as threads snoozed in the active session.
     """
+    await _acquire_queue_lock(user_id, db)
+
     excluded_ids = set(excluded_thread_ids or ())
 
     result = await db.execute(
-        sa_select(Thread)
+        select(Thread)
         .where(Thread.user_id == user_id)
         .where(Thread.status == "active")
         .where(Thread.queue_position >= 1)
-        .order_by(Thread.queue_position)
+        .order_by(Thread.queue_position, Thread.id)
     )
     all_active = list(result.scalars().all())
 
@@ -363,11 +361,7 @@ async def move_to_safe_position(
 
 
 async def shuffle_queue(user_id: int, db: AsyncSession) -> int:
-    """Randomize the order of active queue threads for a user.
-
-    Uses a single CASE-based UPDATE to assign new positions in bulk,
-    eliminating the previous row-by-row ORM mutations and reducing
-    the operation to a single SQL statement.
+    """Randomize active queue positions for a user in one array-backed update.
 
     Args:
         user_id: The user whose active queue should be shuffled.
@@ -379,7 +373,7 @@ async def shuffle_queue(user_id: int, db: AsyncSession) -> int:
     await _acquire_queue_lock(user_id, db)
 
     result = await db.execute(
-        sa_select(Thread.id)
+        select(Thread.id)
         .where(Thread.user_id == user_id)
         .where(Thread.status == "active")
         .where(Thread.queue_position >= 1)
@@ -388,24 +382,22 @@ async def shuffle_queue(user_id: int, db: AsyncSession) -> int:
     active_ids = [row[0] for row in result.fetchall()]
 
     if len(active_ids) < 2:
+        await db.commit()
         return len(active_ids)
 
     shuffled_ids = list(active_ids)
     random.shuffle(shuffled_ids)
 
-    case_expr = case(
-        *[(Thread.id == tid, pos) for pos, tid in enumerate(shuffled_ids, start=1)],
-        else_=Thread.queue_position,
+    result = await db.execute(
+        _SHUFFLE_SQL,
+        {
+            "uid": user_id,
+            "thread_ids": shuffled_ids,
+            "positions": list(range(1, len(shuffled_ids) + 1)),
+        },
     )
-    await db.execute(
-        update(Thread)
-        .where(Thread.user_id == user_id)
-        .where(Thread.status == "active")
-        .where(Thread.queue_position >= 1)
-        .values(queue_position=case_expr)
-    )
-
-    await _refresh_queue_positions(db, user_id)
+    positions = {row.id: row.queue_position for row in result.fetchall()}
+    _sync_cached_queue_positions(db, positions)
 
     await db.commit()
     return len(active_ids)
@@ -429,7 +421,7 @@ async def get_roll_pool(
         List of active threads ordered by queue position.
     """
     query = (
-        sa_select(Thread)
+        select(Thread)
         .where(Thread.user_id == user_id)
         .where(Thread.status == "active")
         .where(Thread.queue_position >= 1)
@@ -455,7 +447,7 @@ async def get_stale_threads(user_id: int, db: AsyncSession, days: int = 7) -> li
     cutoff_date = datetime.now(UTC) - timedelta(days=days)
 
     result = await db.execute(
-        sa_select(Thread)
+        select(Thread)
         .where(Thread.user_id == user_id)
         .where(Thread.status == "active")
         .where(Thread.is_blocked.is_(False))

--- a/comic_pile/queue.py
+++ b/comic_pile/queue.py
@@ -204,7 +204,7 @@ async def move_to_position(
     )
 
     if status != "active" or queue_position < 1:
-        logger.debug("Thread %d is not in the active queue", thread_id)
+        logger.error("Target thread %d not found in active threads list", thread_id)
         if do_commit:
             await db.commit()
         return

--- a/comic_pile/queue.py
+++ b/comic_pile/queue.py
@@ -5,12 +5,68 @@ import logging
 import random
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import select, update
+from sqlalchemy import case, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql import select as sa_select
 
 from app.models import Thread
 
 logger = logging.getLogger(__name__)
+
+ADVISORY_LOCK_NAMESPACE = 699001
+
+
+async def _acquire_queue_lock(user_id: int, db: AsyncSession) -> None:
+    """Acquire a transaction-scoped advisory lock keyed on user_id.
+
+    The lock uses the two-integer form of pg_advisory_xact_lock so it is
+    re-entrant within the same transaction and releases automatically on
+    commit or rollback.
+
+    Args:
+        user_id: Thread owner whose queue is being modified.
+        db: Async database session.
+    """
+    await db.execute(
+        text("SELECT pg_advisory_xact_lock(:ns, :uid)"),
+        {"ns": ADVISORY_LOCK_NAMESPACE, "uid": user_id},
+    )
+
+
+async def _refresh_queue_positions(db: AsyncSession, user_id: int) -> None:
+    """Refresh ``queue_position`` on every cached Thread for *user_id*.
+
+    Core-level UPDATE statements bypass the ORM unit-of-work, so cached
+    ORM objects remain stale after a queue modification.  Refreshing only
+    the position column brings them in sync with the database.
+    """
+    for obj in list(db.identity_map.values()):
+        if isinstance(obj, Thread) and obj.user_id == user_id:
+            await db.refresh(obj, attribute_names=["queue_position"])
+
+
+_MOVE_POSITION_SQL = text("""
+    WITH ranked AS (
+        SELECT id, row_number() OVER (ORDER BY queue_position, id) AS seq
+        FROM threads
+        WHERE user_id = :uid AND status = 'active' AND queue_position >= 1
+    ),
+    target AS (
+        SELECT seq FROM ranked WHERE id = :tid
+    )
+    UPDATE threads AS t
+    SET queue_position = CASE
+        WHEN t.id = :tid THEN :new_pos
+        WHEN (SELECT seq FROM target) < :new_pos THEN
+            CASE WHEN ranked.seq > (SELECT seq FROM target) AND ranked.seq <= :new_pos
+                 THEN ranked.seq - 1 ELSE ranked.seq END
+        ELSE
+            CASE WHEN ranked.seq >= :new_pos AND ranked.seq < (SELECT seq FROM target)
+                 THEN ranked.seq + 1 ELSE ranked.seq END
+    END
+    FROM ranked
+    WHERE t.id = ranked.id
+""")
 
 
 async def move_to_front(
@@ -24,8 +80,10 @@ async def move_to_front(
         db: Async database session.
         commit: Whether to commit inside this helper.
     """
+    await _acquire_queue_lock(user_id, db)
+
     result = await db.execute(
-        select(Thread).where(Thread.id == thread_id).where(Thread.user_id == user_id)
+        sa_select(Thread).where(Thread.id == thread_id).where(Thread.user_id == user_id)
     )
     target_thread = result.scalar_one_or_none()
     if not target_thread:
@@ -57,8 +115,10 @@ async def move_to_back(thread_id: int, user_id: int, db: AsyncSession, commit: b
         db: Async database session.
         commit: Whether to commit inside this helper.
     """
+    await _acquire_queue_lock(user_id, db)
+
     result = await db.execute(
-        select(Thread).where(Thread.id == thread_id).where(Thread.user_id == user_id)
+        sa_select(Thread).where(Thread.id == thread_id).where(Thread.user_id == user_id)
     )
     target_thread = result.scalar_one_or_none()
     if not target_thread:
@@ -67,7 +127,7 @@ async def move_to_back(thread_id: int, user_id: int, db: AsyncSession, commit: b
     original_position = target_thread.queue_position
 
     result = await db.execute(
-        select(Thread.queue_position)
+        sa_select(Thread.queue_position)
         .where(Thread.user_id == user_id)
         .where(Thread.status == "active")
         .where(Thread.queue_position >= 1)
@@ -100,6 +160,11 @@ async def move_to_position(
 ) -> None:
     """Move thread to specific position.
 
+    Uses a single CASE-based UPDATE driven by a single linear scan of
+    active thread IDs — eliminating the previous O(n²) nested list scans
+    and the unconditional post-move full queue reload.  Gap / duplicate
+    positions are normalised to sequential 1..N in the same statement.
+
     Args:
         thread_id: Thread to move.
         user_id: Thread owner.
@@ -108,51 +173,62 @@ async def move_to_position(
         do_commit: Whether to commit inside this helper.
     """
     logger.info(
-        f"move_to_position ENTRY: thread_id={thread_id}, user_id={user_id}, new_position={new_position}"
+        "move_to_position ENTRY: thread_id=%d, user_id=%d, new_position=%d",
+        thread_id,
+        user_id,
+        new_position,
     )
 
-    logger.debug(f"Retrieving thread {thread_id} for user {user_id}")
+    await _acquire_queue_lock(user_id, db)
+
+    logger.debug("Retrieving thread %d for user %d", thread_id, user_id)
     result = await db.execute(
-        select(Thread).where(Thread.id == thread_id).where(Thread.user_id == user_id)
+        sa_select(Thread.id, Thread.queue_position, Thread.title, Thread.status)
+        .where(Thread.id == thread_id)
+        .where(Thread.user_id == user_id)
     )
-    target_thread = result.scalar_one_or_none()
+    row = result.one_or_none()
 
-    if not target_thread:
-        logger.error(f"Thread {thread_id} not found for user {user_id}")
+    if not row:
+        logger.error("Thread %d not found for user %d", thread_id, user_id)
         return
 
+    thread_id_val, queue_position, title, status = row
+
     logger.info(
-        f"Thread found: id={target_thread.id}, title='{target_thread.title}', "
-        f"user_id={target_thread.user_id}, current_position={target_thread.queue_position}, "
-        f"status='{target_thread.status}'"
+        "Thread found: id=%d, title='%s', "
+        "user_id=%d, current_position=%d, "
+        "status='%s'",
+        thread_id_val,
+        title,
+        user_id,
+        queue_position,
+        status,
     )
 
-    old_position = target_thread.queue_position
-    logger.info(f"Current thread position: {old_position}")
+    old_position = queue_position
+    logger.info("Current thread position: %d", old_position)
 
-    # Get all active threads sorted by current position
     result = await db.execute(
-        select(Thread)
+        sa_select(Thread.id)
         .where(Thread.user_id == user_id)
         .where(Thread.status == "active")
         .where(Thread.queue_position >= 1)
-        .order_by(Thread.queue_position)
+        .order_by(Thread.queue_position, Thread.id)
     )
-    all_threads = result.scalars().all()
+    active_ids = [row[0] for row in result.fetchall()]
 
-    thread_count = len(all_threads)
-    logger.info(f"Active thread count: {thread_count}")
+    thread_count = len(active_ids)
+    logger.info("Active thread count: %d", thread_count)
 
-    # Find the current sequential position of our target thread
-    current_sequential_pos = next(
-        (i + 1 for i, thread in enumerate(all_threads) if thread.id == thread_id), 0
+    old_seq = next(
+        (i + 1 for i, tid in enumerate(active_ids) if tid == thread_id), 0
     )
 
-    if current_sequential_pos == 0:
-        logger.error(f"Target thread {thread_id} not found in active threads list")
+    if old_seq == 0:
+        logger.error("Target thread %d not found in active threads list", thread_id)
         return
 
-    # Validate position range only if thread is in active list
     if new_position < 1:
         raise ValueError(f"Position must be at least 1, got {new_position}")
 
@@ -161,75 +237,46 @@ async def move_to_position(
             f"Position {new_position} is out of range. Maximum position is {thread_count}."
         )
 
-    logger.info(f"Final target position: {new_position} (original: {old_position})")
+    logger.info("Final target position: %d (original: %d)", new_position, old_position)
 
-    if current_sequential_pos == new_position:
+    if old_seq == new_position:
         logger.info(
-            f"Thread {thread_id} already at sequential position {new_position}, no movement needed"
+            "Thread %d already at sequential position %d, no movement needed",
+            thread_id,
+            new_position,
         )
         return
 
-    # Normalize all positions to be sequential first
-    for i, thread in enumerate(all_threads):
-        normalized_position = i + 1
-        if thread.queue_position != normalized_position:
-            thread.queue_position = normalized_position
+    await db.execute(
+        _MOVE_POSITION_SQL,
+        {"uid": user_id, "tid": thread_id, "new_pos": new_position},
+    )
 
-    logger.info("Normalized all thread positions to sequential values")
-
-    # Now apply the move using the normalized positions
-    if current_sequential_pos < new_position:
-        logger.info(
-            f"Moving thread BACKWARD: sequential {current_sequential_pos} -> {new_position}"
-        )
-
-        # Shift threads at current position + 1 to new_position back by 1
-        for thread in all_threads:
-            if thread.id != thread_id:
-                current_thread_seq_pos = next(
-                    (i + 1 for i, t in enumerate(all_threads) if t.id == thread.id), 0
-                )
-                if current_sequential_pos < current_thread_seq_pos <= new_position:
-                    thread.queue_position -= 1
-
-        target_thread.queue_position = new_position
-        logger.info(f"Set target thread {thread_id} position to {new_position}")
-
-    else:  # current_sequential_pos > new_position
-        logger.info(f"Moving thread FORWARD: sequential {current_sequential_pos} -> {new_position}")
-
-        # Shift threads at new_position to current_position - 1 forward by 1
-        for thread in all_threads:
-            if thread.id != thread_id:
-                current_thread_seq_pos = next(
-                    (i + 1 for i, t in enumerate(all_threads) if t.id == thread.id), 0
-                )
-                if new_position <= current_thread_seq_pos < current_sequential_pos:
-                    thread.queue_position += 1
-
-        target_thread.queue_position = new_position
-        logger.info(f"Set target thread {thread_id} position to {new_position}")
+    await _refresh_queue_positions(db, user_id)
 
     logger.debug("Committing database transaction")
     if do_commit:
         await db.commit()
 
-    logger.info(f"move_to_position SUCCESS: thread {thread_id} moved to position {new_position}")
+    logger.info("move_to_position SUCCESS: thread %d moved to position %d", thread_id, new_position)
 
-    # Show final queue state for debugging
-    logger.debug("Final queue state after operation:")
-    result = await db.execute(
-        select(Thread)
-        .where(Thread.user_id == user_id)
-        .where(Thread.queue_position >= 1)
-        .order_by(Thread.queue_position)
-    )
-    final_queue = result.scalars().all()
-
-    for thread in final_queue:
-        logger.debug(
-            f"  Position {thread.queue_position}: Thread {thread.id} ('{thread.title[:50]}...')"
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("Final queue state after operation:")
+        result = await db.execute(
+            sa_select(Thread)
+            .where(Thread.user_id == user_id)
+            .where(Thread.queue_position >= 1)
+            .order_by(Thread.queue_position)
         )
+        final_queue = result.scalars().all()
+
+        for thread in final_queue:
+            logger.debug(
+                "  Position %d: Thread %d ('%s...')",
+                thread.queue_position,
+                thread.id,
+                thread.title[:50],
+            )
 
 
 async def move_to_safe_position(
@@ -271,7 +318,7 @@ async def move_to_safe_position(
     excluded_ids = set(excluded_thread_ids or ())
 
     result = await db.execute(
-        select(Thread)
+        sa_select(Thread)
         .where(Thread.user_id == user_id)
         .where(Thread.status == "active")
         .where(Thread.queue_position >= 1)
@@ -279,7 +326,6 @@ async def move_to_safe_position(
     )
     all_active = list(result.scalars().all())
 
-    # Build the rollable pool (same filter as get_roll_pool: non-blocked only)
     rollable = [t for t in all_active if not t.is_blocked and t.id not in excluded_ids]
 
     target_rollable_index = next(
@@ -291,25 +337,18 @@ async def move_to_safe_position(
     if len(rollable) <= 1:
         return
 
-    # If the target is already at or beyond the die range in the rollable
-    # pool, no move is needed — it's already outside the next roll pool.
     if target_rollable_index >= die_size:
         return
 
-    # Walk the full active list (including blocked) and count non-blocked
-    # threads (excluding the target) until we've seen die_size of them.
-    # The target goes right after that point in the all-active list,
-    # guaranteeing it has die_size rollable threads before it and is
-    # therefore outside the roll pool.
     non_blocked_seen = 0
-    target_seq = len(all_active)  # default: back of queue (small-pool fallback)
+    target_seq = len(all_active)
     for i, t in enumerate(all_active):
         if t.id == thread_id:
             continue
         if not t.is_blocked and t.id not in excluded_ids:
             non_blocked_seen += 1
         if non_blocked_seen >= die_size:
-            target_seq = i + 1  # 1-indexed position in all_active
+            target_seq = i + 1
             break
 
     target_seq = min(target_seq, len(all_active))
@@ -326,6 +365,10 @@ async def move_to_safe_position(
 async def shuffle_queue(user_id: int, db: AsyncSession) -> int:
     """Randomize the order of active queue threads for a user.
 
+    Uses a single CASE-based UPDATE to assign new positions in bulk,
+    eliminating the previous row-by-row ORM mutations and reducing
+    the operation to a single SQL statement.
+
     Args:
         user_id: The user whose active queue should be shuffled.
         db: The async database session.
@@ -333,24 +376,39 @@ async def shuffle_queue(user_id: int, db: AsyncSession) -> int:
     Returns:
         Number of active threads that were shuffled.
     """
+    await _acquire_queue_lock(user_id, db)
+
     result = await db.execute(
-        select(Thread)
+        sa_select(Thread.id)
         .where(Thread.user_id == user_id)
         .where(Thread.status == "active")
         .where(Thread.queue_position >= 1)
         .order_by(Thread.queue_position, Thread.id)
     )
-    threads = list(result.scalars().all())
+    active_ids = [row[0] for row in result.fetchall()]
 
-    if len(threads) < 2:
-        return len(threads)
+    if len(active_ids) < 2:
+        return len(active_ids)
 
-    random.shuffle(threads)
-    for position, thread in enumerate(threads, start=1):
-        thread.queue_position = position
+    shuffled_ids = list(active_ids)
+    random.shuffle(shuffled_ids)
+
+    case_expr = case(
+        *[(Thread.id == tid, pos) for pos, tid in enumerate(shuffled_ids, start=1)],
+        else_=Thread.queue_position,
+    )
+    await db.execute(
+        update(Thread)
+        .where(Thread.user_id == user_id)
+        .where(Thread.status == "active")
+        .where(Thread.queue_position >= 1)
+        .values(queue_position=case_expr)
+    )
+
+    await _refresh_queue_positions(db, user_id)
 
     await db.commit()
-    return len(threads)
+    return len(active_ids)
 
 
 async def get_roll_pool(
@@ -371,7 +429,7 @@ async def get_roll_pool(
         List of active threads ordered by queue position.
     """
     query = (
-        select(Thread)
+        sa_select(Thread)
         .where(Thread.user_id == user_id)
         .where(Thread.status == "active")
         .where(Thread.queue_position >= 1)
@@ -397,7 +455,7 @@ async def get_stale_threads(user_id: int, db: AsyncSession, days: int = 7) -> li
     cutoff_date = datetime.now(UTC) - timedelta(days=days)
 
     result = await db.execute(
-        select(Thread)
+        sa_select(Thread)
         .where(Thread.user_id == user_id)
         .where(Thread.status == "active")
         .where(Thread.is_blocked.is_(False))

--- a/tests/test_queue_position_perf.py
+++ b/tests/test_queue_position_perf.py
@@ -1,8 +1,8 @@
 """Regression tests for the set-based queue repositioning rewrite (#699).
 
-Covers: duplicate-position determinism, concurrent-move integrity,
-debug-log no-reload, cross-user isolation, gapped-position order
-preservation, and no-op moves.
+Covers deterministic normalization, concurrency, bounded database work,
+logging guards, cross-user isolation, safe-position behavior, and front/back
+movement with gaps, duplicates, and completed targets.
 """
 
 import asyncio
@@ -10,22 +10,25 @@ import logging
 from datetime import UTC, datetime
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import event, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.models import Thread, User
-from comic_pile.queue import move_to_position, move_to_front, move_to_back, shuffle_queue
+from comic_pile.queue import (
+    move_to_back,
+    move_to_front,
+    move_to_position,
+    move_to_safe_position,
+    shuffle_queue,
+)
 from tests.conftest import get_or_create_user_async, get_test_database_url
-
-
-# ── duplicate starting positions ────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
 async def test_duplicate_starting_positions_deterministic(
     async_db: AsyncSession, default_user: User
 ) -> None:
-    """Duplicate queue_position values normalise deterministically (id tie-break)."""
+    """Duplicate queue positions normalize deterministically using the ID tie-break."""
     now = datetime.now(UTC)
     threads = [
         Thread(
@@ -58,151 +61,222 @@ async def test_duplicate_starting_positions_deterministic(
     ]
     async_db.add_all(threads)
     await async_db.commit()
-    for t in threads:
-        await async_db.refresh(t)
+    for thread in threads:
+        await async_db.refresh(thread)
 
-    # Move Dup A (seq=1 due to id tie-break) to position 3 (backward).
-    # The combined normalisation + shift must produce sequential 1,2,3.
+    ids = [thread.id for thread in threads]
+    assert ids == sorted(ids), f"Test assumes ascending IDs for the tie-break: {ids}"
+
+    # Move Dup A from sequential position 1 to position 3.
     await move_to_position(threads[0].id, default_user.id, 3, async_db)
 
-    for t in threads:
-        await async_db.refresh(t)
+    for thread in threads:
+        await async_db.refresh(thread)
 
-    positions = {t.id: t.queue_position for t in threads}
+    positions = {thread.id: thread.queue_position for thread in threads}
     assert sorted(positions.values()) == [1, 2, 3], f"Positions not sequential: {positions}"
-
-    # Dup A moved to position 3; Dup B should be at 1 (shifted up), Dup C at 2
     assert positions[threads[0].id] == 3
     assert positions[threads[1].id] == 1
     assert positions[threads[2].id] == 2
-
-
-# ── gapped starting positions (sample_data-like) ────────────────────────────────
 
 
 @pytest.mark.asyncio
 async def test_gapped_positions_preserve_order_after_move(
     async_db: AsyncSession, default_user: User
 ) -> None:
-    """Moving through a gap preserves correct sequential order."""
+    """Moving through a gap preserves the active queue's relative order."""
     now = datetime.now(UTC)
     threads = [
-        Thread(title="A", format="Comic", issues_remaining=1, queue_position=1,
-               status="active", user_id=default_user.id, created_at=now),
-        Thread(title="B", format="Comic", issues_remaining=1, queue_position=2,
-               status="active", user_id=default_user.id, created_at=now),
-        Thread(title="Complete", format="Comic", issues_remaining=1, queue_position=3,
-               status="completed", user_id=default_user.id, created_at=now),
-        Thread(title="C", format="Comic", issues_remaining=1, queue_position=4,
-               status="active", user_id=default_user.id, created_at=now),
-        Thread(title="D", format="Comic", issues_remaining=1, queue_position=5,
-               status="active", user_id=default_user.id, created_at=now),
+        Thread(
+            title="A",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=1,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        ),
+        Thread(
+            title="B",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=2,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        ),
+        Thread(
+            title="Complete",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=3,
+            status="completed",
+            user_id=default_user.id,
+            created_at=now,
+        ),
+        Thread(
+            title="C",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=4,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        ),
+        Thread(
+            title="D",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=5,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        ),
     ]
     async_db.add_all(threads)
     await async_db.commit()
-    for t in threads:
-        await async_db.refresh(t)
+    for thread in threads:
+        await async_db.refresh(thread)
 
-    # Move C (at sequential pos 3 among actives: A=1, B=2, C=3, D=4) to position 1
-    thread_c = threads[3]  # "C", queue_position=4
+    thread_c = threads[3]
     await move_to_position(thread_c.id, default_user.id, 1, async_db)
 
-    for t in threads:
-        await async_db.refresh(t)
+    for thread in threads:
+        await async_db.refresh(thread)
 
-    # After move: C=1, A=2, B=3, D=4
     assert thread_c.queue_position == 1
-    # Verify non-completed stays untouched
-    assert threads[2].queue_position == 3  # completed, unchanged
+    assert threads[2].queue_position == 3
 
-    # Check active threads are in correct order
     result = await async_db.execute(
         select(Thread)
         .where(Thread.user_id == default_user.id)
         .where(Thread.status == "active")
         .where(Thread.queue_position >= 1)
-        .order_by(Thread.queue_position)
+        .order_by(Thread.queue_position, Thread.id)
     )
     active = result.scalars().all()
-    active_titles = [t.title for t in active]
-    assert active_titles == ["C", "A", "B", "D"]
-
-
-# ── no-op moves ──────────────────────────────────────────────────────────────────
+    assert [thread.title for thread in active] == ["C", "A", "B", "D"]
+    assert [thread.queue_position for thread in active] == [1, 2, 3, 4]
 
 
 @pytest.mark.asyncio
-async def test_move_to_position_noop_does_nothing(
+async def test_move_to_position_noop_keeps_clean_queue_unchanged(
     async_db: AsyncSession, default_user: User
 ) -> None:
-    """A no-op move leaves the queue untouched."""
+    """A no-op move leaves an already normalized queue untouched."""
     now = datetime.now(UTC)
     threads = [
-        Thread(title=f"T{i}", format="Comic", issues_remaining=1,
-               queue_position=i, status="active",
-               user_id=default_user.id, created_at=now)
+        Thread(
+            title=f"T{i}",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=i,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        )
         for i in range(1, 6)
     ]
     async_db.add_all(threads)
     await async_db.commit()
-    for t in threads:
-        await async_db.refresh(t)
+    for thread in threads:
+        await async_db.refresh(thread)
 
-    original_positions = {t.id: t.queue_position for t in threads}
-
-    # Move thread at position 3 to position 3 (no-op)
+    original_positions = {thread.id: thread.queue_position for thread in threads}
     await move_to_position(threads[2].id, default_user.id, 3, async_db)
 
-    for t in threads:
-        await async_db.refresh(t)
+    for thread in threads:
+        await async_db.refresh(thread)
 
-    current_positions = {t.id: t.queue_position for t in threads}
+    current_positions = {thread.id: thread.queue_position for thread in threads}
     assert current_positions == original_positions
 
 
-# ── concurrent-move integrity ────────────────────────────────────────────────────
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_position", [0, -1, 11])
+async def test_move_to_position_rejects_out_of_range(
+    async_db: AsyncSession,
+    default_user: User,
+    bad_position: int,
+) -> None:
+    """Positions outside the active 1..N range raise ValueError."""
+    now = datetime.now(UTC)
+    threads = [
+        Thread(
+            title=f"V-{i}",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=i,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        )
+        for i in range(1, 11)
+    ]
+    async_db.add_all(threads)
+    await async_db.commit()
+    for thread in threads:
+        await async_db.refresh(thread)
+
+    with pytest.raises(ValueError):
+        await move_to_position(
+            threads[0].id,
+            default_user.id,
+            bad_position,
+            async_db,
+        )
+
+    # The helper acquired a transaction-scoped advisory lock before validating.
+    await async_db.rollback()
 
 
 @pytest.mark.asyncio
 async def test_concurrent_repositioning_no_duplicate_positions(
     async_db_committed: AsyncSession,
 ) -> None:
-    """Concurrent move_to_position calls must not produce duplicate active positions.
-
-    This uses real commits across independent sessions, mirroring the pattern
-    from test_concurrent_issue_creation.py.
-    """
+    """Concurrent moves serialize without producing duplicate active positions."""
     user = await get_or_create_user_async(async_db_committed)
 
     now = datetime.now(UTC)
     for i in range(1, 21):
-        t = Thread(
-            title=f"Conc {i}",
-            format="Comic",
-            issues_remaining=1,
-            queue_position=i,
-            status="active",
-            user_id=user.id,
-            created_at=now,
+        async_db_committed.add(
+            Thread(
+                title=f"Conc {i}",
+                format="Comic",
+                issues_remaining=1,
+                queue_position=i,
+                status="active",
+                user_id=user.id,
+                created_at=now,
+            )
         )
-        async_db_committed.add(t)
     await async_db_committed.commit()
 
     result = await async_db_committed.execute(
-        select(Thread.id).where(Thread.user_id == user.id, Thread.status == "active")
+        select(Thread.id)
+        .where(Thread.user_id == user.id, Thread.status == "active")
+        .order_by(Thread.queue_position, Thread.id)
     )
     thread_ids = [row[0] for row in result.fetchall()]
 
     database_url = get_test_database_url()
     engine = create_async_engine(database_url, echo=False, pool_size=20, max_overflow=0)
-    session_maker = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    session_maker = async_sessionmaker(
+        bind=engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
 
-    async def move_in_new_session(tid: int, target_pos: int) -> None:
-        async with session_maker() as s:
-            await move_to_position(tid, user.id, target_pos, s, do_commit=True)
+    async def move_in_new_session(thread_id: int, target_position: int) -> None:
+        async with session_maker() as session:
+            await move_to_position(
+                thread_id,
+                user.id,
+                target_position,
+                session,
+                do_commit=True,
+            )
 
-    # Launch 10 concurrent moves — different threads to different positions.
-    # Each move acquires the advisory lock, so serialisation is guaranteed.
     moves = [
         (thread_ids[0], 10),
         (thread_ids[1], 1),
@@ -215,12 +289,13 @@ async def test_concurrent_repositioning_no_duplicate_positions(
         (thread_ids[8], 12),
         (thread_ids[9], 2),
     ]
-    tasks = [move_in_new_session(tid, pos) for tid, pos in moves]
-    await asyncio.gather(*tasks)
 
-    await engine.dispose()
+    try:
+        tasks = [move_in_new_session(thread_id, position) for thread_id, position in moves]
+        await asyncio.gather(*tasks)
+    finally:
+        await engine.dispose()
 
-    # Verify positions are sequential 1..20 with no duplicates
     result = await async_db_committed.execute(
         select(Thread.queue_position)
         .where(Thread.user_id == user.id, Thread.status == "active")
@@ -229,9 +304,6 @@ async def test_concurrent_repositioning_no_duplicate_positions(
     positions = [row[0] for row in result.fetchall()]
     assert len(positions) == len(set(positions)), f"Duplicate positions found: {positions}"
     assert positions == list(range(1, 21)), f"Positions not sequential: {positions}"
-
-
-# ── cross-user isolation ─────────────────────────────────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -246,57 +318,54 @@ async def test_cross_user_isolation(
 
     now = datetime.now(UTC)
     user1_threads = [
-        Thread(title=f"U1-{i}", format="Comic", issues_remaining=1,
-               queue_position=i, status="active",
-               user_id=default_user.id, created_at=now)
+        Thread(
+            title=f"U1-{i}",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=i,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        )
         for i in range(1, 4)
     ]
     user2_threads = [
-        Thread(title=f"U2-{i}", format="Comic", issues_remaining=1,
-               queue_position=i, status="active",
-               user_id=user2.id, created_at=now)
+        Thread(
+            title=f"U2-{i}",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=i,
+            status="active",
+            user_id=user2.id,
+            created_at=now,
+        )
         for i in range(1, 4)
     ]
     async_db.add_all(user1_threads + user2_threads)
     await async_db.commit()
-    for t in user1_threads + user2_threads:
-        await async_db.refresh(t)
+    for thread in user1_threads + user2_threads:
+        await async_db.refresh(thread)
 
-    original_u2_positions = {t.id: t.queue_position for t in user2_threads}
-
-    # Move a thread for user 1 only
+    original_u2_positions = {thread.id: thread.queue_position for thread in user2_threads}
     await move_to_position(user1_threads[0].id, default_user.id, 3, async_db)
 
-    # User 2 positions must be unchanged
-    for t in user2_threads:
-        await async_db.refresh(t)
+    for thread in user2_threads:
+        await async_db.refresh(thread)
+    current_u2_positions = {thread.id: thread.queue_position for thread in user2_threads}
+    assert current_u2_positions == original_u2_positions
 
-    current_u2_positions = {t.id: t.queue_position for t in user2_threads}
-    assert current_u2_positions == original_u2_positions, (
-        f"User 2 positions changed: {original_u2_positions} → {current_u2_positions}"
-    )
-
-    # User 1's positions should be changed (our target moved)
-    for t in user1_threads:
-        await async_db.refresh(t)
-    u1_ids = {t.id for t in user1_threads}
-    result = await async_db.execute(
-        select(Thread.queue_position)
-        .where(Thread.id.in_(u1_ids))
-        .order_by(Thread.queue_position)
-    )
-    u1_positions = [row[0] for row in result.fetchall()]
-    assert u1_positions == [1, 2, 3], f"User 1 positions not sequential: {u1_positions}"
-
-
-# ── shuffle isolation ───────────────────────────────────────────────────────────
+    for thread in user1_threads:
+        await async_db.refresh(thread)
+    u1_positions = sorted(thread.queue_position for thread in user1_threads)
+    assert u1_positions == [1, 2, 3]
+    assert user1_threads[0].queue_position == 3
 
 
 @pytest.mark.asyncio
 async def test_shuffle_isolates_per_user(
     async_db: AsyncSession, default_user: User
 ) -> None:
-    """shuffle_queue only affects the target user."""
+    """Shuffle updates the target user's full permutation and no other user."""
     user2 = User(username="other_shuffle", created_at=datetime.now(UTC))
     async_db.add(user2)
     await async_db.commit()
@@ -304,169 +373,388 @@ async def test_shuffle_isolates_per_user(
 
     now = datetime.now(UTC)
     u1 = [
-        Thread(title=f"SU1-{i}", format="Comic", issues_remaining=1,
-               queue_position=i, status="active",
-               user_id=default_user.id, created_at=now)
+        Thread(
+            title=f"SU1-{i}",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=i,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        )
         for i in range(1, 6)
     ]
     u2 = [
-        Thread(title=f"SU2-{i}", format="Comic", issues_remaining=1,
-               queue_position=i, status="active",
-               user_id=user2.id, created_at=now)
+        Thread(
+            title=f"SU2-{i}",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=i,
+            status="active",
+            user_id=user2.id,
+            created_at=now,
+        )
         for i in range(1, 4)
     ]
     async_db.add_all(u1 + u2)
     await async_db.commit()
+    for thread in u1 + u2:
+        await async_db.refresh(thread)
 
-    original_u2_positions = {t.id: t.queue_position for t in u2}
+    original_u2_positions = {thread.id: thread.queue_position for thread in u2}
+    shuffled_count = await shuffle_queue(default_user.id, async_db)
+    assert shuffled_count == 5
 
-    await shuffle_queue(default_user.id, async_db)
+    for thread in u1 + u2:
+        await async_db.refresh(thread)
 
-    for t in u2:
-        await async_db.refresh(t)
-
-    current_u2_positions = {t.id: t.queue_position for t in u2}
+    current_u2_positions = {thread.id: thread.queue_position for thread in u2}
     assert current_u2_positions == original_u2_positions
-
-
-# ── debug-log no-reload ──────────────────────────────────────────────────────────
+    assert sorted(thread.queue_position for thread in u1) == [1, 2, 3, 4, 5]
 
 
 @pytest.mark.asyncio
-async def test_move_to_position_no_full_reload_when_debug_disabled(
-    async_db: AsyncSession, default_user: User, caplog: pytest.LogCaptureFixture
+async def test_move_to_position_debug_reload_is_level_guarded(
+    async_db: AsyncSession,
+    default_user: User,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """When DEBUG logging is off, the final queue-state reload is NOT executed."""
+    """The final queue reload is absent at INFO and present at DEBUG."""
     now = datetime.now(UTC)
     threads = [
-        Thread(title=f"DL-{i}", format="Comic", issues_remaining=1,
-               queue_position=i, status="active",
-               user_id=default_user.id, created_at=now)
+        Thread(
+            title=f"DL-{i}",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=i,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        )
         for i in range(1, 6)
     ]
     async_db.add_all(threads)
     await async_db.commit()
-    for t in threads:
-        await async_db.refresh(t)
+    for thread in threads:
+        await async_db.refresh(thread)
 
-    queue_logger = logging.getLogger("comic_pile.queue")
-    old_level = queue_logger.level
-    queue_logger.setLevel(logging.INFO)
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="comic_pile.queue"):
+        await move_to_position(threads[0].id, default_user.id, 3, async_db)
 
-    try:
-        caplog.clear()
-        with caplog.at_level(logging.INFO, logger="comic_pile.queue"):
-            await move_to_position(threads[0].id, default_user.id, 3, async_db)
-    finally:
-        queue_logger.setLevel(old_level)
+    assert not [
+        record for record in caplog.records if "Final queue state" in record.getMessage()
+    ], "Final queue state was reloaded even though DEBUG is disabled"
 
-    final_state_records = [
-        r for r in caplog.records
-        if "Final queue state" in r.message
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger="comic_pile.queue"):
+        await move_to_position(threads[0].id, default_user.id, 1, async_db)
+
+    assert [
+        record for record in caplog.records if "Final queue state" in record.getMessage()
+    ], "Final queue state was not reloaded even though DEBUG is enabled"
+
+
+@pytest.mark.asyncio
+async def test_safe_position_has_bounded_database_round_trips(
+    async_db: AsyncSession, default_user: User
+) -> None:
+    """Safe-position movement does not refresh every cached thread individually."""
+    now = datetime.now(UTC)
+    threads = [
+        Thread(
+            title=f"Safe-{i}",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=i,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        )
+        for i in range(1, 51)
     ]
-    assert len(final_state_records) == 0, (
-        f"Final queue state was reloaded even though DEBUG is disabled: {final_state_records}"
-    )
+    async_db.add_all(threads)
+    await async_db.commit()
+    for thread in threads:
+        await async_db.refresh(thread)
 
+    statements: list[str] = []
 
-# ── move_to_front/back order preservation ────────────────────────────────────────
+    def record_statement(
+        _connection: object,
+        _cursor: object,
+        statement: str,
+        _parameters: object,
+        _context: object,
+        _executemany: bool,
+    ) -> None:
+        statements.append(statement)
+
+    sync_connection = async_db.sync_session.connection()
+    event.listen(sync_connection, "before_cursor_execute", record_statement)
+    try:
+        await move_to_safe_position(
+            threads[0].id,
+            default_user.id,
+            6,
+            async_db,
+        )
+    finally:
+        event.remove(sync_connection, "before_cursor_execute", record_statement)
+
+    assert threads[0].queue_position == 7
+    assert len(statements) <= 7, f"Expected bounded SQL work, got {len(statements)} statements"
 
 
 @pytest.mark.asyncio
 async def test_move_to_front_preserves_relative_order(
     async_db: AsyncSession, default_user: User
 ) -> None:
-    """move_to_front shifts all preceding threads back by 1, preserving their relative order."""
+    """Move-to-front preserves the relative order of all other active threads."""
     now = datetime.now(UTC)
     threads = [
-        Thread(title=f"F-{i}", format="Comic", issues_remaining=1,
-               queue_position=i, status="active",
-               user_id=default_user.id, created_at=now)
+        Thread(
+            title=f"F-{i}",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=i,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        )
         for i in range(1, 6)
     ]
     async_db.add_all(threads)
     await async_db.commit()
-    for t in threads:
-        await async_db.refresh(t)
+    for thread in threads:
+        await async_db.refresh(thread)
 
-    # Move thread at position 4 to front
     await move_to_front(threads[3].id, default_user.id, async_db)
 
-    for t in threads:
-        await async_db.refresh(t)
-
-    # Expected order: D(4→1), A(1→2), B(2→3), C(3→4), E(5→5)
     result = await async_db.execute(
-        select(Thread.title)
+        select(Thread.title, Thread.queue_position)
         .where(Thread.user_id == default_user.id, Thread.status == "active")
-        .order_by(Thread.queue_position)
+        .order_by(Thread.queue_position, Thread.id)
     )
-    titles = [row[0] for row in result.fetchall()]
-    assert titles == ["F-4", "F-1", "F-2", "F-3", "F-5"]
+    rows = result.all()
+    assert [row.title for row in rows] == ["F-4", "F-1", "F-2", "F-3", "F-5"]
+    assert [row.queue_position for row in rows] == [1, 2, 3, 4, 5]
+
+
+@pytest.mark.asyncio
+async def test_move_to_front_normalizes_duplicate_positions(
+    async_db: AsyncSession, default_user: User
+) -> None:
+    """Move-to-front uses deterministic ordering when starting positions duplicate."""
+    now = datetime.now(UTC)
+    positions = [1, 1, 3, 4]
+    threads = [
+        Thread(
+            title=f"FD-{i}",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=position,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        )
+        for i, position in enumerate(positions, start=1)
+    ]
+    async_db.add_all(threads)
+    await async_db.commit()
+    for thread in threads:
+        await async_db.refresh(thread)
+
+    await move_to_front(threads[3].id, default_user.id, async_db)
+
+    result = await async_db.execute(
+        select(Thread.title, Thread.queue_position)
+        .where(Thread.user_id == default_user.id, Thread.status == "active")
+        .order_by(Thread.queue_position, Thread.id)
+    )
+    rows = result.all()
+    assert [row.title for row in rows] == ["FD-4", "FD-1", "FD-2", "FD-3"]
+    assert [row.queue_position for row in rows] == [1, 2, 3, 4]
 
 
 @pytest.mark.asyncio
 async def test_move_to_back_preserves_relative_order(
     async_db: AsyncSession, default_user: User
 ) -> None:
-    """move_to_back shifts all following threads forward by 1, preserving their relative order."""
+    """Move-to-back preserves the relative order of all other active threads."""
     now = datetime.now(UTC)
     threads = [
-        Thread(title=f"B-{i}", format="Comic", issues_remaining=1,
-               queue_position=i, status="active",
-               user_id=default_user.id, created_at=now)
+        Thread(
+            title=f"B-{i}",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=i,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        )
         for i in range(1, 6)
     ]
     async_db.add_all(threads)
     await async_db.commit()
-    for t in threads:
-        await async_db.refresh(t)
+    for thread in threads:
+        await async_db.refresh(thread)
 
-    # Move thread at position 2 to back
     await move_to_back(threads[1].id, default_user.id, async_db)
 
-    for t in threads:
-        await async_db.refresh(t)
-
-    # Expected: A(1→1), C(3→2), D(4→3), E(5→4), B(2→5)
     result = await async_db.execute(
-        select(Thread.title)
+        select(Thread.title, Thread.queue_position)
         .where(Thread.user_id == default_user.id, Thread.status == "active")
-        .order_by(Thread.queue_position)
+        .order_by(Thread.queue_position, Thread.id)
     )
-    titles = [row[0] for row in result.fetchall()]
-    assert titles == ["B-1", "B-3", "B-4", "B-5", "B-2"]
+    rows = result.all()
+    assert [row.title for row in rows] == ["B-1", "B-3", "B-4", "B-5", "B-2"]
+    assert [row.queue_position for row in rows] == [1, 2, 3, 4, 5]
 
 
-# ── sequential positions after full cycle ───────────────────────────────────────
+@pytest.mark.asyncio
+async def test_move_to_back_normalizes_gapped_positions(
+    async_db: AsyncSession, default_user: User
+) -> None:
+    """Move-to-back compacts gaps created by non-active queue rows."""
+    now = datetime.now(UTC)
+    threads = [
+        Thread(
+            title="BG-1",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=1,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        ),
+        Thread(
+            title="BG-2",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=2,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        ),
+        Thread(
+            title="BG-complete",
+            format="Comic",
+            issues_remaining=0,
+            queue_position=3,
+            status="completed",
+            user_id=default_user.id,
+            created_at=now,
+        ),
+        Thread(
+            title="BG-4",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=4,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        ),
+        Thread(
+            title="BG-5",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=5,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        ),
+    ]
+    async_db.add_all(threads)
+    await async_db.commit()
+    for thread in threads:
+        await async_db.refresh(thread)
+
+    await move_to_back(threads[1].id, default_user.id, async_db)
+
+    result = await async_db.execute(
+        select(Thread.title, Thread.queue_position)
+        .where(Thread.user_id == default_user.id, Thread.status == "active")
+        .order_by(Thread.queue_position, Thread.id)
+    )
+    rows = result.all()
+    assert [row.title for row in rows] == ["BG-1", "BG-4", "BG-5", "BG-2"]
+    assert [row.queue_position for row in rows] == [1, 2, 3, 4]
+
+
+@pytest.mark.asyncio
+async def test_move_to_back_compacts_queue_for_completed_target(
+    async_db: AsyncSession, default_user: User
+) -> None:
+    """A newly completed target moves behind a compact active queue."""
+    now = datetime.now(UTC)
+    threads = [
+        Thread(
+            title=f"BC-{i}",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=i,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        )
+        for i in range(1, 6)
+    ]
+    async_db.add_all(threads)
+    await async_db.commit()
+    for thread in threads:
+        await async_db.refresh(thread)
+
+    completed = threads[1]
+    completed.status = "completed"
+    completed.issues_remaining = 0
+    await async_db.flush()
+
+    await move_to_back(completed.id, default_user.id, async_db, commit=False)
+
+    result = await async_db.execute(
+        select(Thread.title, Thread.queue_position)
+        .where(Thread.user_id == default_user.id, Thread.status == "active")
+        .order_by(Thread.queue_position, Thread.id)
+    )
+    rows = result.all()
+    assert [row.title for row in rows] == ["BC-1", "BC-3", "BC-4", "BC-5"]
+    assert [row.queue_position for row in rows] == [1, 2, 3, 4]
+    assert completed.queue_position == 5
 
 
 @pytest.mark.asyncio
 async def test_positions_remain_sequential_after_multiple_moves(
     async_db: AsyncSession, default_user: User
 ) -> None:
-    """After multiple move_to_position calls, active positions are sequential 1..N."""
+    """Multiple moves keep active positions sequential and unique."""
     now = datetime.now(UTC)
     threads = [
-        Thread(title=f"M-{i}", format="Comic", issues_remaining=1,
-               queue_position=i, status="active",
-               user_id=default_user.id, created_at=now)
+        Thread(
+            title=f"M-{i}",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=i,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        )
         for i in range(1, 11)
     ]
     async_db.add_all(threads)
     await async_db.commit()
-    for t in threads:
-        await async_db.refresh(t)
+    for thread in threads:
+        await async_db.refresh(thread)
 
     moves = [
-        (threads[0].id, 10),  # first → last
-        (threads[9].id, 1),   # last → first
-        (threads[4].id, 3),   # middle forward
-        (threads[2].id, 8),   # middle backward
-        (threads[7].id, 5),   # middle forward
+        (threads[0].id, 10),
+        (threads[9].id, 1),
+        (threads[4].id, 3),
+        (threads[2].id, 8),
+        (threads[7].id, 5),
     ]
-    for tid, pos in moves:
-        await move_to_position(tid, default_user.id, pos, async_db)
+    for thread_id, position in moves:
+        await move_to_position(thread_id, default_user.id, position, async_db)
 
     result = await async_db.execute(
         select(Thread.queue_position)

--- a/tests/test_queue_position_perf.py
+++ b/tests/test_queue_position_perf.py
@@ -1,0 +1,478 @@
+"""Regression tests for the set-based queue repositioning rewrite (#699).
+
+Covers: duplicate-position determinism, concurrent-move integrity,
+debug-log no-reload, cross-user isolation, gapped-position order
+preservation, and no-op moves.
+"""
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.models import Thread, User
+from comic_pile.queue import move_to_position, move_to_front, move_to_back, shuffle_queue
+from tests.conftest import get_or_create_user_async, get_test_database_url
+
+
+# ── duplicate starting positions ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_duplicate_starting_positions_deterministic(
+    async_db: AsyncSession, default_user: User
+) -> None:
+    """Duplicate queue_position values normalise deterministically (id tie-break)."""
+    now = datetime.now(UTC)
+    threads = [
+        Thread(
+            title="Dup A",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=1,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        ),
+        Thread(
+            title="Dup B",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=1,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        ),
+        Thread(
+            title="Dup C",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=1,
+            status="active",
+            user_id=default_user.id,
+            created_at=now,
+        ),
+    ]
+    async_db.add_all(threads)
+    await async_db.commit()
+    for t in threads:
+        await async_db.refresh(t)
+
+    # Move Dup A (seq=1 due to id tie-break) to position 3 (backward).
+    # The combined normalisation + shift must produce sequential 1,2,3.
+    await move_to_position(threads[0].id, default_user.id, 3, async_db)
+
+    for t in threads:
+        await async_db.refresh(t)
+
+    positions = {t.id: t.queue_position for t in threads}
+    assert sorted(positions.values()) == [1, 2, 3], f"Positions not sequential: {positions}"
+
+    # Dup A moved to position 3; Dup B should be at 1 (shifted up), Dup C at 2
+    assert positions[threads[0].id] == 3
+    assert positions[threads[1].id] == 1
+    assert positions[threads[2].id] == 2
+
+
+# ── gapped starting positions (sample_data-like) ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_gapped_positions_preserve_order_after_move(
+    async_db: AsyncSession, default_user: User
+) -> None:
+    """Moving through a gap preserves correct sequential order."""
+    now = datetime.now(UTC)
+    threads = [
+        Thread(title="A", format="Comic", issues_remaining=1, queue_position=1,
+               status="active", user_id=default_user.id, created_at=now),
+        Thread(title="B", format="Comic", issues_remaining=1, queue_position=2,
+               status="active", user_id=default_user.id, created_at=now),
+        Thread(title="Complete", format="Comic", issues_remaining=1, queue_position=3,
+               status="completed", user_id=default_user.id, created_at=now),
+        Thread(title="C", format="Comic", issues_remaining=1, queue_position=4,
+               status="active", user_id=default_user.id, created_at=now),
+        Thread(title="D", format="Comic", issues_remaining=1, queue_position=5,
+               status="active", user_id=default_user.id, created_at=now),
+    ]
+    async_db.add_all(threads)
+    await async_db.commit()
+    for t in threads:
+        await async_db.refresh(t)
+
+    # Move C (at sequential pos 3 among actives: A=1, B=2, C=3, D=4) to position 1
+    thread_c = threads[3]  # "C", queue_position=4
+    await move_to_position(thread_c.id, default_user.id, 1, async_db)
+
+    for t in threads:
+        await async_db.refresh(t)
+
+    # After move: C=1, A=2, B=3, D=4
+    assert thread_c.queue_position == 1
+    # Verify non-completed stays untouched
+    assert threads[2].queue_position == 3  # completed, unchanged
+
+    # Check active threads are in correct order
+    result = await async_db.execute(
+        select(Thread)
+        .where(Thread.user_id == default_user.id)
+        .where(Thread.status == "active")
+        .where(Thread.queue_position >= 1)
+        .order_by(Thread.queue_position)
+    )
+    active = result.scalars().all()
+    active_titles = [t.title for t in active]
+    assert active_titles == ["C", "A", "B", "D"]
+
+
+# ── no-op moves ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_move_to_position_noop_does_nothing(
+    async_db: AsyncSession, default_user: User
+) -> None:
+    """A no-op move leaves the queue untouched."""
+    now = datetime.now(UTC)
+    threads = [
+        Thread(title=f"T{i}", format="Comic", issues_remaining=1,
+               queue_position=i, status="active",
+               user_id=default_user.id, created_at=now)
+        for i in range(1, 6)
+    ]
+    async_db.add_all(threads)
+    await async_db.commit()
+    for t in threads:
+        await async_db.refresh(t)
+
+    original_positions = {t.id: t.queue_position for t in threads}
+
+    # Move thread at position 3 to position 3 (no-op)
+    await move_to_position(threads[2].id, default_user.id, 3, async_db)
+
+    for t in threads:
+        await async_db.refresh(t)
+
+    current_positions = {t.id: t.queue_position for t in threads}
+    assert current_positions == original_positions
+
+
+# ── concurrent-move integrity ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_concurrent_repositioning_no_duplicate_positions(
+    async_db_committed: AsyncSession,
+) -> None:
+    """Concurrent move_to_position calls must not produce duplicate active positions.
+
+    This uses real commits across independent sessions, mirroring the pattern
+    from test_concurrent_issue_creation.py.
+    """
+    user = await get_or_create_user_async(async_db_committed)
+
+    now = datetime.now(UTC)
+    for i in range(1, 21):
+        t = Thread(
+            title=f"Conc {i}",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=i,
+            status="active",
+            user_id=user.id,
+            created_at=now,
+        )
+        async_db_committed.add(t)
+    await async_db_committed.commit()
+
+    result = await async_db_committed.execute(
+        select(Thread.id).where(Thread.user_id == user.id, Thread.status == "active")
+    )
+    thread_ids = [row[0] for row in result.fetchall()]
+
+    database_url = get_test_database_url()
+    engine = create_async_engine(database_url, echo=False, pool_size=20, max_overflow=0)
+    session_maker = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def move_in_new_session(tid: int, target_pos: int) -> None:
+        async with session_maker() as s:
+            await move_to_position(tid, user.id, target_pos, s, do_commit=True)
+
+    # Launch 10 concurrent moves — different threads to different positions.
+    # Each move acquires the advisory lock, so serialisation is guaranteed.
+    moves = [
+        (thread_ids[0], 10),
+        (thread_ids[1], 1),
+        (thread_ids[2], 20),
+        (thread_ids[3], 5),
+        (thread_ids[4], 15),
+        (thread_ids[5], 3),
+        (thread_ids[6], 18),
+        (thread_ids[7], 7),
+        (thread_ids[8], 12),
+        (thread_ids[9], 2),
+    ]
+    tasks = [move_in_new_session(tid, pos) for tid, pos in moves]
+    await asyncio.gather(*tasks)
+
+    await engine.dispose()
+
+    # Verify positions are sequential 1..20 with no duplicates
+    result = await async_db_committed.execute(
+        select(Thread.queue_position)
+        .where(Thread.user_id == user.id, Thread.status == "active")
+        .order_by(Thread.queue_position)
+    )
+    positions = [row[0] for row in result.fetchall()]
+    assert len(positions) == len(set(positions)), f"Duplicate positions found: {positions}"
+    assert positions == list(range(1, 21)), f"Positions not sequential: {positions}"
+
+
+# ── cross-user isolation ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cross_user_isolation(
+    async_db: AsyncSession, default_user: User
+) -> None:
+    """Queue operations for one user do not affect another user's positions."""
+    user2 = User(username="other_user", created_at=datetime.now(UTC))
+    async_db.add(user2)
+    await async_db.commit()
+    await async_db.refresh(user2)
+
+    now = datetime.now(UTC)
+    user1_threads = [
+        Thread(title=f"U1-{i}", format="Comic", issues_remaining=1,
+               queue_position=i, status="active",
+               user_id=default_user.id, created_at=now)
+        for i in range(1, 4)
+    ]
+    user2_threads = [
+        Thread(title=f"U2-{i}", format="Comic", issues_remaining=1,
+               queue_position=i, status="active",
+               user_id=user2.id, created_at=now)
+        for i in range(1, 4)
+    ]
+    async_db.add_all(user1_threads + user2_threads)
+    await async_db.commit()
+    for t in user1_threads + user2_threads:
+        await async_db.refresh(t)
+
+    original_u2_positions = {t.id: t.queue_position for t in user2_threads}
+
+    # Move a thread for user 1 only
+    await move_to_position(user1_threads[0].id, default_user.id, 3, async_db)
+
+    # User 2 positions must be unchanged
+    for t in user2_threads:
+        await async_db.refresh(t)
+
+    current_u2_positions = {t.id: t.queue_position for t in user2_threads}
+    assert current_u2_positions == original_u2_positions, (
+        f"User 2 positions changed: {original_u2_positions} → {current_u2_positions}"
+    )
+
+    # User 1's positions should be changed (our target moved)
+    for t in user1_threads:
+        await async_db.refresh(t)
+    u1_ids = {t.id for t in user1_threads}
+    result = await async_db.execute(
+        select(Thread.queue_position)
+        .where(Thread.id.in_(u1_ids))
+        .order_by(Thread.queue_position)
+    )
+    u1_positions = [row[0] for row in result.fetchall()]
+    assert u1_positions == [1, 2, 3], f"User 1 positions not sequential: {u1_positions}"
+
+
+# ── shuffle isolation ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_shuffle_isolates_per_user(
+    async_db: AsyncSession, default_user: User
+) -> None:
+    """shuffle_queue only affects the target user."""
+    user2 = User(username="other_shuffle", created_at=datetime.now(UTC))
+    async_db.add(user2)
+    await async_db.commit()
+    await async_db.refresh(user2)
+
+    now = datetime.now(UTC)
+    u1 = [
+        Thread(title=f"SU1-{i}", format="Comic", issues_remaining=1,
+               queue_position=i, status="active",
+               user_id=default_user.id, created_at=now)
+        for i in range(1, 6)
+    ]
+    u2 = [
+        Thread(title=f"SU2-{i}", format="Comic", issues_remaining=1,
+               queue_position=i, status="active",
+               user_id=user2.id, created_at=now)
+        for i in range(1, 4)
+    ]
+    async_db.add_all(u1 + u2)
+    await async_db.commit()
+
+    original_u2_positions = {t.id: t.queue_position for t in u2}
+
+    await shuffle_queue(default_user.id, async_db)
+
+    for t in u2:
+        await async_db.refresh(t)
+
+    current_u2_positions = {t.id: t.queue_position for t in u2}
+    assert current_u2_positions == original_u2_positions
+
+
+# ── debug-log no-reload ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_move_to_position_no_full_reload_when_debug_disabled(
+    async_db: AsyncSession, default_user: User, caplog: pytest.LogCaptureFixture
+) -> None:
+    """When DEBUG logging is off, the final queue-state reload is NOT executed."""
+    now = datetime.now(UTC)
+    threads = [
+        Thread(title=f"DL-{i}", format="Comic", issues_remaining=1,
+               queue_position=i, status="active",
+               user_id=default_user.id, created_at=now)
+        for i in range(1, 6)
+    ]
+    async_db.add_all(threads)
+    await async_db.commit()
+    for t in threads:
+        await async_db.refresh(t)
+
+    queue_logger = logging.getLogger("comic_pile.queue")
+    old_level = queue_logger.level
+    queue_logger.setLevel(logging.INFO)
+
+    try:
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="comic_pile.queue"):
+            await move_to_position(threads[0].id, default_user.id, 3, async_db)
+    finally:
+        queue_logger.setLevel(old_level)
+
+    final_state_records = [
+        r for r in caplog.records
+        if "Final queue state" in r.message
+    ]
+    assert len(final_state_records) == 0, (
+        f"Final queue state was reloaded even though DEBUG is disabled: {final_state_records}"
+    )
+
+
+# ── move_to_front/back order preservation ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_move_to_front_preserves_relative_order(
+    async_db: AsyncSession, default_user: User
+) -> None:
+    """move_to_front shifts all preceding threads back by 1, preserving their relative order."""
+    now = datetime.now(UTC)
+    threads = [
+        Thread(title=f"F-{i}", format="Comic", issues_remaining=1,
+               queue_position=i, status="active",
+               user_id=default_user.id, created_at=now)
+        for i in range(1, 6)
+    ]
+    async_db.add_all(threads)
+    await async_db.commit()
+    for t in threads:
+        await async_db.refresh(t)
+
+    # Move thread at position 4 to front
+    await move_to_front(threads[3].id, default_user.id, async_db)
+
+    for t in threads:
+        await async_db.refresh(t)
+
+    # Expected order: D(4→1), A(1→2), B(2→3), C(3→4), E(5→5)
+    result = await async_db.execute(
+        select(Thread.title)
+        .where(Thread.user_id == default_user.id, Thread.status == "active")
+        .order_by(Thread.queue_position)
+    )
+    titles = [row[0] for row in result.fetchall()]
+    assert titles == ["F-4", "F-1", "F-2", "F-3", "F-5"]
+
+
+@pytest.mark.asyncio
+async def test_move_to_back_preserves_relative_order(
+    async_db: AsyncSession, default_user: User
+) -> None:
+    """move_to_back shifts all following threads forward by 1, preserving their relative order."""
+    now = datetime.now(UTC)
+    threads = [
+        Thread(title=f"B-{i}", format="Comic", issues_remaining=1,
+               queue_position=i, status="active",
+               user_id=default_user.id, created_at=now)
+        for i in range(1, 6)
+    ]
+    async_db.add_all(threads)
+    await async_db.commit()
+    for t in threads:
+        await async_db.refresh(t)
+
+    # Move thread at position 2 to back
+    await move_to_back(threads[1].id, default_user.id, async_db)
+
+    for t in threads:
+        await async_db.refresh(t)
+
+    # Expected: A(1→1), C(3→2), D(4→3), E(5→4), B(2→5)
+    result = await async_db.execute(
+        select(Thread.title)
+        .where(Thread.user_id == default_user.id, Thread.status == "active")
+        .order_by(Thread.queue_position)
+    )
+    titles = [row[0] for row in result.fetchall()]
+    assert titles == ["B-1", "B-3", "B-4", "B-5", "B-2"]
+
+
+# ── sequential positions after full cycle ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_positions_remain_sequential_after_multiple_moves(
+    async_db: AsyncSession, default_user: User
+) -> None:
+    """After multiple move_to_position calls, active positions are sequential 1..N."""
+    now = datetime.now(UTC)
+    threads = [
+        Thread(title=f"M-{i}", format="Comic", issues_remaining=1,
+               queue_position=i, status="active",
+               user_id=default_user.id, created_at=now)
+        for i in range(1, 11)
+    ]
+    async_db.add_all(threads)
+    await async_db.commit()
+    for t in threads:
+        await async_db.refresh(t)
+
+    moves = [
+        (threads[0].id, 10),  # first → last
+        (threads[9].id, 1),   # last → first
+        (threads[4].id, 3),   # middle forward
+        (threads[2].id, 8),   # middle backward
+        (threads[7].id, 5),   # middle forward
+    ]
+    for tid, pos in moves:
+        await move_to_position(tid, default_user.id, pos, async_db)
+
+    result = await async_db.execute(
+        select(Thread.queue_position)
+        .where(Thread.user_id == default_user.id, Thread.status == "active")
+        .order_by(Thread.queue_position)
+    )
+    positions = [row[0] for row in result.fetchall()]
+    assert positions == list(range(1, 11)), f"Not sequential after multiple moves: {positions}"
+    assert len(positions) == len(set(positions)), f"Duplicates after multiple moves: {positions}"

--- a/tests/test_queue_ui.py
+++ b/tests/test_queue_ui.py
@@ -78,8 +78,8 @@ async def test_drag_and_drop_updates_position(
 async def test_move_to_front_via_api(
     auth_client: AsyncClient, async_db: AsyncSession, sample_data: dict
 ) -> None:
-    """Move to front endpoint works correctly."""
-    thread_id = sample_data["threads"][2].id
+    """Move an active thread to the normalized front."""
+    thread_id = sample_data["threads"][3].id
 
     response = await auth_client.put(f"/api/queue/threads/{thread_id}/front/")
     assert response.status_code == 200
@@ -93,14 +93,14 @@ async def test_move_to_front_via_api(
 async def test_move_to_back_via_api(
     auth_client: AsyncClient, async_db: AsyncSession, sample_data: dict
 ) -> None:
-    """Move to back endpoint works correctly."""
+    """Move an active thread to the normalized back."""
     thread_id = sample_data["threads"][0].id
 
     response = await auth_client.get("/api/threads/")
     data = response.json()
     threads = data["threads"]
     active_threads = [t for t in threads if t["status"] == "active"]
-    last_position = max(t["queue_position"] for t in active_threads)
+    last_position = len(active_threads)
 
     response = await auth_client.put(f"/api/queue/threads/{thread_id}/back/")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary

Rewrites queue repositioning around deterministic, set-based PostgreSQL updates. Moves now normalize gaps and duplicates, serialize per user with transaction-scoped advisory locks, synchronize cached ORM state without per-object reloads, and avoid unconditional debug queries.

## Changes

### `comic_pile/queue.py`

- **Deterministic moves:** `move_to_position()` ranks active rows by `(queue_position, id)` and applies normalization plus movement in one CTE-backed `UPDATE ... RETURNING` statement.
- **Bounded ORM synchronization:** returned `(id, queue_position)` values update cached `Thread` objects with `set_committed_value()`, avoiding the previous N-query refresh loop.
- **Bounded rank lookup:** active count and target rank are computed in SQL rather than transferring every active ID into Python.
- **Concurrency safety:** per-user `pg_advisory_xact_lock()` protection covers position moves, safe-position calculation, move-to-back, and shuffle.
- **Safe-position consistency:** the queue is read under the lock and uses the same `(queue_position, id)` tie-break as the move statement.
- **Front/back normalization:** move-to-front delegates to the canonical move implementation. Move-to-back uses a set-based statement that compacts active rows and still supports a target that was just marked completed by the rating flow.
- **Scalable shuffle:** shuffle uses paired PostgreSQL arrays through `unnest()` instead of a large generated `CASE` expression.
- **Logging:** hot-path details moved to DEBUG, user-supplied titles were removed from routine move logs, and the final queue reload is DEBUG-only and active-row-only.

### Regression coverage

Coverage now includes:

- deterministic duplicate-position handling
- gapped-position normalization
- clean no-op behavior
- invalid position errors and transaction rollback
- concurrent repositioning across independent sessions
- cross-user move and shuffle isolation
- INFO/DEBUG reload guard behavior
- bounded SQL statement count for the safe-position path
- front moves with duplicate positions
- back moves with gaps
- completed-target move-to-back behavior
- sequential integrity after repeated moves
- API assertions aligned with the normalized active-queue contract

## Review follow-up

Addresses all actionable CodeRabbit findings and the additional manual review findings concerning per-object ORM refreshes, safe-position locking, front/back normalization, completed-thread behavior, large shuffle statements, and stale UI test expectations.

## Verification

- Backend test suite and coverage gate: passed
- Frontend Vitest suite and coverage gate: passed
- Ruff: passed
- `ty`: passed
- Frontend lint and typecheck: passed
- Migration health: passed
- E2E API tests: passed
- E2E dice-ladder tests: passed
- CodeRabbit: passed, all actionable threads resolved

Closes #699