### PR TITLE
perf(api): add batch blocking-info endpoint to eliminate N+1 queries (#667)

### DIFF
--- a/app/api/dependency.py
+++ b/app/api/dependency.py
@@ -4,7 +4,7 @@ import asyncio
 from typing import Annotated, TypedDict
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -14,6 +14,8 @@ from app.database import get_db
 from app.models import Dependency, Issue, Thread
 from app.models.user import User
 from app.schemas.dependency import (
+    BatchBlockingExplanationRequest,
+    BatchBlockingExplanationResponse,
     BlockingExplanation,
     ConnectedThreadInfo,
     DependencyCreate,
@@ -31,6 +33,7 @@ from comic_pile.dependencies import (
     detect_circular_dependency,
     get_blocked_thread_ids,
     get_blocking_explanations,
+    get_blocking_explanations_batch,
     get_dependency_order_conflicts,
     refresh_user_blocked_status,
 )
@@ -55,6 +58,7 @@ async def _invalidate_dependency_caches(user_id: int, dependency_id: int | None 
         invalidate_cache(f"cache:list_thread_dependencies:*:User:{user_id}:"),
         invalidate_cache(f"cache:list_issue_dependencies:*:User:{user_id}:"),
         invalidate_cache(f"cache:get_thread_blocking_info:*:User:{user_id}:"),
+        invalidate_cache(f"cache:get_threads_blocking_info:*:User:{user_id}:"),
         invalidate_cache(f"cache:check_thread_dependency_order:*:User:{user_id}:"),
         invalidate_cache(f"cache:get_thread_connected_threads:*:User:{user_id}:"),
     ]
@@ -304,6 +308,47 @@ async def get_thread_blocking_info(
 
     reasons = await get_blocking_explanations(thread_id, current_user.id, db)
     return BlockingExplanation(is_blocked=True, blocking_reasons=reasons)
+
+
+@router.post("/threads:getBlockingInfo", response_model=BatchBlockingExplanationResponse)
+@cached(ttl=TTL.SHORT)
+async def get_threads_blocking_info(
+    request: BatchBlockingExplanationRequest,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: AsyncSession = Depends(get_db),
+) -> BatchBlockingExplanationResponse:
+    """Return blocked status and human-readable blocking reasons for multiple threads."""
+    thread_count = await db.scalar(
+        select(func.count()).select_from(Thread).where(
+            Thread.id.in_(request.thread_ids),
+            Thread.user_id == current_user.id,
+        )
+    )
+    if thread_count != len(request.thread_ids):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="One or more threads not found",
+        )
+
+    blocked_ids = await get_blocked_thread_ids(current_user.id, db)
+    reasons_map = await get_blocking_explanations_batch(
+        request.thread_ids, current_user.id, db
+    )
+
+    result: dict[int, BlockingExplanation] = {}
+    for tid in request.thread_ids:
+        if tid in blocked_ids:
+            result[tid] = BlockingExplanation(
+                is_blocked=True,
+                blocking_reasons=reasons_map.get(tid, []),
+            )
+        else:
+            result[tid] = BlockingExplanation(
+                is_blocked=False,
+                blocking_reasons=[],
+            )
+
+    return BatchBlockingExplanationResponse(threads=result)
 
 
 @router.post(

--- a/app/schemas/dependency.py
+++ b/app/schemas/dependency.py
@@ -96,6 +96,18 @@ class ThreadDependencyOrderCheckResponse(BaseModel):
     conflicts: list[DependencyOrderConflict]
 
 
+class BatchBlockingExplanationRequest(BaseModel):
+    """Schema for batch blocking-info request."""
+
+    thread_ids: list[int] = Field(..., min_length=1, max_length=500)
+
+
+class BatchBlockingExplanationResponse(BaseModel):
+    """Schema for batch blocking-info response — keyed by thread ID."""
+
+    threads: dict[int, BlockingExplanation]
+
+
 class ConnectedThreadInfo(BaseModel):
     """Lightweight info about a thread connected via dependencies."""
 

--- a/app/schemas/dependency.py
+++ b/app/schemas/dependency.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class DependencyCreate(BaseModel):
@@ -100,6 +100,12 @@ class BatchBlockingExplanationRequest(BaseModel):
     """Schema for batch blocking-info request."""
 
     thread_ids: list[int] = Field(..., min_length=1, max_length=500)
+
+    @field_validator("thread_ids")
+    @classmethod
+    def deduplicate_thread_ids(cls, thread_ids: list[int]) -> list[int]:
+        """Deduplicate thread IDs while preserving the caller's order."""
+        return list(dict.fromkeys(thread_ids))
 
 
 class BatchBlockingExplanationResponse(BaseModel):

--- a/comic_pile/dependencies.py
+++ b/comic_pile/dependencies.py
@@ -77,6 +77,50 @@ async def get_blocking_explanations(thread_id: int, user_id: int, db: AsyncSessi
     ]
 
 
+async def get_blocking_explanations_batch(
+    thread_ids: list[int],
+    user_id: int,
+    db: AsyncSession,
+) -> dict[int, list[str]]:
+    """Human-readable blocking reasons for multiple threads in one query."""
+    if not thread_ids:
+        return {}
+
+    source_issue = Issue.__table__.alias("source_issue")
+    next_unread_issue = Issue.__table__.alias("next_unread_issue")
+    source_thread = Thread.__table__.alias("source_thread")
+    target_thread = Thread.__table__.alias("target_thread")
+
+    result = await db.execute(
+        select(
+            target_thread.c.id,
+            source_thread.c.id,
+            source_thread.c.title,
+            source_issue.c.id,
+            source_issue.c.issue_number,
+        )
+        .join(
+            next_unread_issue,
+            next_unread_issue.c.id == target_thread.c.next_unread_issue_id,
+        )
+        .join(Dependency, Dependency.target_issue_id == next_unread_issue.c.id)
+        .join(source_issue, Dependency.source_issue_id == source_issue.c.id)
+        .join(source_thread, source_issue.c.thread_id == source_thread.c.id)
+        .where(target_thread.c.id.in_(thread_ids))
+        .where(target_thread.c.user_id == user_id)
+        .where(source_thread.c.user_id == user_id)
+        .where(source_issue.c.status != "read")
+        .where(target_thread.c.next_unread_issue_id.isnot(None))
+    )
+
+    reasons_map: dict[int, list[str]] = {}
+    for target_tid, src_tid, src_title, _src_iid, src_issue_num in result.all():
+        reasons_map.setdefault(target_tid, []).append(
+            f"Blocked by issue #{src_issue_num} in {src_title} (thread #{src_tid})"
+        )
+    return reasons_map
+
+
 async def validate_position_dependency_consistency(
     thread_id: int,
     user_id: int,

--- a/tests/test_dependency_api.py
+++ b/tests/test_dependency_api.py
@@ -1318,3 +1318,335 @@ async def test_dependency_future_target_returns_warning(auth_client, async_db, t
     assert "#8" in data["warning"]
     assert "2 issues" in data["warning"]
     assert "will block when the target thread reaches it" in data["warning"]
+
+
+@pytest.mark.asyncio
+async def test_batch_blocking_info_multiple_threads(auth_client, async_db, test_username):
+    """Batch endpoint returns blocking info for all requested threads."""
+    user_result = await async_db.execute(select(User).where(User.username == test_username))
+    user = user_result.scalar_one()
+
+    t1 = Thread(
+        title="Batch Source A",
+        format="Comic",
+        issues_remaining=1,
+        queue_position=1,
+        status="active",
+        user_id=user.id,
+        total_issues=1,
+    )
+    t2 = Thread(
+        title="Batch Target B",
+        format="Comic",
+        issues_remaining=1,
+        queue_position=2,
+        status="active",
+        user_id=user.id,
+        total_issues=1,
+    )
+    t3 = Thread(
+        title="Batch Loner C",
+        format="Comic",
+        issues_remaining=1,
+        queue_position=3,
+        status="active",
+        user_id=user.id,
+        total_issues=1,
+    )
+    async_db.add_all([t1, t2, t3])
+    await async_db.flush()
+
+    source_issue = Issue(thread_id=t1.id, issue_number="1", position=1, status="unread")
+    target_issue = Issue(thread_id=t2.id, issue_number="1", position=1, status="unread")
+    loner_issue = Issue(thread_id=t3.id, issue_number="1", position=1, status="unread")
+    async_db.add_all([source_issue, target_issue, loner_issue])
+    await async_db.flush()
+
+    t1.next_unread_issue_id = source_issue.id
+    t2.next_unread_issue_id = target_issue.id
+    t3.next_unread_issue_id = loner_issue.id
+    await async_db.commit()
+    await async_db.refresh(source_issue)
+    await async_db.refresh(target_issue)
+    await async_db.refresh(loner_issue)
+
+    dep_resp = await auth_client.post(
+        "/api/v1/dependencies/",
+        json={
+            "source_type": "issue",
+            "source_id": source_issue.id,
+            "target_type": "issue",
+            "target_id": target_issue.id,
+        },
+    )
+    assert dep_resp.status_code == 201
+
+    resp = await auth_client.post(
+        "/api/v1/threads:getBlockingInfo",
+        json={"thread_ids": [t1.id, t2.id, t3.id]},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    threads = data["threads"]
+
+    assert str(t1.id) in threads
+    assert str(t2.id) in threads
+    assert str(t3.id) in threads
+
+    assert threads[str(t1.id)]["is_blocked"] is False
+    assert threads[str(t1.id)]["blocking_reasons"] == []
+
+    assert threads[str(t2.id)]["is_blocked"] is True
+    assert len(threads[str(t2.id)]["blocking_reasons"]) > 0
+
+    assert threads[str(t3.id)]["is_blocked"] is False
+    assert threads[str(t3.id)]["blocking_reasons"] == []
+
+
+@pytest.mark.asyncio
+async def test_batch_blocking_info_single_thread(auth_client, async_db, test_username):
+    """Batch endpoint with one thread ID returns same result as per-thread endpoint."""
+    user_result = await async_db.execute(select(User).where(User.username == test_username))
+    user = user_result.scalar_one()
+
+    t1 = Thread(
+        title="Single Source",
+        format="Comic",
+        issues_remaining=1,
+        queue_position=1,
+        status="active",
+        user_id=user.id,
+        total_issues=1,
+    )
+    t2 = Thread(
+        title="Single Target",
+        format="Comic",
+        issues_remaining=1,
+        queue_position=2,
+        status="active",
+        user_id=user.id,
+        total_issues=1,
+    )
+    async_db.add_all([t1, t2])
+    await async_db.flush()
+
+    source_issue = Issue(thread_id=t1.id, issue_number="1", position=1, status="unread")
+    target_issue = Issue(thread_id=t2.id, issue_number="1", position=1, status="unread")
+    async_db.add_all([source_issue, target_issue])
+    await async_db.flush()
+
+    t1.next_unread_issue_id = source_issue.id
+    t2.next_unread_issue_id = target_issue.id
+    await async_db.commit()
+    await async_db.refresh(source_issue)
+    await async_db.refresh(target_issue)
+
+    dep_resp = await auth_client.post(
+        "/api/v1/dependencies/",
+        json={
+            "source_type": "issue",
+            "source_id": source_issue.id,
+            "target_type": "issue",
+            "target_id": target_issue.id,
+        },
+    )
+    assert dep_resp.status_code == 201
+
+    single_resp = await auth_client.post(f"/api/v1/threads/{t2.id}:getBlockingInfo")
+    assert single_resp.status_code == 200
+    single_data = single_resp.json()
+
+    batch_resp = await auth_client.post(
+        "/api/v1/threads:getBlockingInfo",
+        json={"thread_ids": [t2.id]},
+    )
+    assert batch_resp.status_code == 200
+    batch_data = batch_resp.json()
+
+    assert batch_data["threads"][str(t2.id)]["is_blocked"] == single_data["is_blocked"]
+    assert batch_data["threads"][str(t2.id)]["blocking_reasons"] == single_data["blocking_reasons"]
+
+
+@pytest.mark.asyncio
+async def test_batch_blocking_info_no_n_plus_one(
+    auth_client,
+    async_db,
+    db_engine,
+) -> None:
+    """Batch endpoint uses one query, not N per-thread queries."""
+    from app.cache import invalidate_cache
+    from sqlalchemy import event
+    from tests.conftest import get_or_create_user_async
+
+    user = await get_or_create_user_async(async_db)
+
+    thread_count = 10
+    thread_ids: list[int] = []
+    for i in range(thread_count):
+        t = Thread(
+            title=f"Bulk Block {i}",
+            format="Comic",
+            issues_remaining=1,
+            queue_position=i + 1,
+            status="active",
+            user_id=user.id,
+            total_issues=1,
+        )
+        async_db.add(t)
+        await async_db.flush()
+        issue = Issue(thread_id=t.id, issue_number="1", position=1, status="unread")
+        async_db.add(issue)
+        await async_db.flush()
+        t.next_unread_issue_id = issue.id
+        thread_ids.append(t.id)
+
+    # Make first thread block all the others via chain dependencies
+    for i in range(1, thread_count):
+        dep = Dependency(
+            source_issue_id=(
+                await async_db.execute(
+                    select(Issue.id).where(Issue.thread_id == thread_ids[0])
+                )
+            ).scalar_one(),
+            target_issue_id=(
+                await async_db.execute(
+                    select(Issue.id).where(Issue.thread_id == thread_ids[i])
+                )
+            ).scalar_one(),
+        )
+        async_db.add(dep)
+    await async_db.commit()
+
+    await invalidate_cache("cache:*")
+
+    captured: list[str] = []
+
+    def _capture(conn, cursor, statement, parameters, context, executemany):
+        captured.append(str(statement))
+
+    event.listen(db_engine.sync_engine, "before_cursor_execute", _capture)
+    try:
+        response = await auth_client.post(
+            "/api/v1/threads:getBlockingInfo",
+            json={"thread_ids": thread_ids},
+        )
+    finally:
+        event.remove(db_engine.sync_engine, "before_cursor_execute", _capture)
+
+    assert response.status_code == 200
+    data = response.json()
+    threads = data["threads"]
+    assert len(threads) == thread_count
+
+    # First thread is not blocked, all others are
+    assert threads[str(thread_ids[0])]["is_blocked"] is False
+    for i in range(1, thread_count):
+        assert threads[str(thread_ids[i])]["is_blocked"] is True
+
+    # Verify that no per-thread COUNT query was issued
+    per_thread_counts = [
+        s
+        for s in captured
+        if "count(" in s.lower()
+        and "threads" in s.lower()
+        and "user_id" in s.lower()
+    ]
+    # One COUNT is expected (the ownership validation query with IN clause)
+    assert len(per_thread_counts) <= 1, (
+        f"Expected at most 1 COUNT query, found {len(per_thread_counts)}: {per_thread_counts}"
+    )
+
+    # Verify query count is bounded (not exploding with N threads)
+    assert len(captured) < 20, (
+        f"Expected bounded query count (<20), got {len(captured)}: {captured}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_batch_blocking_info_cross_user_isolation(auth_client, async_db, test_username):
+    """Batch endpoint returns 404 when thread_ids include another user's thread."""
+    user_result = await async_db.execute(select(User).where(User.username == test_username))
+    user = user_result.scalar_one()
+
+    other_user = User(username="other_batch", email="other_batch@example.com", password_hash="hash")
+    async_db.add(other_user)
+    await async_db.flush()
+
+    t1 = Thread(
+        title="My Thread",
+        format="Comic",
+        issues_remaining=1,
+        queue_position=1,
+        status="active",
+        user_id=user.id,
+        total_issues=1,
+    )
+    t2 = Thread(
+        title="Their Thread",
+        format="Comic",
+        issues_remaining=1,
+        queue_position=1,
+        status="active",
+        user_id=other_user.id,
+        total_issues=1,
+    )
+    async_db.add_all([t1, t2])
+    await async_db.flush()
+
+    issue1 = Issue(thread_id=t1.id, issue_number="1", position=1, status="unread")
+    issue2 = Issue(thread_id=t2.id, issue_number="1", position=1, status="unread")
+    async_db.add_all([issue1, issue2])
+    await async_db.flush()
+
+    t1.next_unread_issue_id = issue1.id
+    t2.next_unread_issue_id = issue2.id
+    await async_db.commit()
+
+    resp = await auth_client.post(
+        "/api/v1/threads:getBlockingInfo",
+        json={"thread_ids": [t1.id, t2.id]},
+    )
+    assert resp.status_code == 404
+    assert "not found" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_batch_blocking_info_empty_list(auth_client):
+    """Empty thread_ids returns 422 validation error."""
+    resp = await auth_client.post(
+        "/api/v1/threads:getBlockingInfo",
+        json={"thread_ids": []},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_batch_blocking_info_nonexistent_threads(auth_client, async_db, test_username):
+    """Nonexistent thread IDs return 404."""
+    user_result = await async_db.execute(select(User).where(User.username == test_username))
+    user = user_result.scalar_one()
+
+    t1 = Thread(
+        title="Existing Thread",
+        format="Comic",
+        issues_remaining=1,
+        queue_position=1,
+        status="active",
+        user_id=user.id,
+        total_issues=1,
+    )
+    async_db.add(t1)
+    await async_db.flush()
+
+    issue = Issue(thread_id=t1.id, issue_number="1", position=1, status="unread")
+    async_db.add(issue)
+    await async_db.flush()
+    t1.next_unread_issue_id = issue.id
+    await async_db.commit()
+
+    resp = await auth_client.post(
+        "/api/v1/threads:getBlockingInfo",
+        json={"thread_ids": [t1.id, 99999]},
+    )
+    assert resp.status_code == 404
+    assert "not found" in resp.json()["detail"].lower()

--- a/tests/test_dependency_batch_request.py
+++ b/tests/test_dependency_batch_request.py
@@ -1,0 +1,45 @@
+"""Regression tests for batch blocking-info request normalization."""
+
+import pytest
+from sqlalchemy import select
+
+from app.models import Thread, User
+
+
+@pytest.mark.asyncio
+async def test_batch_blocking_info_deduplicates_thread_ids(
+    auth_client,
+    async_db,
+    test_username,
+) -> None:
+    """Duplicate owned IDs should not fail the ownership-count validation."""
+    user_result = await async_db.execute(select(User).where(User.username == test_username))
+    user = user_result.scalar_one()
+
+    thread = Thread(
+        title="Duplicate Batch Target",
+        format="Comic",
+        issues_remaining=1,
+        queue_position=1,
+        status="active",
+        user_id=user.id,
+        total_issues=1,
+    )
+    async_db.add(thread)
+    await async_db.commit()
+    await async_db.refresh(thread)
+
+    response = await auth_client.post(
+        "/api/v1/threads:getBlockingInfo",
+        json={"thread_ids": [thread.id, thread.id, thread.id]},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "threads": {
+            str(thread.id): {
+                "is_blocked": False,
+                "blocking_reasons": [],
+            }
+        }
+    }


### PR DESCRIPTION
## Summary

Adds the backend batch endpoint for #667: `POST /api/v1/threads:getBlockingInfo` accepts multiple thread IDs and returns blocking explanations in a single bounded query instead of N per-thread calls.

This PR is intentionally the **backend slice only**. It does not close #667. The remaining frontend work must use the TanStack Query conventions from #701/#702 to share cached results across Queue and Roll, deduplicate in-flight reads, ignore stale responses, and lazy-load detailed explanations.

### Changes

- **`comic_pile/dependencies.py`**: Added `get_blocking_explanations_batch()` using one set-based query keyed by target thread ID.
- **`app/schemas/dependency.py`**: Added bounded batch request/response schemas and order-preserving duplicate-ID normalization.
- **`app/api/dependency.py`**: Added the authenticated batch endpoint with ownership validation, blocked-ID lookup, and cache invalidation support.
- **`tests/test_dependency_api.py`**: Added multi-target, parity, no-N+1, cross-user, empty, and nonexistent-ID coverage.
- **`tests/test_dependency_batch_request.py`**: Added regression coverage proving duplicate owned IDs do not cause a false ownership 404.

### Previously verified on the original revision

- Full pytest: 792 passed, 96.37% coverage
- Frontend: 63 test files / 587 tests passed, lint clean, typecheck clean, build succeeded
- Ruff and ty passed

The duplicate-ID repair is on a newer revision and must pass the current CI run before integration.

### Design

The existing per-thread endpoint `POST /api/v1/threads/{thread_id}:getBlockingInfo` remains unchanged because other routes still call it. The batch endpoint returns the same `BlockingExplanation` shape keyed by thread ID.

Part of #667.