### PR TITLE
perf(roll): consolidate post-action refreshes into targeted updates (#668)

### DIFF
--- a/frontend/src/hooks/useRate.ts
+++ b/frontend/src/hooks/useRate.ts
@@ -11,7 +11,7 @@ export function useRate() {
     setIsPending(true)
     setIsError(false)
     try {
-      await rateApi.rate(data)
+      return await rateApi.rate(data)
     } catch (error: unknown) {
       setIsError(true)
       console.error('Failed to rate thread:', getApiErrorDetail(error))

--- a/frontend/src/pages/RollPage/index.tsx
+++ b/frontend/src/pages/RollPage/index.tsx
@@ -79,7 +79,7 @@ export default function RollPage() {
   const { activeCollectionId = null } = useCollections()
   const { setRestoreAction, clearRestoreAction } = useBugReportRestore()
   const { data: threads, refetch: refetchThreads } = useThreads('', activeCollectionId)
-  const { data: staleThreads, refetch: refetchStaleThreads } = useStaleThreads(7)
+  const { data: staleThreads } = useStaleThreads(7)
   const navigate = useNavigate()
 
   useEffect(() => {
@@ -226,11 +226,10 @@ export default function RollPage() {
 const handleMigrationComplete = useCallback((migratedThread: Thread) => {
   refetchThreads()
   refetchSession()
-  refetchStaleThreads()
   setShowMigrationDialog(false)
   setThreadToMigrate(null)
   enterRatingView(migratedThread.id, null, migratedThread)
-}, [refetchThreads, refetchSession, refetchStaleThreads, enterRatingView, setShowMigrationDialog, setThreadToMigrate])
+}, [refetchThreads, refetchSession, enterRatingView, setShowMigrationDialog, setThreadToMigrate])
 
 const handleMigrationSkip = useCallback(() => {
   setShowMigrationDialog(false)
@@ -249,7 +248,16 @@ const handleMigrationClose = useCallback(() => {
       rating,
       finish_session: false,
       issue_number: issueNumber,
-    }).then(() => {
+    }).then((rateResponse) => {
+      if (rateResponse && activeRatingThread) {
+        setActiveRatingThread({
+          ...activeRatingThread,
+          issues_remaining: rateResponse.issues_remaining,
+          total_issues: rateResponse.total_issues ?? null,
+          reading_progress: rateResponse.reading_progress ?? null,
+          last_rolled_result: null,
+        })
+      }
       suppressPendingAutoOpenRef.current = true
       setIsRolling(false)
       setIsRatingView(false)
@@ -257,11 +265,11 @@ const handleMigrationClose = useCallback(() => {
       setSelectedThreadId(null)
       setActiveRatingThread(null)
       setErrorMessage('')
-      Promise.allSettled([refetchSession(), refetchThreads(), refetchStaleThreads()])
+      refetchSession()
     }).catch((error: unknown) => {
       setErrorMessage(getApiErrorDetail(error))
     })
-  }, [activeRatingThread, rating, rateMutation, refetchSession, refetchThreads, refetchStaleThreads, setShowSimpleMigration, suppressPendingAutoOpenRef, setIsRolling, setIsRatingView, setRolledResult, setSelectedThreadId, setActiveRatingThread, setErrorMessage])
+  }, [activeRatingThread, rating, rateMutation, refetchSession, setShowSimpleMigration, suppressPendingAutoOpenRef, setIsRolling, setIsRatingView, setRolledResult, setSelectedThreadId, setActiveRatingThread, setErrorMessage])
 
   async function handleAction(action: string) {
     setIsActionSheetOpen(false)
@@ -305,7 +313,6 @@ case 'read': {
             await snoozeMutation.mutate()
           }
           await refetchSession()
-          await refetchThreads()
           break
         case 'edit':
           navigate('/queue', { state: { editThreadId: selectedThread!.id } })
@@ -489,15 +496,29 @@ useEffect(() => {
     if (!activeRatingThread) return
 
     try {
-      await rateMutation.mutate({
+      const rateResponse = await rateMutation.mutate({
         thread_id: activeRatingThread!.id,
         rating,
         finish_session: finishSession,
         issue_number: activeRatingThread!.issue_number || undefined
       })
 
-      const refreshResults = await Promise.allSettled([refetchSession(), refetchThreads(), refetchStaleThreads()])
-      if (refreshResults[0].status === 'rejected' || refreshResults[1].status === 'rejected') {
+      if (rateResponse && activeRatingThread) {
+        setActiveRatingThread({
+          ...activeRatingThread,
+          issues_remaining: rateResponse.issues_remaining,
+          queue_position: rateResponse.queue_position,
+          total_issues: rateResponse.total_issues ?? null,
+          reading_progress: rateResponse.reading_progress ?? null,
+          issue_id: rateResponse.next_unread_issue_id ?? null,
+          issue_number: rateResponse.next_unread_issue_number ?? null,
+          last_rolled_result: null,
+        })
+      }
+
+      try {
+        await refetchSession()
+      } catch {
         setErrorMessage('Rating saved but failed to refresh. Please refresh the page.')
         return
       }
@@ -519,7 +540,6 @@ useEffect(() => {
     try {
       await snoozeMutation.mutate()
       await refetchSession()
-      await refetchThreads()
       setIsRolling(false)
       setIsRatingView(false)
       setRolledResult(null)
@@ -532,7 +552,7 @@ useEffect(() => {
 
   async function handleRefreshThread() {
     try {
-      const [latestSession] = await Promise.all([refetchSession(), refetchThreads()])
+      const latestSession = await refetchSession()
       const refreshedThread = latestSession?.active_thread
 
       if (activeRatingThread && refreshedThread?.id === activeRatingThread.id) {
@@ -786,7 +806,6 @@ useEffect(() => {
                   try {
                     await dismissPendingMutation.mutate()
                     await refetchSession()
-                    await refetchThreads()
                   } catch (error) {
                     setErrorMessage(getApiErrorDetail(error))
                     return

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -301,7 +301,7 @@ export const rollApi = {
 
 export const rateApi = {
   rate: (data: { thread_id: number; rating: number; issues_read?: number; finish_session?: boolean; issue_number?: string }) =>
-    api.post<void, { thread_id: number; rating: number; issues_read?: number; finish_session?: boolean; issue_number?: string }>('/rate/', data),
+    api.post<Thread, { thread_id: number; rating: number; issues_read?: number; finish_session?: boolean; issue_number?: string }>('/rate/', data),
 }
 
 export const sessionApi = {

--- a/frontend/src/unit/RollPage.test.tsx
+++ b/frontend/src/unit/RollPage.test.tsx
@@ -548,115 +548,115 @@ describe('Rating View', () => {
     expect(within(poolList).getByText('X-Men')).toBeInTheDocument()
   })
 
-  it('[P4] refetches threads after successful rating', async () => {
+  it('[P4] refetches session but not threads after successful rating', async () => {
     const { threadsApi } = await import('../services/api')
     vi.spyOn(threadsApi, 'setPending').mockResolvedValue(baseRollResponse)
 
-    const mockRate = vi.fn().mockResolvedValue({})
+    const mockRate = vi.fn().mockResolvedValue(baseRollResponse)
     mockedUseRate.mockReturnValue({ mutate: mockRate, isPending: false })
 
     const mockRefetchThreads = vi.fn()
+    const mockRefetchSession = vi.fn().mockResolvedValue({})
     mockedUseThreads.mockReturnValue({
       data: [{ id: 1, title: 'Saga', format: 'Comics', status: 'active' }],
       refetch: mockRefetchThreads
+    })
+    mockedUseSession.mockReturnValue({
+      data: {
+        id: 1,
+        current_die: 6,
+        last_rolled_result: null,
+        manual_die: null,
+        pending_thread_id: 1,
+        snoozed_threads: [],
+        active_thread: { id: 1, title: 'Saga', format: 'Comics', issues_remaining: 5, queue_position: 1, total_issues: 50 },
+      },
+      refetch: mockRefetchSession,
     })
 
     const user = userEvent.setup()
     render(<RollPage />)
 
-    // 1. Enter rating view
-    const sagaItem = getPoolItem('Saga')
-    await user.click(sagaItem)
-    await user.click(screen.getByText('Read Now'))
+    await waitFor(() => {
+      expect(screen.getByText('How was it?')).toBeInTheDocument()
+    })
 
-    // 2. Submit rating
     await user.click(screen.getByText('Save & Continue'))
 
-    // 3. Verify refetchThreads was called
     await waitFor(() => {
-      expect(mockRefetchThreads).toHaveBeenCalled()
+      expect(mockRefetchSession).toHaveBeenCalled()
     })
+    expect(mockRefetchThreads).not.toHaveBeenCalled()
   })
 
   it('[P5] closes rating view even if post-save refresh fails', async () => {
     const { threadsApi } = await import('../services/api')
     vi.spyOn(threadsApi, 'setPending').mockResolvedValue(baseRollResponse)
 
-    const mockRate = vi.fn().mockResolvedValue({})
+    const mockRate = vi.fn().mockResolvedValue(baseRollResponse)
     mockedUseRate.mockReturnValue({ mutate: mockRate, isPending: false })
 
     const refetchSessionError = new Error('session refresh failed')
     const mockRefetchSession = vi.fn().mockRejectedValue(refetchSessionError)
     mockedUseSession.mockReturnValue({
       data: {
+        id: 1,
         current_die: 6,
         last_rolled_result: null,
         manual_die: null,
+        pending_thread_id: 1,
         has_restore_point: false,
         snoozed_threads: [],
+        active_thread: { id: 1, title: 'Saga', format: 'Comics', issues_remaining: 5, queue_position: 1, total_issues: 50 },
       },
       refetch: mockRefetchSession,
-    })
-
-    const mockRefetchThreads = vi.fn().mockRejectedValue(new Error('threads refresh failed'))
-    mockedUseThreads.mockReturnValue({
-      data: [
-        { id: 1, title: 'Saga', format: 'Comics', status: 'active' },
-        { id: 2, title: 'X-Men', format: 'Comics', status: 'active' },
-      ],
-      refetch: mockRefetchThreads,
     })
 
     const user = userEvent.setup()
     render(<RollPage />)
 
-    const sagaItem = getPoolItem('Saga')
-    await user.click(sagaItem)
-    await user.click(screen.getByText('Read Now'))
+    await waitFor(() => {
+      expect(screen.getByText('How was it?')).toBeInTheDocument()
+    })
     await user.click(screen.getByText('Save & Continue'))
 
     await waitFor(() => expect(screen.getByText(/failed to refresh/i)).toBeInTheDocument())
   })
 
-  it('[P5b] closes rating view when threads refresh fails after session refresh succeeds', async () => {
+  it('[P5b] closes rating view when session refresh succeeds after successful rating', async () => {
     const { threadsApi } = await import('../services/api')
     vi.spyOn(threadsApi, 'setPending').mockResolvedValue(baseRollResponse)
 
-    const mockRate = vi.fn().mockResolvedValue({})
+    const mockRate = vi.fn().mockResolvedValue(baseRollResponse)
     mockedUseRate.mockReturnValue({ mutate: mockRate, isPending: false })
 
     const mockRefetchSession = vi.fn().mockResolvedValue({})
     mockedUseSession.mockReturnValue({
       data: {
+        id: 1,
         current_die: 6,
         last_rolled_result: null,
         manual_die: null,
+        pending_thread_id: 1,
         has_restore_point: false,
         snoozed_threads: [],
+        active_thread: { id: 1, title: 'Saga', format: 'Comics', issues_remaining: 5, queue_position: 1, total_issues: 50 },
       },
       refetch: mockRefetchSession,
-    })
-
-    const mockRefetchThreads = vi.fn().mockRejectedValue(new Error('threads refresh failed'))
-    mockedUseThreads.mockReturnValue({
-      data: [
-        { id: 1, title: 'Saga', format: 'Comics', status: 'active' },
-        { id: 2, title: 'X-Men', format: 'Comics', status: 'active' },
-      ],
-      refetch: mockRefetchThreads,
     })
 
     const user = userEvent.setup()
     render(<RollPage />)
 
-    const sagaItem = getPoolItem('Saga')
-    await user.click(sagaItem)
-    await user.click(screen.getByText('Read Now'))
+    await waitFor(() => {
+      expect(screen.getByText('How was it?')).toBeInTheDocument()
+    })
     await user.click(screen.getByText('Save & Continue'))
 
-    await waitFor(() => expect(screen.getByText(/failed to refresh/i)).toBeInTheDocument())
-    expect(mockRefetchSession).toHaveBeenCalled()
-    expect(mockRefetchThreads).toHaveBeenCalled()
+    await waitFor(() => {
+      expect(mockRefetchSession).toHaveBeenCalled()
+    })
+    expect(screen.queryByText(/failed to refresh/i)).not.toBeInTheDocument()
   })
 
   it('[P6] does not auto-finish session when rating the last issue', async () => {
@@ -957,7 +957,6 @@ describe('Rating View', () => {
   it('cancels pending roll through dismiss mutation', async () => {
     const dismissSpy = vi.fn().mockResolvedValue({})
     const refetchSessionSpy = vi.fn().mockResolvedValue({})
-    const refetchThreadsSpy = vi.fn().mockResolvedValue({})
 
     mockedUseDismissPending.mockReturnValue({ mutate: dismissSpy, isPending: false })
     mockedUseSession.mockReturnValue({
@@ -981,7 +980,7 @@ describe('Rating View', () => {
         { id: 1, title: 'Saga', format: 'Comics', status: 'active', queue_position: 1 },
         { id: 2, title: 'X-Men', format: 'Comics', status: 'active', queue_position: 2 },
       ],
-      refetch: refetchThreadsSpy,
+      refetch: vi.fn(),
     })
 
     const user = userEvent.setup()
@@ -996,7 +995,6 @@ describe('Rating View', () => {
     await waitFor(() => {
       expect(dismissSpy).toHaveBeenCalled()
       expect(refetchSessionSpy).toHaveBeenCalled()
-      expect(refetchThreadsSpy).toHaveBeenCalled()
     })
   })
 
@@ -1143,6 +1141,142 @@ describe('Rating View', () => {
       await user.click(screen.getByRole('button', { name: 'Go to Queue' }))
 
       expect(navigateSpy).toHaveBeenCalledWith('/queue')
+    })
+  })
+
+  describe('Post-action refresh contract', () => {
+    it('rate: does not refetch threads or stale threads', async () => {
+      const { threadsApi } = await import('../services/api')
+      vi.spyOn(threadsApi, 'setPending').mockResolvedValue(baseRollResponse)
+
+      const mockRate = vi.fn().mockResolvedValue(baseRollResponse)
+      mockedUseRate.mockReturnValue({ mutate: mockRate, isPending: false })
+
+      const mockRefetchThreads = vi.fn()
+      const mockRefetchStale = vi.fn()
+      const mockRefetchSession = vi.fn().mockResolvedValue({})
+
+      mockedUseThreads.mockReturnValue({
+        data: [{ id: 1, title: 'Saga', format: 'Comics', status: 'active' }],
+        refetch: mockRefetchThreads,
+      })
+      mockedUseStaleThreads.mockReturnValue({ data: [], refetch: mockRefetchStale })
+      mockedUseSession.mockReturnValue({
+        data: {
+          id: 1,
+          current_die: 6,
+          last_rolled_result: null,
+          manual_die: null,
+          pending_thread_id: 1,
+          has_restore_point: false,
+          snoozed_threads: [],
+          active_thread: { id: 1, title: 'Saga', format: 'Comics', issues_remaining: 5, queue_position: 1, total_issues: 50 },
+        },
+        refetch: mockRefetchSession,
+      })
+
+      const user = userEvent.setup()
+      render(<RollPage />)
+
+      await waitFor(() => {
+        expect(screen.getByText('How was it?')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByText('Save & Continue'))
+
+      await waitFor(() => {
+        expect(mockRefetchSession).toHaveBeenCalled()
+      })
+      expect(mockRefetchThreads).not.toHaveBeenCalled()
+      expect(mockRefetchStale).not.toHaveBeenCalled()
+    })
+
+    it('snooze: only refetches session', async () => {
+      const snoozeSpy = vi.fn().mockResolvedValue({})
+      mockedUseSnooze.mockReturnValue({ mutate: snoozeSpy, isPending: false })
+
+      const mockRefetchThreads = vi.fn()
+      const mockRefetchStale = vi.fn()
+      const mockRefetchSession = vi.fn().mockResolvedValue({})
+
+      mockedUseThreads.mockReturnValue({
+        data: [{ id: 1, title: 'Saga', format: 'Comics', status: 'active' }],
+        refetch: mockRefetchThreads,
+      })
+      mockedUseStaleThreads.mockReturnValue({ data: [], refetch: mockRefetchStale })
+      mockedUseSession.mockReturnValue({
+        data: {
+          id: 1,
+          current_die: 6,
+          last_rolled_result: 3,
+          manual_die: null,
+          pending_thread_id: 1,
+          has_restore_point: false,
+          snoozed_threads: [],
+          active_thread: { id: 1, title: 'Saga', format: 'Comics', issues_remaining: 5, queue_position: 1, total_issues: 50 },
+        },
+        refetch: mockRefetchSession,
+      })
+
+      const user = userEvent.setup()
+      render(<RollPage />)
+
+      await waitFor(() => {
+        expect(screen.getByText('How was it?')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByText('Snooze'))
+
+      await waitFor(() => {
+        expect(snoozeSpy).toHaveBeenCalled()
+        expect(mockRefetchSession).toHaveBeenCalled()
+      })
+      expect(mockRefetchThreads).not.toHaveBeenCalled()
+      expect(mockRefetchStale).not.toHaveBeenCalled()
+    })
+
+    it('dismiss: only refetches session', async () => {
+      const dismissSpy = vi.fn().mockResolvedValue({})
+      mockedUseDismissPending.mockReturnValue({ mutate: dismissSpy, isPending: false })
+
+      const mockRefetchThreads = vi.fn()
+      const mockRefetchStale = vi.fn()
+      const mockRefetchSession = vi.fn().mockResolvedValue({})
+
+      mockedUseThreads.mockReturnValue({
+        data: [
+          { id: 1, title: 'Saga', format: 'Comics', status: 'active', queue_position: 1 },
+          { id: 2, title: 'X-Men', format: 'Comics', status: 'active', queue_position: 2 },
+        ],
+        refetch: mockRefetchThreads,
+      })
+      mockedUseStaleThreads.mockReturnValue({ data: [], refetch: mockRefetchStale })
+      mockedUseSession.mockReturnValue({
+        data: {
+          current_die: 6,
+          last_rolled_result: 2,
+          pending_thread_id: 1,
+          manual_die: null,
+          active_thread: { id: 1, title: 'Saga', format: 'Comics', issues_remaining: 5, queue_position: 1, total_issues: 50 },
+        },
+        refetch: mockRefetchSession,
+      })
+
+      const user = userEvent.setup()
+      render(<RollPage />)
+
+      await waitFor(() => {
+        expect(screen.getByText('How was it?')).toBeInTheDocument()
+      })
+
+      await user.click(screen.getByText('Cancel'))
+
+      await waitFor(() => {
+        expect(dismissSpy).toHaveBeenCalled()
+        expect(mockRefetchSession).toHaveBeenCalled()
+      })
+      expect(mockRefetchThreads).not.toHaveBeenCalled()
+      expect(mockRefetchStale).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
## Summary

Consolidates broad refetch cascades after rate, snooze, and dismiss
actions into intentional refresh plans. Replaces the previous pattern of
`Promise.allSettled([refetchSession(), refetchThreads(), refetchStaleThreads()])`
with targeted updates that use mutation response data and refetch only
what actually changed.

Part of #668.

## Changes

### Refresh contract (`handleSubmitRating`)
- Rate API now returns a `ThreadResponse` instead of void
- Uses the response to update local state (issues_remaining, queue_position, etc.)
- Only refetches session after save
- Properly handles session refresh failure with specific error message
- **Before**: rate + session + threads + stale = 4 requests
- **After**: rate + session = 2 requests

### Refresh contract (`handleSnooze`)
- Only refetches session; snooze only changes session snoozed_threads
- **Before**: snooze + session + threads = 3 requests
- **After**: snooze + session = 2 requests

### Refresh contract (cancel/dismiss)
- Only refetches session; dismiss only clears pending state
- **Before**: dismiss + session + threads = 3 requests
- **After**: dismiss + session = 2 requests

### Other targeted updates
- `handleSimpleMigrationComplete`: use rate response data
- `handleMigrationComplete`: drop unnecessary stale-threads refetch
- `handleRefreshThread`: refetch session only
- Action sheet snooze/unsnooze: only refetch session

### Files changed
- `frontend/src/hooks/useRate.ts` — return ThreadResponse from mutate
- `frontend/src/services/api.ts` — type rateApi.rate as returning Thread
- `frontend/src/pages/RollPage/index.tsx` — targeted refresh plans for all post-action handlers
- `frontend/src/unit/RollPage.test.tsx` — updated existing tests + 3 new request-count tests

## Acceptance criteria

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Roll and rate each trigger one intentional refresh plan | PASS | Roll already uses response data directly. Rate now uses ThreadResponse + session only. |
| 2 | Unchanged collections are not refetched | PASS | After rate, snooze, and dismiss, threads and stale threads are no longer refetched. Verified by 3 dedicated request-count tests. |
| 3 | Post-action request count covered by frontend tests | PASS | 3 new tests in `RollPage.test.tsx` verify that rate, snooze, and dismiss do NOT trigger threads or stale-threads refetches. |
| 4 | UI remains consistent after roll, rate, reroll, and failed mutation cases | PASS | Session refresh failure after rate shows specific error message. All existing tests updated and pass. Dismiss, snooze, and rate all correctly close rating view and return to roll state. |

## Verification

- Frontend tests: 590 passed (63 test files)
- ESLint: 0 errors (3 pre-existing warnings)
- TypeScript typecheck: clean (both tsconfig.json and tsconfig.test.json)