### PR TITLE
fix(ui): brand the browser title as Comic Pile (#654)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <title>frontend</title>
+    <title>Comic Pile</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/test/title.spec.ts
+++ b/frontend/src/test/title.spec.ts
@@ -1,0 +1,7 @@
+import { expect, test } from '@playwright/test'
+
+test('uses Comic Pile branding in the browser title', async ({ page }) => {
+  await page.goto('/')
+
+  await expect(page).toHaveTitle('Comic Pile')
+})


### PR DESCRIPTION
## Summary

Fixes the browser tab title reported in #654.

## Changes

- Replaces the generic `frontend` document title with `Comic Pile`.
- Adds Playwright regression coverage that verifies the rendered application title.

## Validation

The change is intentionally bounded to the static Vite document shell and one browser assertion. Exact-SHA CI is the broad validation source for this factory runtime.

Closes #654

This PR is non-draft and must not be merged without Josh's explicit authorization.