### PR TITLE
feat(api): add initial queue and history response contracts (#705)

### DIFF
--- a/.agents/skills/plan-task-handoff/SKILL.md
+++ b/.agents/skills/plan-task-handoff/SKILL.md
@@ -176,15 +176,33 @@ Run command: bash -c 'set -a; source .env.test; set +a; .venv/bin/python -m pyte
 When you are done, write a brief completion summary to .opencode_handoff/<handoff-file>_done.md
 ```
 
-For backend issues the focused test run is a must; for frontend issues lead with the
-`cd frontend && pnpm run lint/typecheck/build/test` block. For browser-visible behavior
-the worker must run Playwright per `AGENTS.md` (backend on port 9000).
+### Test suite scoping — E2E / Playwright is conditional
+
+**Backend-only or schema-only issues (no browser-visible behavior changed):**
+Remove step 3's Playwright mention entirely. The worker prompt for these issues must NOT
+include Playwright. Backend tests + frontend lint/typecheck/build/unit tests are
+sufficient.
+
+**Frontend or browser-visible issues (user-visible UI changes):**
+The worker must run Playwright E2E tests per `AGENTS.md`. The planner MUST set the
+bash timeout on `opencode run` high enough: `--timeout 3600000` (60 minutes). E2E tests
+against multiple browsers routinely take 20–40 minutes. Do not let the bash tool kill
+the worker mid-test.
+
+**Planner (Step 4):** Never run Playwright/E2E tests during planning. The planner's
+baseline run is focused pytest only (the `-q` variant). E2E is the worker's job and
+takes too long for planning.
 
 ## Step 8 — Launch the worker
 
 ```bash
 opencode run -m "<resolved-model-id>" --dir "<repo-root>" "<worker-prompt>"
 ```
+
+**Timeout**: The bash tool wrapping `opencode run` must use a generous timeout.
+Backend-only issues: `--timeout 600000` (10 minutes). Frontend/browser-visible
+issues: `--timeout 3600000` (60 minutes). Never let the bash tool timeout kill
+the worker before it finishes its test suite.
 
 Stream the output. When it finishes:
 
@@ -210,6 +228,9 @@ Stream the output. When it finishes:
 - The planner may reuse existing skills: `github-issue-kanban` for selection/status
   labels and `handoff` for the launch mechanics; this skill supersedes them for the
   full plan-then-handoff loop.
+- E2E/Playwright tests are ONLY for frontend/browser-visible issues. Backend-only
+  issues skip Playwright entirely. When Playwright IS required, set the bash timeout
+  to 60 minutes — these tests are slow and must not be killed mid-run.
 
 ## Notes
 
@@ -217,3 +238,6 @@ Stream the output. When it finishes:
 - Ports: dev 5435, test 5437, CI 5432. Coverage gate is 94%.
 - `.opencode_handoff/` and `.opencode_logs/` hold prior handoffs and model test results —
   useful when deciding the worker model.
+- E2E test runtime: Chromium only ≈ 5–10 min, all 3 browsers ≈ 20–40 min. The
+  planner should not run E2E during Step 4 (planning). Only the worker runs them,
+  and only when the issue changes browser-visible behavior.

--- a/.agents/skills/plan-task-handoff/SKILL.md
+++ b/.agents/skills/plan-task-handoff/SKILL.md
@@ -176,33 +176,15 @@ Run command: bash -c 'set -a; source .env.test; set +a; .venv/bin/python -m pyte
 When you are done, write a brief completion summary to .opencode_handoff/<handoff-file>_done.md
 ```
 
-### Test suite scoping — E2E / Playwright is conditional
-
-**Backend-only or schema-only issues (no browser-visible behavior changed):**
-Remove step 3's Playwright mention entirely. The worker prompt for these issues must NOT
-include Playwright. Backend tests + frontend lint/typecheck/build/unit tests are
-sufficient.
-
-**Frontend or browser-visible issues (user-visible UI changes):**
-The worker must run Playwright E2E tests per `AGENTS.md`. The planner MUST set the
-bash timeout on `opencode run` high enough: `--timeout 3600000` (60 minutes). E2E tests
-against multiple browsers routinely take 20–40 minutes. Do not let the bash tool kill
-the worker mid-test.
-
-**Planner (Step 4):** Never run Playwright/E2E tests during planning. The planner's
-baseline run is focused pytest only (the `-q` variant). E2E is the worker's job and
-takes too long for planning.
+For backend issues the focused test run is a must; for frontend issues lead with the
+`cd frontend && pnpm run lint/typecheck/build/test` block. For browser-visible behavior
+the worker must run Playwright per `AGENTS.md` (backend on port 9000).
 
 ## Step 8 — Launch the worker
 
 ```bash
 opencode run -m "<resolved-model-id>" --dir "<repo-root>" "<worker-prompt>"
 ```
-
-**Timeout**: The bash tool wrapping `opencode run` must use a generous timeout.
-Backend-only issues: `--timeout 600000` (10 minutes). Frontend/browser-visible
-issues: `--timeout 3600000` (60 minutes). Never let the bash tool timeout kill
-the worker before it finishes its test suite.
 
 Stream the output. When it finishes:
 
@@ -228,9 +210,6 @@ Stream the output. When it finishes:
 - The planner may reuse existing skills: `github-issue-kanban` for selection/status
   labels and `handoff` for the launch mechanics; this skill supersedes them for the
   full plan-then-handoff loop.
-- E2E/Playwright tests are ONLY for frontend/browser-visible issues. Backend-only
-  issues skip Playwright entirely. When Playwright IS required, set the bash timeout
-  to 60 minutes — these tests are slow and must not be killed mid-run.
 
 ## Notes
 
@@ -238,6 +217,3 @@ Stream the output. When it finishes:
 - Ports: dev 5435, test 5437, CI 5432. Coverage gate is 94%.
 - `.opencode_handoff/` and `.opencode_logs/` hold prior handoffs and model test results —
   useful when deciding the worker model.
-- E2E test runtime: Chromium only ≈ 5–10 min, all 3 browsers ≈ 20–40 min. The
-  planner should not run E2E during Step 4 (planning). Only the worker runs them,
-  and only when the issue changes browser-visible behavior.

--- a/app/api/session.py
+++ b/app/api/session.py
@@ -17,7 +17,8 @@ from app.schemas import (
     ActiveThreadInfo,
     EventDetail,
     SessionDetailsResponse,
-    SessionListResponse,
+    SessionHistoryListResponse,
+    SessionListItem,
     SessionResponse,
     SnapshotResponse,
     SnapshotsListResponse,
@@ -28,6 +29,28 @@ from comic_pile.dependencies import refresh_user_blocked_status
 from comic_pile.session import get_current_die, get_or_create, is_active
 
 router = APIRouter(tags=["sessions"])
+
+
+def _to_session_list_item(sr: SessionResponse) -> SessionListItem:
+    """Convert a full SessionResponse to a narrow SessionListItem.
+
+    Deliberately drops snoozed_thread_ids, snoozed_threads, and pending_thread_id
+    to reduce payload size for session history list views.
+    """
+    return SessionListItem(
+        id=sr.id,
+        started_at=sr.started_at,
+        ended_at=sr.ended_at,
+        start_die=sr.start_die,
+        manual_die=sr.manual_die,
+        user_id=sr.user_id,
+        ladder_path=sr.ladder_path,
+        active_thread=sr.active_thread,
+        current_die=sr.current_die,
+        last_rolled_result=sr.last_rolled_result,
+        has_restore_point=sr.has_restore_point,
+        snapshot_count=sr.snapshot_count,
+    )
 
 
 async def _invalidate_session_caches(user_id: int) -> None:
@@ -402,7 +425,7 @@ async def get_current_session(
     raise RuntimeError(f"Failed to get current session after {max_retries} retries")
 
 
-@router.get("/", response_model=SessionListResponse)
+@router.get("/", response_model=SessionHistoryListResponse)
 @cached(ttl=TTL.SHORT)
 async def list_sessions(
     current_user: Annotated[User, Depends(get_current_user)],
@@ -416,7 +439,7 @@ async def list_sessions(
         default=None, description="Token for pagination continuation (started_at,session_id)"
     ),
     db: AsyncSession = Depends(get_db),
-) -> SessionListResponse:
+) -> SessionHistoryListResponse:
     """List sessions with cursor-based pagination.
 
     Args:
@@ -426,7 +449,7 @@ async def list_sessions(
         db: SQLAlchemy session for database operations.
 
     Returns:
-        SessionListResponse with paginated sessions and next_page_token if more exist.
+        SessionHistoryListResponse with paginated sessions and next_page_token if more exist.
     """
     from fastapi import HTTPException, status
     from sqlalchemy import func, or_
@@ -461,7 +484,7 @@ async def list_sessions(
     sessions_to_return = sessions[:page_size]
 
     if not sessions_to_return:
-        return SessionListResponse(sessions=[], next_page_token=None)
+        return SessionHistoryListResponse(sessions=[], next_page_token=None)
 
     session_ids = [s.id for s in sessions_to_return]
 
@@ -564,35 +587,34 @@ async def list_sessions(
             else:
                 active_threads_dict[sid] = None
 
-    responses = []
+    responses: list[SessionListItem] = []
     for session in sessions_to_return:
         active_thread = active_threads_dict.get(session.id)
-        snapshot_count = snapshot_counts.get(session.id, 0)
+        snapshot_count_num = snapshot_counts.get(session.id, 0)
 
-        responses.append(
-            SessionResponse(
-                id=session.id,
-                started_at=session.started_at,
-                ended_at=session.ended_at,
-                start_die=session.start_die,
-                manual_die=session.manual_die,
-                user_id=session.user_id,
-                ladder_path=ladder_paths[session.id],
-                active_thread=active_thread,
-                current_die=current_die[session.id],
-                last_rolled_result=active_thread.last_rolled_result if active_thread else None,
-                has_restore_point=snapshot_count > 0,
-                snapshot_count=snapshot_count,
-                pending_thread_id=session.pending_thread_id,
-            )
+        sr = SessionResponse(
+            id=session.id,
+            started_at=session.started_at,
+            ended_at=session.ended_at,
+            start_die=session.start_die,
+            manual_die=session.manual_die,
+            user_id=session.user_id,
+            ladder_path=ladder_paths[session.id],
+            active_thread=active_thread,
+            current_die=current_die[session.id],
+            last_rolled_result=active_thread.last_rolled_result if active_thread else None,
+            has_restore_point=snapshot_count_num > 0,
+            snapshot_count=snapshot_count_num,
+            pending_thread_id=session.pending_thread_id,
         )
+        responses.append(_to_session_list_item(sr))
 
     next_page_token = None
     if has_more and sessions_to_return:
         last = sessions_to_return[-1]
         next_page_token = f"{last.started_at.isoformat()},{last.id}"
 
-    return SessionListResponse(sessions=responses, next_page_token=next_page_token)
+    return SessionHistoryListResponse(sessions=responses, next_page_token=next_page_token)
 
 
 @router.get("/{session_id}")

--- a/app/api/thread.py
+++ b/app/api/thread.py
@@ -24,10 +24,12 @@ from app.models import Event, Issue, Review, Thread
 from app.models.user import User
 from app.schemas import (
     MigrateToIssuesRequest,
+    QueueThreadListItem,
+    QueueThreadListResponse,
     ReactivateRequest,
     RollResponse,
     ThreadCreate,
-    ThreadListResponse,
+    ThreadDetail,
     ThreadResponse,
     ThreadUpdate,
 )
@@ -158,6 +160,31 @@ async def _threads_to_responses(threads: list[Thread], db: AsyncSession) -> list
     ]
 
 
+def _to_queue_list_item(tr: ThreadResponse) -> QueueThreadListItem:
+    """Convert a full ThreadResponse to a narrow QueueThreadListItem.
+
+    Deliberately drops detail-only fields (last_rating, review_url, last_review_at,
+    is_test, reading_progress, next_unread_issue_id) to reduce
+    payload size for list views.
+    """
+    return QueueThreadListItem(
+        id=tr.id,
+        title=tr.title,
+        format=tr.format,
+        issues_remaining=tr.issues_remaining,
+        queue_position=tr.queue_position,
+        status=tr.status,
+        is_blocked=tr.is_blocked,
+        blocking_reasons=tr.blocking_reasons,
+        collection_id=tr.collection_id,
+        last_activity_at=tr.last_activity_at,
+        total_issues=tr.total_issues,
+        next_unread_issue_number=tr.next_unread_issue_number,
+        notes=tr.notes,
+        created_at=tr.created_at,
+    )
+
+
 @router.get("/stale", response_model=list[ThreadResponse])
 async def list_stale_threads(
     current_user: Annotated[User, Depends(get_current_user)],
@@ -189,7 +216,7 @@ async def list_stale_threads(
     return await _threads_to_responses(threads, db)
 
 
-@router.get("/", response_model=ThreadListResponse)
+@router.get("/", response_model=QueueThreadListResponse)
 @limiter.limit("100/minute")
 @cached(ttl=TTL.SHORT)
 async def list_threads(
@@ -207,7 +234,7 @@ async def list_threads(
     page_token: str | None = Query(
         default=None, description="Token for pagination continuation (queue_position,thread_id)"
     ),
-) -> ThreadListResponse:
+) -> QueueThreadListResponse:
     """List threads ordered by position with cursor-based pagination.
 
     Args:
@@ -220,7 +247,7 @@ async def list_threads(
         db: SQLAlchemy session for database operations.
 
     Returns:
-        ThreadListResponse with paginated threads and next_page_token if more exist.
+        QueueThreadListResponse with paginated threads and next_page_token if more exist.
     """
     normalized_search = search.strip() if search is not None else None
     query = select(Thread).where(Thread.user_id == current_user.id)
@@ -268,14 +295,17 @@ async def list_threads(
 
     thread_responses = await _threads_to_responses(threads_to_return, db)
 
+    # Convert full ThreadResponse to narrow QueueThreadListItem for list views
+    queue_items = [_to_queue_list_item(tr) for tr in thread_responses]
+
     # Set next_page_token to composite cursor of last item if there are more pages
     next_token = None
     if has_more and threads_to_return:
         last = threads_to_return[-1]
         next_token = f"{last.queue_position},{last.id}"
 
-    return ThreadListResponse(
-        threads=thread_responses,
+    return QueueThreadListResponse(
+        threads=queue_items,
         next_page_token=next_token,
     )
 
@@ -414,13 +444,13 @@ async def create_thread(
     raise RuntimeError(f"Failed to create thread after {max_retries} retries")
 
 
-@router.get("/{thread_id}", response_model=ThreadResponse)
+@router.get("/{thread_id}", response_model=ThreadDetail)
 @cached(ttl=TTL.MEDIUM)
 async def get_thread(
     thread_id: int,
     current_user: Annotated[User, Depends(get_current_user)],
     db: AsyncSession = Depends(get_db),
-) -> ThreadResponse:
+) -> ThreadDetail:
     """Get a single thread by ID.
 
     Args:
@@ -429,13 +459,14 @@ async def get_thread(
         db: SQLAlchemy session for database operations.
 
     Returns:
-        ThreadResponse with thread details.
+        ThreadDetail with thread details.
 
     Raises:
         HTTPException: If thread not found.
     """
     thread = await get_owned_thread_or_404(db, current_user.id, thread_id)
-    return await thread_to_response(thread, db)
+    tr = await thread_to_response(thread, db)
+    return ThreadDetail(**tr.model_dump())
 
 
 @router.put("/{thread_id}", response_model=ThreadResponse)

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -30,13 +30,18 @@ from app.schemas.session import (
     ActiveThreadInfo,
     EventDetail,
     SessionDetailsResponse,
+    SessionHistoryListResponse,
+    SessionListItem,
     SessionListResponse,
     SessionResponse,
 )
 from app.schemas.snapshot import SnapshotResponse, SnapshotsListResponse
 from app.schemas.thread import (
+    QueueThreadListItem,
+    QueueThreadListResponse,
     ReactivateRequest,
     ThreadCreate,
+    ThreadDetail,
     ThreadListResponse,
     ThreadResponse,
     ThreadUpdate,
@@ -53,7 +58,10 @@ __all__ = [
     "ThreadCreate",
     "ThreadUpdate",
     "ThreadResponse",
+    "ThreadDetail",
     "ThreadListResponse",
+    "QueueThreadListItem",
+    "QueueThreadListResponse",
     "ReactivateRequest",
     # Dependency
     "DependencyCreate",
@@ -80,6 +88,8 @@ __all__ = [
     # Session
     "SessionResponse",
     "SessionListResponse",
+    "SessionListItem",
+    "SessionHistoryListResponse",
     "SessionDetailsResponse",
     "ActiveThreadInfo",
     "EventDetail",

--- a/app/schemas/session.py
+++ b/app/schemas/session.py
@@ -159,3 +159,48 @@ class SessionListResponse(BaseModel):
 
     sessions: list[SessionResponse]
     next_page_token: str | None = None
+
+
+class SessionListItem(BaseModel):
+    """Schema for a single session in the history list view.
+
+    A deliberate subset of SessionResponse. The list view does not need
+    snoozed_thread_ids, snoozed_threads, or pending_thread_id, which
+    reduces payload size for session history lists.
+    """
+
+    id: int
+    started_at: datetime
+    ended_at: datetime | None
+    start_die: int
+    manual_die: int | None
+    user_id: int
+    ladder_path: str
+    active_thread: ActiveThreadInfo | None
+    current_die: int
+    last_rolled_result: int | None
+    has_restore_point: bool
+    snapshot_count: int
+
+    @field_serializer("started_at", "ended_at")
+    def serialize_datetime(self, value: datetime | None) -> str | None:
+        """Serialize datetime to ISO 8601 format with timezone.
+
+        Ensures naive datetimes are treated as UTC for consistent serialization.
+
+        Args:
+            value: The datetime value to serialize.
+
+        Returns:
+            ISO 8601 formatted string with timezone, or None if value is None.
+        """
+        if value is None:
+            return None
+        return _to_utc_iso(value)
+
+
+class SessionHistoryListResponse(BaseModel):
+    """Schema for paginated session history list response."""
+
+    sessions: list[SessionListItem]
+    next_page_token: str | None = None

--- a/app/schemas/thread.py
+++ b/app/schemas/thread.py
@@ -53,6 +53,34 @@ class ThreadResponse(BaseModel):
     next_unread_issue_number: str | None = None
 
 
+class ThreadDetail(ThreadResponse):
+    """Schema for thread detail view (single thread with full detail fields)."""
+
+
+class QueueThreadListItem(BaseModel):
+    """Schema for a single thread in the list/queue view.
+
+    A deliberate subset of ThreadResponse. The list view does not need
+    detail-only fields like review_url, last_review_at, last_rating,
+    is_test, or reading_progress, which reduces payload size for large lists.
+    """
+
+    id: int
+    title: str
+    format: str
+    issues_remaining: int
+    queue_position: int
+    status: str
+    last_activity_at: datetime | None
+    is_blocked: bool = False
+    blocking_reasons: list[str] = []
+    collection_id: int | None = None
+    total_issues: int | None = None
+    next_unread_issue_number: str | None = None
+    notes: str | None = None
+    created_at: datetime
+
+
 class ReactivateRequest(BaseModel):
     """Schema for reactivating a completed thread."""
 
@@ -64,4 +92,11 @@ class ThreadListResponse(BaseModel):
     """Schema for paginated thread list response."""
 
     threads: list[ThreadResponse]
+    next_page_token: str | None = None
+
+
+class QueueThreadListResponse(BaseModel):
+    """Schema for paginated thread list response using the queue-optimized item."""
+
+    threads: list[QueueThreadListItem]
     next_page_token: str | None = None

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -21,6 +21,31 @@ export interface Collection {
 }
 
 /**
+ * Represents a thread in list view (QueuePage).
+ *
+ * A deliberate subset of Thread — the list endpoint does not return
+ * detail-only fields like reading_progress, next_unread_issue_id,
+ * last_rating, review_url, last_review_at, or is_test to reduce payload
+ * size for large lists.
+ */
+export interface ThreadListItem {
+  id: number;
+  title: string;
+  format: string;
+  issues_remaining: number;
+  total_issues: number | null;
+  next_unread_issue_number?: string | null;
+  queue_position: number;
+  status: string;
+  is_blocked: boolean;
+  blocking_reasons: string[];
+  collection_id: number | null;
+  notes?: string | null;
+  last_activity_at?: string | null;
+  created_at: string;
+}
+
+/**
  * Represents a comic thread/series
  */
 export interface Thread {
@@ -34,12 +59,12 @@ export interface Thread {
   issues_remaining: number;
   /** Total number of issues in the thread (nullable for future use) */
   total_issues: number | null;
-  /** ID of the next unread issue (nullable if all read) */
-  next_unread_issue_id: number | null;
+  /** ID of the next unread issue (nullable if all read, omitted in list views) */
+  next_unread_issue_id?: number | null;
   /** Issue number of the next unread issue */
   next_unread_issue_number?: string | null;
-  /** Reading progress percentage (0-100, nullable) */
-  reading_progress: string | null;
+  /** Reading progress percentage (0-100, nullable, omitted in list views) */
+  reading_progress?: string | null;
   /** Position in the reading queue */
   queue_position: number;
   /** Current status (e.g., 'active', 'completed', 'pending') */

--- a/frontend/src/utils/readingOrderTimeline.ts
+++ b/frontend/src/utils/readingOrderTimeline.ts
@@ -141,7 +141,7 @@ export function buildReadingOrderTimelineEntries({ thread, dependencies }: Build
   )
 
   const nextIssueNumberValue = issueStringToNumber(thread.next_unread_issue_number ?? null)
-  const nextOrderValue = determineOrderValue(nextIssueNumberValue, thread.next_unread_issue_id)
+  const nextOrderValue = determineOrderValue(nextIssueNumberValue, thread.next_unread_issue_id ?? null)
   const isThreadComplete = thread.issues_remaining === 0
 
   const entries: TimelineEntry[] = []
@@ -177,7 +177,7 @@ export function buildReadingOrderTimelineEntries({ thread, dependencies }: Build
      const status = resolveGateStatus({
        isThreadComplete,
        gateIssueId: gate.targetIssueId,
-       nextIssueId: thread.next_unread_issue_id,
+        nextIssueId: thread.next_unread_issue_id ?? null,
        gateValue: gate.orderValue,
        nextValue: nextOrderValue,
      })

--- a/tests/test_screen_response_contracts.py
+++ b/tests/test_screen_response_contracts.py
@@ -1,0 +1,102 @@
+"""Regression tests for screen-specific API response contracts."""
+
+from typing import Any
+
+from app.main import app
+from app.schemas.session import SessionListItem, SessionResponse
+from app.schemas.thread import QueueThreadListItem, ThreadDetail, ThreadResponse
+
+
+QUEUE_FIELDS = {
+    "id",
+    "title",
+    "format",
+    "issues_remaining",
+    "queue_position",
+    "status",
+    "last_activity_at",
+    "is_blocked",
+    "blocking_reasons",
+    "collection_id",
+    "total_issues",
+    "next_unread_issue_number",
+    "notes",
+    "created_at",
+}
+QUEUE_DROPPED_FIELDS = {
+    "last_rating",
+    "review_url",
+    "last_review_at",
+    "is_test",
+    "reading_progress",
+    "next_unread_issue_id",
+}
+SESSION_HISTORY_FIELDS = {
+    "id",
+    "started_at",
+    "ended_at",
+    "start_die",
+    "manual_die",
+    "user_id",
+    "ladder_path",
+    "active_thread",
+    "current_die",
+    "last_rolled_result",
+    "has_restore_point",
+    "snapshot_count",
+}
+SESSION_HISTORY_DROPPED_FIELDS = {
+    "snoozed_thread_ids",
+    "snoozed_threads",
+    "pending_thread_id",
+}
+
+
+def _response_schema(path: str) -> dict[str, Any]:
+    """Return the successful GET response schema for an OpenAPI path."""
+    return app.openapi()["paths"][path]["get"]["responses"]["200"]["content"][
+        "application/json"
+    ]["schema"]
+
+
+def test_queue_item_contract_is_exact_and_measurably_narrower() -> None:
+    """Queue items expose only the documented 14-field screen contract."""
+    full_fields = set(ThreadResponse.model_fields)
+    queue_fields = set(QueueThreadListItem.model_fields)
+
+    assert queue_fields == QUEUE_FIELDS
+    assert full_fields - queue_fields == QUEUE_DROPPED_FIELDS
+    assert len(full_fields) == 20
+    assert len(queue_fields) == 14
+    assert (len(full_fields) - len(queue_fields)) / len(full_fields) == 0.30
+
+
+def test_session_history_item_contract_is_exact_and_measurably_narrower() -> None:
+    """History items expose only the documented 12-field screen contract."""
+    full_fields = set(SessionResponse.model_fields)
+    history_fields = set(SessionListItem.model_fields)
+
+    assert history_fields == SESSION_HISTORY_FIELDS
+    assert full_fields - history_fields == SESSION_HISTORY_DROPPED_FIELDS
+    assert len(full_fields) == 15
+    assert len(history_fields) == 12
+    assert (len(full_fields) - len(history_fields)) / len(full_fields) == 0.20
+
+
+def test_thread_detail_preserves_the_complete_thread_contract() -> None:
+    """Thread detail remains a named compatibility contract with every full field."""
+    assert set(ThreadDetail.model_fields) == set(ThreadResponse.model_fields)
+    assert len(ThreadDetail.model_fields) == 20
+
+
+def test_routes_publish_the_screen_specific_openapi_contracts() -> None:
+    """The three affected GET routes advertise their intended response models."""
+    assert _response_schema("/api/threads/") == {
+        "$ref": "#/components/schemas/QueueThreadListResponse"
+    }
+    assert _response_schema("/api/threads/{thread_id}") == {
+        "$ref": "#/components/schemas/ThreadDetail"
+    }
+    assert _response_schema("/api/sessions/") == {
+        "$ref": "#/components/schemas/SessionHistoryListResponse"
+    }

--- a/tests/test_screen_response_contracts.py
+++ b/tests/test_screen_response_contracts.py
@@ -1,6 +1,6 @@
 """Regression tests for screen-specific API response contracts."""
 
-from typing import Any
+from typing import cast
 
 from app.main import app
 from app.schemas.session import SessionListItem, SessionResponse
@@ -52,11 +52,12 @@ SESSION_HISTORY_DROPPED_FIELDS = {
 }
 
 
-def _response_schema(path: str) -> dict[str, Any]:
+def _response_schema(path: str) -> dict[str, object]:
     """Return the successful GET response schema for an OpenAPI path."""
-    return app.openapi()["paths"][path]["get"]["responses"]["200"]["content"][
+    schema = app.openapi()["paths"][path]["get"]["responses"]["200"]["content"][
         "application/json"
     ]["schema"]
+    return cast(dict[str, object], schema)
 
 
 def test_queue_item_contract_is_exact_and_measurably_narrower() -> None:


### PR DESCRIPTION
## Stage scope

This is an intentionally bounded **contract-foundation slice** of #705. It introduces narrower named response models for the existing Queue thread-list and Session History routes, plus an explicit Thread Detail name, without claiming to complete the issue's full screen-model and query-plan redesign.

Part of #705 and #687 Wave 1 Lane D.

## Changes

### Backend response contracts

| Schema | Current route | Fields | Field-count reduction |
|---|---|---:|---:|
| `QueueThreadListItem` | `GET /api/threads/` | 14 | 6 of 20 fields removed (30%) |
| `ThreadDetail` | `GET /api/threads/{id}` | 20 | naming/compatibility alias |
| `SessionListItem` | `GET /api/sessions/` | 12 | 3 of 15 fields removed (20%) |

The percentages above are deliberately limited to deterministic response-field counts. This stage does not claim representative byte-size or database-query reductions.

Dropped from the Queue response contract: `last_rating`, `review_url`, `last_review_at`, `is_test`, `reading_progress`, and `next_unread_issue_id`.

Dropped from the Session History response contract: `snoozed_thread_ids`, `snoozed_threads`, and `pending_thread_id`.

### Contract regression coverage

`tests/test_screen_response_contracts.py` now proves:

- the exact 14-field Queue item contract and all six excluded fields;
- the exact 12-field Session History item contract and all three excluded fields;
- the 30% and 20% field-count calculations;
- Thread Detail remains field-for-field compatible with `ThreadResponse`;
- the affected OpenAPI routes publish `QueueThreadListResponse`, `SessionHistoryListResponse`, and `ThreadDetail`.

### Frontend compatibility

- Added `ThreadListItem` matching `QueueThreadListItem`.
- Made `Thread.next_unread_issue_id` and `Thread.reading_progress` optional so existing callers remain structurally compatible while routes migrate to distinct models.

## Important limitation

This PR narrows serialized response contracts, but it **does not yet eliminate all detail-only construction or database work**. Queue still constructs the broad internal thread response before projecting it to `QueueThreadListItem`, and Session History still constructs the broad session response before projection. Those query/construction changes remain required before #705 is complete.

## Remaining #705 work

- Build Queue list items directly from a bounded, set-based projection and add query-count evidence.
- Build Session History items directly without assembling detail-only fields.
- Define and wire the remaining Roll, summary, issue-list, blocked-summary, current-session, and history-detail contracts.
- Make thread detail and issue-list data independently fetchable where required.
- Add ownership, payload-boundary, and query-count tests for later route migrations.
- Record representative byte-size and query-count measurements for Queue, Roll, History, and Thread Details.

## Backward compatibility

- `ThreadResponse` remains for create, update, reactivate, stale, and rating paths.
- `SessionResponse` remains for current-session and session-detail paths.
- No database query logic changes are included in this stage.

## Verification

Previously verified on the prior revision:

- Backend: 796 tests passed with the repository coverage gate.
- Frontend: 587 tests passed.
- `ruff check .`: passed.
- `ty check --error-on-warning`: passed.
- `pnpm run lint`: passed with no errors.
- `pnpm run typecheck`: passed.
- `pnpm run build`: passed.

The current revision adds the focused contract suite above and is running the required CI checks.

Part of #705. This PR intentionally does not close the issue.