### PR TITLE
refactor(collections): replay provider lifecycle removal on current main (#636)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,7 +12,6 @@ import type { DiagnosticData } from './hooks/useDiagnostics'
 import { ToastProvider } from './contexts/ToastProvider'
 import { CacheProvider } from './contexts/CacheContext'
 import { BugReportRestoreProvider } from './contexts/BugReportRestoreContext'
-import { CollectionProvider } from './contexts/CollectionContext'
 import './index.css'
 
 declare global {
@@ -245,10 +244,7 @@ function AppRoutes() {
             </PublicRoute>
           }
         />
-        <Route
-          path="/rate"
-          element={<Navigate to="/" replace />}
-        />
+        <Route path="/rate" element={<Navigate to="/" replace />} />
         <Route
           path="/"
           element={
@@ -329,7 +325,7 @@ function AppRoutes() {
             </ProtectedRoute>
           }
         />
-        </Routes>
+      </Routes>
       {isAuthenticated && <BugReportConnected onSubmit={submit} />}
     </Suspense>
   )
@@ -343,9 +339,7 @@ function App() {
           <ToastProvider>
             <CacheProvider>
               <AuthProvider>
-                <AuthenticatedCollectionProvider>
-                  <AppRoutes />
-                </AuthenticatedCollectionProvider>
+                <AppRoutes />
               </AuthProvider>
             </CacheProvider>
           </ToastProvider>
@@ -353,16 +347,6 @@ function App() {
       </QueryClientProvider>
     </BrowserRouter>
   )
-}
-
-function AuthenticatedCollectionProvider({ children }: { children: ReactNode }) {
-  const { isAuthenticated } = useAuth()
-
-  if (!isAuthenticated) {
-    return children
-  }
-
-  return <CollectionProvider>{children}</CollectionProvider>
 }
 
 export { AppRoutes }

--- a/frontend/src/contexts/CollectionContext.tsx
+++ b/frontend/src/contexts/CollectionContext.tsx
@@ -1,4 +1,3 @@
-import { createContext, useContext } from 'react'
 import type { ReactNode } from 'react'
 import type { Collection, CollectionCreate, CollectionUpdate } from '../types'
 
@@ -7,7 +6,7 @@ interface CollectionError {
   status?: number
 }
 
-interface CollectionContextType {
+interface RemovedCollectionsState {
   collections: Collection[]
   activeCollectionId: number | null
   setActiveCollectionId: (id: number | null) => void
@@ -20,7 +19,7 @@ interface CollectionContextType {
   retry: () => void
 }
 
-const removedCollectionsContext: CollectionContextType = {
+const removedCollectionsState: RemovedCollectionsState = {
   collections: [],
   activeCollectionId: null,
   setActiveCollectionId: () => undefined,
@@ -33,23 +32,19 @@ const removedCollectionsContext: CollectionContextType = {
   retry: () => undefined,
 }
 
-const CollectionContext = createContext<CollectionContextType>(removedCollectionsContext)
-
 /**
- * Transitional compatibility provider for #636.
- *
- * Collections are no longer loaded, persisted, selected, or mutated. This
- * provider remains only while the remaining Roll and Queue callers are removed
- * in follow-up slices, after which this file can be deleted entirely.
+ * Inert compatibility wrapper for test harnesses that still render the removed
+ * provider boundary. It creates no context, state, persistence, or requests.
  */
 export function CollectionProvider({ children }: { children: ReactNode }) {
-  return (
-    <CollectionContext.Provider value={removedCollectionsContext}>
-      {children}
-    </CollectionContext.Provider>
-  )
+  return children
 }
 
-export function useCollections() {
-  return useContext(CollectionContext)
+/**
+ * Temporary caller shim while the last Roll and Queue collection branches are
+ * deleted under #636. It owns no React state, context, persistence, requests,
+ * or mutation behavior and therefore requires no provider in the app shell.
+ */
+export function useCollections(): RemovedCollectionsState {
+  return removedCollectionsState
 }

--- a/frontend/src/unit/CollectionContext.test.tsx
+++ b/frontend/src/unit/CollectionContext.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import {
+  CollectionProvider,
+  useCollections,
+} from '../contexts/CollectionContext'
+
+describe('removed Collections compatibility shim', () => {
+  it('renders children without creating a provider-owned lifecycle', () => {
+    render(
+      <CollectionProvider>
+        <span>provider-free child</span>
+      </CollectionProvider>,
+    )
+
+    expect(screen.getByText('provider-free child')).toBeInTheDocument()
+  })
+
+  it('returns one stable inert state with no persistence or mutation behavior', async () => {
+    const firstState = useCollections()
+    const secondState = useCollections()
+
+    expect(secondState).toBe(firstState)
+    expect(firstState.collections).toEqual([])
+    expect(firstState.activeCollectionId).toBeNull()
+    expect(firstState.isLoading).toBe(false)
+    expect(firstState.error).toBeNull()
+
+    expect(firstState.setActiveCollectionId(42)).toBeUndefined()
+    expect(firstState.retry()).toBeUndefined()
+    await expect(firstState.createCollection({ name: 'Removed' })).resolves.toBeUndefined()
+    await expect(
+      firstState.updateCollection(1, { name: 'Still removed' }),
+    ).resolves.toBeUndefined()
+    await expect(firstState.deleteCollection(1)).resolves.toBeUndefined()
+    await expect(firstState.moveCollection(1, 2)).resolves.toBeUndefined()
+
+    expect(useCollections()).toBe(firstState)
+    expect(firstState.collections).toEqual([])
+    expect(firstState.activeCollectionId).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Replays the bounded Collections provider-lifecycle removal from superseded PR #726 onto current `main` after PR #723 changed the integration base.

Part of #636.

## Stage scope

- Removes `CollectionProvider` from the authenticated application shell.
- Replaces the remaining React context with one stable, inert compatibility state.
- Keeps temporary Roll and Queue callers compiling while later #636 stages delete their collection-specific branches.
- Adds focused regression coverage proving the compatibility wrapper owns no lifecycle and its mutation methods cannot recreate collection state.

## Branch repair

This branch starts from current `main` and semantically replays the three-file change from PR #726 without force-rewriting its exact-SHA history.

## Remaining work

- Delete remaining `useCollections` callers and collection props/state from Roll and Queue.
- Delete the temporary compatibility module after its final callers are removed.
- Remove collection API clients, types, backend routes, schemas, models, persistence, fixtures, and documentation.

## Verification

No local result is claimed because this automation runtime has no repository checkout. CI must validate frontend lint, typecheck, unit coverage, backend tests, migrations, and API E2E on exact SHA `585cc7cb0d5d12c9b7b5a1b0fc876d615e911be3`.

This PR is non-draft and must not be merged without Josh's explicit authorization.