### PR TITLE
fix(snooze): move snoozed threads beyond the roll range (#747)

### DIFF
--- a/app/api/snooze.py
+++ b/app/api/snooze.py
@@ -19,6 +19,7 @@ from app.models.user import User
 from app.schemas import ActiveThreadInfo, SessionResponse
 from app.schemas.session import SnoozedThreadInfo
 from comic_pile.dice_ladder import step_up
+from comic_pile.queue import move_to_safe_position
 from comic_pile.session import get_current_die
 
 logger = logging.getLogger(__name__)
@@ -113,15 +114,16 @@ async def snooze_thread(
     current_user: Annotated[User, Depends(get_current_user)],
     db: AsyncSession = Depends(get_db),
 ) -> SessionResponse:
-    """Snooze the pending thread and step the die up.
+    """Snooze the pending thread, demote it in the queue, and step the die up.
 
     This endpoint:
     1. Gets the current session (must exist with a pending_thread_id)
-    2. Adds the pending_thread_id to snoozed_thread_ids
-    3. Steps the die UP (wider pool) using dice ladder logic
-    4. Records a "snooze" event
-    5. Clears pending_thread_id
-    6. Returns the updated session
+    2. Moves the pending thread beyond the widened roll range
+    3. Adds the pending_thread_id to snoozed_thread_ids
+    4. Steps the die UP (wider pool) using dice ladder logic
+    5. Records a "snooze" event
+    6. Clears pending_thread_id
+    7. Returns the updated session
 
     Args:
         request: FastAPI request object for rate limiting.
@@ -158,7 +160,17 @@ async def snooze_thread(
     pending_thread_id = current_session.pending_thread_id
     current_session_id = current_session.id
 
-    # Add to snoozed_thread_ids list
+    current_die = await get_current_die(current_session_id, db)
+    new_die = step_up(current_die)
+
+    await move_to_safe_position(
+        pending_thread_id,
+        current_user.id,
+        new_die,
+        db,
+        excluded_thread_ids=current_session.snoozed_thread_ids,
+    )
+
     snoozed_ids = (
         list(current_session.snoozed_thread_ids) if current_session.snoozed_thread_ids else []
     )
@@ -170,11 +182,6 @@ async def snooze_thread(
     else:
         logger.info(f"Snooze: thread {pending_thread_id} already in snoozed list")
 
-    # Step die UP (wider pool)
-    current_die = await get_current_die(current_session_id, db)
-    new_die = step_up(current_die)
-
-    # Record snooze event
     event = Event(
         type="snooze",
         session_id=current_session_id,
@@ -184,7 +191,6 @@ async def snooze_thread(
     )
     db.add(event)
 
-    # Clear pending_thread_id
     current_session.pending_thread_id = None
     current_session.pending_thread_updated_at = None
 
@@ -235,7 +241,6 @@ async def unsnooze_thread(
     snoozed_ids.remove(thread_id)
     current_session.snoozed_thread_ids = snoozed_ids
 
-    # Record unsnooze event
     event = Event(
         type="unsnooze",
         session_id=current_session.id,

--- a/tests/test_snooze_queue_placement.py
+++ b/tests/test_snooze_queue_placement.py
@@ -9,18 +9,16 @@ from app.models import Event, Thread
 from app.models import Session as SessionModel
 
 
-@pytest.mark.asyncio
-async def test_snooze_moves_thread_beyond_widened_roll_range(
-    auth_client: AsyncClient,
+async def _create_pending_snooze_session(
     async_db: AsyncSession,
-) -> None:
-    """Snoozing uses the same safe-position behavior as a low rating."""
+    *,
+    thread_count: int,
+    snoozed_indexes: list[int] | None = None,
+) -> tuple[int, list[Thread]]:
+    """Create a session whose first thread is pending for snooze."""
     from tests.conftest import get_or_create_user_async
 
     user = await get_or_create_user_async(async_db)
-    session = SessionModel(start_die=6, user_id=user.id)
-    async_db.add(session)
-
     threads = [
         Thread(
             title=f"Thread {index}",
@@ -30,15 +28,21 @@ async def test_snooze_moves_thread_beyond_widened_roll_range(
             status="active",
             user_id=user.id,
         )
-        for index in range(1, 11)
+        for index in range(1, thread_count + 1)
     ]
     async_db.add_all(threads)
-    await async_db.commit()
-    await async_db.refresh(session)
-    for thread in threads:
-        await async_db.refresh(thread)
+    await async_db.flush()
 
+    snoozed_ids = [threads[index].id for index in snoozed_indexes or []]
     target = threads[0]
+    session = SessionModel(
+        start_die=6,
+        user_id=user.id,
+        pending_thread_id=target.id,
+        snoozed_thread_ids=snoozed_ids,
+    )
+    async_db.add(session)
+    await async_db.flush()
     async_db.add(
         Event(
             type="roll",
@@ -50,21 +54,63 @@ async def test_snooze_moves_thread_beyond_widened_roll_range(
             thread_id=target.id,
         )
     )
-    session.pending_thread_id = target.id
     await async_db.commit()
+    return user.id, threads
+
+
+async def _load_queue(async_db: AsyncSession, user_id: int):
+    """Return the user's queue in deterministic position order."""
+    result = await async_db.execute(
+        select(Thread.id, Thread.queue_position)
+        .where(Thread.user_id == user_id)
+        .order_by(Thread.queue_position, Thread.id)
+    )
+    return result.all()
+
+
+@pytest.mark.asyncio
+async def test_snooze_moves_thread_beyond_widened_roll_range(
+    auth_client: AsyncClient,
+    async_db: AsyncSession,
+) -> None:
+    """Snoozing uses the same safe-position behavior as a low rating."""
+    user_id, threads = await _create_pending_snooze_session(async_db, thread_count=10)
+    target = threads[0]
 
     response = await auth_client.post("/api/snooze/")
 
     assert response.status_code == 200
     assert response.json()["current_die"] == 8
 
-    result = await async_db.execute(
-        select(Thread.id, Thread.queue_position)
-        .where(Thread.user_id == user.id)
-        .order_by(Thread.queue_position, Thread.id)
-    )
-    queue = result.all()
+    queue = await _load_queue(async_db, user_id)
 
     assert queue[8].id == target.id
     assert queue[8].queue_position == 9
     assert [row.queue_position for row in queue] == list(range(1, 11))
+
+
+@pytest.mark.asyncio
+async def test_snooze_placement_does_not_count_existing_snoozed_threads(
+    auth_client: AsyncClient,
+    async_db: AsyncSession,
+) -> None:
+    """Already-snoozed threads do not consume slots in the widened roll pool."""
+    user_id, threads = await _create_pending_snooze_session(
+        async_db,
+        thread_count=11,
+        snoozed_indexes=[1],
+    )
+    target = threads[0]
+    already_snoozed = threads[1]
+
+    response = await auth_client.post("/api/snooze/")
+
+    assert response.status_code == 200
+    assert response.json()["current_die"] == 8
+    assert set(response.json()["snoozed_thread_ids"]) == {target.id, already_snoozed.id}
+
+    queue = await _load_queue(async_db, user_id)
+
+    assert queue[9].id == target.id
+    assert queue[9].queue_position == 10
+    assert [row.queue_position for row in queue] == list(range(1, 12))

--- a/tests/test_snooze_queue_placement.py
+++ b/tests/test_snooze_queue_placement.py
@@ -58,14 +58,14 @@ async def _create_pending_snooze_session(
     return user.id, threads
 
 
-async def _load_queue(async_db: AsyncSession, user_id: int):
+async def _load_queue(async_db: AsyncSession, user_id: int) -> list[tuple[int, int]]:
     """Return the user's queue in deterministic position order."""
     result = await async_db.execute(
         select(Thread.id, Thread.queue_position)
         .where(Thread.user_id == user_id)
         .order_by(Thread.queue_position, Thread.id)
     )
-    return result.all()
+    return [(row.id, row.queue_position) for row in result.all()]
 
 
 @pytest.mark.asyncio
@@ -84,9 +84,8 @@ async def test_snooze_moves_thread_beyond_widened_roll_range(
 
     queue = await _load_queue(async_db, user_id)
 
-    assert queue[8].id == target.id
-    assert queue[8].queue_position == 9
-    assert [row.queue_position for row in queue] == list(range(1, 11))
+    assert queue[8] == (target.id, 9)
+    assert [position for _, position in queue] == list(range(1, 11))
 
 
 @pytest.mark.asyncio
@@ -111,6 +110,5 @@ async def test_snooze_placement_does_not_count_existing_snoozed_threads(
 
     queue = await _load_queue(async_db, user_id)
 
-    assert queue[9].id == target.id
-    assert queue[9].queue_position == 10
-    assert [row.queue_position for row in queue] == list(range(1, 12))
+    assert queue[9] == (target.id, 10)
+    assert [position for _, position in queue] == list(range(1, 12))

--- a/tests/test_snooze_queue_placement.py
+++ b/tests/test_snooze_queue_placement.py
@@ -1,0 +1,70 @@
+"""Regression coverage for snooze queue placement."""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Event, Thread
+from app.models import Session as SessionModel
+
+
+@pytest.mark.asyncio
+async def test_snooze_moves_thread_beyond_widened_roll_range(
+    auth_client: AsyncClient,
+    async_db: AsyncSession,
+) -> None:
+    """Snoozing uses the same safe-position behavior as a low rating."""
+    from tests.conftest import get_or_create_user_async
+
+    user = await get_or_create_user_async(async_db)
+    session = SessionModel(start_die=6, user_id=user.id)
+    async_db.add(session)
+
+    threads = [
+        Thread(
+            title=f"Thread {index}",
+            format="Comic",
+            issues_remaining=5,
+            queue_position=index,
+            status="active",
+            user_id=user.id,
+        )
+        for index in range(1, 11)
+    ]
+    async_db.add_all(threads)
+    await async_db.commit()
+    await async_db.refresh(session)
+    for thread in threads:
+        await async_db.refresh(thread)
+
+    target = threads[0]
+    async_db.add(
+        Event(
+            type="roll",
+            die=6,
+            result=1,
+            selected_thread_id=target.id,
+            selection_method="random",
+            session_id=session.id,
+            thread_id=target.id,
+        )
+    )
+    session.pending_thread_id = target.id
+    await async_db.commit()
+
+    response = await auth_client.post("/api/snooze/")
+
+    assert response.status_code == 200
+    assert response.json()["current_die"] == 8
+
+    result = await async_db.execute(
+        select(Thread.id, Thread.queue_position)
+        .where(Thread.user_id == user.id)
+        .order_by(Thread.queue_position, Thread.id)
+    )
+    queue = result.all()
+
+    assert queue[8].id == target.id
+    assert queue[8].queue_position == 9
+    assert [row.queue_position for row in queue] == list(range(1, 11))


### PR DESCRIPTION
## Summary

Snoozing now applies the same safe queue-placement behavior as a below-threshold rating. The snoozed thread is moved just beyond the newly widened die range before it is excluded from the active session pool, so unwanted comics do not remain parked near the top of the queue after the session ends.

## Implementation

- Reuse `move_to_safe_position()` from the low-rating path with the post-snooze die size.
- Preserve existing snoozed-thread exclusions when calculating the safe position.
- Add deterministic API regression coverage proving a position-1 thread moves to position 9 when snoozing widens d6 to d8, while queue positions remain contiguous.

## Validation

Focused validation is delegated to exact-SHA CI because this automation runtime has no writable repository checkout or network path for cloning. The branch diff was inspected against current `main` and contains only the snooze behavior and regression test.

Closes #747