### PR TITLE
feat(query): define retained resource key factories (#702)

### DIFF
--- a/frontend/src/query/queryKeys.ts
+++ b/frontend/src/query/queryKeys.ts
@@ -1,3 +1,85 @@
-export const queryKeys = {
-    collections: ['collections'] as const,
+export type QueueSort = 'position' | 'alphabetical' | 'created'
+
+export interface QueuePageKeyOptions {
+  search?: string
+  sort: QueueSort
+  pageToken?: string | null
+  pageSize: number
 }
+
+export interface SessionPageKeyOptions {
+  pageToken?: string | null
+  pageSize: number
+}
+
+export interface ThreadIssuePageKeyOptions {
+  pageToken?: string | null
+  pageSize: number
+  status?: 'read' | 'unread'
+}
+
+function normalizedSearch(search?: string): string | null {
+  const value = search?.trim()
+  return value ? value : null
+}
+
+export const queryKeys = {
+  session: {
+    all: ['session'] as const,
+    current: () => ['session', 'current'] as const,
+    pages: () => ['session', 'pages'] as const,
+    page: ({ pageToken, pageSize }: SessionPageKeyOptions) =>
+      ['session', 'pages', { pageToken: pageToken ?? null, pageSize }] as const,
+    detail: (sessionId: number) => ['session', 'detail', sessionId] as const,
+  },
+  queue: {
+    all: ['queue'] as const,
+    pages: () => ['queue', 'pages'] as const,
+    page: ({ search, sort, pageToken, pageSize }: QueuePageKeyOptions) =>
+      [
+        'queue',
+        'pages',
+        {
+          search: normalizedSearch(search),
+          sort,
+          pageToken: pageToken ?? null,
+          pageSize,
+        },
+      ] as const,
+  },
+  roll: {
+    all: ['roll'] as const,
+    bootstrap: () => ['roll', 'bootstrap'] as const,
+  },
+  thread: {
+    all: ['thread'] as const,
+    summaries: () => ['thread', 'summary'] as const,
+    summary: (threadId: number) => ['thread', 'summary', threadId] as const,
+    details: () => ['thread', 'detail'] as const,
+    detail: (threadId: number) => ['thread', 'detail', threadId] as const,
+    issuePages: (threadId: number) => ['thread', threadId, 'issues'] as const,
+    issuePage: (
+      threadId: number,
+      { pageToken, pageSize, status }: ThreadIssuePageKeyOptions,
+    ) =>
+      [
+        'thread',
+        threadId,
+        'issues',
+        {
+          pageToken: pageToken ?? null,
+          pageSize,
+          status: status ?? null,
+        },
+      ] as const,
+  },
+  dependencies: {
+    all: ['dependencies'] as const,
+    forThread: (threadId: number) => ['dependencies', 'thread', threadId] as const,
+    blocking: (threadId: number) => ['dependencies', 'blocking', threadId] as const,
+  },
+  analytics: {
+    all: ['analytics'] as const,
+    overview: () => ['analytics', 'overview'] as const,
+  },
+} as const

--- a/frontend/src/unit/queryKeys.test.ts
+++ b/frontend/src/unit/queryKeys.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { queryKeys } from '../query/queryKeys'
+
+describe('queryKeys', () => {
+  it('builds stable session keys with pagination inputs', () => {
+    expect(queryKeys.session.current()).toEqual(['session', 'current'])
+    expect(queryKeys.session.page({ pageSize: 25 })).toEqual([
+      'session',
+      'pages',
+      { pageToken: null, pageSize: 25 },
+    ])
+    expect(queryKeys.session.detail(42)).toEqual(['session', 'detail', 42])
+  })
+
+  it('normalizes queue search and includes every page-shaping input', () => {
+    expect(
+      queryKeys.queue.page({
+        search: '  Saga  ',
+        sort: 'alphabetical',
+        pageToken: 'next-1',
+        pageSize: 50,
+      }),
+    ).toEqual([
+      'queue',
+      'pages',
+      {
+        search: 'Saga',
+        sort: 'alphabetical',
+        pageToken: 'next-1',
+        pageSize: 50,
+      },
+    ])
+
+    expect(
+      queryKeys.queue.page({
+        search: '   ',
+        sort: 'position',
+        pageSize: 20,
+      }),
+    ).toEqual([
+      'queue',
+      'pages',
+      {
+        search: null,
+        sort: 'position',
+        pageToken: null,
+        pageSize: 20,
+      },
+    ])
+  })
+
+  it('scopes thread details, issue pages, and dependency data by resource id', () => {
+    expect(queryKeys.thread.detail(7)).toEqual(['thread', 'detail', 7])
+    expect(
+      queryKeys.thread.issuePage(7, {
+        pageToken: 'issues-2',
+        pageSize: 100,
+        status: 'unread',
+      }),
+    ).toEqual([
+      'thread',
+      7,
+      'issues',
+      {
+        pageToken: 'issues-2',
+        pageSize: 100,
+        status: 'unread',
+      },
+    ])
+    expect(queryKeys.dependencies.forThread(7)).toEqual(['dependencies', 'thread', 7])
+    expect(queryKeys.dependencies.blocking(7)).toEqual(['dependencies', 'blocking', 7])
+  })
+
+  it('defines retained roll and analytics roots without a collections key family', () => {
+    expect(queryKeys.roll.bootstrap()).toEqual(['roll', 'bootstrap'])
+    expect(queryKeys.analytics.overview()).toEqual(['analytics', 'overview'])
+    expect('collections' in queryKeys).toBe(false)
+  })
+})

--- a/frontend/src/unit/queryKeys.test.ts
+++ b/frontend/src/unit/queryKeys.test.ts
@@ -3,16 +3,25 @@ import { queryKeys } from '../query/queryKeys'
 
 describe('queryKeys', () => {
   it('builds stable session keys with pagination inputs', () => {
+    expect(queryKeys.session.all).toEqual(['session'])
     expect(queryKeys.session.current()).toEqual(['session', 'current'])
+    expect(queryKeys.session.pages()).toEqual(['session', 'pages'])
     expect(queryKeys.session.page({ pageSize: 25 })).toEqual([
       'session',
       'pages',
       { pageToken: null, pageSize: 25 },
     ])
+    expect(queryKeys.session.page({ pageToken: 'sessions-2', pageSize: 10 })).toEqual([
+      'session',
+      'pages',
+      { pageToken: 'sessions-2', pageSize: 10 },
+    ])
     expect(queryKeys.session.detail(42)).toEqual(['session', 'detail', 42])
   })
 
   it('normalizes queue search and includes every page-shaping input', () => {
+    expect(queryKeys.queue.all).toEqual(['queue'])
+    expect(queryKeys.queue.pages()).toEqual(['queue', 'pages'])
     expect(
       queryKeys.queue.page({
         search: '  Saga  ',
@@ -49,8 +58,13 @@ describe('queryKeys', () => {
     ])
   })
 
-  it('scopes thread details, issue pages, and dependency data by resource id', () => {
+  it('scopes every thread and dependency key by resource id', () => {
+    expect(queryKeys.thread.all).toEqual(['thread'])
+    expect(queryKeys.thread.summaries()).toEqual(['thread', 'summary'])
+    expect(queryKeys.thread.summary(7)).toEqual(['thread', 'summary', 7])
+    expect(queryKeys.thread.details()).toEqual(['thread', 'detail'])
     expect(queryKeys.thread.detail(7)).toEqual(['thread', 'detail', 7])
+    expect(queryKeys.thread.issuePages(7)).toEqual(['thread', 7, 'issues'])
     expect(
       queryKeys.thread.issuePage(7, {
         pageToken: 'issues-2',
@@ -67,12 +81,25 @@ describe('queryKeys', () => {
         status: 'unread',
       },
     ])
+    expect(queryKeys.thread.issuePage(7, { pageSize: 25 })).toEqual([
+      'thread',
+      7,
+      'issues',
+      {
+        pageToken: null,
+        pageSize: 25,
+        status: null,
+      },
+    ])
+    expect(queryKeys.dependencies.all).toEqual(['dependencies'])
     expect(queryKeys.dependencies.forThread(7)).toEqual(['dependencies', 'thread', 7])
     expect(queryKeys.dependencies.blocking(7)).toEqual(['dependencies', 'blocking', 7])
   })
 
   it('defines retained roll and analytics roots without a collections key family', () => {
+    expect(queryKeys.roll.all).toEqual(['roll'])
     expect(queryKeys.roll.bootstrap()).toEqual(['roll', 'bootstrap'])
+    expect(queryKeys.analytics.all).toEqual(['analytics'])
     expect(queryKeys.analytics.overview()).toEqual(['analytics', 'overview'])
     expect('collections' in queryKeys).toBe(false)
   })


### PR DESCRIPTION
## Summary

Introduces typed, centralized TanStack Query key factories for retained ComicPile resources and deletes the collection-only key family.

Part of #702.

## Stage scope

This bounded foundation stage defines stable key contracts for:

- current session, session pages, and session details;
- Queue pages with search, sort, cursor, and page size represented in the key;
- Roll bootstrap state;
- thread summaries, thread details, and paginated issue lists;
- dependency and blocking reads;
- analytics overview data.

It also adds focused tests that lock exact key shapes, search normalization, pagination inputs, resource IDs, and the absence of a Collections key family.

## Remaining work

- Migrate retained hooks to these key factories as their bounded API contracts land.
- Document and implement authoritative cache updates or narrow invalidation for rating, queue movement, snooze, thread edits, and issue edits.
- Add optimistic rollback where interaction quality warrants it.
- Prove at least three high-frequency mutations no longer trigger broad page-wide refetches.
- Remove the old custom cache plumbing after all retained callers migrate.

## Collision boundary

This PR does not touch the active #636 provider-removal branch, QueuePage, RollPage, or mutation hooks. Collections remain a deletion target and receive no key, compatibility contract, or modernization.

## Verification

No local result is claimed because this automation runtime does not have a repository checkout. CI must validate frontend lint, typecheck, unit coverage, and the broader required matrix on the exact head SHA.

This PR is non-draft and must not be merged without Josh's explicit authorization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured query support for sessions, queues, rolls, threads, dependencies, and analytics.
  * Added pagination, filtering, sorting, status, detail, summary, and relationship query options.
  * Added queue sorting by position, alphabetical order, or creation date.

* **Bug Fixes**
  * Improved consistency for queue searches and thread issue status filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->