### PR TITLE
feat(query): replay retained resource key factories (#702)

### DIFF
--- a/frontend/src/hooks/useCurrentSessionQuery.ts
+++ b/frontend/src/hooks/useCurrentSessionQuery.ts
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useRef, type SetStateAction } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useToast } from '../contexts/useToast'
+import { queryKeys } from '../query/queryKeys'
+import { sessionApi } from '../services/api'
+import type { SessionCurrent } from '../types'
+
+const STORAGE_KEY_PREFIX = 'comic_pile_last_session_id'
+
+/**
+ * Load current-session state through the canonical TanStack query key.
+ *
+ * Rating, snooze, and Queue mutations invalidate this exact key, so consumers
+ * using this hook receive one shared refresh instead of maintaining isolated
+ * request state that cannot observe centralized cache effects.
+ */
+export function useCurrentSessionQuery() {
+  const client = useQueryClient()
+  const { showToast } = useToast()
+  const lastNotifiedSessionIdRef = useRef<number | null>(null)
+  const key = queryKeys.session.current()
+
+  const query = useQuery({
+    queryKey: key,
+    queryFn: () => sessionApi.getCurrent(),
+  })
+
+  useEffect(() => {
+    const session = query.data
+    if (!session) return
+
+    const currentSessionId = session.id
+    const currentUserId = session.user_id ?? 'anonymous'
+    const storageKey = `${STORAGE_KEY_PREFIX}_${currentUserId}`
+    let storedSessionId: string | null = null
+
+    try {
+      storedSessionId = localStorage.getItem(storageKey)
+    } catch {
+      // Session loading must still succeed when browser storage is unavailable.
+    }
+
+    const parsedSessionId = storedSessionId
+      ? Number.parseInt(storedSessionId, 10)
+      : Number.NaN
+    const previousSessionId = Number.isFinite(parsedSessionId)
+      ? parsedSessionId
+      : null
+
+    if (
+      previousSessionId !== null &&
+      currentSessionId !== previousSessionId &&
+      currentSessionId !== lastNotifiedSessionIdRef.current
+    ) {
+      showToast('Session started. Happy reading!', 'info')
+      lastNotifiedSessionIdRef.current = currentSessionId
+    }
+
+    try {
+      localStorage.setItem(storageKey, currentSessionId.toString())
+    } catch {
+      // Persisting the session ID is best effort and must not hide API data.
+    }
+  }, [query.data, showToast])
+
+  const setData = useCallback(
+    (value: SetStateAction<SessionCurrent | null>) => {
+      client.setQueryData<SessionCurrent | null>(key, (current) =>
+        typeof value === 'function' ? value(current ?? null) : value,
+      )
+    },
+    [client, key],
+  )
+
+  return {
+    ...query,
+    data: query.data ?? null,
+    setData,
+  }
+}

--- a/frontend/src/hooks/useQueue.ts
+++ b/frontend/src/hooks/useQueue.ts
@@ -1,4 +1,6 @@
 import { useCallback, useState } from 'react'
+import { invalidateAfterQueueMovement } from '../query/cacheEffects'
+import { queryClient } from '../query/queryClient'
 import { queueApi } from '../services/api'
 import { getApiErrorDetail } from '../utils/apiError'
 import type { MoveToPositionPayload } from '../types'
@@ -12,6 +14,7 @@ export function useMoveToPosition() {
       setIsPending(true)
       setIsError(false)
       await queueApi.moveToPosition(id, position)
+      await invalidateAfterQueueMovement(queryClient)
     } catch (error: unknown) {
       setIsError(true)
       console.error('Failed to move thread to position:', getApiErrorDetail(error))
@@ -33,6 +36,7 @@ export function useMoveToFront() {
       setIsPending(true)
       setIsError(false)
       await queueApi.moveToFront(id)
+      await invalidateAfterQueueMovement(queryClient)
     } catch (error: unknown) {
       setIsError(true)
       console.error('Failed to move thread to front:', getApiErrorDetail(error))
@@ -54,6 +58,7 @@ export function useMoveToBack() {
       setIsPending(true)
       setIsError(false)
       await queueApi.moveToBack(id)
+      await invalidateAfterQueueMovement(queryClient)
     } catch (error: unknown) {
       setIsError(true)
       console.error('Failed to move thread to back:', getApiErrorDetail(error))
@@ -75,6 +80,7 @@ export function useShuffleQueue() {
       setIsPending(true)
       setIsError(false)
       await queueApi.shuffle()
+      await invalidateAfterQueueMovement(queryClient)
     } catch (error: unknown) {
       setIsError(true)
       console.error('Failed to shuffle queue:', getApiErrorDetail(error))

--- a/frontend/src/hooks/useRate.ts
+++ b/frontend/src/hooks/useRate.ts
@@ -1,4 +1,6 @@
 import { useState } from 'react'
+import { queryClient } from '../query/queryClient'
+import { applyRatedThreadCache } from '../query/cacheEffects'
 import { rateApi } from '../services/api'
 import { getApiErrorDetail } from '../utils/apiError'
 import type { RatePayload } from '../types'
@@ -11,7 +13,9 @@ export function useRate() {
     setIsPending(true)
     setIsError(false)
     try {
-      return await rateApi.rate(data)
+      const thread = await rateApi.rate(data)
+      await applyRatedThreadCache(queryClient, thread)
+      return thread
     } catch (error: unknown) {
       setIsError(true)
       console.error('Failed to rate thread:', getApiErrorDetail(error))

--- a/frontend/src/hooks/useSnooze.ts
+++ b/frontend/src/hooks/useSnooze.ts
@@ -1,4 +1,6 @@
 import { useState } from 'react'
+import { invalidateCurrentSessionAfterSnooze } from '../query/cacheEffects'
+import { queryClient } from '../query/queryClient'
 import { snoozeApi } from '../services/api'
 import { getApiErrorDetail } from '../utils/apiError'
 
@@ -11,6 +13,7 @@ export function useSnooze() {
     setIsError(false)
     try {
       await snoozeApi.snooze()
+      await invalidateCurrentSessionAfterSnooze(queryClient)
     } catch (error: unknown) {
       setIsError(true)
       console.error('Failed to snooze thread:', getApiErrorDetail(error))
@@ -32,6 +35,7 @@ export function useUnsnooze() {
     setIsError(false)
     try {
       await snoozeApi.unsnooze(threadId)
+      await invalidateCurrentSessionAfterSnooze(queryClient)
     } catch (error: unknown) {
       setIsError(true)
       console.error('Failed to unsnooze thread:', getApiErrorDetail(error))

--- a/frontend/src/hooks/useThread.ts
+++ b/frontend/src/hooks/useThread.ts
@@ -3,6 +3,8 @@ import axios from 'axios';
 import { threadsApi } from '../services/api';
 import type { ReactivateThreadPayload, Thread, ThreadCreatePayload, ThreadListResponse, ThreadQueryParams, ThreadUpdatePayload } from '../types';
 import { CacheContext } from '../contexts/CacheContextValue';
+import { applyUpdatedThreadCache } from '../query/cacheEffects';
+import { queryClient } from '../query/queryClient';
 
 type UseThreadsOptions = {
   searchTerm?: string;
@@ -222,8 +224,6 @@ export function useCreateThread() {
 }
 
 export function useUpdateThread() {
-  const cache = useContext(CacheContext);
-  const invalidateQueries = useMemo(() => cache?.invalidateQueries ?? (() => {}), [cache]);
   const [isPending, setIsPending] = useState(false);
   const [isError, setIsError] = useState(false);
 
@@ -234,7 +234,7 @@ export function useUpdateThread() {
 
       try {
         const result = await threadsApi.update(id, data);
-        invalidateQueries(['threads']);
+        await applyUpdatedThreadCache(queryClient, result);
         return result;
       } catch (error: unknown) {
         const detail = axios.isAxiosError<{ detail?: string }>(error)
@@ -247,7 +247,7 @@ export function useUpdateThread() {
         setIsPending(false);
       }
     },
-    [invalidateQueries]
+    []
   );
 
   return { mutate, isPending, isError };

--- a/frontend/src/query/cacheEffects.ts
+++ b/frontend/src/query/cacheEffects.ts
@@ -22,6 +22,34 @@ export async function applyRatedThreadCache(
 }
 
 /**
+ * Apply the authoritative thread returned by a successful thread edit.
+ *
+ * Thread edits can change Queue ordering/filter presentation and Roll eligibility,
+ * so those screen read models are recalculated narrowly. The returned entity remains
+ * authoritative for exact thread detail and summary caches. History, dependencies,
+ * analytics, and unrelated thread entries remain valid.
+ */
+export async function applyUpdatedThreadCache(
+  client: QueryClient,
+  thread: Thread,
+): Promise<void> {
+  client.setQueryData(queryKeys.thread.detail(thread.id), thread)
+  client.setQueryData(queryKeys.thread.summary(thread.id), thread)
+
+  await Promise.all([
+    client.invalidateQueries({ queryKey: queryKeys.queue.pages() }),
+    client.invalidateQueries({
+      queryKey: queryKeys.session.current(),
+      exact: true,
+    }),
+    client.invalidateQueries({
+      queryKey: queryKeys.roll.bootstrap(),
+      exact: true,
+    }),
+  ])
+}
+
+/**
  * Reconcile snooze and unsnooze mutations through their authoritative owner.
  *
  * Snooze membership lives on the current session, so these mutations must not

--- a/frontend/src/query/cacheEffects.ts
+++ b/frontend/src/query/cacheEffects.ts
@@ -50,6 +50,37 @@ export async function applyUpdatedThreadCache(
 }
 
 /**
+ * Reconcile an issue edit through the thread-owned read models it can change.
+ *
+ * Issue title, number, read state, and ordering changes affect the edited thread's
+ * paginated issue rows. They can also alter thread summary/detail counters and the
+ * current session when the edited issue is pending. Unrelated threads, Queue pages,
+ * History, dependencies, Roll bootstrap, and analytics remain valid.
+ */
+export async function invalidateAfterIssueEdit(
+  client: QueryClient,
+  threadId: number,
+): Promise<void> {
+  await Promise.all([
+    client.invalidateQueries({
+      queryKey: queryKeys.thread.issuePages(threadId),
+    }),
+    client.invalidateQueries({
+      queryKey: queryKeys.thread.detail(threadId),
+      exact: true,
+    }),
+    client.invalidateQueries({
+      queryKey: queryKeys.thread.summary(threadId),
+      exact: true,
+    }),
+    client.invalidateQueries({
+      queryKey: queryKeys.session.current(),
+      exact: true,
+    }),
+  ])
+}
+
+/**
  * Reconcile snooze and unsnooze mutations through their authoritative owner.
  *
  * Snooze membership lives on the current session, so these mutations must not

--- a/frontend/src/query/cacheEffects.ts
+++ b/frontend/src/query/cacheEffects.ts
@@ -1,0 +1,37 @@
+import type { QueryClient } from '@tanstack/react-query'
+import type { Thread } from '../types'
+import { queryKeys } from './queryKeys'
+
+/**
+ * Apply the authoritative thread returned by a successful rating mutation.
+ *
+ * Rating changes the rated thread and current-session state. It must not invalidate
+ * every Queue, History, analytics, dependency, or thread-page query.
+ */
+export async function applyRatedThreadCache(
+  client: QueryClient,
+  thread: Thread,
+): Promise<void> {
+  client.setQueryData(queryKeys.thread.detail(thread.id), thread)
+  client.setQueryData(queryKeys.thread.summary(thread.id), thread)
+
+  await client.invalidateQueries({
+    queryKey: queryKeys.session.current(),
+    exact: true,
+  })
+}
+
+/**
+ * Reconcile snooze and unsnooze mutations through their authoritative owner.
+ *
+ * Snooze membership lives on the current session, so these mutations must not
+ * invalidate full thread pages or unrelated screen caches.
+ */
+export async function invalidateCurrentSessionAfterSnooze(
+  client: QueryClient,
+): Promise<void> {
+  await client.invalidateQueries({
+    queryKey: queryKeys.session.current(),
+    exact: true,
+  })
+}

--- a/frontend/src/query/cacheEffects.ts
+++ b/frontend/src/query/cacheEffects.ts
@@ -35,3 +35,26 @@ export async function invalidateCurrentSessionAfterSnooze(
     exact: true,
   })
 }
+
+/**
+ * Reconcile queue ordering mutations without evicting unrelated server state.
+ *
+ * A move can reshape every filtered or paginated Queue page and can change the
+ * current session and Roll selection. Thread details, History, dependencies, and
+ * analytics remain valid and must not be globally invalidated.
+ */
+export async function invalidateAfterQueueMovement(
+  client: QueryClient,
+): Promise<void> {
+  await Promise.all([
+    client.invalidateQueries({ queryKey: queryKeys.queue.pages() }),
+    client.invalidateQueries({
+      queryKey: queryKeys.session.current(),
+      exact: true,
+    }),
+    client.invalidateQueries({
+      queryKey: queryKeys.roll.bootstrap(),
+      exact: true,
+    }),
+  ])
+}

--- a/frontend/src/query/queryKeys.ts
+++ b/frontend/src/query/queryKeys.ts
@@ -1,3 +1,85 @@
-export const queryKeys = {
-    collections: ['collections'] as const,
+export type QueueSort = 'position' | 'alphabetical' | 'created'
+
+export interface QueuePageKeyOptions {
+  search?: string
+  sort: QueueSort
+  pageToken?: string | null
+  pageSize: number
 }
+
+export interface SessionPageKeyOptions {
+  pageToken?: string | null
+  pageSize: number
+}
+
+export interface ThreadIssuePageKeyOptions {
+  pageToken?: string | null
+  pageSize: number
+  status?: 'read' | 'unread'
+}
+
+function normalizedSearch(search?: string): string | null {
+  const value = search?.trim()
+  return value ? value : null
+}
+
+export const queryKeys = {
+  session: {
+    all: ['session'] as const,
+    current: () => ['session', 'current'] as const,
+    pages: () => ['session', 'pages'] as const,
+    page: ({ pageToken, pageSize }: SessionPageKeyOptions) =>
+      ['session', 'pages', { pageToken: pageToken ?? null, pageSize }] as const,
+    detail: (sessionId: number) => ['session', 'detail', sessionId] as const,
+  },
+  queue: {
+    all: ['queue'] as const,
+    pages: () => ['queue', 'pages'] as const,
+    page: ({ search, sort, pageToken, pageSize }: QueuePageKeyOptions) =>
+      [
+        'queue',
+        'pages',
+        {
+          search: normalizedSearch(search),
+          sort,
+          pageToken: pageToken ?? null,
+          pageSize,
+        },
+      ] as const,
+  },
+  roll: {
+    all: ['roll'] as const,
+    bootstrap: () => ['roll', 'bootstrap'] as const,
+  },
+  thread: {
+    all: ['thread'] as const,
+    summaries: () => ['thread', 'summary'] as const,
+    summary: (threadId: number) => ['thread', 'summary', threadId] as const,
+    details: () => ['thread', 'detail'] as const,
+    detail: (threadId: number) => ['thread', 'detail', threadId] as const,
+    issuePages: (threadId: number) => ['thread', threadId, 'issues'] as const,
+    issuePage: (
+      threadId: number,
+      { pageToken, pageSize, status }: ThreadIssuePageKeyOptions,
+    ) =>
+      [
+        'thread',
+        threadId,
+        'issues',
+        {
+          pageToken: pageToken ?? null,
+          pageSize,
+          status: status ?? null,
+        },
+      ] as const,
+  },
+  dependencies: {
+    all: ['dependencies'] as const,
+    forThread: (threadId: number) => ['dependencies', 'thread', threadId] as const,
+    blocking: (threadId: number) => ['dependencies', 'blocking', threadId] as const,
+  },
+  analytics: {
+    all: ['analytics'] as const,
+    overview: () => ['analytics', 'overview'] as const,
+  },
+} as const

--- a/frontend/src/unit/cacheEffects.test.ts
+++ b/frontend/src/unit/cacheEffects.test.ts
@@ -1,0 +1,58 @@
+import { QueryClient } from '@tanstack/react-query'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  applyRatedThreadCache,
+  invalidateCurrentSessionAfterSnooze,
+} from '../query/cacheEffects'
+import { queryKeys } from '../query/queryKeys'
+import type { Thread } from '../types'
+
+function buildThread(id: number): Thread {
+  return {
+    id,
+    title: 'Saga',
+  } as Thread
+}
+
+describe('retained mutation cache effects', () => {
+  it('uses the rating response as authoritative thread state and invalidates current session only', async () => {
+    const client = new QueryClient()
+    const invalidateQueries = vi.spyOn(client, 'invalidateQueries')
+    const thread = buildThread(7)
+
+    await applyRatedThreadCache(client, thread)
+
+    expect(client.getQueryData(queryKeys.thread.detail(7))).toEqual(thread)
+    expect(client.getQueryData(queryKeys.thread.summary(7))).toEqual(thread)
+    expect(invalidateQueries).toHaveBeenCalledTimes(1)
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.session.current(),
+      exact: true,
+    })
+    expect(invalidateQueries).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: queryKeys.queue.pages() }),
+    )
+    expect(invalidateQueries).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: queryKeys.thread.all }),
+    )
+  })
+
+  it('reconciles snooze and unsnooze through current-session state without thread-page invalidation', async () => {
+    const client = new QueryClient()
+    const invalidateQueries = vi.spyOn(client, 'invalidateQueries')
+
+    await invalidateCurrentSessionAfterSnooze(client)
+
+    expect(invalidateQueries).toHaveBeenCalledTimes(1)
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.session.current(),
+      exact: true,
+    })
+    expect(invalidateQueries).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: queryKeys.thread.all }),
+    )
+    expect(invalidateQueries).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: queryKeys.analytics.all }),
+    )
+  })
+})

--- a/frontend/src/unit/cacheEffects.test.ts
+++ b/frontend/src/unit/cacheEffects.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   applyRatedThreadCache,
   applyUpdatedThreadCache,
+  invalidateAfterIssueEdit,
   invalidateAfterQueueMovement,
   invalidateCurrentSessionAfterSnooze,
 } from '../query/cacheEffects'
@@ -62,6 +63,45 @@ describe('retained mutation cache effects', () => {
     })
     expect(invalidateQueries).not.toHaveBeenCalledWith(
       expect.objectContaining({ queryKey: queryKeys.session.pages() }),
+    )
+    expect(invalidateQueries).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: queryKeys.dependencies.all }),
+    )
+    expect(invalidateQueries).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: queryKeys.analytics.all }),
+    )
+  })
+
+  it('invalidates only the edited thread issue pages, summaries, detail, and current session', async () => {
+    const client = new QueryClient()
+    const invalidateQueries = vi.spyOn(client, 'invalidateQueries')
+
+    await invalidateAfterIssueEdit(client, 12)
+
+    expect(invalidateQueries).toHaveBeenCalledTimes(4)
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.thread.issuePages(12),
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.thread.detail(12),
+      exact: true,
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.thread.summary(12),
+      exact: true,
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.session.current(),
+      exact: true,
+    })
+    expect(invalidateQueries).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: queryKeys.thread.issuePages(13) }),
+    )
+    expect(invalidateQueries).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: queryKeys.queue.pages() }),
+    )
+    expect(invalidateQueries).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: queryKeys.roll.bootstrap() }),
     )
     expect(invalidateQueries).not.toHaveBeenCalledWith(
       expect.objectContaining({ queryKey: queryKeys.dependencies.all }),

--- a/frontend/src/unit/cacheEffects.test.ts
+++ b/frontend/src/unit/cacheEffects.test.ts
@@ -2,6 +2,7 @@ import { QueryClient } from '@tanstack/react-query'
 import { describe, expect, it, vi } from 'vitest'
 import {
   applyRatedThreadCache,
+  invalidateAfterQueueMovement,
   invalidateCurrentSessionAfterSnooze,
 } from '../query/cacheEffects'
 import { queryKeys } from '../query/queryKeys'
@@ -50,6 +51,35 @@ describe('retained mutation cache effects', () => {
     })
     expect(invalidateQueries).not.toHaveBeenCalledWith(
       expect.objectContaining({ queryKey: queryKeys.thread.all }),
+    )
+    expect(invalidateQueries).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: queryKeys.analytics.all }),
+    )
+  })
+
+  it('invalidates queue pages and their selection owners without evicting unrelated resources', async () => {
+    const client = new QueryClient()
+    const invalidateQueries = vi.spyOn(client, 'invalidateQueries')
+
+    await invalidateAfterQueueMovement(client)
+
+    expect(invalidateQueries).toHaveBeenCalledTimes(3)
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.queue.pages(),
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.session.current(),
+      exact: true,
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.roll.bootstrap(),
+      exact: true,
+    })
+    expect(invalidateQueries).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: queryKeys.thread.all }),
+    )
+    expect(invalidateQueries).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: queryKeys.session.pages() }),
     )
     expect(invalidateQueries).not.toHaveBeenCalledWith(
       expect.objectContaining({ queryKey: queryKeys.analytics.all }),

--- a/frontend/src/unit/cacheEffects.test.ts
+++ b/frontend/src/unit/cacheEffects.test.ts
@@ -2,6 +2,7 @@ import { QueryClient } from '@tanstack/react-query'
 import { describe, expect, it, vi } from 'vitest'
 import {
   applyRatedThreadCache,
+  applyUpdatedThreadCache,
   invalidateAfterQueueMovement,
   invalidateCurrentSessionAfterSnooze,
 } from '../query/cacheEffects'
@@ -35,6 +36,38 @@ describe('retained mutation cache effects', () => {
     )
     expect(invalidateQueries).not.toHaveBeenCalledWith(
       expect.objectContaining({ queryKey: queryKeys.thread.all }),
+    )
+  })
+
+  it('uses a thread edit response directly and recalculates only affected screens', async () => {
+    const client = new QueryClient()
+    const invalidateQueries = vi.spyOn(client, 'invalidateQueries')
+    const thread = buildThread(9)
+
+    await applyUpdatedThreadCache(client, thread)
+
+    expect(client.getQueryData(queryKeys.thread.detail(9))).toEqual(thread)
+    expect(client.getQueryData(queryKeys.thread.summary(9))).toEqual(thread)
+    expect(invalidateQueries).toHaveBeenCalledTimes(3)
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.queue.pages(),
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.session.current(),
+      exact: true,
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.roll.bootstrap(),
+      exact: true,
+    })
+    expect(invalidateQueries).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: queryKeys.session.pages() }),
+    )
+    expect(invalidateQueries).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: queryKeys.dependencies.all }),
+    )
+    expect(invalidateQueries).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: queryKeys.analytics.all }),
     )
   })
 

--- a/frontend/src/unit/queryKeys.test.ts
+++ b/frontend/src/unit/queryKeys.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import { queryKeys } from '../query/queryKeys'
+
+describe('queryKeys', () => {
+  it('builds stable session keys with pagination inputs', () => {
+    expect(queryKeys.session.all).toEqual(['session'])
+    expect(queryKeys.session.current()).toEqual(['session', 'current'])
+    expect(queryKeys.session.pages()).toEqual(['session', 'pages'])
+    expect(queryKeys.session.page({ pageSize: 25 })).toEqual([
+      'session',
+      'pages',
+      { pageToken: null, pageSize: 25 },
+    ])
+    expect(queryKeys.session.page({ pageToken: 'sessions-2', pageSize: 10 })).toEqual([
+      'session',
+      'pages',
+      { pageToken: 'sessions-2', pageSize: 10 },
+    ])
+    expect(queryKeys.session.detail(42)).toEqual(['session', 'detail', 42])
+  })
+
+  it('normalizes queue search and includes every page-shaping input', () => {
+    expect(queryKeys.queue.all).toEqual(['queue'])
+    expect(queryKeys.queue.pages()).toEqual(['queue', 'pages'])
+    expect(
+      queryKeys.queue.page({
+        search: '  Saga  ',
+        sort: 'alphabetical',
+        pageToken: 'next-1',
+        pageSize: 50,
+      }),
+    ).toEqual([
+      'queue',
+      'pages',
+      {
+        search: 'Saga',
+        sort: 'alphabetical',
+        pageToken: 'next-1',
+        pageSize: 50,
+      },
+    ])
+
+    expect(
+      queryKeys.queue.page({
+        search: '   ',
+        sort: 'position',
+        pageSize: 20,
+      }),
+    ).toEqual([
+      'queue',
+      'pages',
+      {
+        search: null,
+        sort: 'position',
+        pageToken: null,
+        pageSize: 20,
+      },
+    ])
+  })
+
+  it('scopes every thread and dependency key by resource id', () => {
+    expect(queryKeys.thread.all).toEqual(['thread'])
+    expect(queryKeys.thread.summaries()).toEqual(['thread', 'summary'])
+    expect(queryKeys.thread.summary(7)).toEqual(['thread', 'summary', 7])
+    expect(queryKeys.thread.details()).toEqual(['thread', 'detail'])
+    expect(queryKeys.thread.detail(7)).toEqual(['thread', 'detail', 7])
+    expect(queryKeys.thread.issuePages(7)).toEqual(['thread', 7, 'issues'])
+    expect(
+      queryKeys.thread.issuePage(7, {
+        pageToken: 'issues-2',
+        pageSize: 100,
+        status: 'unread',
+      }),
+    ).toEqual([
+      'thread',
+      7,
+      'issues',
+      {
+        pageToken: 'issues-2',
+        pageSize: 100,
+        status: 'unread',
+      },
+    ])
+    expect(queryKeys.thread.issuePage(7, { pageSize: 25 })).toEqual([
+      'thread',
+      7,
+      'issues',
+      {
+        pageToken: null,
+        pageSize: 25,
+        status: null,
+      },
+    ])
+    expect(queryKeys.dependencies.all).toEqual(['dependencies'])
+    expect(queryKeys.dependencies.forThread(7)).toEqual(['dependencies', 'thread', 7])
+    expect(queryKeys.dependencies.blocking(7)).toEqual(['dependencies', 'blocking', 7])
+  })
+
+  it('defines retained roll and analytics roots without a collections key family', () => {
+    expect(queryKeys.roll.all).toEqual(['roll'])
+    expect(queryKeys.roll.bootstrap()).toEqual(['roll', 'bootstrap'])
+    expect(queryKeys.analytics.all).toEqual(['analytics'])
+    expect(queryKeys.analytics.overview()).toEqual(['analytics', 'overview'])
+    expect('collections' in queryKeys).toBe(false)
+  })
+})

--- a/frontend/src/unit/useCurrentSessionQuery.test.tsx
+++ b/frontend/src/unit/useCurrentSessionQuery.test.tsx
@@ -84,7 +84,7 @@ describe('useCurrentSessionQuery', () => {
       )
     })
 
-    expect(result.current.data?.id).toBe(21)
+    await waitFor(() => expect(result.current.data?.id).toBe(21))
     expect(client.getQueryData(queryKeys.session.current())).toMatchObject({ id: 21 })
   })
 })

--- a/frontend/src/unit/useCurrentSessionQuery.test.tsx
+++ b/frontend/src/unit/useCurrentSessionQuery.test.tsx
@@ -126,7 +126,9 @@ describe('useCurrentSessionQuery', () => {
   })
 
   it('accepts a direct cache value when no current session is cached', async () => {
-    vi.mocked(sessionApi.getCurrent).mockResolvedValue(null)
+    vi.mocked(sessionApi.getCurrent).mockImplementation(
+      () => new Promise(() => undefined),
+    )
 
     const client = new QueryClient({
       defaultOptions: {
@@ -138,7 +140,6 @@ describe('useCurrentSessionQuery', () => {
     )
 
     const { result } = renderHook(() => useCurrentSessionQuery(), { wrapper })
-    await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
     act(() => {
       result.current.setData({ id: 31, current_die: 4, user_id: 12 })

--- a/frontend/src/unit/useCurrentSessionQuery.test.tsx
+++ b/frontend/src/unit/useCurrentSessionQuery.test.tsx
@@ -87,4 +87,64 @@ describe('useCurrentSessionQuery', () => {
     await waitFor(() => expect(result.current.data?.id).toBe(21))
     expect(client.getQueryData(queryKeys.session.current())).toMatchObject({ id: 21 })
   })
+
+  it('keeps API data usable when browser storage reads and writes fail', async () => {
+    vi.mocked(sessionApi.getCurrent).mockResolvedValue({
+      id: 30,
+      current_die: 20,
+      user_id: 12,
+    })
+    const getItem = vi
+      .spyOn(Storage.prototype, 'getItem')
+      .mockImplementation(() => {
+        throw new Error('storage read blocked')
+      })
+    const setItem = vi
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('storage write blocked')
+      })
+
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    })
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(() => useCurrentSessionQuery(), { wrapper })
+
+    await waitFor(() => expect(result.current.data?.id).toBe(30))
+    expect(showToast).not.toHaveBeenCalled()
+    expect(getItem).toHaveBeenCalledWith('comic_pile_last_session_id_12')
+    expect(setItem).toHaveBeenCalledWith('comic_pile_last_session_id_12', '30')
+
+    getItem.mockRestore()
+    setItem.mockRestore()
+  })
+
+  it('accepts a direct cache value when no current session is cached', async () => {
+    vi.mocked(sessionApi.getCurrent).mockResolvedValue(null)
+
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    })
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(() => useCurrentSessionQuery(), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    act(() => {
+      result.current.setData({ id: 31, current_die: 4, user_id: 12 })
+    })
+
+    await waitFor(() => expect(result.current.data?.id).toBe(31))
+    expect(client.getQueryData(queryKeys.session.current())).toMatchObject({ id: 31 })
+  })
 })

--- a/frontend/src/unit/useCurrentSessionQuery.test.tsx
+++ b/frontend/src/unit/useCurrentSessionQuery.test.tsx
@@ -27,8 +27,8 @@ describe('useCurrentSessionQuery', () => {
 
   it('shares the canonical current-session key and refetches after exact invalidation', async () => {
     vi.mocked(sessionApi.getCurrent)
-      .mockResolvedValueOnce({ id: 10, user_id: 7 })
-      .mockResolvedValueOnce({ id: 11, user_id: 7 })
+      .mockResolvedValueOnce({ id: 10, current_die: 6, user_id: 7 })
+      .mockResolvedValueOnce({ id: 11, current_die: 8, user_id: 7 })
 
     const client = new QueryClient({
       defaultOptions: {
@@ -60,7 +60,11 @@ describe('useCurrentSessionQuery', () => {
   })
 
   it('writes compatible local updates into the same canonical cache entry', async () => {
-    vi.mocked(sessionApi.getCurrent).mockResolvedValue({ id: 20, user_id: 9 })
+    vi.mocked(sessionApi.getCurrent).mockResolvedValue({
+      id: 20,
+      current_die: 12,
+      user_id: 9,
+    })
 
     const client = new QueryClient({
       defaultOptions: {

--- a/frontend/src/unit/useCurrentSessionQuery.test.tsx
+++ b/frontend/src/unit/useCurrentSessionQuery.test.tsx
@@ -1,0 +1,86 @@
+import type { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useCurrentSessionQuery } from '../hooks/useCurrentSessionQuery'
+import { queryKeys } from '../query/queryKeys'
+import { sessionApi } from '../services/api'
+
+const showToast = vi.fn()
+
+vi.mock('../contexts/useToast', () => ({
+  useToast: () => ({ showToast }),
+}))
+
+vi.mock('../services/api', () => ({
+  sessionApi: {
+    getCurrent: vi.fn(),
+  },
+}))
+
+describe('useCurrentSessionQuery', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    showToast.mockReset()
+    vi.mocked(sessionApi.getCurrent).mockReset()
+  })
+
+  it('shares the canonical current-session key and refetches after exact invalidation', async () => {
+    vi.mocked(sessionApi.getCurrent)
+      .mockResolvedValueOnce({ id: 10, user_id: 7 })
+      .mockResolvedValueOnce({ id: 11, user_id: 7 })
+
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    })
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(() => useCurrentSessionQuery(), { wrapper })
+
+    await waitFor(() => expect(result.current.data?.id).toBe(10))
+    expect(client.getQueryData(queryKeys.session.current())).toMatchObject({ id: 10 })
+
+    await act(async () => {
+      await client.invalidateQueries({
+        queryKey: queryKeys.session.current(),
+        exact: true,
+      })
+    })
+
+    await waitFor(() => expect(result.current.data?.id).toBe(11))
+    expect(sessionApi.getCurrent).toHaveBeenCalledTimes(2)
+    expect(showToast).toHaveBeenCalledWith(
+      'Session started. Happy reading!',
+      'info',
+    )
+  })
+
+  it('writes compatible local updates into the same canonical cache entry', async () => {
+    vi.mocked(sessionApi.getCurrent).mockResolvedValue({ id: 20, user_id: 9 })
+
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    })
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    )
+
+    const { result } = renderHook(() => useCurrentSessionQuery(), { wrapper })
+    await waitFor(() => expect(result.current.data?.id).toBe(20))
+
+    act(() => {
+      result.current.setData((current) =>
+        current ? { ...current, id: 21 } : current,
+      )
+    })
+
+    expect(result.current.data?.id).toBe(21)
+    expect(client.getQueryData(queryKeys.session.current())).toMatchObject({ id: 21 })
+  })
+})

--- a/frontend/src/unit/useQueue.test.tsx
+++ b/frontend/src/unit/useQueue.test.tsx
@@ -1,6 +1,12 @@
 import { act, renderHook } from '@testing-library/react'
 import { beforeEach, expect, it, vi } from 'vitest'
-import { useMoveToBack, useMoveToFront, useMoveToPosition, useShuffleQueue } from '../hooks/useQueue'
+import {
+  useMoveToBack,
+  useMoveToFront,
+  useMoveToPosition,
+  useShuffleQueue,
+} from '../hooks/useQueue'
+import { invalidateAfterQueueMovement } from '../query/cacheEffects'
 import { queueApi } from '../services/api'
 
 vi.mock('../services/api', () => ({
@@ -12,16 +18,25 @@ vi.mock('../services/api', () => ({
   },
 }))
 
+vi.mock('../query/cacheEffects', () => ({
+  invalidateAfterQueueMovement: vi.fn(),
+}))
+
 const mockedQueueApi = vi.mocked(queueApi)
+const mockedInvalidateAfterQueueMovement = vi.mocked(
+  invalidateAfterQueueMovement,
+)
 
 beforeEach(() => {
+  vi.clearAllMocks()
   mockedQueueApi.moveToPosition.mockResolvedValue(undefined as never)
   mockedQueueApi.moveToFront.mockResolvedValue(undefined as never)
   mockedQueueApi.moveToBack.mockResolvedValue(undefined as never)
   mockedQueueApi.shuffle.mockResolvedValue(undefined as never)
+  mockedInvalidateAfterQueueMovement.mockResolvedValue(undefined)
 })
 
-it('moves queue position', async () => {
+it('moves queue position and reconciles retained queue owners', async () => {
   const { result } = renderHook(() => useMoveToPosition())
 
   await act(async () => {
@@ -29,9 +44,10 @@ it('moves queue position', async () => {
   })
 
   expect(mockedQueueApi.moveToPosition).toHaveBeenCalledWith(4, 2)
+  expect(mockedInvalidateAfterQueueMovement).toHaveBeenCalledTimes(1)
 })
 
-it('moves thread to front and back', async () => {
+it('moves thread to front and back and reconciles each successful movement', async () => {
   const { result: frontResult } = renderHook(() => useMoveToFront())
   await act(async () => {
     await frontResult.current.mutate(8)
@@ -44,9 +60,10 @@ it('moves thread to front and back', async () => {
 
   expect(mockedQueueApi.moveToFront).toHaveBeenCalledWith(8)
   expect(mockedQueueApi.moveToBack).toHaveBeenCalledWith(9)
+  expect(mockedInvalidateAfterQueueMovement).toHaveBeenCalledTimes(2)
 })
 
-it('shuffles the queue', async () => {
+it('shuffles the queue and reconciles retained queue owners', async () => {
   const { result } = renderHook(() => useShuffleQueue())
 
   await act(async () => {
@@ -54,4 +71,19 @@ it('shuffles the queue', async () => {
   })
 
   expect(mockedQueueApi.shuffle).toHaveBeenCalled()
+  expect(mockedInvalidateAfterQueueMovement).toHaveBeenCalledTimes(1)
+})
+
+it('does not invalidate retained queue owners when the mutation fails', async () => {
+  mockedQueueApi.moveToFront.mockRejectedValueOnce(new Error('move failed'))
+  const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+  const { result } = renderHook(() => useMoveToFront())
+
+  await act(async () => {
+    await expect(result.current.mutate(12)).rejects.toThrow('move failed')
+  })
+
+  expect(result.current.isError).toBe(true)
+  expect(mockedInvalidateAfterQueueMovement).not.toHaveBeenCalled()
+  consoleError.mockRestore()
 })

--- a/frontend/src/unit/useRate.test.tsx
+++ b/frontend/src/unit/useRate.test.tsx
@@ -2,7 +2,7 @@ import { act, renderHook } from '@testing-library/react'
 import { beforeEach, expect, it, vi } from 'vitest'
 import { useRate } from '../hooks/useRate'
 import { rateApi } from '../services/api'
-import type { RatePayload } from '../types'
+import type { RatePayload, Thread } from '../types'
 
 vi.mock('../services/api', () => ({
   rateApi: {
@@ -12,17 +12,38 @@ vi.mock('../services/api', () => ({
 
 const mockedRateApi = vi.mocked(rateApi)
 
+const ratedThread: Thread = {
+  id: 1,
+  title: 'Rated thread',
+  format: 'issue',
+  issues_remaining: 9,
+  total_issues: 10,
+  next_unread_issue_id: 2,
+  next_unread_issue_number: '2',
+  reading_progress: '10.00',
+  queue_position: 1,
+  status: 'active',
+  is_blocked: false,
+  blocking_reasons: [],
+  collection_id: null,
+  notes: null,
+  last_activity_at: '2026-08-03T01:00:00Z',
+  created_at: '2026-08-01T00:00:00Z',
+}
+
 beforeEach(() => {
-  mockedRateApi.rate.mockResolvedValue(undefined as never)
+  mockedRateApi.rate.mockResolvedValue(ratedThread)
 })
 
-it('submits ratings', async () => {
+it('submits ratings and returns the authoritative updated thread', async () => {
   const { result } = renderHook(() => useRate())
   const payload: RatePayload = { thread_id: 1, rating: 4 }
+  let response: Thread | undefined
 
   await act(async () => {
-    await result.current.mutate(payload)
+    response = await result.current.mutate(payload)
   })
 
   expect(mockedRateApi.rate).toHaveBeenCalledWith(payload)
+  expect(response).toEqual(ratedThread)
 })


### PR DESCRIPTION
## Summary

Advances #702 from typed query-key scaffolding into executable retained-mutation cache behavior.

Part of #702.

## Implemented

- Defines typed centralized query keys for sessions, Queue, Roll, threads, dependencies, and analytics.
- Removes the Collections key family.
- Adds exact-shape key tests covering filters, sort, search normalization, pagination, and resource IDs.
- Adds centralized cache effects for rating, snooze, unsnooze, Queue movement, and thread edits.
- Uses authoritative mutation responses to update exact thread detail and summary cache entries directly.
- Invalidates only the current-session key after rating, snooze, and unsnooze.
- Invalidates only Queue pages, current session, and Roll bootstrap after Queue movement and thread edits.
- Adds `useCurrentSessionQuery`, which owns current-session reads under the canonical key while preserving session notifications and compatible local updates.
- Adds regression coverage proving unrelated thread, History, dependency, and analytics caches are not broadly invalidated.
- Adds guarded browser-storage coverage and active-observer refetch coverage.

## Closure status

Issue #702 remains owned and incomplete. This PR must not merge yet.

The remaining acceptance contract requires migrating retained read callers to the centralized keys, defining issue-edit behavior, adding optimistic rollback where interaction quality benefits, removing the obsolete custom invalidation plumbing after callers migrate, validating cross-route/tab behavior, and recording rating plus Queue-movement request counts.

## Verification

Current head: `56282dfbf5a9f74aab6ac1ca1e1d98fcb0778bc5`.

Exact-SHA CI run #733 passed the complete configured matrix on this head. No unresolved review threads are present.

Focused regression coverage includes:

- `frontend/src/unit/queryKeys.test.ts`
- `frontend/src/unit/cacheEffects.test.ts`
- `frontend/src/unit/useCurrentSessionQuery.test.tsx`
- `frontend/src/unit/useRate.test.tsx`
- `frontend/src/unit/useQueue.test.tsx`
- `frontend/src/unit/useThread.test.tsx`

This PR is non-draft and must not be merged without Josh's explicit authorization.