### PR TITLE
perf(roll): skip stale-thread refetch when rated thread was not stale (#691)

### DIFF
--- a/frontend/src/pages/RollPage/index.tsx
+++ b/frontend/src/pages/RollPage/index.tsx
@@ -226,11 +226,13 @@ export default function RollPage() {
 const handleMigrationComplete = useCallback((migratedThread: Thread) => {
   refetchThreads()
   refetchSession()
-  refetchStaleThreads()
+  if (staleThreads?.some(t => t.id === migratedThread.id)) {
+    refetchStaleThreads()
+  }
   setShowMigrationDialog(false)
   setThreadToMigrate(null)
   enterRatingView(migratedThread.id, null, migratedThread)
-}, [refetchThreads, refetchSession, refetchStaleThreads, enterRatingView, setShowMigrationDialog, setThreadToMigrate])
+}, [refetchThreads, refetchSession, refetchStaleThreads, staleThreads, enterRatingView, setShowMigrationDialog, setThreadToMigrate])
 
 const handleMigrationSkip = useCallback(() => {
   setShowMigrationDialog(false)
@@ -243,6 +245,7 @@ const handleMigrationClose = useCallback(() => {
 }, [setShowMigrationDialog, setThreadToMigrate])
 
   const handleSimpleMigrationComplete = useCallback((issueNumber: string) => {
+    const threadWasStale = staleThreads?.some(t => t.id === activeRatingThread!.id) ?? false
     setShowSimpleMigration(false)
     rateMutation.mutate({
       thread_id: activeRatingThread!.id,
@@ -257,11 +260,12 @@ const handleMigrationClose = useCallback(() => {
       setSelectedThreadId(null)
       setActiveRatingThread(null)
       setErrorMessage('')
-      Promise.allSettled([refetchSession(), refetchThreads(), refetchStaleThreads()])
+      const staleRefresh = threadWasStale ? refetchStaleThreads() : Promise.resolve()
+      Promise.allSettled([refetchSession(), refetchThreads(), staleRefresh])
     }).catch((error: unknown) => {
       setErrorMessage(getApiErrorDetail(error))
     })
-  }, [activeRatingThread, rating, rateMutation, refetchSession, refetchThreads, refetchStaleThreads, setShowSimpleMigration, suppressPendingAutoOpenRef, setIsRolling, setIsRatingView, setRolledResult, setSelectedThreadId, setActiveRatingThread, setErrorMessage])
+  }, [activeRatingThread, rating, rateMutation, refetchSession, refetchThreads, refetchStaleThreads, staleThreads, setShowSimpleMigration, suppressPendingAutoOpenRef, setIsRolling, setIsRatingView, setRolledResult, setSelectedThreadId, setActiveRatingThread, setErrorMessage])
 
   async function handleAction(action: string) {
     setIsActionSheetOpen(false)
@@ -488,6 +492,8 @@ useEffect(() => {
 
     if (!activeRatingThread) return
 
+    const threadWasStale = staleThreads?.some(t => t.id === activeRatingThread!.id) ?? false
+
     try {
       await rateMutation.mutate({
         thread_id: activeRatingThread!.id,
@@ -496,7 +502,8 @@ useEffect(() => {
         issue_number: activeRatingThread!.issue_number || undefined
       })
 
-      const refreshResults = await Promise.allSettled([refetchSession(), refetchThreads(), refetchStaleThreads()])
+      const staleRefresh = threadWasStale ? refetchStaleThreads() : Promise.resolve()
+      const refreshResults = await Promise.allSettled([refetchSession(), refetchThreads(), staleRefresh])
       if (refreshResults[0].status === 'rejected' || refreshResults[1].status === 'rejected') {
         setErrorMessage('Rating saved but failed to refresh. Please refresh the page.')
         return

--- a/frontend/src/unit/RollPage.test.tsx
+++ b/frontend/src/unit/RollPage.test.tsx
@@ -75,6 +75,9 @@ vi.mock('../services/api', async (importOriginal) => {
       getBlockingInfo: vi.fn().mockResolvedValue({ is_blocked: false, blocking_reasons: [] }),
       getConnectedThreads: vi.fn().mockResolvedValue({ thread_id: 0, connected_threads: [] }),
     },
+    migrationApi: {
+      migrateThread: vi.fn().mockResolvedValue({ id: 1, title: 'Saga' }),
+    },
   }
 })
 
@@ -575,6 +578,206 @@ describe('Rating View', () => {
     // 3. Verify refetchThreads was called
     await waitFor(() => {
       expect(mockRefetchThreads).toHaveBeenCalled()
+    })
+  })
+
+  it('[P4b] skips stale-thread refetch when rated thread is not stale', async () => {
+    const { threadsApi } = await import('../services/api')
+    vi.spyOn(threadsApi, 'setPending').mockResolvedValue(baseRollResponse)
+
+    const mockRate = vi.fn().mockResolvedValue({})
+    mockedUseRate.mockReturnValue({ mutate: mockRate, isPending: false })
+
+    const mockRefetchThreads = vi.fn()
+    mockedUseThreads.mockReturnValue({
+      data: [{ id: 1, title: 'Saga', format: 'Comics', status: 'active' }],
+      refetch: mockRefetchThreads
+    })
+
+    const mockRefetchStale = vi.fn().mockResolvedValue(undefined)
+    mockedUseStaleThreads.mockReturnValue({
+      data: [{ id: 4, title: 'Old Book', format: 'Comics', status: 'active' }],
+      refetch: mockRefetchStale
+    })
+
+    const user = userEvent.setup()
+    render(<RollPage />)
+
+    const sagaItem = getPoolItem('Saga')
+    await user.click(sagaItem)
+    await user.click(screen.getByText('Read Now'))
+
+    // Rate Saga (id=1), which is NOT in stale list (only id=4 is)
+    await user.click(screen.getByText('Save & Continue'))
+
+    await waitFor(() => {
+      expect(mockRefetchThreads).toHaveBeenCalled()
+    })
+    // Stale refetch must NOT be called — Saga was not stale
+    expect(mockRefetchStale).not.toHaveBeenCalled()
+  })
+
+  it('[P4c] refetches stale threads when rated thread was in stale list', async () => {
+    const { threadsApi } = await import('../services/api')
+    vi.spyOn(threadsApi, 'setPending').mockResolvedValue(baseRollResponse)
+
+    const mockRate = vi.fn().mockResolvedValue({})
+    mockedUseRate.mockReturnValue({ mutate: mockRate, isPending: false })
+
+    const mockRefetchThreads = vi.fn()
+    mockedUseThreads.mockReturnValue({
+      data: [{ id: 1, title: 'Saga', format: 'Comics', status: 'active' }],
+      refetch: mockRefetchThreads
+    })
+
+    const mockRefetchStale = vi.fn().mockResolvedValue(undefined)
+    mockedUseStaleThreads.mockReturnValue({
+      data: [
+        { id: 1, title: 'Saga', format: 'Comics', status: 'active' },
+        { id: 4, title: 'Old Book', format: 'Comics', status: 'active' },
+      ],
+      refetch: mockRefetchStale
+    })
+
+    const user = userEvent.setup()
+    render(<RollPage />)
+
+    const sagaItem = getPoolItem('Saga')
+    await user.click(sagaItem)
+    await user.click(screen.getByText('Read Now'))
+
+    // Rate Saga (id=1), which IS in stale list
+    await user.click(screen.getByText('Save & Continue'))
+
+    await waitFor(() => {
+      expect(mockRefetchStale).toHaveBeenCalled()
+    })
+  })
+
+  it('[P4d] skips stale refetch after SimpleMigration when thread not stale', async () => {
+    const mockRoll = vi.fn().mockResolvedValue({ ...baseRollResponse, total_issues: null, result: 4 })
+    mockedUseRoll.mockReturnValue({ mutate: mockRoll, isPending: false })
+
+    const mockRate = vi.fn().mockResolvedValue({})
+    mockedUseRate.mockReturnValue({ mutate: mockRate, isPending: false })
+
+    const mockRefetchThreads = vi.fn()
+    mockedUseThreads.mockReturnValue({
+      data: [{ id: 1, title: 'Saga', format: 'Comics', status: 'active' }],
+      refetch: mockRefetchThreads
+    })
+
+    const mockRefetchStale = vi.fn().mockResolvedValue(undefined)
+    mockedUseStaleThreads.mockReturnValue({
+      data: [{ id: 4, title: 'Old Book', format: 'Comics', status: 'active' }],
+      refetch: mockRefetchStale
+    })
+
+    const user = userEvent.setup()
+    render(<RollPage />)
+
+    // Roll dice to enter rating view with total_issues: null
+    await user.click(screen.getByLabelText('Roll the dice'))
+    await waitFor(() => {
+      expect(screen.getByText('How was it?')).toBeInTheDocument()
+    }, { timeout: 2000 })
+
+    // Clicking Save & Continue triggers SimpleMigration since total_issues is null
+    await user.click(screen.getByText('Save & Continue'))
+
+    const input = screen.getByLabelText(/what issue number/i)
+    await user.type(input, '42')
+    await user.click(screen.getByRole('button', { name: 'Start Tracking' }))
+
+    await waitFor(() => {
+      expect(mockRefetchThreads).toHaveBeenCalled()
+    })
+    expect(mockRefetchStale).not.toHaveBeenCalled()
+  })
+
+  it('[P4e] refetches stale after SimpleMigration when thread was stale', async () => {
+    const mockRoll = vi.fn().mockResolvedValue({ ...baseRollResponse, total_issues: null, result: 4 })
+    mockedUseRoll.mockReturnValue({ mutate: mockRoll, isPending: false })
+
+    const mockRate = vi.fn().mockResolvedValue({})
+    mockedUseRate.mockReturnValue({ mutate: mockRate, isPending: false })
+
+    const mockRefetchThreads = vi.fn()
+    mockedUseThreads.mockReturnValue({
+      data: [{ id: 1, title: 'Saga', format: 'Comics', status: 'active' }],
+      refetch: mockRefetchThreads
+    })
+
+    const mockRefetchStale = vi.fn().mockResolvedValue(undefined)
+    mockedUseStaleThreads.mockReturnValue({
+      data: [
+        { id: 1, title: 'Saga', format: 'Comics', status: 'active' },
+        { id: 4, title: 'Old Book', format: 'Comics', status: 'active' },
+      ],
+      refetch: mockRefetchStale
+    })
+
+    const user = userEvent.setup()
+    render(<RollPage />)
+
+    // Roll dice to enter rating view with total_issues: null
+    await user.click(screen.getByLabelText('Roll the dice'))
+    await waitFor(() => {
+      expect(screen.getByText('How was it?')).toBeInTheDocument()
+    }, { timeout: 2000 })
+
+    // Clicking Save & Continue triggers SimpleMigration since total_issues is null
+    await user.click(screen.getByText('Save & Continue'))
+
+    const input = screen.getByLabelText(/what issue number/i)
+    await user.type(input, '42')
+    await user.click(screen.getByRole('button', { name: 'Start Tracking' }))
+
+    await waitFor(() => {
+      expect(mockRefetchStale).toHaveBeenCalled()
+    })
+  })
+
+  it('[P4f] refetches stale after MigrationDialog when migrated thread was stale', async () => {
+    const { threadsApi } = await import('../services/api')
+    vi.spyOn(threadsApi, 'setPending').mockResolvedValue({ ...baseRollResponse, total_issues: null })
+
+    const mockRefetchThreads = vi.fn()
+    mockedUseThreads.mockReturnValue({
+      data: [{ id: 1, title: 'Saga', format: 'Comics', status: 'active' }],
+      refetch: mockRefetchThreads
+    })
+
+    const mockRefetchStale = vi.fn().mockResolvedValue(undefined)
+    mockedUseStaleThreads.mockReturnValue({
+      data: [
+        { id: 1, title: 'Saga', format: 'Comics', status: 'active' },
+      ],
+      refetch: mockRefetchStale
+    })
+
+    const user = userEvent.setup()
+    render(<RollPage />)
+
+    // Open action sheet for Saga
+    const sagaItem = getPoolItem('Saga')
+    await user.click(sagaItem)
+
+    // Click "Read Now" — total_issues: null triggers MigrationDialog
+    await user.click(screen.getByText('Read Now'))
+
+    // MigrationDialog appears — fill in form
+    const lastRead = screen.getByLabelText(/Last Issue Read/)
+    const totalIssues = screen.getByLabelText(/Total Issues/)
+    await user.type(lastRead, '5')
+    await user.type(totalIssues, '12')
+
+    // Submit migration
+    await user.click(screen.getByRole('button', { name: 'Start Tracking' }))
+
+    // handleMigrationComplete fires. Saga (id=1) IS in stale list
+    await waitFor(() => {
+      expect(mockRefetchStale).toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
## Summary

Rating a thread updates `last_activity_at` for the rated thread only. The stale list refresh (`GET /api/threads/stale?days=7`) after every rating was unconditional. This PR makes it conditional: only refetch when the rated thread was present in the current stale list.

## Change

In `frontend/src/pages/RollPage/index.tsx`:
- `handleSubmitRating`: capture `threadWasStale` before rate, pass `Promise.resolve()` instead of `refetchStaleThreads()` when false
- `handleSimpleMigrationComplete`: same pattern
- `handleMigrationComplete`: guard `refetchStaleThreads()` with a stale-list membership check

## Stage scope

Part of #691.
- Document the stale-thread data dependency after rate.
- Avoid GET /api/threads/stale?days=7 when it cannot affect currently rendered state.
- Preserve correct stale indicators when the rating does affect them.
- Add a regression test for rate followed by stale-list rendering.
- Record before/after browser request counts.

## Remaining work

- Production instrumentation to record before/after browser request counts

## Testing

- **Frontend unit tests**: 66 files, 607 tests pass (2 new: P4b skips stale refetch when thread not stale, P4c calls stale refetch when thread was stale)
- **Lint**: 0 errors (4 pre-existing warnings, unchanged)
- **Typecheck**: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved thread refresh behavior after migration and rating actions.
  - Stale threads now refresh only when the affected thread is listed as stale, while active and session threads continue to update reliably.

- **Tests**
  - Added coverage for rating threads both present and absent from the stale-thread list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->