### PR TITLE
fix(ui): make bug report modal fit narrow iOS viewports (#614)

### DIFF
--- a/frontend/src/components/BugReportModal.tsx
+++ b/frontend/src/components/BugReportModal.tsx
@@ -117,19 +117,19 @@ export default function BugReportModal({
           </div>
         )}
 
-        <div className="grid grid-cols-2 gap-3 pt-2">
+        <div className="grid grid-cols-1 min-[360px]:grid-cols-2 gap-3 pt-2">
           <button
             type="button"
             onClick={onClose}
             disabled={isSubmitting}
-            className="w-full py-3 bg-white/5 hover:bg-white/10 border border-white/10 rounded-xl text-[10px] font-black uppercase tracking-[0.2em] transition-all disabled:opacity-50"
+            className="w-full py-3 bg-white/5 hover:bg-white/10 border border-white/10 rounded-xl text-[10px] font-black uppercase tracking-[0.1em] min-[360px]:tracking-[0.2em] transition-all disabled:opacity-50"
           >
             Cancel
           </button>
           <button
             type="submit"
             disabled={isSubmitting || !title.trim() || !description.trim()}
-            className="w-full py-3 bg-amber-600/20 hover:bg-amber-600/30 border border-amber-600/50 rounded-xl text-[10px] font-black uppercase tracking-[0.2em] transition-all disabled:opacity-50"
+            className="w-full py-3 bg-amber-600/20 hover:bg-amber-600/30 border border-amber-600/50 rounded-xl text-[10px] font-black uppercase tracking-[0.1em] min-[360px]:tracking-[0.2em] transition-all disabled:opacity-50"
           >
             {isSubmitting ? 'Submitting...' : 'Submit Report'}
           </button>

--- a/frontend/src/test/bug-report-button.spec.ts
+++ b/frontend/src/test/bug-report-button.spec.ts
@@ -32,4 +32,31 @@ test.describe('Bug Report Button', () => {
     const modal = authenticatedPage.getByRole('dialog', { name: 'Report a Bug' })
     await expect(modal).toBeVisible({ timeout: 10000 })
   })
+
+  test('fits within a 320px-wide viewport without horizontal overflow', async ({ authenticatedPage }) => {
+    await authenticatedPage.setViewportSize({ width: 320, height: 568 })
+    await authenticatedPage.reload({ waitUntil: 'domcontentloaded' })
+
+    const reportButton = authenticatedPage.getByRole('button', { name: /report a bug/i }).last()
+    await expect(reportButton).toBeVisible()
+    await reportButton.click()
+
+    const modal = authenticatedPage.getByRole('dialog', { name: 'Report a Bug' })
+    await expect(modal).toBeVisible({ timeout: 10000 })
+
+    const titleInput = modal.getByLabel('Title')
+    const descriptionInput = modal.getByLabel('Description')
+
+    await titleInput.fill('Test bug on narrow screen')
+    await descriptionInput.fill('This is a test description for the bug report form on a 320px wide viewport.')
+
+    const submitButton = modal.getByRole('button', { name: 'Submit Report' })
+    const cancelButton = modal.getByRole('button', { name: 'Cancel' })
+
+    await expect(submitButton).toBeVisible()
+    await expect(cancelButton).toBeVisible()
+
+    await expect(titleInput).toHaveValue('Test bug on narrow screen')
+    await expect(descriptionInput).toHaveValue('This is a test description for the bug report form on a 320px wide viewport.')
+  })
 })

--- a/frontend/src/test/bug-report-button.spec.ts
+++ b/frontend/src/test/bug-report-button.spec.ts
@@ -47,8 +47,10 @@ test.describe('Bug Report Button', () => {
     const titleInput = modal.getByLabel('Title')
     const descriptionInput = modal.getByLabel('Description')
 
-    await titleInput.fill('Test bug on narrow screen')
-    await descriptionInput.fill('This is a test description for the bug report form on a 320px wide viewport.')
+    await titleInput.fill('Test bug on narrow screen with an intentionally long title')
+    await descriptionInput.fill(
+      'This is an intentionally long description that verifies the form content remains contained inside the dialog on a 320px-wide viewport without widening the page.',
+    )
 
     const submitButton = modal.getByRole('button', { name: 'Submit Report' })
     const cancelButton = modal.getByRole('button', { name: 'Cancel' })
@@ -56,7 +58,28 @@ test.describe('Bug Report Button', () => {
     await expect(submitButton).toBeVisible()
     await expect(cancelButton).toBeVisible()
 
-    await expect(titleInput).toHaveValue('Test bug on narrow screen')
-    await expect(descriptionInput).toHaveValue('This is a test description for the bug report form on a 320px wide viewport.')
+    const viewport = authenticatedPage.viewportSize()
+    const modalBox = await modal.boundingBox()
+    const submitBox = await submitButton.boundingBox()
+    const cancelBox = await cancelButton.boundingBox()
+
+    expect(viewport).not.toBeNull()
+    expect(modalBox).not.toBeNull()
+    expect(submitBox).not.toBeNull()
+    expect(cancelBox).not.toBeNull()
+
+    expect(modalBox!.x).toBeGreaterThanOrEqual(0)
+    expect(modalBox!.x + modalBox!.width).toBeLessThanOrEqual(viewport!.width)
+
+    for (const buttonBox of [submitBox!, cancelBox!]) {
+      expect(buttonBox.x).toBeGreaterThanOrEqual(modalBox!.x)
+      expect(buttonBox.x + buttonBox.width).toBeLessThanOrEqual(modalBox!.x + modalBox!.width)
+    }
+
+    const documentWidths = await authenticatedPage.evaluate(() => ({
+      clientWidth: document.documentElement.clientWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+    }))
+    expect(documentWidths.scrollWidth).toBeLessThanOrEqual(documentWidths.clientWidth)
   })
 })

--- a/frontend/src/test/bug-report-button.spec.ts
+++ b/frontend/src/test/bug-report-button.spec.ts
@@ -33,8 +33,8 @@ test.describe('Bug Report Button', () => {
     await expect(modal).toBeVisible({ timeout: 10000 })
   })
 
-  test('fits within a 320px-wide viewport without horizontal overflow', async ({ authenticatedPage }) => {
-    await authenticatedPage.setViewportSize({ width: 320, height: 568 })
+  test('fits and scrolls on a 320px-wide viewport without horizontal overflow', async ({ authenticatedPage }) => {
+    await authenticatedPage.setViewportSize({ width: 320, height: 400 })
     await authenticatedPage.reload({ waitUntil: 'domcontentloaded' })
 
     const reportButton = authenticatedPage.getByRole('button', { name: /report a bug/i }).last()
@@ -43,6 +43,14 @@ test.describe('Bug Report Button', () => {
 
     const modal = authenticatedPage.getByRole('dialog', { name: 'Report a Bug' })
     await expect(modal).toBeVisible({ timeout: 10000 })
+
+    // Exercise the validation-error state directly. The visible submit button is
+    // correctly disabled while required fields are blank, but the form handler
+    // still needs to keep its error message contained on a narrow viewport.
+    await modal.locator('form').evaluate(form => {
+      form.dispatchEvent(new SubmitEvent('submit', { bubbles: true, cancelable: true }))
+    })
+    await expect(modal.getByText('Title and description are required')).toBeVisible()
 
     const titleInput = modal.getByLabel('Title')
     const descriptionInput = modal.getByLabel('Description')
@@ -75,6 +83,18 @@ test.describe('Bug Report Button', () => {
       expect(buttonBox.x).toBeGreaterThanOrEqual(modalBox!.x)
       expect(buttonBox.x + buttonBox.width).toBeLessThanOrEqual(modalBox!.x + modalBox!.width)
     }
+
+    const scrollRegion = modal.locator('.overflow-y-auto')
+    const scrollMetrics = await scrollRegion.evaluate(element => ({
+      clientHeight: element.clientHeight,
+      scrollHeight: element.scrollHeight,
+    }))
+    expect(scrollMetrics.scrollHeight).toBeGreaterThan(scrollMetrics.clientHeight)
+
+    await scrollRegion.evaluate(element => {
+      element.scrollTop = element.scrollHeight
+    })
+    await expect.poll(() => scrollRegion.evaluate(element => element.scrollTop)).toBeGreaterThan(0)
 
     const documentWidths = await authenticatedPage.evaluate(() => ({
       clientWidth: document.documentElement.clientWidth,


### PR DESCRIPTION
Closes #614.

## Problem
The bug report modal was too wide on narrow iOS viewports (approximately 328px). The two-column button grid with wide letter-spacing caused the Submit Report button to overflow its grid cell, creating horizontal scroll.

## Fix
Stack action buttons vertically on viewports narrower than 360px and reduce letter-spacing at those widths so the modal fits within 320px-wide screens without horizontal overflow.

## Changes

- `frontend/src/components/BugReportModal.tsx`
  - Uses one button column below 360px and two columns at 360px and wider.
  - Reduces button letter-spacing below 360px.
- `frontend/src/test/bug-report-button.spec.ts`
  - Opens the modal at a 320×400 viewport.
  - Exercises the required-fields validation error state.
  - Enters intentionally long title and description text.
  - Asserts the dialog remains inside the viewport.
  - Asserts both action buttons remain inside the dialog.
  - Proves the modal content region overflows vertically and can be scrolled.
  - Asserts the document does not gain horizontal overflow.

## Acceptance evidence

| Criterion | Evidence |
|---|---|
| Modal fits within a 320px-wide viewport | Playwright asserts the dialog bounding box remains inside the 320px viewport. |
| Title, description, controls, and error states do not cause horizontal scrolling | Playwright renders the validation error, enters long form text, bounds both buttons to the dialog, and asserts `documentElement.scrollWidth <= clientWidth`. |
| Long text does not widen the modal | Covered by the same long-text narrow-viewport regression. |
| Modal remains internally scrollable when content exceeds viewport height | The 320×400 regression proves the modal scroll region has `scrollHeight > clientHeight`, scrolls it to the bottom, and asserts `scrollTop > 0`. |
| Existing desktop and mobile behavior remains intact | The original two-column layout and tracking remain active at 360px and wider; required CI validates the broader suite. |

## Verification

CI is the source of truth for the current revision. The initial revision passed CI run 605. The complete acceptance regression is now on `81062322`, and its required CI run must pass before this PR is ready.