### PR TITLE
feat(thread): lazy-load and incrementally page issues on Thread Details (#697)

### DIFF
--- a/frontend/src/pages/ThreadDetailView.tsx
+++ b/frontend/src/pages/ThreadDetailView.tsx
@@ -220,7 +220,7 @@ export default function ThreadDetailView() {
           <div className="glass-card p-3 md:p-4 space-y-3">
             <div className="flex justify-between items-center">
               <span className="text-xs font-black uppercase tracking-widest text-stone-500">
-                Issues ({issuesTotal > 0 ? issuesTotal : issues.length})
+                Issues ({issuesTotal > 0 ? issuesTotal : (thread.total_issues ?? issues.length)})
               </span>
               <button
                 type="button"

--- a/frontend/src/pages/ThreadDetailView.tsx
+++ b/frontend/src/pages/ThreadDetailView.tsx
@@ -24,6 +24,11 @@ export default function ThreadDetailView() {
   const [editForm, setEditForm] = useState<QueueFormState>(DEFAULT_CREATE_STATE)
   const [issues, setIssues] = useState<Issue[]>([])
   const [issuesExpanded, setIssuesExpanded] = useState(false)
+  const [issuesLoading, setIssuesLoading] = useState(false)
+  const [issuesError, setIssuesError] = useState<string | null>(null)
+  const [issuesLoaded, setIssuesLoaded] = useState(false)
+  const [nextPageToken, setNextPageToken] = useState<string | null>(null)
+  const [issuesTotal, setIssuesTotal] = useState(0)
 
   useEffect(() => {
     async function fetchThread() {
@@ -36,11 +41,6 @@ export default function ThreadDetailView() {
         setIsLoading(true)
         const threadData = await threadsApi.get(Number(id))
         setThread(threadData)
-
-        if (threadData && threadData.total_issues !== null) {
-          await fetchIssues(Number(id))
-        }
-
       } catch (err: unknown) {
         setError(getApiErrorDetail(err))
       } finally {
@@ -51,23 +51,36 @@ export default function ThreadDetailView() {
     fetchThread()
   }, [id])
 
-  async function fetchIssues(threadId: number) {
+  async function loadIssuesPage(threadId: number, pageToken: string | null) {
+    setIssuesLoading(true)
+    setIssuesError(null)
     try {
-      const allIssues: Issue[] = []
-      let nextPageToken: string | null = null
+      const data = await issuesApi.list(threadId, {
+        page_size: 100,
+        ...(pageToken ? { page_token: pageToken } : {}),
+      })
+      setIssues((prev) => (pageToken ? [...prev, ...data.issues] : data.issues))
+      setNextPageToken(data.next_page_token)
+      setIssuesTotal(data.total_count)
+      setIssuesLoaded(true)
+    } catch {
+      setIssuesError('Failed to load issues')
+    } finally {
+      setIssuesLoading(false)
+    }
+  }
 
-      do {
-        const data = await issuesApi.list(threadId, {
-          page_size: 100,
-          ...(nextPageToken ? { page_token: nextPageToken } : {}),
-        })
-        allIssues.push(...data.issues)
-        nextPageToken = data.next_page_token
-      } while (nextPageToken)
+  function handleToggleIssues() {
+    const next = !issuesExpanded
+    setIssuesExpanded(next)
+    if (next && thread && thread.total_issues !== null && !issuesLoaded) {
+      void loadIssuesPage(thread.id, null)
+    }
+  }
 
-      setIssues(allIssues)
-    } catch (err: unknown) {
-      console.error('Failed to fetch issues:', err)
+  function handleLoadMore() {
+    if (thread && thread.total_issues !== null && nextPageToken) {
+      void loadIssuesPage(thread.id, nextPageToken)
     }
   }
 
@@ -94,8 +107,10 @@ export default function ThreadDetailView() {
       setThread(updatedThread)
       setIsEditOpen(false)
 
-      if (updatedThread.total_issues !== null) {
-        await fetchIssues(updatedThread.id)
+      if (updatedThread.total_issues !== null && issuesLoaded) {
+        setIssues([])
+        setNextPageToken(null)
+        await loadIssuesPage(updatedThread.id, null)
       }
     } catch {
       console.error('Failed to update thread')
@@ -201,15 +216,15 @@ export default function ThreadDetailView() {
           </div>
         )}
 
-        {isMigrated && issues.length > 0 && (
+        {isMigrated && (
           <div className="glass-card p-3 md:p-4 space-y-3">
             <div className="flex justify-between items-center">
               <span className="text-xs font-black uppercase tracking-widest text-stone-500">
-                Issues ({issues.length})
+                Issues ({issuesTotal > 0 ? issuesTotal : issues.length})
               </span>
               <button
                 type="button"
-                onClick={() => setIssuesExpanded(!issuesExpanded)}
+                onClick={handleToggleIssues}
                 className="text-xs font-black uppercase tracking-widest text-amber-400 hover:text-amber-300"
               >
                 {issuesExpanded ? 'Collapse' : 'Expand'}
@@ -226,27 +241,72 @@ export default function ThreadDetailView() {
 
             {issuesExpanded && (
               <div className="space-y-2 mt-3">
-                {issues.map((issue) => (
-                  <div
-                    key={issue.id}
-                    className={`flex items-center justify-between p-2 rounded-lg border ${
-                      issue.status === 'read'
-                        ? 'bg-green-500/10 border-green-500/20'
-                        : 'bg-white/5 border-white/10'
-                    }`}
-                  >
-                    <span className="text-sm font-medium text-stone-300">
-                      #{issue.issue_number}
-                    </span>
-                    <span className="text-xs font-black uppercase tracking-widest">
-                      {issue.status === 'read' ? (
-                        <span className="text-green-400">Read</span>
-                      ) : (
-                        <span className="text-stone-500">Unread</span>
-                      )}
-                    </span>
+                {issuesLoading && issues.length === 0 && (
+                  <p className="text-xs text-stone-500">Loading issues...</p>
+                )}
+
+                {issuesError && !issuesLoading && (
+                  <div className="space-y-2">
+                    <p className="text-xs text-red-400">{issuesError}</p>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (thread && thread.total_issues !== null) {
+                          setIssues([])
+                          setNextPageToken(null)
+                          void loadIssuesPage(thread.id, null)
+                        }
+                      }}
+                      className="text-xs font-black uppercase tracking-widest text-amber-400 hover:text-amber-300"
+                    >
+                      Retry
+                    </button>
                   </div>
-                ))}
+                )}
+
+                {issuesLoaded && !issuesLoading && !issuesError && issues.length === 0 && (
+                  <p className="text-xs text-stone-500">No issues yet</p>
+                )}
+
+                {issuesLoaded && issues.length > 0 && (
+                  <div className="space-y-2">
+                    {issues.map((issue) => (
+                      <div
+                        key={issue.id}
+                        className={`flex items-center justify-between p-2 rounded-lg border ${
+                          issue.status === 'read'
+                            ? 'bg-green-500/10 border-green-500/20'
+                            : 'bg-white/5 border-white/10'
+                        }`}
+                      >
+                        <span className="text-sm font-medium text-stone-300">
+                          #{issue.issue_number}
+                        </span>
+                        <span className="text-xs font-black uppercase tracking-widest">
+                          {issue.status === 'read' ? (
+                            <span className="text-green-400">Read</span>
+                          ) : (
+                            <span className="text-stone-500">Unread</span>
+                          )}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {nextPageToken && !issuesLoading && (
+                  <button
+                    type="button"
+                    onClick={handleLoadMore}
+                    className="w-full py-2 rounded-lg border border-white/10 text-xs font-black uppercase tracking-widest text-amber-400 hover:text-amber-300 hover:border-white/20"
+                  >
+                    Load more
+                  </button>
+                )}
+
+                {issuesLoading && issues.length > 0 && (
+                  <p className="text-xs text-stone-500">Loading more...</p>
+                )}
               </div>
             )}
           </div>

--- a/frontend/src/pages/ThreadDetailView.tsx
+++ b/frontend/src/pages/ThreadDetailView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import Modal from '../components/Modal'
 import LoadingSpinner from '../components/LoadingSpinner'
@@ -16,6 +16,7 @@ export default function ThreadDetailView() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
   const updateMutation = useUpdateThread()
+  const activeThreadIdRef = useRef<number | null>(null)
 
   const [thread, setThread] = useState<Thread | null>(null)
   const [isLoading, setIsLoading] = useState(true)
@@ -31,20 +32,36 @@ export default function ThreadDetailView() {
   const [issuesTotal, setIssuesTotal] = useState(0)
 
   useEffect(() => {
+    const threadId = id ? Number(id) : null
+    activeThreadIdRef.current = threadId
+    setThread(null)
+    setError(null)
+    setIssues([])
+    setIssuesExpanded(false)
+    setIssuesLoading(false)
+    setIssuesError(null)
+    setIssuesLoaded(false)
+    setNextPageToken(null)
+    setIssuesTotal(0)
+
     async function fetchThread() {
-      if (!id) {
+      if (threadId === null) {
         setIsLoading(false)
         return
       }
 
       try {
         setIsLoading(true)
-        const threadData = await threadsApi.get(Number(id))
+        const threadData = await threadsApi.get(threadId)
+        if (activeThreadIdRef.current !== threadId) return
         setThread(threadData)
       } catch (err: unknown) {
+        if (activeThreadIdRef.current !== threadId) return
         setError(getApiErrorDetail(err))
       } finally {
-        setIsLoading(false)
+        if (activeThreadIdRef.current === threadId) {
+          setIsLoading(false)
+        }
       }
     }
 
@@ -59,14 +76,18 @@ export default function ThreadDetailView() {
         page_size: 100,
         ...(pageToken ? { page_token: pageToken } : {}),
       })
+      if (activeThreadIdRef.current !== threadId) return
       setIssues((prev) => (pageToken ? [...prev, ...data.issues] : data.issues))
       setNextPageToken(data.next_page_token)
       setIssuesTotal(data.total_count)
       setIssuesLoaded(true)
     } catch {
+      if (activeThreadIdRef.current !== threadId) return
       setIssuesError('Failed to load issues')
     } finally {
-      setIssuesLoading(false)
+      if (activeThreadIdRef.current === threadId) {
+        setIssuesLoading(false)
+      }
     }
   }
 

--- a/frontend/src/unit/ThreadDetailView.route-change.test.tsx
+++ b/frontend/src/unit/ThreadDetailView.route-change.test.tsx
@@ -13,20 +13,22 @@ vi.mock('react-router-dom', async () => {
   return { ...actual, useNavigate: () => vi.fn(), useParams: () => routeParams }
 })
 vi.mock('../hooks/useThread', () => ({ useUpdateThread: vi.fn() }))
-vi.mock('../services/api', () => ({
-  threadsApi: { get: vi.fn() },
-  dependenciesApi: { getIssueDependencies: vi.fn().mockResolvedValue({ incoming: [], outgoing: [] }) },
-}))
+vi.mock('../services/api', () => {
+  const client = { get: vi.fn() }
+  return {
+    default: client,
+    threadsApi: { get: vi.fn() },
+    dependenciesApi: { getIssueDependencies: vi.fn().mockResolvedValue({ incoming: [], outgoing: [] }) },
+  }
+})
 vi.mock('../services/api-issues', () => ({ issuesApi: { list: vi.fn() } }))
 
 const mockedUseUpdateThread = vi.mocked(useUpdateThread)
 const mockedThreadsApiGet = vi.mocked(threadsApi.get)
 const mockedIssuesApiList = vi.mocked(issuesApi.list)
 
-beforeEach(() => {
-  routeParams.id = '1'
-  mockedUseUpdateThread.mockReturnValue({ mutate: vi.fn(), isPending: false } as never)
-  mockedThreadsApiGet.mockImplementation(async (id: number) => ({
+function threadResult(id: number) {
+  return {
     id,
     title: id === 1 ? 'Saga' : 'Monstress',
     format: 'Comics',
@@ -36,8 +38,11 @@ beforeEach(() => {
     total_issues: 1,
     next_unread_issue_number: '1',
     notes: null,
-  } as never))
-  mockedIssuesApiList.mockImplementation(async (threadId: number) => ({
+  } as never
+}
+
+function issueResult(threadId: number) {
+  return {
     issues: [{
       id: threadId,
       thread_id: threadId,
@@ -49,7 +54,24 @@ beforeEach(() => {
     next_page_token: null,
     total_count: 1,
     page_size: 100,
-  }))
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+beforeEach(() => {
+  routeParams.id = '1'
+  mockedUseUpdateThread.mockReturnValue({ mutate: vi.fn(), isPending: false } as never)
+  mockedThreadsApiGet.mockImplementation(async (id: number) => threadResult(id))
+  mockedIssuesApiList.mockImplementation(async (threadId: number) => issueResult(threadId))
 })
 
 it('clears loaded issues and fetches the new thread after a route change', async () => {
@@ -70,4 +92,74 @@ it('clears loaded issues and fetches the new thread after a route change', async
 
   expect(mockedIssuesApiList).toHaveBeenNthCalledWith(1, 1, { page_size: 100 })
   expect(mockedIssuesApiList).toHaveBeenNthCalledWith(2, 2, { page_size: 100 })
+})
+
+it('ignores stale successful and failed thread requests after navigation', async () => {
+  const firstRequest = deferred<ReturnType<typeof threadResult>>()
+  mockedThreadsApiGet.mockImplementation((id: number) => (
+    id === 1 ? firstRequest.promise : Promise.resolve(threadResult(id))
+  ))
+  const view = render(<ThreadDetailView />)
+
+  routeParams.id = '2'
+  view.rerender(<ThreadDetailView />)
+  await waitFor(() => expect(screen.getByText('Monstress')).toBeInTheDocument())
+
+  firstRequest.resolve(threadResult(1))
+  await waitFor(() => expect(screen.queryByText('Saga')).not.toBeInTheDocument())
+
+  const rejectedRequest = deferred<ReturnType<typeof threadResult>>()
+  mockedThreadsApiGet.mockImplementation((id: number) => (
+    id === 1 ? rejectedRequest.promise : Promise.resolve(threadResult(id))
+  ))
+  routeParams.id = '1'
+  view.rerender(<ThreadDetailView />)
+  routeParams.id = '2'
+  view.rerender(<ThreadDetailView />)
+  await waitFor(() => expect(screen.getByText('Monstress')).toBeInTheDocument())
+
+  rejectedRequest.reject(new Error('stale failure'))
+  await waitFor(() => expect(screen.queryByText('stale failure')).not.toBeInTheDocument())
+})
+
+it('ignores stale successful and failed issue requests after navigation', async () => {
+  const user = userEvent.setup()
+  const firstIssues = deferred<ReturnType<typeof issueResult>>()
+  mockedIssuesApiList.mockImplementation((threadId: number) => (
+    threadId === 1 ? firstIssues.promise : Promise.resolve(issueResult(threadId))
+  ))
+  const view = render(<ThreadDetailView />)
+
+  await waitFor(() => expect(screen.getByText('Saga')).toBeInTheDocument())
+  await user.click(screen.getByRole('button', { name: 'Expand' }))
+  routeParams.id = '2'
+  view.rerender(<ThreadDetailView />)
+  await waitFor(() => expect(screen.getByText('Monstress')).toBeInTheDocument())
+
+  firstIssues.resolve(issueResult(1))
+  await waitFor(() => expect(screen.queryByText('#Saga 1')).not.toBeInTheDocument())
+
+  const rejectedIssues = deferred<ReturnType<typeof issueResult>>()
+  mockedIssuesApiList.mockImplementation((threadId: number) => (
+    threadId === 1 ? rejectedIssues.promise : Promise.resolve(issueResult(threadId))
+  ))
+  routeParams.id = '1'
+  view.rerender(<ThreadDetailView />)
+  await waitFor(() => expect(screen.getByText('Saga')).toBeInTheDocument())
+  await user.click(screen.getByRole('button', { name: 'Expand' }))
+  routeParams.id = '2'
+  view.rerender(<ThreadDetailView />)
+  await waitFor(() => expect(screen.getByText('Monstress')).toBeInTheDocument())
+
+  rejectedIssues.reject(new Error('stale issue failure'))
+  await waitFor(() => expect(screen.queryByText('Failed to load issues')).not.toBeInTheDocument())
+})
+
+it('handles a route without a thread id without making requests', async () => {
+  routeParams.id = ''
+  render(<ThreadDetailView />)
+
+  await waitFor(() => expect(screen.getByText('Thread not found')).toBeInTheDocument())
+  expect(mockedThreadsApiGet).not.toHaveBeenCalled()
+  expect(mockedIssuesApiList).not.toHaveBeenCalled()
 })

--- a/frontend/src/unit/ThreadDetailView.route-change.test.tsx
+++ b/frontend/src/unit/ThreadDetailView.route-change.test.tsx
@@ -5,7 +5,7 @@ import ThreadDetailView from '../pages/ThreadDetailView'
 import { useUpdateThread } from '../hooks/useThread'
 import { threadsApi } from '../services/api'
 import { issuesApi } from '../services/api-issues'
-import type { Thread } from '../types'
+import type { IssueListResponse, Thread } from '../types'
 
 const routeParams = { id: '1' }
 
@@ -42,7 +42,7 @@ function threadResult(id: number): Thread {
   } as unknown as Thread
 }
 
-function issueResult(threadId: number) {
+function issueResult(threadId: number): IssueListResponse {
   return {
     issues: [{
       id: threadId,
@@ -69,6 +69,7 @@ function deferred<T>() {
 }
 
 beforeEach(() => {
+  vi.clearAllMocks()
   routeParams.id = '1'
   mockedUseUpdateThread.mockReturnValue({ mutate: vi.fn(), isPending: false } as never)
   mockedThreadsApiGet.mockImplementation(async (id: number) => threadResult(id))
@@ -125,7 +126,7 @@ it('ignores stale successful and failed thread requests after navigation', async
 
 it('ignores stale successful and failed issue requests after navigation', async () => {
   const user = userEvent.setup()
-  const firstIssues = deferred<ReturnType<typeof issueResult>>()
+  const firstIssues = deferred<IssueListResponse>()
   mockedIssuesApiList.mockImplementation((threadId: number) => (
     threadId === 1 ? firstIssues.promise : Promise.resolve(issueResult(threadId))
   ))
@@ -140,7 +141,7 @@ it('ignores stale successful and failed issue requests after navigation', async 
   firstIssues.resolve(issueResult(1))
   await waitFor(() => expect(screen.queryByText('#Saga 1')).not.toBeInTheDocument())
 
-  const rejectedIssues = deferred<ReturnType<typeof issueResult>>()
+  const rejectedIssues = deferred<IssueListResponse>()
   mockedIssuesApiList.mockImplementation((threadId: number) => (
     threadId === 1 ? rejectedIssues.promise : Promise.resolve(issueResult(threadId))
   ))

--- a/frontend/src/unit/ThreadDetailView.route-change.test.tsx
+++ b/frontend/src/unit/ThreadDetailView.route-change.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, expect, it, vi } from 'vitest'
+import ThreadDetailView from '../pages/ThreadDetailView'
+import { useUpdateThread } from '../hooks/useThread'
+import { threadsApi } from '../services/api'
+import { issuesApi } from '../services/api-issues'
+
+const routeParams = { id: '1' }
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => vi.fn(), useParams: () => routeParams }
+})
+vi.mock('../hooks/useThread', () => ({ useUpdateThread: vi.fn() }))
+vi.mock('../services/api', () => ({
+  threadsApi: { get: vi.fn() },
+  dependenciesApi: { getIssueDependencies: vi.fn().mockResolvedValue({ incoming: [], outgoing: [] }) },
+}))
+vi.mock('../services/api-issues', () => ({ issuesApi: { list: vi.fn() } }))
+
+const mockedUseUpdateThread = vi.mocked(useUpdateThread)
+const mockedThreadsApiGet = vi.mocked(threadsApi.get)
+const mockedIssuesApiList = vi.mocked(issuesApi.list)
+
+beforeEach(() => {
+  routeParams.id = '1'
+  mockedUseUpdateThread.mockReturnValue({ mutate: vi.fn(), isPending: false } as never)
+  mockedThreadsApiGet.mockImplementation(async (id: number) => ({
+    id,
+    title: id === 1 ? 'Saga' : 'Monstress',
+    format: 'Comics',
+    issues_remaining: 1,
+    queue_position: id,
+    status: 'active',
+    total_issues: 1,
+    next_unread_issue_number: '1',
+    notes: null,
+  } as never))
+  mockedIssuesApiList.mockImplementation(async (threadId: number) => ({
+    issues: [{
+      id: threadId,
+      thread_id: threadId,
+      issue_number: threadId === 1 ? 'Saga 1' : 'Monstress 1',
+      status: 'unread',
+      read_at: null,
+      created_at: 'now',
+    }],
+    next_page_token: null,
+    total_count: 1,
+    page_size: 100,
+  }))
+})
+
+it('clears loaded issues and fetches the new thread after a route change', async () => {
+  const user = userEvent.setup()
+  const view = render(<ThreadDetailView />)
+
+  await waitFor(() => expect(screen.getByText('Saga')).toBeInTheDocument())
+  await user.click(screen.getByRole('button', { name: 'Expand' }))
+  await waitFor(() => expect(screen.getByText('#Saga 1')).toBeInTheDocument())
+
+  routeParams.id = '2'
+  view.rerender(<ThreadDetailView />)
+
+  await waitFor(() => expect(screen.getByText('Monstress')).toBeInTheDocument())
+  expect(screen.queryByText('#Saga 1')).not.toBeInTheDocument()
+  await user.click(screen.getByRole('button', { name: 'Expand' }))
+  await waitFor(() => expect(screen.getByText('#Monstress 1')).toBeInTheDocument())
+
+  expect(mockedIssuesApiList).toHaveBeenNthCalledWith(1, 1, { page_size: 100 })
+  expect(mockedIssuesApiList).toHaveBeenNthCalledWith(2, 2, { page_size: 100 })
+})

--- a/frontend/src/unit/ThreadDetailView.route-change.test.tsx
+++ b/frontend/src/unit/ThreadDetailView.route-change.test.tsx
@@ -5,6 +5,7 @@ import ThreadDetailView from '../pages/ThreadDetailView'
 import { useUpdateThread } from '../hooks/useThread'
 import { threadsApi } from '../services/api'
 import { issuesApi } from '../services/api-issues'
+import type { Thread } from '../types'
 
 const routeParams = { id: '1' }
 
@@ -27,7 +28,7 @@ const mockedUseUpdateThread = vi.mocked(useUpdateThread)
 const mockedThreadsApiGet = vi.mocked(threadsApi.get)
 const mockedIssuesApiList = vi.mocked(issuesApi.list)
 
-function threadResult(id: number) {
+function threadResult(id: number): Thread {
   return {
     id,
     title: id === 1 ? 'Saga' : 'Monstress',
@@ -38,7 +39,7 @@ function threadResult(id: number) {
     total_issues: 1,
     next_unread_issue_number: '1',
     notes: null,
-  } as never
+  } as unknown as Thread
 }
 
 function issueResult(threadId: number) {
@@ -95,7 +96,7 @@ it('clears loaded issues and fetches the new thread after a route change', async
 })
 
 it('ignores stale successful and failed thread requests after navigation', async () => {
-  const firstRequest = deferred<ReturnType<typeof threadResult>>()
+  const firstRequest = deferred<Thread>()
   mockedThreadsApiGet.mockImplementation((id: number) => (
     id === 1 ? firstRequest.promise : Promise.resolve(threadResult(id))
   ))
@@ -108,7 +109,7 @@ it('ignores stale successful and failed thread requests after navigation', async
   firstRequest.resolve(threadResult(1))
   await waitFor(() => expect(screen.queryByText('Saga')).not.toBeInTheDocument())
 
-  const rejectedRequest = deferred<ReturnType<typeof threadResult>>()
+  const rejectedRequest = deferred<Thread>()
   mockedThreadsApiGet.mockImplementation((id: number) => (
     id === 1 ? rejectedRequest.promise : Promise.resolve(threadResult(id))
   ))

--- a/frontend/src/unit/ThreadDetailView.scale.test.tsx
+++ b/frontend/src/unit/ThreadDetailView.scale.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, expect, it, vi } from 'vitest'
+import ThreadDetailView from '../pages/ThreadDetailView'
+import { useUpdateThread } from '../hooks/useThread'
+import { threadsApi } from '../services/api'
+import { issuesApi } from '../services/api-issues'
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+    useParams: () => ({ id: '1' }),
+  }
+})
+
+vi.mock('../hooks/useThread', () => ({ useUpdateThread: vi.fn() }))
+vi.mock('../services/api', () => ({
+  threadsApi: { get: vi.fn() },
+  dependenciesApi: {
+    getIssueDependencies: vi.fn().mockResolvedValue({ incoming: [], outgoing: [] }),
+  },
+}))
+vi.mock('../services/api-issues', () => ({
+  issuesApi: { list: vi.fn() },
+}))
+
+const mockedUseUpdateThread = vi.mocked(useUpdateThread)
+const mockedThreadsApiGet = vi.mocked(threadsApi.get)
+const mockedIssuesApiList = vi.mocked(issuesApi.list)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockedUseUpdateThread.mockReturnValue({ mutate: vi.fn(), isPending: false } as never)
+})
+
+it.each([25, 250, 1_000, 10_000])(
+  'renders metadata for a %,d-issue thread without requesting issue rows',
+  async (totalIssues) => {
+    mockedThreadsApiGet.mockResolvedValue({
+      id: 1,
+      title: `Scale Test ${totalIssues}`,
+      format: 'Comics',
+      issues_remaining: totalIssues - 1,
+      queue_position: 1,
+      status: 'active',
+      total_issues: totalIssues,
+      next_unread_issue_number: '2',
+      notes: null,
+    } as never)
+
+    render(<ThreadDetailView />)
+
+    await waitFor(() => {
+      expect(screen.getByText(`Scale Test ${totalIssues}`)).toBeInTheDocument()
+    })
+
+    expect(screen.getByText(`Issues (${totalIssues})`)).toBeInTheDocument()
+    expect(screen.getByText('Next up: #2')).toBeInTheDocument()
+    expect(mockedIssuesApiList).not.toHaveBeenCalled()
+  },
+)
+
+it('keeps unmigrated threads independent from the issue-list endpoint', async () => {
+  mockedThreadsApiGet.mockResolvedValue({
+    id: 1,
+    title: 'Legacy Thread',
+    format: 'Comics',
+    issues_remaining: 12,
+    queue_position: 3,
+    status: 'active',
+    total_issues: null,
+    notes: null,
+  } as never)
+
+  render(<ThreadDetailView />)
+
+  await waitFor(() => {
+    expect(screen.getByText('Legacy Thread')).toBeInTheDocument()
+  })
+
+  expect(screen.getByText('12 issues')).toBeInTheDocument()
+  expect(screen.queryByRole('button', { name: 'Expand' })).not.toBeInTheDocument()
+  expect(mockedIssuesApiList).not.toHaveBeenCalled()
+})

--- a/frontend/src/unit/ThreadDetailView.test.tsx
+++ b/frontend/src/unit/ThreadDetailView.test.tsx
@@ -52,6 +52,7 @@ it('does not fetch issues before the Issues section expands', async () => {
   renderPage()
   await waitFor(() => expect(screen.getByText('Saga')).toBeInTheDocument())
   expect(mockedIssuesApiList).not.toHaveBeenCalled()
+  expect(screen.getByText('Issues (10)')).toBeInTheDocument()
   expect(screen.getByText(/Next up: #3/)).toBeInTheDocument()
 })
 

--- a/frontend/src/unit/ThreadDetailView.test.tsx
+++ b/frontend/src/unit/ThreadDetailView.test.tsx
@@ -44,14 +44,108 @@ it('renders a thread without legacy rating content', async () => {
   expect(screen.queryByText(/Reviews/)).not.toBeInTheDocument()
 })
 
+it('does not fetch issues before the Issues section expands', async () => {
+  mockedThreadsApiGet.mockResolvedValue({
+    id: 1, title: 'Saga', format: 'Comics', issues_remaining: 2, queue_position: 1,
+    status: 'active', total_issues: 10, next_unread_issue_number: '3', notes: null,
+  } as never)
+  renderPage()
+  await waitFor(() => expect(screen.getByText('Saga')).toBeInTheDocument())
+  expect(mockedIssuesApiList).not.toHaveBeenCalled()
+  expect(screen.getByText(/Next up: #3/)).toBeInTheDocument()
+})
+
+it('fetches one bounded page when the Issues section expands', async () => {
+  mockedThreadsApiGet.mockResolvedValue({
+    id: 1, title: 'Saga', format: 'Comics', issues_remaining: 2, queue_position: 1,
+    status: 'active', total_issues: 10, next_unread_issue_number: '3', notes: null,
+  } as never)
+  mockedIssuesApiList.mockResolvedValueOnce({
+    issues: [{ id: 1, thread_id: 1, issue_number: '1', status: 'read', read_at: 'now', created_at: 'now' }],
+    next_page_token: 'next', total_count: 2, page_size: 100,
+  })
+  renderPage()
+  await waitFor(() => expect(screen.getByText('Saga')).toBeInTheDocument())
+  const user = userEvent.setup()
+  await user.click(screen.getByRole('button', { name: 'Expand' }))
+  await waitFor(() => expect(mockedIssuesApiList).toHaveBeenCalledTimes(1))
+  expect(mockedIssuesApiList).toHaveBeenCalledWith(1, { page_size: 100 })
+  expect(screen.getByText('#1')).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Load more' })).toBeInTheDocument()
+})
+
+it('loads the next page without duplicates or gaps', async () => {
+  mockedThreadsApiGet.mockResolvedValue({
+    id: 1, title: 'Saga', format: 'Comics', issues_remaining: 2, queue_position: 1,
+    status: 'active', total_issues: 10, next_unread_issue_number: '3', notes: null,
+  } as never)
+  mockedIssuesApiList
+    .mockResolvedValueOnce({
+      issues: [{ id: 1, thread_id: 1, issue_number: '1', status: 'read', read_at: 'now', created_at: 'now' }],
+      next_page_token: 'next', total_count: 2, page_size: 100,
+    })
+    .mockResolvedValueOnce({
+      issues: [{ id: 2, thread_id: 1, issue_number: '2', status: 'unread', read_at: null, created_at: 'now' }],
+      next_page_token: null, total_count: 2, page_size: 100,
+    })
+  renderPage()
+  await waitFor(() => expect(screen.getByText('Saga')).toBeInTheDocument())
+  const user = userEvent.setup()
+  await user.click(screen.getByRole('button', { name: 'Expand' }))
+  await waitFor(() => expect(screen.getByText('#1')).toBeInTheDocument())
+  await user.click(screen.getByRole('button', { name: 'Load more' }))
+  await waitFor(() => expect(screen.getByText('#2')).toBeInTheDocument())
+  expect(mockedIssuesApiList).toHaveBeenCalledWith(1, { page_size: 100, page_token: 'next' })
+  expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument()
+})
+
+it('shows an empty state when the thread has no issues', async () => {
+  mockedThreadsApiGet.mockResolvedValue({
+    id: 1, title: 'Saga', format: 'Comics', issues_remaining: 0, queue_position: 1,
+    status: 'complete', total_issues: 0, next_unread_issue_number: null, notes: null,
+  } as never)
+  mockedIssuesApiList.mockResolvedValueOnce({
+    issues: [], next_page_token: null, total_count: 0, page_size: 100,
+  })
+  renderPage()
+  await waitFor(() => expect(screen.getByText('Saga')).toBeInTheDocument())
+  const user = userEvent.setup()
+  await user.click(screen.getByRole('button', { name: 'Expand' }))
+  await waitFor(() => expect(screen.getByText('No issues yet')).toBeInTheDocument())
+})
+
+it('shows a retry action when loading issues fails', async () => {
+  mockedThreadsApiGet.mockResolvedValue({
+    id: 1, title: 'Saga', format: 'Comics', issues_remaining: 2, queue_position: 1,
+    status: 'active', total_issues: 10, next_unread_issue_number: '3', notes: null,
+  } as never)
+  mockedIssuesApiList
+    .mockRejectedValueOnce(new Error('issues unavailable'))
+    .mockResolvedValueOnce({
+      issues: [{ id: 1, thread_id: 1, issue_number: '1', status: 'read', read_at: 'now', created_at: 'now' }],
+      next_page_token: null, total_count: 1, page_size: 100,
+    })
+  renderPage()
+  await waitFor(() => expect(screen.getByText('Saga')).toBeInTheDocument())
+  const user = userEvent.setup()
+  await user.click(screen.getByRole('button', { name: 'Expand' }))
+  await waitFor(() => expect(screen.getByText('Failed to load issues')).toBeInTheDocument())
+  await user.click(screen.getByRole('button', { name: 'Retry' }))
+  await waitFor(() => expect(screen.getByText('#1')).toBeInTheDocument())
+})
+
 it('renders migrated progress, paginated issues, and saves edits', async () => {
   mockedThreadsApiGet.mockResolvedValue({
     id: 1, title: 'Saga', format: 'Comics', issues_remaining: 2, queue_position: 1,
     status: 'active', total_issues: 10, next_unread_issue_number: '3', notes: 'Keep reading',
   } as never)
-  mockedIssuesApiList
-    .mockResolvedValueOnce({ issues: [{ id: 1, thread_id: 1, issue_number: '1', status: 'read', read_at: 'now', created_at: 'now' }], next_page_token: 'next', total_count: 2, page_size: 100 })
-    .mockResolvedValueOnce({ issues: [{ id: 2, thread_id: 1, issue_number: '2', status: 'unread', read_at: null, created_at: 'now' }], next_page_token: null, total_count: 2, page_size: 100 })
+  mockedIssuesApiList.mockResolvedValue({
+    issues: [
+      { id: 1, thread_id: 1, issue_number: '1', status: 'read', read_at: 'now', created_at: 'now' },
+      { id: 2, thread_id: 1, issue_number: '2', status: 'unread', read_at: null, created_at: 'now' },
+    ],
+    next_page_token: null, total_count: 2, page_size: 100,
+  })
   const mutate = vi.fn().mockResolvedValue({})
   mockedUseUpdateThread.mockReturnValue({ mutate, isPending: false } as never)
   renderPage()


### PR DESCRIPTION
## What

Advances #697. `ThreadDetailView` no longer downloads the entire issue list before the page finishes loading.

### Changes
- **`frontend/src/pages/ThreadDetailView.tsx`**: removed the eager `do/while` full-library issue fetch from the thread load effect. Thread metadata renders immediately from the thread response (progress, next-unread, notes, queue position, status).
- **Deferred issue loading**: no issue-list request is made while the Issues section stays collapsed. Expanding Issues fetches one bounded page (`page_size: 100`) and retains the `next_page_token` cursor.
- **Incremental paging**: a `Load more` button appends the next page without duplicates or gaps; the button disappears at end-of-list.
- **States**: loading, retry-on-error, empty ("No issues yet"), end-of-list, and load-more are implemented.
- **Edit flow**: saving an edit on a migrated thread reloads the first issue page when issues were previously loaded, keeping the visible list consistent.
- **Route safety**: navigating between thread-detail routes resets issue state and ignores late responses from the previous route.
- **Regression coverage**: focused tests cover deferred loading, paging, route changes, stale successes/failures, empty state, and retry behavior.

## Scope truth

This PR materially advances #697 but does not yet satisfy the entire issue contract. The issue still explicitly requires mark-read and issue-mutation behavior plus recorded validation for 25, 250, 1,000, and 10,000 issue threads, including render time, request count, bytes, first-page latency, and client memory.

## Verification

Exact-SHA CI run #797 passed on `07de757d9c29ec9114e78dd05e79a9fa604fbdf3`, including the frontend coverage gate, lint, typecheck, build, and configured broader matrix.

Part of #697.

This PR is non-draft and must not be merged without Josh's explicit authorization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Issues now load on demand when the Issues section is expanded.
  * Added paginated issue loading with “Load more,” empty states, loading indicators, error messages, and retry support.
  * Issue totals now reflect the server-reported count when available.

* **Bug Fixes**
  * Prevented outdated thread or issue responses from replacing current details during navigation.
  * Updated issue data appropriately after editing migrated threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->