### PR TITLE
refactor(session): consolidate History and current-session read pipelines (#700)

### DIFF
--- a/app/api/session.py
+++ b/app/api/session.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_current_user
@@ -85,6 +85,54 @@ async def _fetch_thread_issue_metadata(
     if next_issue:
         return next_issue.id, next_issue.issue_number
     return None, None
+
+
+async def _bulk_unread_counts(threads: list[Thread], db: AsyncSession) -> dict[int, int]:
+    """Bulk-load unread issue counts for migrated threads in one grouped query.
+
+    Unmigrated threads (``total_issues`` null) fall back to their stored
+    ``issues_remaining`` value and are omitted from the returned map.
+
+    Args:
+        threads: Threads that may appear as an active thread in the History page.
+        db: Database session.
+
+    Returns:
+        Mapping of migrated thread ID to its unread issue count.
+    """
+    migrated_ids = [t.id for t in threads if t.uses_issue_tracking()]
+    if not migrated_ids:
+        return {}
+
+    result = await db.execute(
+        select(Issue.thread_id, func.count())
+        .where(Issue.thread_id.in_(migrated_ids))
+        .where(Issue.status == "unread")
+        .group_by(Issue.thread_id)
+    )
+    return {row[0]: row[1] for row in result.all()}
+
+
+async def _bulk_next_issue_numbers(threads: list[Thread], db: AsyncSession) -> dict[int, str]:
+    """Bulk-load next-unread issue numbers in one query.
+
+    Args:
+        threads: Threads that may appear as an active thread in the History page.
+        db: Database session.
+
+    Returns:
+        Mapping of issue ID to issue number for every referenced next-unread issue.
+    """
+    issue_ids = {
+        t.next_unread_issue_id
+        for t in threads
+        if t.uses_issue_tracking() and t.next_unread_issue_id is not None
+    }
+    if not issue_ids:
+        return {}
+
+    result = await db.execute(select(Issue.id, Issue.issue_number).where(Issue.id.in_(issue_ids)))
+    return {row[0]: row[1] for row in result.all()}
 
 
 async def get_session_with_thread_safe(
@@ -453,7 +501,7 @@ async def list_sessions(
         SessionHistoryListResponse with paginated sessions and next_page_token if more exist.
     """
     from fastapi import HTTPException, status
-    from sqlalchemy import func, or_
+    from sqlalchemy import or_
 
     query = select(SessionModel).where(SessionModel.user_id == current_user.id)
     query = query.order_by(SessionModel.started_at.desc(), SessionModel.id.desc())
@@ -538,14 +586,26 @@ async def list_sessions(
     if thread_ids:
         threads_result = await db.execute(select(Thread).where(Thread.id.in_(thread_ids)))
         threads_by_id = {t.id: t for t in threads_result.scalars().all()}
+        threads = list(threads_by_id.values())
+        unread_counts = await _bulk_unread_counts(threads, db)
+        issue_numbers = await _bulk_next_issue_numbers(threads, db)
 
         for sid in session_ids:
             roll_event = projection.latest_roll_by_session.get(sid)
             if roll_event is not None and roll_event.selected_thread_id is not None:
                 thread = threads_by_id.get(roll_event.selected_thread_id)
                 if thread:
-                    issues_remaining = await thread.get_issues_remaining(db)
-                    issue_id, issue_number = await _fetch_thread_issue_metadata(thread, db)
+                    if thread.uses_issue_tracking():
+                        issues_remaining = unread_counts.get(thread.id, 0)
+                    else:
+                        issues_remaining = thread.issues_remaining
+                    issue_id: int | None = None
+                    issue_number: str | None = None
+                    if thread.uses_issue_tracking() and thread.next_unread_issue_id is not None:
+                        resolved_number = issue_numbers.get(thread.next_unread_issue_id)
+                        if resolved_number is not None:
+                            issue_id = thread.next_unread_issue_id
+                            issue_number = resolved_number
                     active_threads_dict[sid] = ActiveThreadInfo(
                         id=thread.id,
                         title=thread.title,

--- a/app/api/session.py
+++ b/app/api/session.py
@@ -25,6 +25,7 @@ from app.schemas import (
 )
 from app.schemas.session import SnoozedThreadInfo
 from app.services.ownership import get_owned_session_or_404
+from app.services.session_history_projection import project_session_history_events
 from comic_pile.dependencies import refresh_user_blocked_status
 from comic_pile.session import get_current_die, get_or_create, is_active
 
@@ -488,15 +489,20 @@ async def list_sessions(
 
     session_ids = [s.id for s in sessions_to_return]
 
-    active_threads_result = await db.execute(
+    history_events_result = await db.execute(
         select(Event)
         .where(Event.session_id.in_(session_ids))
-        .where(Event.type == "roll")
-        .where(Event.selected_thread_id.is_not(None))
-        .distinct(Event.session_id)
-        .order_by(Event.session_id, Event.timestamp.desc())
+        .where(
+            or_(
+                (Event.type == "roll") & (Event.selected_thread_id.is_not(None)),
+                (Event.type.in_(("rate", "snooze", "undo"))) & (Event.die_after.is_not(None)),
+            )
+        )
+        .order_by(Event.session_id, Event.timestamp, Event.id)
     )
-    active_thread_events = active_threads_result.scalars().all()
+    history_events = history_events_result.scalars().all()
+
+    projection = project_session_history_events(session_ids, history_events)
 
     snapshot_count_result = await db.execute(
         select(Snapshot.session_id, func.count())
@@ -505,56 +511,28 @@ async def list_sessions(
     )
     snapshot_counts = {row[0]: row[1] for row in snapshot_count_result.all()}
 
-    ladder_events_result = await db.execute(
-        select(Event)
-        .where(Event.session_id.in_(session_ids))
-        .where(Event.type.in_(("rate", "snooze", "undo")))
-        .where(Event.die_after.is_not(None))
-        .order_by(Event.session_id, Event.timestamp, Event.id)
-    )
-    ladder_events = ladder_events_result.scalars().all()
-
-    die_events_result = await db.execute(
-        select(Event)
-        .where(Event.session_id.in_(session_ids))
-        .where(Event.type.in_(("rate", "snooze", "undo")))
-        .where(Event.die_after.is_not(None))
-        .order_by(Event.session_id, Event.timestamp.desc(), Event.id.desc())
-    )
-    die_events = die_events_result.scalars().all()
+    sessions_by_id = {s.id: s for s in sessions_to_return}
 
     ladder_paths: dict[int, str] = {}
     for sid in session_ids:
-        sid_events = [e for e in ladder_events if e.session_id == sid]
-        session = next(s for s in sessions_to_return if s.id == sid)
-        if not sid_events:
-            ladder_paths[sid] = str(session.start_die)
-            continue
-        path = [session.start_die]
-        for event in sid_events:
-            if event.die_after:
-                path.append(event.die_after)
+        session = sessions_by_id[sid]
+        die_path = projection.die_path_by_session[sid]
+        path = [session.start_die, *die_path]
         ladder_paths[sid] = " → ".join(str(d) for d in path)
 
     current_die: dict[int, int] = {}
     for sid in session_ids:
-        session = next(s for s in sessions_to_return if s.id == sid)
+        session = sessions_by_id[sid]
         if session.manual_die:
             current_die[sid] = session.manual_die
             continue
+        current_die[sid] = projection.latest_die_by_session.get(sid, session.start_die)
 
-        sid_events = [e for e in die_events if e.session_id == sid]
-        if sid_events:
-            current_die[sid] = (
-                sid_events[0].die_after if sid_events[0].die_after else session.start_die
-            )
-        else:
-            current_die[sid] = session.start_die
-
-    thread_ids = set()
-    for event in active_thread_events:
-        if event.selected_thread_id:
-            thread_ids.add(event.selected_thread_id)
+    thread_ids = {
+        event.selected_thread_id
+        for event in projection.latest_roll_by_session.values()
+        if event.selected_thread_id is not None
+    }
 
     active_threads_dict: dict[int, ActiveThreadInfo | None] = {}
     if thread_ids:
@@ -562,9 +540,9 @@ async def list_sessions(
         threads_by_id = {t.id: t for t in threads_result.scalars().all()}
 
         for sid in session_ids:
-            sid_events = [e for e in active_thread_events if e.session_id == sid]
-            if sid_events and sid_events[0].selected_thread_id:
-                thread = threads_by_id.get(sid_events[0].selected_thread_id)
+            roll_event = projection.latest_roll_by_session.get(sid)
+            if roll_event is not None and roll_event.selected_thread_id is not None:
+                thread = threads_by_id.get(roll_event.selected_thread_id)
                 if thread:
                     issues_remaining = await thread.get_issues_remaining(db)
                     issue_id, issue_number = await _fetch_thread_issue_metadata(thread, db)
@@ -574,7 +552,7 @@ async def list_sessions(
                         format=thread.format,
                         issues_remaining=issues_remaining,
                         queue_position=thread.queue_position,
-                        last_rolled_result=sid_events[0].result,
+                        last_rolled_result=roll_event.result,
                         total_issues=thread.total_issues,
                         reading_progress=thread.reading_progress,
                         issue_id=issue_id,

--- a/app/api/session.py
+++ b/app/api/session.py
@@ -404,21 +404,18 @@ async def get_current_session(
 
     while retries < max_retries:
         try:
-            active_sessions_result = await db.execute(
+            active_session_result = await db.execute(
                 select(SessionModel)
                 .where(SessionModel.user_id == current_user.id)
                 .where(SessionModel.ended_at.is_(None))
                 .order_by(SessionModel.started_at.desc(), SessionModel.id.desc())
+                .limit(1)
             )
-            active_sessions = active_sessions_result.scalars().all()
+            active_session = active_session_result.scalars().first()
 
-            active_session = None
-            for session in active_sessions:
-                if await is_active(session.started_at, session.ended_at, db):
-                    active_session = session
-                    break
-
-            if not active_session:
+            if active_session is None or not await is_active(
+                active_session.started_at, active_session.ended_at, db
+            ):
                 active_session = await get_or_create(db, user_id=current_user.id)
 
             await db.refresh(active_session)

--- a/app/services/session_history_projection.py
+++ b/app/services/session_history_projection.py
@@ -44,7 +44,7 @@ def project_session_history_events(
 
     for event in events:
         session_id = event.session_id
-        if session_id not in included_session_ids:
+        if session_id is None or session_id not in included_session_ids:
             continue
 
         if event.type == "roll" and event.selected_thread_id is not None:

--- a/app/services/session_history_projection.py
+++ b/app/services/session_history_projection.py
@@ -1,0 +1,64 @@
+"""Linear event projection for session-history summaries."""
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from app.models import Event
+
+_DIE_EVENT_TYPES = frozenset({"rate", "snooze", "undo"})
+
+
+@dataclass(frozen=True, slots=True)
+class SessionHistoryEventProjection:
+    """Precomputed event-derived values for a bounded History page."""
+
+    latest_roll_by_session: dict[int, Event]
+    die_path_by_session: dict[int, tuple[int, ...]]
+    latest_die_by_session: dict[int, int]
+
+
+def project_session_history_events(
+    session_ids: Iterable[int],
+    events: Iterable[Event],
+) -> SessionHistoryEventProjection:
+    """Project ordered History events into constant-time session lookups.
+
+    Events must be ordered by ``(session_id, timestamp, id)``. Later events
+    overwrite earlier latest-event values, which gives deterministic event-ID
+    precedence when timestamps are equal.
+
+    Args:
+        session_ids: Session IDs included in the bounded History page.
+        events: Events ordered by session ID, timestamp, and event ID.
+
+    Returns:
+        Constant-time maps for latest rolls, chronological die paths, and the
+        latest event-derived die value.
+    """
+    included_session_ids = set(session_ids)
+    latest_roll_by_session: dict[int, Event] = {}
+    die_path_lists: dict[int, list[int]] = {
+        session_id: [] for session_id in included_session_ids
+    }
+    latest_die_by_session: dict[int, int] = {}
+
+    for event in events:
+        session_id = event.session_id
+        if session_id not in included_session_ids:
+            continue
+
+        if event.type == "roll" and event.selected_thread_id is not None:
+            latest_roll_by_session[session_id] = event
+
+        if event.type in _DIE_EVENT_TYPES and event.die_after is not None:
+            die_path_lists[session_id].append(event.die_after)
+            latest_die_by_session[session_id] = event.die_after
+
+    return SessionHistoryEventProjection(
+        latest_roll_by_session=latest_roll_by_session,
+        die_path_by_session={
+            session_id: tuple(die_values)
+            for session_id, die_values in die_path_lists.items()
+        },
+        latest_die_by_session=latest_die_by_session,
+    )

--- a/docs/issue-plans/700-session-read-query-plan.md
+++ b/docs/issue-plans/700-session-read-query-plan.md
@@ -1,0 +1,118 @@
+# Issue #700: bounded session-read query plan
+
+## Goal
+
+Consolidate the current-session and History read pipelines so their SQL and Python work stays bounded, while preserving session creation, pending-roll recovery, snoozes, ladder state, snapshots, ownership, cursor pagination, and response contracts.
+
+This plan follows the benchmark harness merged in PR #721. It does not claim latency, query-count, or payload improvements until the implementation is measured with that harness.
+
+## Current flow and concrete multipliers
+
+`app/api/session.py` currently has two related read paths with duplicated work:
+
+- `get_current_session()` loads every open session for a user and calls `is_active()` in Python until one qualifies. It then independently loads the latest action, selected or pending thread, unread count, next issue metadata, snapshot count, snoozed threads, ladder events, and current-die events.
+- `list_sessions()` fetches the page and then separately loads latest roll events, snapshot counts, ladder events, and current-die events. It repeatedly filters those event lists and repeatedly searches `sessions_to_return` inside loops. Active migrated threads still invoke per-thread unread-count and next-issue reads.
+
+The page itself is bounded, but the current shape performs duplicate event queries, O(page_size²) Python scans, and thread-dependent SQL.
+
+## Stage 1: shared event projection and linear History assembly
+
+### Production changes
+
+In `app/api/session.py`:
+
+1. Add a private typed projection for the event-derived fields needed by session summaries:
+   - latest roll event per session;
+   - ordered non-null `die_after` values for ladder construction;
+   - latest non-null `die_after` per session.
+2. Fetch the relevant events for all page session IDs once, ordered by `(session_id, timestamp, id)`.
+3. Build dictionaries in one pass:
+   - `sessions_by_id`;
+   - `latest_roll_by_session`;
+   - `die_path_by_session`;
+   - `latest_die_by_session`.
+4. Replace every per-session list comprehension and `next()` search with O(1) dictionary access.
+5. Preserve manual-die precedence and use `(timestamp, id)` as the deterministic tie break.
+
+### Tests
+
+Extend the session API tests with assertions for:
+
+- duplicate event timestamps resolved by event ID;
+- manual die overriding event-derived die;
+- no die events falling back to `start_die`;
+- ladder ordering remaining chronological;
+- deleted historical threads producing `active_thread=None`;
+- first and later cursor pages returning unchanged ordering and tokens.
+
+Add a SQL statement-count regression around History that compares one returned session with a full page and proves event-query count does not grow per session.
+
+## Stage 2: bulk active-thread metadata for History
+
+### Production changes
+
+Reuse the grouped unread-count approach established by #693:
+
+1. Collect selected thread IDs from `latest_roll_by_session`.
+2. Load owned threads in one query.
+3. Bulk-load unread issue counts for migrated thread IDs in one grouped query.
+4. Bulk-load referenced `next_unread_issue_id` rows in one query.
+5. Build `ActiveThreadInfo` from maps without calling `Thread.get_issues_remaining()` or `_fetch_thread_issue_metadata()` per thread.
+6. Preserve the stored `threads.issues_remaining` value for unmigrated threads.
+
+Keep the helper contract explicit so a future caller cannot silently fall back to N+1 reads.
+
+### Tests
+
+Cover mixed migrated and unmigrated threads, missing next-issue rows, completed threads, deleted threads, and a full History page. Assert bounded SQL statement count across 1, 50, and 200 sessions.
+
+## Stage 3: bounded current-session selection and shared summary read
+
+### Production changes
+
+1. Replace loading every open session with a newest-first bounded candidate query. Fetch one candidate at a time only when expiry semantics require examining an older open row.
+2. Extract a current-session summary loader that derives latest action, ladder path, current die, snapshot count, snoozed summaries, and active-thread metadata from explicit bounded queries.
+3. Do not run concurrent statements through the same `AsyncSession`. Independent reads may be combined in SQL or performed sequentially with measured evidence.
+4. Keep the existing deadlock retry boundary, ownership checks, cache behavior, and `get_or_create()` behavior unchanged.
+5. Add phase timing fields through the existing structured request instrumentation rather than introducing a second logging format.
+
+### Tests
+
+Cover active and expired open sessions, no existing session, pending-thread precedence, selected-thread fallback, missing pending thread, snoozed rows, deadlock retry, snapshot presence, and cache invalidation compatibility.
+
+## API and data compatibility
+
+- No route, status code, pagination token, authentication, ownership, or response-field change is intended.
+- No database migration is required.
+- `SessionHistoryListResponse`, `SessionListItem`, and `SessionResponse` remain the public contracts.
+- Collections are not introduced, preserved, or optimized by this work.
+
+## Validation sequence
+
+Run the narrowest affected checks first:
+
+```bash
+uv run pytest tests/test_session_api.py tests/test_session_pagination.py -q
+uv run pytest tests/test_session_api.py tests/test_session_pagination.py --cov=app.api.session --cov-branch --cov-report=term-missing
+uv run ruff check app/api/session.py tests/test_session_api.py tests/test_session_pagination.py
+uv run ty check --error-on-warning
+```
+
+Then run the repository-required backend and API E2E matrix. After deployment, run `scripts/benchmark_session_reads.py` against local, preview, and production targets and record first-observed and steady-state results for:
+
+- current session with and without an active session;
+- first History page;
+- a later cursor page;
+- a session with many events.
+
+Record status, duration, response bytes, `X-App-DB-Queries`, `Server-Timing`, request ID, and cache state. Compare against the pre-change report using the same account, page size, iteration count, and deployment-idle conditions.
+
+## Rollback and containment
+
+Each stage should be independently revertible:
+
+- Stage 1 changes only in-memory event assembly and its tests.
+- Stage 2 changes only History active-thread metadata loading and its tests.
+- Stage 3 changes only current-session selection/summary loading and instrumentation.
+
+Do not combine frontend cache migration, response-model redesign, or Collections removal into these stages. If measured query count or behavior regresses, revert the affected stage without removing the benchmark harness or changing public contracts.

--- a/tests/test_session_history_projection.py
+++ b/tests/test_session_history_projection.py
@@ -1,0 +1,74 @@
+"""Tests for bounded session-history event projection."""
+
+from datetime import UTC, datetime
+
+from app.models import Event
+from app.services.session_history_projection import project_session_history_events
+
+
+def _event(
+    *,
+    event_id: int,
+    session_id: int | None,
+    event_type: str,
+    selected_thread_id: int | None = None,
+    die_after: int | None = None,
+) -> Event:
+    """Build an ordered event fixture without database persistence."""
+    return Event(
+        id=event_id,
+        session_id=session_id,
+        type=event_type,
+        timestamp=datetime(2026, 8, 2, 12, 0, tzinfo=UTC),
+        selected_thread_id=selected_thread_id,
+        die_after=die_after,
+    )
+
+
+def test_projection_keeps_latest_roll_and_chronological_die_path() -> None:
+    events = [
+        _event(event_id=1, session_id=10, event_type="roll", selected_thread_id=101),
+        _event(event_id=2, session_id=10, event_type="rate", die_after=6),
+        _event(event_id=3, session_id=10, event_type="snooze", die_after=8),
+        _event(event_id=4, session_id=10, event_type="roll", selected_thread_id=102),
+    ]
+
+    projection = project_session_history_events([10], events)
+
+    assert projection.latest_roll_by_session[10].selected_thread_id == 102
+    assert projection.die_path_by_session[10] == (6, 8)
+    assert projection.latest_die_by_session[10] == 8
+
+
+def test_projection_uses_event_order_to_break_duplicate_timestamps() -> None:
+    events = [
+        _event(event_id=20, session_id=10, event_type="undo", die_after=6),
+        _event(event_id=21, session_id=10, event_type="rate", die_after=12),
+    ]
+
+    projection = project_session_history_events([10], events)
+
+    assert projection.die_path_by_session[10] == (6, 12)
+    assert projection.latest_die_by_session[10] == 12
+
+
+def test_projection_ignores_events_outside_the_bounded_page() -> None:
+    events = [
+        _event(event_id=1, session_id=10, event_type="rate", die_after=6),
+        _event(event_id=2, session_id=11, event_type="rate", die_after=20),
+        _event(event_id=3, session_id=None, event_type="rate", die_after=100),
+    ]
+
+    projection = project_session_history_events([10], events)
+
+    assert projection.die_path_by_session == {10: (6,)}
+    assert projection.latest_die_by_session == {10: 6}
+    assert projection.latest_roll_by_session == {}
+
+
+def test_projection_preserves_empty_sessions_for_constant_time_fallbacks() -> None:
+    projection = project_session_history_events([10, 11], [])
+
+    assert projection.die_path_by_session == {10: (), 11: ()}
+    assert projection.latest_die_by_session == {}
+    assert projection.latest_roll_by_session == {}

--- a/tests/test_session_history_projection.py
+++ b/tests/test_session_history_projection.py
@@ -26,6 +26,7 @@ def _event(
 
 
 def test_projection_keeps_latest_roll_and_chronological_die_path() -> None:
+    """Keep the newest roll and preserve chronological die transitions."""
     events = [
         _event(event_id=1, session_id=10, event_type="roll", selected_thread_id=101),
         _event(event_id=2, session_id=10, event_type="rate", die_after=6),
@@ -41,6 +42,7 @@ def test_projection_keeps_latest_roll_and_chronological_die_path() -> None:
 
 
 def test_projection_uses_event_order_to_break_duplicate_timestamps() -> None:
+    """Use deterministic input order when event timestamps are identical."""
     events = [
         _event(event_id=20, session_id=10, event_type="undo", die_after=6),
         _event(event_id=21, session_id=10, event_type="rate", die_after=12),
@@ -53,6 +55,7 @@ def test_projection_uses_event_order_to_break_duplicate_timestamps() -> None:
 
 
 def test_projection_ignores_events_outside_the_bounded_page() -> None:
+    """Ignore events that do not belong to the requested History page."""
     events = [
         _event(event_id=1, session_id=10, event_type="rate", die_after=6),
         _event(event_id=2, session_id=11, event_type="rate", die_after=20),
@@ -67,6 +70,7 @@ def test_projection_ignores_events_outside_the_bounded_page() -> None:
 
 
 def test_projection_preserves_empty_sessions_for_constant_time_fallbacks() -> None:
+    """Create empty path entries for sessions without matching events."""
     projection = project_session_history_events([10, 11], [])
 
     assert projection.die_path_by_session == {10: (), 11: ()}

--- a/tests/test_session_history_projection_wiring.py
+++ b/tests/test_session_history_projection_wiring.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import event as sa_event
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from app.models import Event, Thread, User
 from app.models import Session as SessionModel
@@ -217,7 +217,7 @@ async def test_history_deleted_thread_yields_null_active_thread(
 async def test_history_event_reads_do_not_grow_per_session(
     auth_client: AsyncClient,
     async_db: AsyncSession,
-    db_engine,
+    db_engine: AsyncEngine,
     default_user: User,
 ) -> None:
     """The History page performs one events read regardless of page size."""
@@ -266,3 +266,88 @@ async def test_history_event_reads_do_not_grow_per_session(
     assert len(event_reads) == 1, (
         f"Expected a single events read, got {len(event_reads)}: {event_reads}"
     )
+
+
+@pytest.mark.asyncio
+async def test_history_pagination_preserves_ordering_and_tokens(
+    auth_client: AsyncClient, async_db: AsyncSession, default_user: User
+) -> None:
+    """Cursor pages keep reverse-chronological ordering and stable tokens."""
+    for i in range(5):
+        session = SessionModel(
+            start_die=6,
+            user_id=default_user.id,
+            started_at=datetime(2026, 8, 2, 12, 0, 50 - i, tzinfo=UTC),
+        )
+        async_db.add(session)
+        await async_db.flush()
+    await _commit_all(async_db)
+
+    first_page = await auth_client.get("/api/sessions/?page_size=2")
+    assert first_page.status_code == 200
+    first_data = first_page.json()
+    first_sessions = first_data["sessions"]
+    assert len(first_sessions) == 2
+    assert [s["started_at"] for s in first_sessions] == sorted(
+        (s["started_at"] for s in first_sessions), reverse=True
+    ), "Sessions must be newest-first by started_at"
+
+    next_token = first_data.get("next_page_token")
+    assert next_token is not None
+
+    second_page = await auth_client.get(
+        "/api/sessions/", params={"page_size": 2, "page_token": next_token}
+    )
+    assert second_page.status_code == 200
+    second_data = second_page.json()
+    second_sessions = second_data["sessions"]
+    assert len(second_sessions) == 2
+    assert [s["started_at"] for s in second_sessions] == sorted(
+        (s["started_at"] for s in second_sessions), reverse=True
+    ), "Second page continues newest-first ordering"
+
+    assert {s["id"] for s in first_sessions}.isdisjoint({s["id"] for s in second_sessions})
+    assert all(first_sessions[-1]["started_at"] > s["started_at"] for s in second_sessions), (
+        "First page must be strictly newer than the second page"
+    )
+
+    third_page = await auth_client.get(
+        "/api/sessions/", params={"page_size": 2, "page_token": second_data["next_page_token"]}
+    )
+    assert third_page.status_code == 200
+    third_data = third_page.json()
+    assert len(third_data["sessions"]) == 1
+    assert third_data["next_page_token"] is None
+
+
+@pytest.mark.asyncio
+async def test_history_duplicate_timestamps_break_ties_by_event_id(
+    auth_client: AsyncClient, async_db: AsyncSession, default_user: User
+) -> None:
+    """Latest die selection uses event ID to break equal timestamp ties."""
+    thread = Thread(
+        title="Tie Comic",
+        format="Comic",
+        issues_remaining=10,
+        queue_position=1,
+        user_id=default_user.id,
+    )
+    async_db.add(thread)
+    session = SessionModel(start_die=6, user_id=default_user.id, started_at=datetime.now(UTC))
+    async_db.add(session)
+    await async_db.flush()
+
+    first = _die_event(session, thread, timestamp=1, die_after=8)
+    second = _die_event(session, thread, timestamp=1, die_after=12)
+    async_db.add_all([first, second])
+    await async_db.flush()
+
+    first.id, second.id = 100, 101
+    await _commit_all(async_db)
+
+    response = await auth_client.get("/api/sessions/")
+    assert response.status_code == 200
+    item = next(s for s in response.json()["sessions"] if s["id"] == session.id)
+
+    assert item["current_die"] == 12
+    assert item["ladder_path"] == "6 → 8 → 12"

--- a/tests/test_session_history_projection_wiring.py
+++ b/tests/test_session_history_projection_wiring.py
@@ -351,3 +351,259 @@ async def test_history_duplicate_timestamps_break_ties_by_event_id(
 
     assert item["current_die"] == 12
     assert item["ladder_path"] == "6 → 8 → 12"
+
+
+@pytest.mark.asyncio
+async def test_history_active_thread_metadata_loads_in_bulk(
+    auth_client: AsyncClient,
+    async_db: AsyncSession,
+    db_engine: AsyncEngine,
+    default_user: User,
+) -> None:
+    """Migrated unread counts and issue numbers are bulk-loaded, not per-thread."""
+    from app.models import Issue
+
+    migrated = Thread(
+        title="Migrated Comic",
+        format="Comic",
+        issues_remaining=0,
+        queue_position=1,
+        user_id=default_user.id,
+        total_issues=5,
+        reading_progress="in_progress",
+    )
+    unmigrated = Thread(
+        title="Legacy Comic",
+        format="Comic",
+        issues_remaining=42,
+        queue_position=2,
+        user_id=default_user.id,
+    )
+    async_db.add_all([migrated, unmigrated])
+    await async_db.flush()
+    session_a = SessionModel(start_die=6, user_id=default_user.id, started_at=datetime.now(UTC))
+    session_b = SessionModel(start_die=8, user_id=default_user.id, started_at=datetime.now(UTC))
+    async_db.add_all([session_a, session_b])
+    await async_db.flush()
+
+    for i in range(1, 6):
+        async_db.add(
+            Issue(
+                thread_id=migrated.id,
+                issue_number=str(i),
+                position=i,
+                status="read" if i <= 3 else "unread",
+            )
+        )
+    await async_db.flush()
+    async_db.add_all(
+        [
+            _roll_event(session_a, migrated, timestamp=1),
+            _roll_event(session_b, unmigrated, timestamp=1),
+        ]
+    )
+    await _commit_all(async_db)
+
+    statements: list[str] = []
+
+    def record_statement(
+        _connection: object,
+        _cursor: object,
+        statement: str,
+        _parameters: object,
+        _context: object,
+        _executemany: bool,
+    ) -> None:
+        statements.append(statement)
+
+    sa_event.listen(db_engine.sync_engine, "before_cursor_execute", record_statement)
+    try:
+        response = await auth_client.get("/api/sessions/")
+    finally:
+        sa_event.remove(db_engine.sync_engine, "before_cursor_execute", record_statement)
+
+    assert response.status_code == 200
+    sessions = {s["id"]: s for s in response.json()["sessions"]}
+
+    migrated_active = sessions[session_a.id]["active_thread"]
+    assert migrated_active is not None
+    assert migrated_active["title"] == "Migrated Comic"
+    assert migrated_active["issues_remaining"] == 2
+    assert migrated_active["total_issues"] == 5
+
+    unmigrated_active = sessions[session_b.id]["active_thread"]
+    assert unmigrated_active is not None
+    assert unmigrated_active["title"] == "Legacy Comic"
+    assert unmigrated_active["issues_remaining"] == 42
+
+    issue_reads = [s for s in statements if "from issues" in s.lower()]
+    assert len(issue_reads) <= 2, (
+        f"Expected bounded issue reads, got {len(issue_reads)}: {issue_reads}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_history_missing_next_issue_yields_null_issue_metadata(
+    auth_client: AsyncClient, async_db: AsyncSession, default_user: User
+) -> None:
+    """A dangling next_unread_issue_id produces null issue fields, not an error."""
+    from app.models import Issue
+
+    migrated = Thread(
+        title="Broken Reference Comic",
+        format="Comic",
+        issues_remaining=3,
+        queue_position=1,
+        user_id=default_user.id,
+        total_issues=5,
+        reading_progress="in_progress",
+    )
+    async_db.add(migrated)
+    session = SessionModel(start_die=6, user_id=default_user.id, started_at=datetime.now(UTC))
+    async_db.add(session)
+    await async_db.flush()
+
+    issues = [
+        Issue(
+            thread_id=migrated.id,
+            issue_number=str(i),
+            position=i,
+            status="read" if i <= 3 else "unread",
+        )
+        for i in range(1, 6)
+    ]
+    async_db.add_all(issues)
+    await async_db.flush()
+    migrated.next_unread_issue_id = issues[0].id
+    await _commit_all(async_db)
+
+    await async_db.delete(issues[0])
+    await _commit_all(async_db)
+
+    async_db.add(_roll_event(session, migrated, timestamp=1))
+    await _commit_all(async_db)
+
+    response = await auth_client.get("/api/sessions/")
+    assert response.status_code == 200
+    item = next(s for s in response.json()["sessions"] if s["id"] == session.id)
+
+    assert item["active_thread"] is not None
+    assert item["active_thread"]["issues_remaining"] == 2
+    assert item["active_thread"]["issue_id"] is None
+    assert item["active_thread"]["issue_number"] is None
+    assert item["active_thread"]["next_issue_id"] is None
+    assert item["active_thread"]["next_issue_number"] is None
+
+
+@pytest.mark.asyncio
+async def test_history_issue_reads_stay_bounded_across_page_sizes(
+    auth_client: AsyncClient,
+    async_db: AsyncSession,
+    db_engine: AsyncEngine,
+    default_user: User,
+) -> None:
+    """Issue metadata reads stay bounded as the History page grows."""
+    from app.models import Issue
+
+    for i in range(10):
+        migrated = Thread(
+            title=f"Bulk Comic {i}",
+            format="Comic",
+            issues_remaining=0,
+            queue_position=i + 1,
+            user_id=default_user.id,
+            total_issues=5,
+            reading_progress="in_progress",
+        )
+        async_db.add(migrated)
+        session = SessionModel(
+            start_die=6,
+            user_id=default_user.id,
+            started_at=datetime(2026, 8, 2, 12, 1, i, tzinfo=UTC),
+        )
+        async_db.add(session)
+        await _commit_all(async_db)
+        for j in range(1, 6):
+            async_db.add(
+                Issue(
+                    thread_id=migrated.id,
+                    issue_number=str(j),
+                    position=j,
+                    status="unread" if j <= 2 else "read",
+                )
+            )
+        await _commit_all(async_db)
+        async_db.add(_roll_event(session, migrated, timestamp=i))
+        await _commit_all(async_db)
+
+    statements: list[str] = []
+
+    def record_statement(
+        _connection: object,
+        _cursor: object,
+        statement: str,
+        _parameters: object,
+        _context: object,
+        _executemany: bool,
+    ) -> None:
+        statements.append(statement)
+
+    sa_event.listen(db_engine.sync_engine, "before_cursor_execute", record_statement)
+    try:
+        response = await auth_client.get("/api/sessions/?page_size=200")
+    finally:
+        sa_event.remove(db_engine.sync_engine, "before_cursor_execute", record_statement)
+
+    assert response.status_code == 200
+    sessions = response.json()["sessions"]
+    assert len(sessions) == 10
+
+    issue_reads = [s for s in statements if "from issues" in s.lower()]
+    assert len(issue_reads) <= 2, (
+        f"Expected bounded issue reads, got {len(issue_reads)}: {issue_reads}"
+    )
+
+    active_threads = [s["active_thread"] for s in sessions]
+    assert all(t is not None and t["issues_remaining"] == 2 for t in active_threads)
+
+
+@pytest.mark.asyncio
+async def test_history_migrated_zero_unread_returns_zero_not_stored_counter(
+    auth_client: AsyncClient, async_db: AsyncSession, default_user: User
+) -> None:
+    """A migrated thread with no unread issues reports 0, not a stale counter."""
+    from app.models import Issue
+
+    migrated = Thread(
+        title="All Read Comic",
+        format="Comic",
+        issues_remaining=99,
+        queue_position=1,
+        user_id=default_user.id,
+        total_issues=5,
+        reading_progress="in_progress",
+    )
+    async_db.add(migrated)
+    session = SessionModel(start_die=6, user_id=default_user.id, started_at=datetime.now(UTC))
+    async_db.add(session)
+    await async_db.flush()
+
+    for i in range(1, 6):
+        async_db.add(
+            Issue(
+                thread_id=migrated.id,
+                issue_number=str(i),
+                position=i,
+                status="read",
+            )
+        )
+    await async_db.flush()
+    async_db.add(_roll_event(session, migrated, timestamp=1))
+    await _commit_all(async_db)
+
+    response = await auth_client.get("/api/sessions/")
+    assert response.status_code == 200
+    item = next(s for s in response.json()["sessions"] if s["id"] == session.id)
+
+    assert item["active_thread"] is not None
+    assert item["active_thread"]["issues_remaining"] == 0

--- a/tests/test_session_history_projection_wiring.py
+++ b/tests/test_session_history_projection_wiring.py
@@ -1,0 +1,268 @@
+"""Endpoint-level regression coverage for the linear History event projection.
+
+These tests prove ``list_sessions()`` preserves the exact History response
+contract when it assembles summaries from the single ordered event read
+produced by ``project_session_history_events()``.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import event as sa_event
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Event, Thread, User
+from app.models import Session as SessionModel
+
+
+async def _commit_all(async_db: AsyncSession) -> None:
+    await async_db.flush()
+    await async_db.commit()
+
+
+def _roll_event(
+    session: SessionModel,
+    thread: Thread,
+    *,
+    timestamp: int,
+    thread_id: int | None = None,
+) -> Event:
+    """Build a roll event for a fixed deterministic wall clock."""
+    return Event(
+        type="roll",
+        session_id=session.id,
+        selected_thread_id=thread.id,
+        thread_id=thread_id,
+        die=session.start_die,
+        result=timestamp,
+        selection_method="random",
+        timestamp=datetime(2026, 8, 2, 12, 0, timestamp, tzinfo=UTC),
+    )
+
+
+def _die_event(
+    session: SessionModel,
+    thread: Thread,
+    *,
+    timestamp: int,
+    die_after: int,
+) -> Event:
+    """Build a rate/snooze die-transition event at a fixed wall clock."""
+    return Event(
+        type="rate",
+        session_id=session.id,
+        thread_id=thread.id,
+        die_after=die_after,
+        timestamp=datetime(2026, 8, 2, 12, 0, timestamp, tzinfo=UTC),
+    )
+
+
+@pytest.mark.asyncio
+async def test_history_ladder_is_chronological_and_current_die_uses_latest(
+    auth_client: AsyncClient, async_db: AsyncSession, default_user: User
+) -> None:
+    """Ladder order stays chronological and current_die uses the newest event."""
+    thread = Thread(
+        title="Ladder Comic",
+        format="Comic",
+        issues_remaining=10,
+        queue_position=1,
+        user_id=default_user.id,
+    )
+    async_db.add(thread)
+    session = SessionModel(start_die=6, user_id=default_user.id, started_at=datetime.now(UTC))
+    async_db.add(session)
+    await async_db.flush()
+    async_db.add_all(
+        [
+            _die_event(session, thread, timestamp=1, die_after=8),
+            _die_event(session, thread, timestamp=2, die_after=12),
+            _die_event(session, thread, timestamp=3, die_after=10),
+        ]
+    )
+    await _commit_all(async_db)
+
+    response = await auth_client.get("/api/sessions/")
+    assert response.status_code == 200
+    item = next(s for s in response.json()["sessions"] if s["id"] == session.id)
+
+    assert item["ladder_path"] == "6 → 8 → 12 → 10"
+    assert item["current_die"] == 10
+    assert item["start_die"] == 6
+
+
+@pytest.mark.asyncio
+async def test_history_manual_die_overrides_event_derived_die(
+    auth_client: AsyncClient, async_db: AsyncSession, default_user: User
+) -> None:
+    """A manual die takes precedence over event-derived current die."""
+    thread = Thread(
+        title="Manual Die Comic",
+        format="Comic",
+        issues_remaining=10,
+        queue_position=1,
+        user_id=default_user.id,
+    )
+    async_db.add(thread)
+    session = SessionModel(
+        start_die=6,
+        manual_die=20,
+        user_id=default_user.id,
+        started_at=datetime.now(UTC),
+    )
+    async_db.add(session)
+    await async_db.flush()
+    async_db.add(_die_event(session, thread, timestamp=1, die_after=8))
+    await _commit_all(async_db)
+
+    response = await auth_client.get("/api/sessions/")
+    assert response.status_code == 200
+    item = next(s for s in response.json()["sessions"] if s["id"] == session.id)
+
+    assert item["current_die"] == 20
+    assert item["manual_die"] == 20
+    assert item["ladder_path"] == "6 → 8"
+
+
+@pytest.mark.asyncio
+async def test_history_no_die_events_falls_back_to_start_die(
+    auth_client: AsyncClient, async_db: AsyncSession, default_user: User
+) -> None:
+    """Sessions without die events fall back to the start die for ladder and die."""
+    session = SessionModel(start_die=10, user_id=default_user.id, started_at=datetime.now(UTC))
+    async_db.add(session)
+    await _commit_all(async_db)
+
+    response = await auth_client.get("/api/sessions/")
+    assert response.status_code == 200
+    item = next(s for s in response.json()["sessions"] if s["id"] == session.id)
+
+    assert item["ladder_path"] == "10"
+    assert item["current_die"] == 10
+
+
+@pytest.mark.asyncio
+async def test_history_latest_roll_wins_when_multiple_rolls_exist(
+    auth_client: AsyncClient, async_db: AsyncSession, default_user: User
+) -> None:
+    """Latest roll selection uses event order and returns the newest thread."""
+    thread_a = Thread(
+        title="First Comic",
+        format="Comic",
+        issues_remaining=10,
+        queue_position=1,
+        user_id=default_user.id,
+    )
+    thread_b = Thread(
+        title="Second Comic",
+        format="Comic",
+        issues_remaining=5,
+        queue_position=2,
+        user_id=default_user.id,
+    )
+    async_db.add_all([thread_a, thread_b])
+    session = SessionModel(start_die=6, user_id=default_user.id, started_at=datetime.now(UTC))
+    async_db.add(session)
+    await async_db.flush()
+    async_db.add_all(
+        [
+            _roll_event(session, thread_a, timestamp=1),
+            _roll_event(session, thread_b, timestamp=2),
+        ]
+    )
+    await _commit_all(async_db)
+
+    response = await auth_client.get("/api/sessions/")
+    assert response.status_code == 200
+    item = next(s for s in response.json()["sessions"] if s["id"] == session.id)
+
+    assert item["active_thread"] is not None
+    assert item["active_thread"]["title"] == "Second Comic"
+    assert item["last_rolled_result"] == 2
+
+
+@pytest.mark.asyncio
+async def test_history_deleted_thread_yields_null_active_thread(
+    auth_client: AsyncClient, async_db: AsyncSession, default_user: User
+) -> None:
+    """Rolls referencing a deleted thread produce active_thread=None."""
+    thread = Thread(
+        title="Doomed Comic",
+        format="Comic",
+        issues_remaining=10,
+        queue_position=1,
+        user_id=default_user.id,
+    )
+    async_db.add(thread)
+    session = SessionModel(start_die=6, user_id=default_user.id, started_at=datetime.now(UTC))
+    async_db.add(session)
+    await async_db.flush()
+    await _commit_all(async_db)
+
+    async_db.add(_roll_event(session, thread, timestamp=1, thread_id=None))
+    await _commit_all(async_db)
+
+    await async_db.delete(thread)
+    await _commit_all(async_db)
+    response = await auth_client.get("/api/sessions/")
+    assert response.status_code == 200
+    item = next(s for s in response.json()["sessions"] if s["id"] == session.id)
+
+    assert item["active_thread"] is None
+    assert item["last_rolled_result"] is None
+
+
+@pytest.mark.asyncio
+async def test_history_event_reads_do_not_grow_per_session(
+    auth_client: AsyncClient,
+    async_db: AsyncSession,
+    db_engine,
+    default_user: User,
+) -> None:
+    """The History page performs one events read regardless of page size."""
+    for i in range(5):
+        thread = Thread(
+            title=f"Comic {i}",
+            format="Comic",
+            issues_remaining=10,
+            queue_position=i + 1,
+            user_id=default_user.id,
+        )
+        async_db.add(thread)
+        session = SessionModel(
+            start_die=6,
+            user_id=default_user.id,
+            started_at=datetime(2026, 8, 2, 12, 0, i, tzinfo=UTC),
+        )
+        async_db.add(session)
+        await _commit_all(async_db)
+        async_db.add(_roll_event(session, thread, timestamp=i))
+        async_db.add(_die_event(session, thread, timestamp=i, die_after=8 + i))
+        await _commit_all(async_db)
+
+    statements: list[str] = []
+
+    def record_statement(
+        _connection: object,
+        _cursor: object,
+        statement: str,
+        _parameters: object,
+        _context: object,
+        _executemany: bool,
+    ) -> None:
+        statements.append(statement)
+
+    sa_event.listen(db_engine.sync_engine, "before_cursor_execute", record_statement)
+    try:
+        response = await auth_client.get("/api/sessions/?page_size=50")
+    finally:
+        sa_event.remove(db_engine.sync_engine, "before_cursor_execute", record_statement)
+
+    assert response.status_code == 200
+    assert len(response.json()["sessions"]) == 5
+
+    event_reads = [s for s in statements if "from events" in s.lower()]
+    assert len(event_reads) == 1, (
+        f"Expected a single events read, got {len(event_reads)}: {event_reads}"
+    )

--- a/tests/test_session_history_projection_wiring.py
+++ b/tests/test_session_history_projection_wiring.py
@@ -5,7 +5,7 @@ contract when it assembles summaries from the single ordered event read
 produced by ``project_session_history_events()``.
 """
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from httpx import AsyncClient
@@ -607,3 +607,77 @@ async def test_history_migrated_zero_unread_returns_zero_not_stored_counter(
 
     assert item["active_thread"] is not None
     assert item["active_thread"]["issues_remaining"] == 0
+
+
+@pytest.mark.asyncio
+async def test_current_session_selects_newest_active_candidate(
+    auth_client: AsyncClient, async_db: AsyncSession, default_user: User
+) -> None:
+    """Current-session selection uses the newest open candidate and stays active."""
+    now = datetime.now(UTC)
+    open_sessions = [
+        SessionModel(start_die=6, user_id=default_user.id, started_at=now),
+        SessionModel(start_die=8, user_id=default_user.id, started_at=now),
+        SessionModel(
+            start_die=10,
+            user_id=default_user.id,
+            started_at=now - timedelta(hours=2),
+            ended_at=now - timedelta(hours=1),
+        ),
+    ]
+    async_db.add_all(open_sessions)
+    await _commit_all(async_db)
+
+    response = await auth_client.get("/api/sessions/current/")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["start_die"] in {6, 8}, "Must select one of the active open sessions"
+
+
+@pytest.mark.asyncio
+async def test_current_session_candidate_read_is_bounded(
+    auth_client: AsyncClient,
+    async_db: AsyncSession,
+    db_engine: AsyncEngine,
+    default_user: User,
+) -> None:
+    """Current-session selection reads at most one candidate session row."""
+    now = datetime.now(UTC)
+    for i in range(10):
+        async_db.add(
+            SessionModel(
+                start_die=6,
+                user_id=default_user.id,
+                started_at=now - timedelta(minutes=i),
+            )
+        )
+    await _commit_all(async_db)
+
+    statements: list[str] = []
+
+    def record_statement(
+        _connection: object,
+        _cursor: object,
+        statement: str,
+        _parameters: object,
+        _context: object,
+        _executemany: bool,
+    ) -> None:
+        statements.append(statement)
+
+    sa_event.listen(db_engine.sync_engine, "before_cursor_execute", record_statement)
+    try:
+        response = await auth_client.get("/api/sessions/current/")
+    finally:
+        sa_event.remove(db_engine.sync_engine, "before_cursor_execute", record_statement)
+
+    assert response.status_code == 200
+    assert response.json()["start_die"] == 6
+
+    session_candidate_reads = [
+        s for s in statements if "from sessions" in s.lower() and "order by" in s.lower()
+    ]
+    assert len(session_candidate_reads) == 1, (
+        f"Expected one bounded candidate read, got {len(session_candidate_reads)}: "
+        f"{session_candidate_reads}"
+    )


### PR DESCRIPTION
## Summary

Consolidates the session-read query pipelines: linear History event projection, bulk-loaded History active-thread metadata, and bounded current-session selection.

Part of #700 and #687.

## Stage 1: linear History event projection

- Adds a typed `SessionHistoryEventProjection` boundary for the bounded History page.
- Projects latest rolls, chronological die paths, and latest event-derived dice in one linear pass using deterministic `(timestamp, id)` tie-breaking.
- `list_sessions()` fetches roll and die-transition events once in `(session_id, timestamp, id)` order and replaces the former `active_thread_events`, `ladder_events`, and `die_events` queries plus repeated per-session scans/`next()` searches with constant-time map lookups.
- Preserves manual-die precedence, ladder ordering, latest-roll selection, `start_die` fallbacks, pagination, and deleted-thread `active_thread=None`.

## Stage 2: bulk active-thread metadata

- `list_sessions()` bulk-loads migrated unread counts via one grouped `COUNT` query and next-unread issue numbers via one `in_` query, replacing per-thread `get_issues_remaining()`/`_fetch_thread_issue_metadata()` calls.
- Unmigrated threads keep stored `issues_remaining`; migrated threads with zero unread report 0; dangling `next_unread_issue_id` yields null issue fields exactly as before.

## Stage 3: bounded current-session selection

- `get_current_session()` no longer loads every open session. It fetches the single newest open candidate (`LIMIT 1`) and only falls through to `get_or_create()` when that candidate is missing or expired.
- Open sessions are ordered newest-first and `is_active()` depends only on `started_at`/`ended_at`, so the newest candidate is the only one that can be active; the previous loop could never pick an older active session. Behavior is unchanged while the candidate read is bounded to one row.

## Verification

- `tests/test_session_history_projection.py` covers projection unit behavior.
- `tests/test_session_history_projection_wiring.py` adds endpoint-level regression coverage for ladder order, manual-die precedence, no-die fallback, latest-roll selection, deleted threads, pagination, duplicate-timestamp tie-breaks, bulk metadata, missing next-issue rows, migrated-zero-unread, bounded `events`/`issues` reads, and bounded current-session candidate selection.
- Exact-SHA CI passed on `720ede8f` (backend, frontend, E2E API, E2E dice-ladder, lint, type checks, migration health, Docker build, coverage).
- Local: 115 session/history/auth tests pass against PostgreSQL; full backend suite 798 passed; ruff and ty clean.

## Remaining work before #700 can close

- Add structured phase/query-count instrumentation and exact statement-count regressions for the current-session path.
- Record comparable cold and warm production evidence without increasing payload size (post-deployment).

This PR is non-draft and must not be merged without Josh's explicit authorization.