### PR TITLE
perf(frontend): skip /auth/me and /auth/refresh calls when no access token exists (#689)

### DIFF
--- a/.agents/skills/plan-task-handoff/SKILL.md
+++ b/.agents/skills/plan-task-handoff/SKILL.md
@@ -72,7 +72,26 @@ Before editing, print to the user:
 - Why it does not conflict with current open PRs
 - The primary files expected to change
 
-If no issue is executable, report the exact blockers and stop without changing code.
+If no campaign (#687) issue is executable, fall back to non-campaign issues using the
+same filter rules minus #687-specific constraints:
+
+1. Must have: `ralph-task`, `ralph-status:pending`.
+2. Must NOT have: `epic`, `ralph-status:blocked`, `ralph-status:in-progress`,
+   `ralph-status:in-review`, `ralph-status:done`.
+3. Every required dependency named in the issue must be closed or explicitly non-blocking.
+4. Do not select work that conflicts with an open PR or active issue touching the
+   same architectural lane or primary files.
+5. Prefer: `ralph-priority:critical` > `high` > `medium` > `low`.
+6. If more than one is equally eligible, choose the lowest-numbered one.
+7. **Verify the issue is genuinely pending** — inspect the referenced files and
+   code paths before selecting. An issue may claim an N+1 pattern exists when the
+   code was already fixed in a later PR (e.g. #669 was already resolved by the
+   bulk endpoint in #677). If the described problem no longer exists, skip the
+   issue and move to the next candidate. Do not close the issue — that is a
+   separate decision.
+
+If no campaign issue AND no non-campaign issue is executable, report the exact blockers
+and stop without changing code.
 
 ## Step 3 — Start the issue
 

--- a/.agents/skills/plan-task-handoff/SKILL.md
+++ b/.agents/skills/plan-task-handoff/SKILL.md
@@ -72,26 +72,7 @@ Before editing, print to the user:
 - Why it does not conflict with current open PRs
 - The primary files expected to change
 
-If no campaign (#687) issue is executable, fall back to non-campaign issues using the
-same filter rules minus #687-specific constraints:
-
-1. Must have: `ralph-task`, `ralph-status:pending`.
-2. Must NOT have: `epic`, `ralph-status:blocked`, `ralph-status:in-progress`,
-   `ralph-status:in-review`, `ralph-status:done`.
-3. Every required dependency named in the issue must be closed or explicitly non-blocking.
-4. Do not select work that conflicts with an open PR or active issue touching the
-   same architectural lane or primary files.
-5. Prefer: `ralph-priority:critical` > `high` > `medium` > `low`.
-6. If more than one is equally eligible, choose the lowest-numbered one.
-7. **Verify the issue is genuinely pending** — inspect the referenced files and
-   code paths before selecting. An issue may claim an N+1 pattern exists when the
-   code was already fixed in a later PR (e.g. #669 was already resolved by the
-   bulk endpoint in #677). If the described problem no longer exists, skip the
-   issue and move to the next candidate. Do not close the issue — that is a
-   separate decision.
-
-If no campaign issue AND no non-campaign issue is executable, report the exact blockers
-and stop without changing code.
+If no issue is executable, report the exact blockers and stop without changing code.
 
 ## Step 3 — Start the issue
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react'
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom'
 import Navigation from './components/Navigation'
 import BugReportButton from './components/BugReportButton'
-import api, { clearAccessToken, setAccessToken } from './services/api'
+import api, { clearAccessToken, setAccessToken, getAccessToken } from './services/api'
 import type { AuthUser } from './types'
 import { useBugReport } from './hooks/useBugReport'
 import type { DiagnosticData } from './hooks/useDiagnostics'
@@ -64,6 +64,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const authChannel = typeof BroadcastChannel !== 'undefined' ? new BroadcastChannel('comic-pile-auth') : null
 
     const validateSession = async () => {
+      if (!getAccessToken() && !window.__COMIC_PILE_ACCESS_TOKEN) {
+        setIsLoading(false)
+        return
+      }
       if (window.__COMIC_PILE_ACCESS_TOKEN) {
         setAccessToken(window.__COMIC_PILE_ACCESS_TOKEN)
         delete window.__COMIC_PILE_ACCESS_TOKEN

--- a/frontend/src/unit/App.test.tsx
+++ b/frontend/src/unit/App.test.tsx
@@ -9,6 +9,7 @@ const mockApiGet = vi.fn()
 const mockCollectionsList = vi.fn()
 const mockSetAccessToken = vi.fn()
 const mockClearAccessToken = vi.fn()
+const mockGetAccessToken = vi.fn<() => string | null>(() => 'test-token')
 
 // Mock the API module with a factory that doesn't reference outer scope
 vi.mock('../services/api', () => {
@@ -25,6 +26,7 @@ vi.mock('../services/api', () => {
     },
     setAccessToken: (...args: Parameters<typeof mockSetAccessToken>) => mockSetAccessToken(...args),
     clearAccessToken: (...args: Parameters<typeof mockClearAccessToken>) => mockClearAccessToken(...args),
+    getAccessToken: () => mockGetAccessToken(),
     collectionsApi: { list: (...args: unknown[]) => mockCollectionsList(...args) },
   }
 })
@@ -315,5 +317,50 @@ describe('auth state race condition regression', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('register-page')).not.toBeInTheDocument()
     })
+  })
+})
+
+describe('anonymous no-token probe suppression', () => {
+  beforeEach(() => {
+    mockApiGet.mockReset()
+    mockGetAccessToken.mockReset()
+    mockGetAccessToken.mockReturnValue(null)
+    mockSetAccessToken.mockReset()
+    mockClearAccessToken.mockReset()
+    delete (window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN
+  })
+
+  afterEach(() => {
+    mockGetAccessToken.mockReset()
+  })
+
+  test('anonymous user does not call /auth/me when no token exists', async () => {
+    renderWithAuth('/login')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('login-page')).toBeInTheDocument()
+    })
+    expect(mockApiGet).not.toHaveBeenCalledWith('/auth/me')
+  })
+
+  test('anonymous user falls through correctly to login page from protected route', async () => {
+    renderWithAuth('/')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('login-page')).toBeInTheDocument()
+    })
+  })
+
+  test('SSR token injection still triggers /auth/me when in-memory token is null', async () => {
+    mockApiGet.mockResolvedValue({ username: 'ssruser', email: 'ssr@test.com' })
+    ;(window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN =
+      'ssr-token'
+    renderWithAuth('/')
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('login-page')).not.toBeInTheDocument()
+    })
+    expect(mockApiGet).toHaveBeenCalledWith('/auth/me')
+    expect(mockSetAccessToken).toHaveBeenCalledWith('ssr-token')
   })
 })

--- a/frontend/src/unit/Navigation.test.tsx
+++ b/frontend/src/unit/Navigation.test.tsx
@@ -10,6 +10,7 @@ const mockApiGet = vi.fn()
 const mockApiPost = vi.fn()
 const mockSetAccessToken = vi.fn()
 const mockClearAccessToken = vi.fn()
+const mockGetAccessToken = vi.fn(() => 'test-token')
 
 vi.mock('../services/api', () => {
   return {
@@ -19,6 +20,7 @@ vi.mock('../services/api', () => {
     },
     setAccessToken: (...args: Parameters<typeof mockSetAccessToken>) => mockSetAccessToken(...args),
     clearAccessToken: (...args: Parameters<typeof mockClearAccessToken>) => mockClearAccessToken(...args),
+    getAccessToken: () => mockGetAccessToken(),
   }
 })
 


### PR DESCRIPTION
Closes #689

## Problem
The AuthProvider unconditionally calls `/auth/me` on mount (even when no access token exists). This triggers a `/auth/refresh` cascade — both returning 401 for anonymous users — producing console errors and unnecessary network noise on the login page.

## Fix
Add an early return in `validateSession()` when no access token exists (checking both in-memory token and SSR-injected `window.__COMIC_PILE_ACCESS_TOKEN`). The response interceptor refresh logic is untouched — only the initial /auth/me probe is gated.

## Changes
- `frontend/src/App.tsx`: Add `getAccessToken` import and early return in `validateSession()` before the /auth/me call
- `frontend/src/unit/App.test.tsx`: Add `getAccessToken` to mock factory, default returns 'test-token' so existing tests keep their behavior. Add 3 regression tests: anonymous user skips /auth/me, anonymous user falls through to login, SSR token injection still works
- `frontend/src/unit/Navigation.test.tsx`: Add `getAccessToken` to api mock

## Verification
- `pnpm run lint`: 0 errors, 3 pre-existing warnings
- `pnpm run typecheck`: clean
- `pnpm run build`: succeeds
- `pnpm test`: 590/590 passing (587 pre-existing + 3 new regression tests)