### PR TITLE
Fix Neon deploy migration path (setup-uv pin + tolerant collections removal)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -114,7 +114,7 @@ jobs:
         run: bash .github/scripts/prune-oldest-vcr-image.sh
 
       - name: Set up Python and runtime dependencies
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           python-version: "3.14"
           enable-cache: true

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -114,7 +114,7 @@ jobs:
         run: bash .github/scripts/prune-oldest-vcr-image.sh
 
       - name: Set up Python and runtime dependencies
-        uses: astral-sh/setup-uv@v9.0.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: "3.14"
           enable-cache: true

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -157,6 +157,28 @@ jobs:
           fi
           echo "Single head confirmed"
 
+      - name: Inspect production schema state
+        env:
+          DATABASE_URL: ${{ steps.neon.outputs.db_url }}
+        run: |
+          set -euo pipefail
+          .venv/bin/python - <<'PY'
+          import os
+          import psycopg
+
+          url = os.environ["DATABASE_URL"]
+          if url.startswith("postgres://"):
+              url = "postgresql://" + url[len("postgres://"):]
+          with psycopg.connect(url) as conn:
+              with conn.cursor() as cur:
+                  cur.execute("SELECT version_num FROM alembic_version")
+                  print("alembic_version:", cur.fetchall())
+                  cur.execute("SELECT to_regclass('public.collections')")
+                  print("collections table:", cur.fetchall())
+                  cur.execute("SELECT indexname FROM pg_indexes WHERE tablename='collections'")
+                  print("collections indexes:", cur.fetchall())
+          PY
+
       - name: Migrate production database before deploy
         env:
           DATABASE_URL: ${{ steps.neon.outputs.db_url }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -157,28 +157,6 @@ jobs:
           fi
           echo "Single head confirmed"
 
-      - name: Inspect production schema state
-        env:
-          DATABASE_URL: ${{ steps.neon.outputs.db_url }}
-        run: |
-          set -euo pipefail
-          .venv/bin/python - <<'PY'
-          import os
-          import psycopg
-
-          url = os.environ["DATABASE_URL"]
-          if url.startswith("postgres://"):
-              url = "postgresql://" + url[len("postgres://"):]
-          with psycopg.connect(url) as conn:
-              with conn.cursor() as cur:
-                  cur.execute("SELECT version_num FROM alembic_version")
-                  print("alembic_version:", cur.fetchall())
-                  cur.execute("SELECT to_regclass('public.collections')")
-                  print("collections table:", cur.fetchall())
-                  cur.execute("SELECT indexname FROM pg_indexes WHERE tablename='collections'")
-                  print("collections indexes:", cur.fetchall())
-          PY
-
       - name: Migrate production database before deploy
         env:
           DATABASE_URL: ${{ steps.neon.outputs.db_url }}

--- a/alembic/versions/remove_collections_persistence.py
+++ b/alembic/versions/remove_collections_persistence.py
@@ -24,13 +24,14 @@ def upgrade() -> None:
         batch_op.drop_index("ix_thread_collection_id")
         batch_op.drop_constraint("fk_threads_collection_id_collections", type_="foreignkey")
         batch_op.drop_column("collection_id")
-    op.drop_index("ix_collections_user_id", table_name="collections")
+    op.drop_index("ix_collections_user_id", table_name="collections", if_exists=True)
     op.drop_index(
         "uq_collections_user_default",
         table_name="collections",
         postgresql_where=sa.text("is_default = TRUE"),
+        if_exists=True,
     )
-    op.drop_table("collections")
+    op.drop_table("collections", if_exists=True)
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Problem

The merged #744 deploy run failed twice:

1. `astral-sh/setup-uv@v9` does not exist, so the action could not resolve.
2. After the first attempted repair, `alembic upgrade head` failed on production with `index "uq_collections_user_default" does not exist`. Read-only production diagnostics showed the database stamped at `4d2403b3a9ac` with the `collections` table present, but without that partial index.

## Fix

- Pin `astral-sh/setup-uv` to the immutable commit for official release `v8.1.0` (`08807647e7069bb48b6ef5acd8ec9567f424441b`) rather than a nonexistent v9 tag.
- Make `remove_collections_persistence` tolerant with `if_exists=True` on the Collections index and table drops. The migration removes retired persistence regardless of whether an optional historical index is present.
- Reproduce production's observed migration state locally by stamping at `4d2403b3a9ac`, removing the partial index, and upgrading through the current Alembic head.

## Validation

The exact-SHA CI run for the corrected action pin and tolerant migration is the broad validation source. Production deployment remains blocked until this PR is merged with Josh's explicit authorization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration reliability by safely handling cases where collection data structures are already absent.
  * Continued cleanup of obsolete thread collection references during migration.

* **Chores**
  * Improved deployment workflow consistency by locking a setup tool to a specific release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->