### PR TITLE
refactor(collections): remove frontend provider lifecycle (#636)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,7 +12,6 @@ import type { DiagnosticData } from './hooks/useDiagnostics'
 import { ToastProvider } from './contexts/ToastProvider'
 import { CacheProvider } from './contexts/CacheContext'
 import { BugReportRestoreProvider } from './contexts/BugReportRestoreContext'
-import { CollectionProvider } from './contexts/CollectionContext'
 import './index.css'
 
 declare global {
@@ -343,9 +342,7 @@ function App() {
           <ToastProvider>
             <CacheProvider>
               <AuthProvider>
-                <AuthenticatedCollectionProvider>
-                  <AppRoutes />
-                </AuthenticatedCollectionProvider>
+                <AppRoutes />
               </AuthProvider>
             </CacheProvider>
           </ToastProvider>
@@ -353,16 +350,6 @@ function App() {
       </QueryClientProvider>
     </BrowserRouter>
   )
-}
-
-function AuthenticatedCollectionProvider({ children }: { children: ReactNode }) {
-  const { isAuthenticated } = useAuth()
-
-  if (!isAuthenticated) {
-    return children
-  }
-
-  return <CollectionProvider>{children}</CollectionProvider>
 }
 
 export { AppRoutes }

--- a/frontend/src/contexts/CollectionContext.tsx
+++ b/frontend/src/contexts/CollectionContext.tsx
@@ -1,5 +1,3 @@
-import { createContext, useContext } from 'react'
-import type { ReactNode } from 'react'
 import type { Collection, CollectionCreate, CollectionUpdate } from '../types'
 
 interface CollectionError {
@@ -7,7 +5,7 @@ interface CollectionError {
   status?: number
 }
 
-interface CollectionContextType {
+interface RemovedCollectionsState {
   collections: Collection[]
   activeCollectionId: number | null
   setActiveCollectionId: (id: number | null) => void
@@ -20,7 +18,7 @@ interface CollectionContextType {
   retry: () => void
 }
 
-const removedCollectionsContext: CollectionContextType = {
+const removedCollectionsState: RemovedCollectionsState = {
   collections: [],
   activeCollectionId: null,
   setActiveCollectionId: () => undefined,
@@ -33,23 +31,11 @@ const removedCollectionsContext: CollectionContextType = {
   retry: () => undefined,
 }
 
-const CollectionContext = createContext<CollectionContextType>(removedCollectionsContext)
-
 /**
- * Transitional compatibility provider for #636.
- *
- * Collections are no longer loaded, persisted, selected, or mutated. This
- * provider remains only while the remaining Roll and Queue callers are removed
- * in follow-up slices, after which this file can be deleted entirely.
+ * Temporary caller shim while the last Roll and Queue collection branches are
+ * deleted under #636. It owns no React state, context, persistence, requests,
+ * or mutation behavior and therefore requires no provider in the app shell.
  */
-export function CollectionProvider({ children }: { children: ReactNode }) {
-  return (
-    <CollectionContext.Provider value={removedCollectionsContext}>
-      {children}
-    </CollectionContext.Provider>
-  )
-}
-
-export function useCollections() {
-  return useContext(CollectionContext)
+export function useCollections(): RemovedCollectionsState {
+  return removedCollectionsState
 }

--- a/frontend/src/contexts/CollectionContext.tsx
+++ b/frontend/src/contexts/CollectionContext.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import type { Collection, CollectionCreate, CollectionUpdate } from '../types'
 
 interface CollectionError {
@@ -29,6 +30,14 @@ const removedCollectionsState: RemovedCollectionsState = {
   isLoading: false,
   error: null,
   retry: () => undefined,
+}
+
+/**
+ * Inert compatibility wrapper for test harnesses that still render the removed
+ * provider boundary. It creates no context, state, persistence, or requests.
+ */
+export function CollectionProvider({ children }: { children: ReactNode }) {
+  return children
 }
 
 /**

--- a/frontend/src/unit/CollectionContext.test.tsx
+++ b/frontend/src/unit/CollectionContext.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import {
+  CollectionProvider,
+  useCollections,
+} from '../contexts/CollectionContext'
+
+describe('removed Collections compatibility shim', () => {
+  it('renders children without creating a provider-owned lifecycle', () => {
+    render(
+      <CollectionProvider>
+        <span>provider-free child</span>
+      </CollectionProvider>,
+    )
+
+    expect(screen.getByText('provider-free child')).toBeInTheDocument()
+  })
+
+  it('returns one stable inert state with no persistence or mutation behavior', async () => {
+    const firstState = useCollections()
+    const secondState = useCollections()
+
+    expect(secondState).toBe(firstState)
+    expect(firstState.collections).toEqual([])
+    expect(firstState.activeCollectionId).toBeNull()
+    expect(firstState.isLoading).toBe(false)
+    expect(firstState.error).toBeNull()
+
+    expect(firstState.setActiveCollectionId(42)).toBeUndefined()
+    expect(firstState.retry()).toBeUndefined()
+    await expect(firstState.createCollection({ name: 'Removed' })).resolves.toBeUndefined()
+    await expect(
+      firstState.updateCollection(1, { name: 'Still removed' }),
+    ).resolves.toBeUndefined()
+    await expect(firstState.deleteCollection(1)).resolves.toBeUndefined()
+    await expect(firstState.moveCollection(1, 2)).resolves.toBeUndefined()
+
+    expect(useCollections()).toBe(firstState)
+    expect(firstState.collections).toEqual([])
+    expect(firstState.activeCollectionId).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Removes the authenticated Collections provider lifecycle from the application shell and collapses the remaining compatibility module to a stateless temporary caller shim.

Part of #636.

## Stage scope

This stage removes the last active React provider/context architecture owned solely by Collections:

- `App` no longer imports or mounts `CollectionProvider` after authentication.
- The compatibility module no longer creates React context, mounts a provider, or participates in the component lifecycle.
- Remaining Roll and Queue callers continue to receive the fixed removed-feature state while their collection-specific branches are deleted in the next stage.

## Why this is staged

RollPage and QueuePage are large, heavily tested files that currently overlap active performance work. This PR removes the provider boundary without colliding with PR #723 and without claiming that all frontend callers, backend routes, or persistence are gone.

## Remaining work

- Delete remaining `useCollections` callers and collection props/state from Roll and Queue.
- Delete the temporary compatibility module once no imports remain.
- Remove collection API clients, types, request parameters, backend routes, schemas, models, services, persistence, fixtures, and documentation.

## Verification

CI will validate TypeScript, lint, frontend unit coverage, backend tests, migrations, and API E2E on the exact head SHA. No local result is claimed because this runtime does not have a repository checkout.

This PR must remain non-draft and must not be merged without Josh's explicit authorization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified collection handling to prevent unnecessary provider-related issues.
  * Removed collection persistence, requests, and mutations from the application flow.
  * Streamlined application startup by eliminating the authenticated collection wrapper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->