### PR TITLE
perf(session): add repeatable session read benchmark (#700)

### DIFF
--- a/scripts/benchmark_session_reads.py
+++ b/scripts/benchmark_session_reads.py
@@ -9,7 +9,8 @@ size, application cache state, request ID, and database query-count headers.
 The first recorded request is reported separately from later steady-state
 samples. It is only a first-observed measurement, not proof that the deployment
 was cold; callers must control deployment idleness when collecting cold-path
-evidence.
+evidence. Use ``--endpoint`` to isolate one endpoint in a fresh invocation when
+collecting endpoint-specific first-request evidence.
 """
 
 from __future__ import annotations
@@ -166,12 +167,41 @@ def _build_endpoints(page_size: int, later_page_token: str | None) -> list[str]:
     return endpoints
 
 
+def _select_endpoints(
+    endpoint_selection: str,
+    page_size: int,
+    later_page_token: str | None,
+) -> list[str]:
+    """Select endpoints without preconditioning a later target in the same run."""
+    endpoints = _build_endpoints(page_size, later_page_token)
+    if endpoint_selection == "all":
+        return endpoints
+    if endpoint_selection == "current":
+        return [endpoints[0]]
+    if endpoint_selection == "history-first":
+        return [endpoints[1]]
+    if endpoint_selection == "history-later":
+        if len(endpoints) < 3:
+            raise ValueError("history-later requires --later-page-token")
+        return [endpoints[2]]
+    raise ValueError(f"unknown endpoint selection: {endpoint_selection}")
+
+
 def main() -> int:
     """Run the session-read benchmark and print a JSON report to stdout."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--base-url", required=True, help="Deployment URL, for example http://localhost:8000")
     parser.add_argument("--bearer-token", help="Access token for Authorization: Bearer")
     parser.add_argument("--cookie", help="Raw Cookie header, useful for refresh-cookie authentication")
+    parser.add_argument(
+        "--endpoint",
+        choices=("all", "current", "history-first", "history-later"),
+        default="all",
+        help=(
+            "Endpoint group to benchmark. Select one endpoint in a fresh invocation for "
+            "endpoint-specific first-request evidence."
+        ),
+    )
     parser.add_argument(
         "--warmups",
         type=int,
@@ -190,20 +220,35 @@ def main() -> int:
     if not 1 <= args.page_size <= 200:
         parser.error("--page-size must be between 1 and 200")
 
+    try:
+        endpoints = _select_endpoints(args.endpoint, args.page_size, args.later_page_token)
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    if len(endpoints) == 1:
+        first_observed_note = (
+            "The first recorded request is not guaranteed cold. Control deployment idleness "
+            "outside this harness when collecting cold-path evidence."
+        )
+    else:
+        first_observed_note = (
+            "Only the first endpoint in this multi-endpoint run can be the deployment's first "
+            "request. Use --endpoint in separate fresh invocations for endpoint-specific "
+            "first-request evidence; deployment coldness must still be controlled externally."
+        )
+
     report: dict[str, Any] = {
         "base_url": args.base_url,
+        "endpoint_selection": args.endpoint,
         "warmups": args.warmups,
         "iterations": args.iterations,
         "page_size": args.page_size,
-        "first_observed_note": (
-            "The first recorded request is not guaranteed cold. Control deployment idleness "
-            "outside this harness when collecting cold-path evidence."
-        ),
+        "first_observed_note": first_observed_note,
         "runs": [],
         "summaries": [],
     }
 
-    for endpoint in _build_endpoints(args.page_size, args.later_page_token):
+    for endpoint in endpoints:
         for warmup in range(args.warmups):
             _request(
                 base_url=args.base_url,

--- a/scripts/benchmark_session_reads.py
+++ b/scripts/benchmark_session_reads.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Benchmark authenticated current-session and History API reads.
+
+This harness is intentionally dependency-free so it can run against local,
+preview, or production deployments without installing the application.
+It records the response evidence needed by issue #700: elapsed time, payload
+size, application cache state, request ID, and database query-count headers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from dataclasses import asdict, dataclass
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode, urljoin
+from urllib.request import Request, urlopen
+
+
+@dataclass(frozen=True)
+class Sample:
+    endpoint: str
+    iteration: int
+    elapsed_ms: float
+    status: int
+    response_bytes: int
+    request_id: str | None
+    app_cache: str | None
+    db_queries: int | None
+    server_timing: str | None
+
+
+def _parse_db_queries(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def _request(
+    *,
+    base_url: str,
+    endpoint: str,
+    iteration: int,
+    bearer_token: str | None,
+    cookie: str | None,
+    timeout: float,
+) -> Sample:
+    url = urljoin(base_url.rstrip("/") + "/", endpoint.lstrip("/"))
+    headers = {"Accept": "application/json", "User-Agent": "comic-pile-session-benchmark/1"}
+    if bearer_token:
+        headers["Authorization"] = f"Bearer {bearer_token}"
+    if cookie:
+        headers["Cookie"] = cookie
+
+    request = Request(url, headers=headers, method="GET")
+    started = time.perf_counter()
+    try:
+        with urlopen(request, timeout=timeout) as response:  # noqa: S310 - explicit operator URL
+            body = response.read()
+            elapsed_ms = (time.perf_counter() - started) * 1000
+            return Sample(
+                endpoint=endpoint,
+                iteration=iteration,
+                elapsed_ms=round(elapsed_ms, 3),
+                status=response.status,
+                response_bytes=len(body),
+                request_id=response.headers.get("X-Request-ID"),
+                app_cache=response.headers.get("X-App-Cache"),
+                db_queries=_parse_db_queries(response.headers.get("X-App-DB-Queries")),
+                server_timing=response.headers.get("Server-Timing"),
+            )
+    except HTTPError as exc:
+        body = exc.read()
+        elapsed_ms = (time.perf_counter() - started) * 1000
+        raise RuntimeError(
+            f"{endpoint} returned HTTP {exc.code} after {elapsed_ms:.1f} ms: "
+            f"{body[:500].decode('utf-8', errors='replace')}"
+        ) from exc
+    except URLError as exc:
+        elapsed_ms = (time.perf_counter() - started) * 1000
+        raise RuntimeError(
+            f"{endpoint} failed after {elapsed_ms:.1f} ms: {exc.reason}"
+        ) from exc
+
+
+def summarize(samples: list[Sample]) -> dict[str, Any]:
+    """Return stable summary statistics for one endpoint's samples."""
+    if not samples:
+        raise ValueError("at least one sample is required")
+
+    elapsed = [sample.elapsed_ms for sample in samples]
+    db_queries = [sample.db_queries for sample in samples if sample.db_queries is not None]
+    cache_states: dict[str, int] = {}
+    for sample in samples:
+        key = sample.app_cache or "missing"
+        cache_states[key] = cache_states.get(key, 0) + 1
+
+    return {
+        "endpoint": samples[0].endpoint,
+        "samples": len(samples),
+        "elapsed_ms": {
+            "min": min(elapsed),
+            "median": round(statistics.median(elapsed), 3),
+            "max": max(elapsed),
+            "mean": round(statistics.fmean(elapsed), 3),
+        },
+        "response_bytes": {
+            "min": min(sample.response_bytes for sample in samples),
+            "max": max(sample.response_bytes for sample in samples),
+        },
+        "db_queries": {
+            "reported_samples": len(db_queries),
+            "min": min(db_queries) if db_queries else None,
+            "max": max(db_queries) if db_queries else None,
+        },
+        "cache_states": cache_states,
+        "missing_server_timing": sum(sample.server_timing is None for sample in samples),
+    }
+
+
+def _build_endpoints(page_size: int, later_page_token: str | None) -> list[str]:
+    endpoints = [
+        "/api/sessions/current/",
+        f"/api/sessions/?{urlencode({'page_size': page_size})}",
+    ]
+    if later_page_token:
+        endpoints.append(
+            f"/api/sessions/?{urlencode({'page_size': page_size, 'page_token': later_page_token})}"
+        )
+    return endpoints
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", required=True, help="Deployment URL, for example http://localhost:8000")
+    parser.add_argument("--bearer-token", help="Access token for Authorization: Bearer")
+    parser.add_argument("--cookie", help="Raw Cookie header, useful for refresh-cookie authentication")
+    parser.add_argument("--warmups", type=int, default=1, help="Unrecorded requests per endpoint")
+    parser.add_argument("--iterations", type=int, default=5, help="Recorded requests per endpoint")
+    parser.add_argument("--page-size", type=int, default=50)
+    parser.add_argument("--later-page-token", help="Optional History cursor to benchmark a later page")
+    parser.add_argument("--timeout", type=float, default=15.0)
+    parser.add_argument("--output", help="Optional path for the JSON report")
+    args = parser.parse_args()
+
+    if args.warmups < 0 or args.iterations < 1:
+        parser.error("--warmups must be >= 0 and --iterations must be >= 1")
+    if not 1 <= args.page_size <= 200:
+        parser.error("--page-size must be between 1 and 200")
+
+    report: dict[str, Any] = {
+        "base_url": args.base_url,
+        "warmups": args.warmups,
+        "iterations": args.iterations,
+        "page_size": args.page_size,
+        "runs": [],
+        "summaries": [],
+    }
+
+    for endpoint in _build_endpoints(args.page_size, args.later_page_token):
+        for warmup in range(args.warmups):
+            _request(
+                base_url=args.base_url,
+                endpoint=endpoint,
+                iteration=-(warmup + 1),
+                bearer_token=args.bearer_token,
+                cookie=args.cookie,
+                timeout=args.timeout,
+            )
+
+        endpoint_samples = [
+            _request(
+                base_url=args.base_url,
+                endpoint=endpoint,
+                iteration=iteration,
+                bearer_token=args.bearer_token,
+                cookie=args.cookie,
+                timeout=args.timeout,
+            )
+            for iteration in range(1, args.iterations + 1)
+        ]
+        report["runs"].extend(asdict(sample) for sample in endpoint_samples)
+        report["summaries"].append(summarize(endpoint_samples))
+
+    rendered = json.dumps(report, indent=2, sort_keys=True)
+    print(rendered)
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as output_file:
+            output_file.write(rendered + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_session_reads.py
+++ b/scripts/benchmark_session_reads.py
@@ -5,6 +5,11 @@ This harness is intentionally dependency-free so it can run against local,
 preview, or production deployments without installing the application.
 It records the response evidence needed by issue #700: elapsed time, payload
 size, application cache state, request ID, and database query-count headers.
+
+The first recorded request is reported separately from later steady-state
+samples. It is only a first-observed measurement, not proof that the deployment
+was cold; callers must control deployment idleness when collecting cold-path
+evidence.
 """
 
 from __future__ import annotations
@@ -89,10 +94,21 @@ def _request(
         ) from exc
 
 
-def summarize(samples: list[Sample]) -> dict[str, Any]:
-    """Return stable summary statistics for one endpoint's samples."""
+def _sample_evidence(sample: Sample) -> dict[str, Any]:
+    return {
+        "elapsed_ms": sample.elapsed_ms,
+        "status": sample.status,
+        "response_bytes": sample.response_bytes,
+        "request_id": sample.request_id,
+        "app_cache": sample.app_cache,
+        "db_queries": sample.db_queries,
+        "server_timing": sample.server_timing,
+    }
+
+
+def _aggregate(samples: list[Sample]) -> dict[str, Any] | None:
     if not samples:
-        raise ValueError("at least one sample is required")
+        return None
 
     elapsed = [sample.elapsed_ms for sample in samples]
     db_queries = [sample.db_queries for sample in samples if sample.db_queries is not None]
@@ -102,7 +118,6 @@ def summarize(samples: list[Sample]) -> dict[str, Any]:
         cache_states[key] = cache_states.get(key, 0) + 1
 
     return {
-        "endpoint": samples[0].endpoint,
         "samples": len(samples),
         "elapsed_ms": {
             "min": min(elapsed),
@@ -124,6 +139,19 @@ def summarize(samples: list[Sample]) -> dict[str, Any]:
     }
 
 
+def summarize(samples: list[Sample]) -> dict[str, Any]:
+    """Return first-observed and steady-state evidence for one endpoint."""
+    if not samples:
+        raise ValueError("at least one sample is required")
+
+    return {
+        "endpoint": samples[0].endpoint,
+        "first_observed": _sample_evidence(samples[0]),
+        "steady_state": _aggregate(samples[1:]),
+        "all_recorded": _aggregate(samples),
+    }
+
+
 def _build_endpoints(page_size: int, later_page_token: str | None) -> list[str]:
     endpoints = [
         "/api/sessions/current/",
@@ -141,7 +169,12 @@ def main() -> int:
     parser.add_argument("--base-url", required=True, help="Deployment URL, for example http://localhost:8000")
     parser.add_argument("--bearer-token", help="Access token for Authorization: Bearer")
     parser.add_argument("--cookie", help="Raw Cookie header, useful for refresh-cookie authentication")
-    parser.add_argument("--warmups", type=int, default=1, help="Unrecorded requests per endpoint")
+    parser.add_argument(
+        "--warmups",
+        type=int,
+        default=0,
+        help="Unrecorded preconditioning requests per endpoint; default 0 retains first-observed evidence",
+    )
     parser.add_argument("--iterations", type=int, default=5, help="Recorded requests per endpoint")
     parser.add_argument("--page-size", type=int, default=50)
     parser.add_argument("--later-page-token", help="Optional History cursor to benchmark a later page")
@@ -159,6 +192,10 @@ def main() -> int:
         "warmups": args.warmups,
         "iterations": args.iterations,
         "page_size": args.page_size,
+        "first_observed_note": (
+            "The first recorded request is not guaranteed cold. Control deployment idleness "
+            "outside this harness when collecting cold-path evidence."
+        ),
         "runs": [],
         "summaries": [],
     }

--- a/scripts/benchmark_session_reads.py
+++ b/scripts/benchmark_session_reads.py
@@ -27,6 +27,8 @@ from urllib.request import Request, urlopen
 
 @dataclass(frozen=True)
 class Sample:
+    """One recorded benchmark observation for a single endpoint request."""
+
     endpoint: str
     iteration: int
     elapsed_ms: float
@@ -165,6 +167,7 @@ def _build_endpoints(page_size: int, later_page_token: str | None) -> list[str]:
 
 
 def main() -> int:
+    """Run the session-read benchmark and print a JSON report to stdout."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--base-url", required=True, help="Deployment URL, for example http://localhost:8000")
     parser.add_argument("--bearer-token", help="Access token for Authorization: Bearer")

--- a/tests/test_benchmark_session_reads.py
+++ b/tests/test_benchmark_session_reads.py
@@ -1,8 +1,11 @@
 """Focused tests for the session-read benchmark harness."""
+import pytest
+
 from scripts.benchmark_session_reads import (
     Sample,
     _build_endpoints,
     _parse_db_queries,
+    _select_endpoints,
     summarize,
 )
 
@@ -26,6 +29,24 @@ def test_build_endpoints_includes_optional_later_history_page() -> None:
         "/api/sessions/?page_size=25",
         "/api/sessions/?page_size=25&page_token=2026-08-01T12%3A00%3A00%2B00%3A00%2C42",
     ]
+
+
+def test_select_endpoints_supports_isolated_first_request_runs() -> None:
+    """Verify each endpoint can be measured without earlier endpoints preconditioning it."""
+    token = "2026-08-01T12:00:00+00:00,42"
+
+    assert _select_endpoints("current", 25, token) == ["/api/sessions/current/"]
+    assert _select_endpoints("history-first", 25, token) == ["/api/sessions/?page_size=25"]
+    assert _select_endpoints("history-later", 25, token) == [
+        "/api/sessions/?page_size=25&page_token=2026-08-01T12%3A00%3A00%2B00%3A00%2C42"
+    ]
+    assert _select_endpoints("all", 25, token) == _build_endpoints(25, token)
+
+
+def test_select_endpoints_requires_token_for_later_history_page() -> None:
+    """Verify an isolated later-page run cannot silently fall back to another endpoint."""
+    with pytest.raises(ValueError, match="history-later requires --later-page-token"):
+        _select_endpoints("history-later", 25, None)
 
 
 def test_summarize_separates_first_observed_from_steady_state() -> None:

--- a/tests/test_benchmark_session_reads.py
+++ b/tests/test_benchmark_session_reads.py
@@ -25,7 +25,7 @@ def test_build_endpoints_includes_optional_later_history_page() -> None:
     ]
 
 
-def test_summarize_reports_latency_payload_query_and_header_evidence() -> None:
+def test_summarize_separates_first_observed_from_steady_state() -> None:
     samples = [
         Sample(
             endpoint="/api/sessions/current/",
@@ -49,14 +49,64 @@ def test_summarize_reports_latency_payload_query_and_header_evidence() -> None:
             db_queries=0,
             server_timing="app;dur=19.5",
         ),
+        Sample(
+            endpoint="/api/sessions/current/",
+            iteration=3,
+            elapsed_ms=30.0,
+            status=200,
+            response_bytes=950,
+            request_id="req-3",
+            app_cache="HIT",
+            db_queries=0,
+            server_timing="app;dur=29.5",
+        ),
     ]
 
     assert summarize(samples) == {
         "endpoint": "/api/sessions/current/",
-        "samples": 2,
-        "elapsed_ms": {"min": 20.0, "median": 30.0, "max": 40.0, "mean": 30.0},
-        "response_bytes": {"min": 900, "max": 1000},
-        "db_queries": {"reported_samples": 2, "min": 0, "max": 8},
-        "cache_states": {"MISS": 1, "HIT": 1},
-        "missing_server_timing": 1,
+        "first_observed": {
+            "elapsed_ms": 40.0,
+            "status": 200,
+            "response_bytes": 1000,
+            "request_id": "req-1",
+            "app_cache": "MISS",
+            "db_queries": 8,
+            "server_timing": None,
+        },
+        "steady_state": {
+            "samples": 2,
+            "elapsed_ms": {"min": 20.0, "median": 25.0, "max": 30.0, "mean": 25.0},
+            "response_bytes": {"min": 900, "max": 950},
+            "db_queries": {"reported_samples": 2, "min": 0, "max": 0},
+            "cache_states": {"HIT": 2},
+            "missing_server_timing": 0,
+        },
+        "all_recorded": {
+            "samples": 3,
+            "elapsed_ms": {"min": 20.0, "median": 30.0, "max": 40.0, "mean": 30.0},
+            "response_bytes": {"min": 900, "max": 1000},
+            "db_queries": {"reported_samples": 3, "min": 0, "max": 8},
+            "cache_states": {"MISS": 1, "HIT": 2},
+            "missing_server_timing": 1,
+        },
     }
+
+
+def test_summarize_handles_a_single_recorded_sample() -> None:
+    sample = Sample(
+        endpoint="/api/sessions/?page_size=50",
+        iteration=1,
+        elapsed_ms=15.0,
+        status=200,
+        response_bytes=500,
+        request_id=None,
+        app_cache=None,
+        db_queries=None,
+        server_timing=None,
+    )
+
+    summary = summarize([sample])
+
+    assert summary["first_observed"]["elapsed_ms"] == 15.0
+    assert summary["steady_state"] is None
+    assert summary["all_recorded"]["samples"] == 1

--- a/tests/test_benchmark_session_reads.py
+++ b/tests/test_benchmark_session_reads.py
@@ -1,3 +1,4 @@
+"""Focused tests for the session-read benchmark harness."""
 from scripts.benchmark_session_reads import (
     Sample,
     _build_endpoints,
@@ -7,6 +8,7 @@ from scripts.benchmark_session_reads import (
 
 
 def test_parse_db_queries_handles_missing_and_invalid_headers() -> None:
+    """Verify the header parser correctly handles missing, empty, invalid, and valid values."""
     assert _parse_db_queries(None) is None
     assert _parse_db_queries("") is None
     assert _parse_db_queries("unknown") is None
@@ -14,6 +16,7 @@ def test_parse_db_queries_handles_missing_and_invalid_headers() -> None:
 
 
 def test_build_endpoints_includes_optional_later_history_page() -> None:
+    """Verify endpoint construction includes the optional later-History-page entry."""
     assert _build_endpoints(25, None) == [
         "/api/sessions/current/",
         "/api/sessions/?page_size=25",
@@ -26,6 +29,7 @@ def test_build_endpoints_includes_optional_later_history_page() -> None:
 
 
 def test_summarize_separates_first_observed_from_steady_state() -> None:
+    """Verify summarize splits first-observed evidence from steady-state aggregate."""
     samples = [
         Sample(
             endpoint="/api/sessions/current/",
@@ -93,6 +97,7 @@ def test_summarize_separates_first_observed_from_steady_state() -> None:
 
 
 def test_summarize_handles_a_single_recorded_sample() -> None:
+    """Verify summarize correctly reports a single-sample run with no steady state."""
     sample = Sample(
         endpoint="/api/sessions/?page_size=50",
         iteration=1,

--- a/tests/test_benchmark_session_reads.py
+++ b/tests/test_benchmark_session_reads.py
@@ -1,0 +1,62 @@
+from scripts.benchmark_session_reads import (
+    Sample,
+    _build_endpoints,
+    _parse_db_queries,
+    summarize,
+)
+
+
+def test_parse_db_queries_handles_missing_and_invalid_headers() -> None:
+    assert _parse_db_queries(None) is None
+    assert _parse_db_queries("") is None
+    assert _parse_db_queries("unknown") is None
+    assert _parse_db_queries("7") == 7
+
+
+def test_build_endpoints_includes_optional_later_history_page() -> None:
+    assert _build_endpoints(25, None) == [
+        "/api/sessions/current/",
+        "/api/sessions/?page_size=25",
+    ]
+    assert _build_endpoints(25, "2026-08-01T12:00:00+00:00,42") == [
+        "/api/sessions/current/",
+        "/api/sessions/?page_size=25",
+        "/api/sessions/?page_size=25&page_token=2026-08-01T12%3A00%3A00%2B00%3A00%2C42",
+    ]
+
+
+def test_summarize_reports_latency_payload_query_and_header_evidence() -> None:
+    samples = [
+        Sample(
+            endpoint="/api/sessions/current/",
+            iteration=1,
+            elapsed_ms=40.0,
+            status=200,
+            response_bytes=1000,
+            request_id="req-1",
+            app_cache="MISS",
+            db_queries=8,
+            server_timing=None,
+        ),
+        Sample(
+            endpoint="/api/sessions/current/",
+            iteration=2,
+            elapsed_ms=20.0,
+            status=200,
+            response_bytes=900,
+            request_id="req-2",
+            app_cache="HIT",
+            db_queries=0,
+            server_timing="app;dur=19.5",
+        ),
+    ]
+
+    assert summarize(samples) == {
+        "endpoint": "/api/sessions/current/",
+        "samples": 2,
+        "elapsed_ms": {"min": 20.0, "median": 30.0, "max": 40.0, "mean": 30.0},
+        "response_bytes": {"min": 900, "max": 1000},
+        "db_queries": {"reported_samples": 2, "min": 0, "max": 8},
+        "cache_states": {"MISS": 1, "HIT": 1},
+        "missing_server_timing": 1,
+    }


### PR DESCRIPTION
## Stage scope

Adds the repeatable evidence harness required by #700 before changing the current-session and History query plans.

Part of #700 and #687.

## Changes

- Adds `scripts/benchmark_session_reads.py`, a dependency-free authenticated benchmark for:
  - `GET /api/sessions/current/`
  - the first History page
  - an optional later History page using a supplied cursor
- Records per-request elapsed time, status, response bytes, `X-Request-ID`, `X-App-Cache`, `X-App-DB-Queries`, and `Server-Timing`.
- Separates the first observed request from later steady-state samples instead of discarding it as a default warmup.
- Clearly states that first-observed evidence is not proof of a cold deployment; deployment idleness must be controlled externally for cold-path measurements.
- Produces stable JSON summaries for first-observed/steady-state comparison, payload bounds, cache behavior, query-count ranges, and missing timing headers.
- Supports bearer-token or raw-cookie authentication and optional report-file output.
- Adds focused tests for header parsing, endpoint construction, first-observed evidence, steady-state aggregation, and single-sample behavior.

## Why this is a bounded stage

This PR does not claim to optimize the database pipeline yet. It turns #700's validation section into a repeatable executable loop so subsequent set-based query changes can prove their effect instead of relying on manual HAR inspection.

The harness cannot force Vercel, Neon, or application caches into a cold state. For a cold-path run, the operator must establish the required idle conditions before invoking it and interpret the separately reported first-observed sample accordingly.

## Remaining #700 work

- Select only the newest potentially active session.
- Share event aggregation for ladder and current-die derivation.
- Remove repeated page-size-squared filtering in History.
- Bulk-load active-thread issue metadata.
- Add phase-level structured instrumentation inside the endpoints.
- Run the new harness against local, preview, and production deployments before and after those changes.

## Verification

CI is the source of truth for the full repository matrix. Focused coverage is in `tests/test_benchmark_session_reads.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line benchmark for authenticated session and history reads.
  * Supports bearer-token or cookie authentication, warmups, pagination, configurable iterations, timeouts, and page sizes.
  * Reports response timing, status, payload size, caching, request metadata, database-query counts, and server timing.
  * Supports human-readable or JSON output, including optional file export.
* **Tests**
  * Added coverage for request construction, response metadata parsing, summary metrics, caching, timing, and single-sample results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->