### PR TITLE
refactor(collections): stop resolving retired collection IDs (#636)

### DIFF
--- a/app/services/ownership.py
+++ b/app/services/ownership.py
@@ -29,6 +29,24 @@ async def get_owned_thread_or_404(
     return thread
 
 
+async def get_owned_collection_or_404(
+    db: AsyncSession,
+    user_id: int,
+    collection_id: int,
+) -> None:
+    """Reject references to the retired Collections product capability.
+
+    Thread create and update compatibility fields still call this helper until
+    those request schemas are removed. Do not query retained collection
+    persistence or allow new application behavior to depend on it.
+    """
+    del db, user_id, collection_id
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail="Collection not found",
+    )
+
+
 async def get_owned_issue_or_404(db: AsyncSession, user_id: int, issue_id: int) -> Issue:
     """Fetch an issue by ID only if its thread belongs to the user."""
     result = await db.execute(

--- a/app/services/ownership.py
+++ b/app/services/ownership.py
@@ -5,7 +5,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.models import Collection, Issue, Review, Session as SessionModel, Thread
+from app.models import Issue, Review, Session as SessionModel, Thread
 
 
 async def get_owned_thread_or_404(
@@ -27,27 +27,6 @@ async def get_owned_thread_or_404(
             detail=f"Thread {thread_id} not found",
         )
     return thread
-
-
-async def get_owned_collection_or_404(
-    db: AsyncSession,
-    user_id: int,
-    collection_id: int,
-) -> Collection:
-    """Fetch a collection by ID only if it belongs to the user."""
-    result = await db.execute(
-        select(Collection).where(
-            Collection.id == collection_id,
-            Collection.user_id == user_id,
-        )
-    )
-    collection = result.scalar_one_or_none()
-    if collection is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Collection {collection_id} not found",
-        )
-    return collection
 
 
 async def get_owned_issue_or_404(db: AsyncSession, user_id: int, issue_id: int) -> Issue:

--- a/tests/test_retired_collection_ownership.py
+++ b/tests/test_retired_collection_ownership.py
@@ -1,0 +1,21 @@
+"""Regression coverage for retired Collections ownership compatibility."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException, status
+
+from app.services.ownership import get_owned_collection_or_404
+
+
+@pytest.mark.asyncio
+async def test_retired_collection_reference_returns_not_found_without_querying_database() -> None:
+    """Reject collection IDs without consulting retained collection persistence."""
+    db = AsyncMock()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_owned_collection_or_404(db, user_id=7, collection_id=11)
+
+    assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+    assert exc_info.value.detail == "Collection not found"
+    db.execute.assert_not_awaited()


### PR DESCRIPTION
## Summary

Continues issue #636 after the Collections API route removal merged.

Part of #636.

## Implemented

- Removes the `Collection` model dependency from the shared ownership service.
- Converts the temporary thread create/update compatibility lookup into a deterministic retired-capability 404.
- Prevents collection IDs from querying retained collection persistence or re-establishing collection-backed application behavior.
- Adds focused regression coverage proving the compatibility path returns 404 without executing a database query.

## Closure status

This is not the final persistence-removal change. The retained thread request/response fields, model relationships, application wiring, fixtures, documentation, and authorized forward migration still belong to issue #636.

## Verification

Focused regression coverage: `tests/test_retired_collection_ownership.py`.

Broad validation is delegated to exact-SHA CI in this automation runtime.

This PR is non-draft and must not be merged without Josh's explicit authorization.