### PR TITLE
feat(analytics): retire primary navigation and route (#611)

### DIFF
--- a/docs/ISSUE_KANBAN.md
+++ b/docs/ISSUE_KANBAN.md
@@ -2,4 +2,4 @@
 
 ## 2026-08-03
 
-- Analytics was retired from the primary application workflow in #611 pending a separately planned redesign. The navigation entry is removed and direct `/analytics` visits redirect to the Roll page. The existing backend analytics API remains available and unchanged.
+- Analytics was retired from the primary application workflow in #611 pending a separately planned redesign. The navigation entry is removed and direct `/analytics` visits redirect to `/`; authenticated users then reach the Roll page, while unauthenticated users follow normal protected-route handling. The existing backend analytics API remains available and unchanged.

--- a/docs/ISSUE_KANBAN.md
+++ b/docs/ISSUE_KANBAN.md
@@ -1,0 +1,5 @@
+# Issue Kanban Notes
+
+## 2026-08-03
+
+- Analytics was retired from the primary application workflow in #611 pending a separately planned redesign. The navigation entry is removed and direct `/analytics` visits redirect to the Roll page. The existing backend analytics API remains available and unchanged.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,7 +31,6 @@ const QueuePage = lazy(() => import('./pages/QueuePage'))
 const ThreadDetailView = lazy(() => import('./pages/ThreadDetailView'))
 const HistoryPage = lazy(() => import('./pages/HistoryPage'))
 const SessionPage = lazy(() => import('./pages/SessionPage'))
-const AnalyticsPage = lazy(() => import('./pages/AnalyticsPage'))
 const HelpPage = lazy(() => import('./pages/HelpPage'))
 const LoginPage = lazy(() => import('./pages/LoginPage'))
 const RegisterPage = lazy(() => import('./pages/RegisterPage'))
@@ -245,6 +244,7 @@ function AppRoutes() {
           }
         />
         <Route path="/rate" element={<Navigate to="/" replace />} />
+        <Route path="/analytics" element={<Navigate to="/" replace />} />
         <Route
           path="/"
           element={
@@ -291,16 +291,6 @@ function AppRoutes() {
             <ProtectedRoute>
               <AuthenticatedLayout onBugReportSubmit={submit}>
                 <SessionPage />
-              </AuthenticatedLayout>
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/analytics"
-          element={
-            <ProtectedRoute>
-              <AuthenticatedLayout onBugReportSubmit={submit}>
-                <AnalyticsPage />
               </AuthenticatedLayout>
             </ProtectedRoute>
           }

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -97,10 +97,6 @@ export default function Navigation({ onBugReportSubmit }: NavigationProps) {
             <span className="text-2xl" aria-hidden="true">📜</span>
             <span className="hidden md:block text-[10px] uppercase tracking-widest font-bold nav-label">History</span>
           </Link>
-          <Link to="/analytics" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isActive('/analytics') ? 'active' : 'hover:bg-white/5'}`} aria-label="Analytics page">
-            <span className="text-2xl" aria-hidden="true">📊</span>
-            <span className="hidden md:block text-[10px] uppercase tracking-widest font-bold nav-label">Stats</span>
-          </Link>
           <Link
             to="/help"
             className={`hidden md:flex nav-item flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isActive('/help') ? 'active' : 'hover:bg-white/5'}`}

--- a/frontend/src/unit/AnalyticsRoute.test.tsx
+++ b/frontend/src/unit/AnalyticsRoute.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, useLocation } from 'react-router-dom'
+import { expect, test, vi } from 'vitest'
+
+const mockApiGet = vi.fn()
+
+vi.mock('../services/api', () => ({
+  default: {
+    get: (...args: Parameters<typeof mockApiGet>) => mockApiGet(...args),
+  },
+  clearAccessToken: vi.fn(),
+  setAccessToken: vi.fn(),
+  getAccessToken: () => 'test-token',
+}))
+
+vi.mock('../hooks/useBugReport', () => ({
+  useBugReport: () => ({ submit: vi.fn() }),
+}))
+
+vi.mock('../components/Navigation', () => ({ default: () => null }))
+vi.mock('../components/BugReportButton', () => ({ default: () => null }))
+vi.mock('../pages/RollPage', () => ({
+  default: () => <div data-testid="roll-page">Roll</div>,
+}))
+
+import { AppRoutes, AuthProvider } from '../App'
+
+function LocationProbe() {
+  const location = useLocation()
+  return <div data-testid="location-pathname">{location.pathname}</div>
+}
+
+test('redirects the retired analytics route to the root path', async () => {
+  mockApiGet.mockResolvedValue({ username: 'testuser', email: 'test@test.com' })
+
+  render(
+    <MemoryRouter initialEntries={['/analytics']}>
+      <AuthProvider>
+        <LocationProbe />
+        <AppRoutes />
+      </AuthProvider>
+    </MemoryRouter>,
+  )
+
+  await waitFor(() => expect(screen.getByTestId('roll-page')).toBeInTheDocument())
+  expect(screen.getByTestId('location-pathname')).toHaveTextContent('/')
+})

--- a/frontend/src/unit/App.test.tsx
+++ b/frontend/src/unit/App.test.tsx
@@ -1,17 +1,15 @@
-import { expect, test, vi, beforeEach, describe } from 'vitest'
+import { expect, test, vi, beforeEach, describe, afterEach } from 'vitest'
 import { render, screen, waitFor, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { useEffect } from 'react'
 import type { AuthContextValue } from '../App'
 
-// Create mock function for API get
 const mockApiGet = vi.fn()
 const mockCollectionsList = vi.fn()
 const mockSetAccessToken = vi.fn()
 const mockClearAccessToken = vi.fn()
 const mockGetAccessToken = vi.fn<() => string | null>(() => 'test-token')
 
-// Mock the API module with a factory that doesn't reference outer scope
 vi.mock('../services/api', () => {
   return {
     default: {
@@ -42,7 +40,6 @@ vi.mock('../pages/RatePage', () => ({ default: () => <div data-testid="rate-page
 vi.mock('../pages/QueuePage', () => ({ default: () => <div data-testid="queue-page">Queue</div> }))
 vi.mock('../pages/HistoryPage', () => ({ default: () => <div data-testid="history-page">History</div> }))
 vi.mock('../pages/SessionPage', () => ({ default: () => <div data-testid="session-page">Session</div> }))
-vi.mock('../pages/AnalyticsPage', () => ({ default: () => <div data-testid="analytics-page">Analytics</div> }))
 vi.mock('../pages/ThreadDetailView', () => ({ default: () => <div data-testid="thread-detail-page">Thread detail</div> }))
 vi.mock('../pages/HelpPage', () => ({ default: () => <div data-testid="help-page">Help</div> }))
 
@@ -73,7 +70,7 @@ const renderWithAuth = (initialEntry = '/') => {
   )
 }
 
-test('renders navigation labels', async () => {
+test('renders retained navigation labels', async () => {
   mockApiGet.mockResolvedValue({ username: 'testuser', email: 'test@test.com' })
   renderWithAuth('/')
 
@@ -82,7 +79,7 @@ test('renders navigation labels', async () => {
   })
   expect(screen.getByRole('link', { name: /queue page/i })).toBeInTheDocument()
   expect(screen.getByRole('link', { name: /history page/i })).toBeInTheDocument()
-  expect(screen.getByRole('link', { name: /analytics page/i })).toBeInTheDocument()
+  expect(screen.queryByRole('link', { name: /analytics page/i })).not.toBeInTheDocument()
 })
 
 test('throws when the auth hook is used outside its provider', () => {
@@ -145,13 +142,12 @@ test('ignores an auth failure that arrives after the provider unmounts', async (
   })
 })
 
-test('loads each authenticated lazy route', async () => {
+test('loads each retained authenticated lazy route', async () => {
   mockApiGet.mockResolvedValue({ username: 'testuser', email: 'test@test.com' })
   const routes = {
     '/queue': 'queue-page',
     '/history': 'history-page',
     '/sessions/1': 'session-page',
-    '/analytics': 'analytics-page',
     '/help': 'help-page',
     '/thread/1': 'thread-detail-page',
   }
@@ -160,6 +156,14 @@ test('loads each authenticated lazy route', async () => {
     await waitFor(() => expect(screen.getByTestId(testId)).toBeInTheDocument())
     unmount()
   }
+})
+
+test('redirects the retired analytics route to Roll', async () => {
+  mockApiGet.mockResolvedValue({ username: 'testuser', email: 'test@test.com' })
+  renderWithAuth('/analytics')
+
+  await waitFor(() => expect(screen.getByTestId('roll-page')).toBeInTheDocument())
+  expect(screen.queryByText('Analytics')).not.toBeInTheDocument()
 })
 
 test('broadcasts logout events and closes the auth channel', async () => {

--- a/frontend/src/unit/Navigation.test.tsx
+++ b/frontend/src/unit/Navigation.test.tsx
@@ -122,6 +122,7 @@ test('clears authentication when the user lookup returns unauthorized', async ()
 })
 
 test('falls back to an empty username when the user profile omits it', async () => {
+  // L43 `setUsername(user.username || '')` — username falsy
   mockApiGet.mockResolvedValue({ username: '', email: 'empty@test.com' })
   render(
     <MemoryRouter initialEntries={['/']}>
@@ -133,5 +134,6 @@ test('falls back to an empty username when the user profile omits it', async () 
     </MemoryRouter>,
   )
   await waitFor(() => expect(screen.getByRole('button', { name: /log out/i })).toBeInTheDocument())
+  // empty username is falsy, so no username span is rendered for it
   expect(screen.queryByText('testuser')).not.toBeInTheDocument()
 })

--- a/frontend/src/unit/Navigation.test.tsx
+++ b/frontend/src/unit/Navigation.test.tsx
@@ -59,7 +59,7 @@ const renderWithoutAuth = () => {
   )
 }
 
-test('renders navigation links when authenticated', async () => {
+test('renders retained navigation links when authenticated', async () => {
   renderWithAuth()
 
   await waitFor(() => {
@@ -67,7 +67,7 @@ test('renders navigation links when authenticated', async () => {
   })
   expect(screen.getByRole('link', { name: /queue page/i })).toBeInTheDocument()
   expect(screen.getByRole('link', { name: /history page/i })).toBeInTheDocument()
-  expect(screen.getByRole('link', { name: /analytics page/i })).toBeInTheDocument()
+  expect(screen.queryByRole('link', { name: /analytics page/i })).not.toBeInTheDocument()
 })
 
 test('does not render when not authenticated', async () => {
@@ -122,7 +122,6 @@ test('clears authentication when the user lookup returns unauthorized', async ()
 })
 
 test('falls back to an empty username when the user profile omits it', async () => {
-  // L43 `setUsername(user.username || '')` — username falsy
   mockApiGet.mockResolvedValue({ username: '', email: 'empty@test.com' })
   render(
     <MemoryRouter initialEntries={['/']}>
@@ -134,6 +133,5 @@ test('falls back to an empty username when the user profile omits it', async () 
     </MemoryRouter>,
   )
   await waitFor(() => expect(screen.getByRole('button', { name: /log out/i })).toBeInTheDocument())
-  // empty username is falsy, so no username span is rendered for it
   expect(screen.queryByText('testuser')).not.toBeInTheDocument()
 })


### PR DESCRIPTION
## Summary

Retires Analytics from ComicPile's primary user workflow without deleting the retained backend analytics API.

## Changes

- Removes the Analytics/Stats link from authenticated navigation.
- Removes the Analytics page lazy route from the application shell.
- Redirects direct `/analytics` visits to the Roll page at `/`.
- Updates navigation coverage to assert Analytics is absent.
- Adds route coverage proving `/analytics` changes the router pathname to `/` and resolves to Roll rather than rendering Analytics.
- Records the retirement decision in `docs/ISSUE_KANBAN.md`.

Closes #611

## Validation

Focused frontend coverage is updated in:

- `frontend/src/unit/App.test.tsx`
- `frontend/src/unit/AnalyticsRoute.test.tsx`
- `frontend/src/unit/Navigation.test.tsx`

Exact-SHA CI is the broad validation source for this automation runtime.

This PR is non-draft and must not be merged without Josh's explicit authorization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed Analytics from the primary application navigation.
  * Visiting `/analytics` now redirects to the Roll page.
  * Existing analytics backend functionality remains available.
* **Tests**
  * Updated navigation and routing coverage to verify Analytics is hidden and redirects correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->