### PR TITLE
fix(auth): preserve logged-in session on hard refresh

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -66,7 +66,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const authChannel = typeof BroadcastChannel !== 'undefined' ? new BroadcastChannel('comic-pile-auth') : null
 
     const validateSession = async () => {
-      if (!getAccessToken() && !window.__COMIC_PILE_ACCESS_TOKEN) {
+      const isPublicAuthPage =
+        window.location.pathname === '/login' || window.location.pathname === '/register'
+      if (!getAccessToken() && !window.__COMIC_PILE_ACCESS_TOKEN && isPublicAuthPage) {
         setIsLoading(false)
         return
       }

--- a/frontend/src/unit/AuthHardRefresh.test.tsx
+++ b/frontend/src/unit/AuthHardRefresh.test.tsx
@@ -80,4 +80,20 @@ describe('hard refresh session bootstrap', () => {
     expect(authState?.isAuthenticated).toBe(false)
     expect(mockApiGet).not.toHaveBeenCalled()
   })
+
+  test('still skips the anonymous probe on the register page', async () => {
+    window.history.replaceState({}, '', '/register')
+
+    render(
+      <AuthProvider>
+        <AuthStateProbe />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => {
+      expect(authState?.isLoading).toBe(false)
+    })
+    expect(authState?.isAuthenticated).toBe(false)
+    expect(mockApiGet).not.toHaveBeenCalled()
+  })
 })

--- a/frontend/src/unit/AuthHardRefresh.test.tsx
+++ b/frontend/src/unit/AuthHardRefresh.test.tsx
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { useEffect } from 'react'
+import type { AuthContextValue } from '../App'
+
+const mockApiGet = vi.fn()
+const mockGetAccessToken = vi.fn<() => string | null>(() => null)
+const mockSetAccessToken = vi.fn()
+const mockClearAccessToken = vi.fn()
+
+vi.mock('../services/api', () => ({
+  default: {
+    get: (...args: Parameters<typeof mockApiGet>) => mockApiGet(...args),
+  },
+  getAccessToken: () => mockGetAccessToken(),
+  setAccessToken: (...args: Parameters<typeof mockSetAccessToken>) => mockSetAccessToken(...args),
+  clearAccessToken: (...args: Parameters<typeof mockClearAccessToken>) => mockClearAccessToken(...args),
+}))
+
+import { AuthProvider, useAuth } from '../App'
+
+let authState: AuthContextValue | null = null
+
+function AuthStateProbe() {
+  const auth = useAuth()
+
+  useEffect(() => {
+    authState = auth
+  }, [auth])
+
+  return null
+}
+
+describe('hard refresh session bootstrap', () => {
+  beforeEach(() => {
+    authState = null
+    mockApiGet.mockReset()
+    mockGetAccessToken.mockReset()
+    mockGetAccessToken.mockReturnValue(null)
+    mockSetAccessToken.mockReset()
+    mockClearAccessToken.mockReset()
+    delete window.__COMIC_PILE_ACCESS_TOKEN
+    vi.stubGlobal('BroadcastChannel', undefined)
+  })
+
+  afterEach(() => {
+    window.history.replaceState({}, '', '/')
+    vi.unstubAllGlobals()
+  })
+
+  test('validates a refresh-cookie session on a protected-route hard reload', async () => {
+    window.history.replaceState({}, '', '/queue')
+    mockApiGet.mockResolvedValue({ username: 'testuser', email: 'test@example.com' })
+
+    render(
+      <AuthProvider>
+        <AuthStateProbe />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => {
+      expect(authState?.isAuthenticated).toBe(true)
+    })
+    expect(mockApiGet).toHaveBeenCalledWith('/auth/me')
+    expect(mockClearAccessToken).not.toHaveBeenCalled()
+  })
+
+  test('still skips the anonymous probe on the login page', async () => {
+    window.history.replaceState({}, '', '/login')
+
+    render(
+      <AuthProvider>
+        <AuthStateProbe />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => {
+      expect(authState?.isLoading).toBe(false)
+    })
+    expect(authState?.isAuthenticated).toBe(false)
+    expect(mockApiGet).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Regression

PR #717 skipped auth bootstrap whenever no in-memory access token existed. A hard browser refresh clears that in-memory token even when the valid HttpOnly refresh cookie remains, so authenticated users were redirected to login before the response interceptor could refresh the session.

## Fix

Only skip the anonymous startup probe on the public auth pages (`/login` and `/register`). On protected routes, continue calling `/auth/me`; when the access token is absent, the existing interceptor can use `/auth/refresh` and retry the request.

## Regression coverage

- Protected-route hard reload with no in-memory token still validates `/auth/me` and restores authentication.
- Anonymous login page still skips `/auth/me`, preserving the noise reduction from #717.

Part of #689. Follow-up to #717.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication handling on login and registration pages so they load correctly without requiring a session.
  * Preserved valid sessions during protected-page refreshes by validating them through the authentication service.
* **Tests**
  * Added coverage for session validation during hard refreshes and for bypassing unnecessary checks on public authentication pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->