### PR TITLE
fix(factory): spell out canonical review verdict markers

### DIFF
--- a/docs/AUTONOMOUS_FACTORY_POLICY.md
+++ b/docs/AUTONOMOUS_FACTORY_POLICY.md
@@ -119,7 +119,8 @@ Use the existing canonical marker schemas:
 - issue claim: `<!-- comic-pile-factory-implement-claim-v3:issue-<n>:<worker>:<epoch>:attempt-<n> -->`
 - issue progress: `<!-- comic-pile-factory-implement-progress-v3:issue-<n>:<worker>:<epoch> -->`
 - review claim: `<!-- comic-pile-factory-review-claim-v2:<sha>:<worker>:<epoch> -->`
-- verdict: `<!-- comic-pile-factory-review-v2:<sha>:pass -->` or `changes-required`
+- review pass verdict: `<!-- comic-pile-factory-review-v2:<sha>:pass -->`
+- review changes-required verdict: `<!-- comic-pile-factory-review-v2:<sha>:changes-required -->`
 - repair claim: `<!-- comic-pile-factory-fix-claim-v3:<sha>:<worker>:<epoch>:attempt-<n> -->`
 - repair progress: `<!-- comic-pile-factory-fix-progress-v3:<sha>:<worker>:<epoch> -->`
 - ready: `<!-- comic-pile-factory-ready-v2:<sha> -->`


### PR DESCRIPTION
## Summary

Repairs the Factory Policy check that remained red after PR #735 merged.

## Root cause

The V11 policy abbreviated the changes-required verdict as plain `changes-required`, while the validator correctly requires the complete canonical marker schema.

## Change

Spell out both review verdict markers in full:

- `<!-- comic-pile-factory-review-v2:<sha>:pass -->`
- `<!-- comic-pile-factory-review-v2:<sha>:changes-required -->`

This preserves the validator and makes the canonical policy unambiguous. No application behavior changes.