### PR TITLE
fix(mobile): contain form controls and prevent input zoom (#602)

### DIFF
--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -36,6 +36,17 @@ body {
   --desktop-nav-height: 5rem;
 }
 
+/* Keep mobile form controls inside their containers and at the iOS no-zoom font threshold. */
+@media (max-width: 767px) {
+  input,
+  textarea,
+  select {
+    min-width: 0;
+    max-width: 100%;
+    font-size: 1rem;
+  }
+}
+
 /* Keep the rating action bar's scroll target above the fixed navigation and iOS home indicator. */
 .rating-actions {
   scroll-margin-bottom: calc(var(--mobile-nav-height) + env(safe-area-inset-bottom));

--- a/frontend/src/test/mobile-form-containment.spec.ts
+++ b/frontend/src/test/mobile-form-containment.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test'
+
+const MOBILE_WIDTHS = [320, 375, 414] as const
+
+for (const width of MOBILE_WIDTHS) {
+  test(`mobile form controls remain contained at ${width}px`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 812 })
+    await page.goto('/queue')
+    await expect(page.getByRole('heading', { name: 'Read Queue' })).toBeVisible()
+
+    await page.getByRole('button', { name: 'Add Thread' }).click()
+
+    const controls = page.locator('input:visible, textarea:visible, select:visible')
+    const count = await controls.count()
+    expect(count).toBeGreaterThan(0)
+
+    for (let index = 0; index < count; index += 1) {
+      const control = controls.nth(index)
+      await control.focus()
+
+      const metrics = await page.evaluate(() => {
+        const root = document.getElementById('root')
+        const active = document.activeElement
+        const fontSize = active instanceof HTMLElement
+          ? Number.parseFloat(window.getComputedStyle(active).fontSize)
+          : 0
+
+        return {
+          documentWidth: document.documentElement.scrollWidth,
+          viewportWidth: document.documentElement.clientWidth,
+          rootWidth: root?.scrollWidth ?? 0,
+          rootClientWidth: root?.clientWidth ?? 0,
+          fontSize,
+        }
+      })
+
+      expect(metrics.documentWidth).toBeLessThanOrEqual(metrics.viewportWidth)
+      expect(metrics.rootWidth).toBeLessThanOrEqual(metrics.rootClientWidth)
+      expect(metrics.fontSize).toBeGreaterThanOrEqual(16)
+    }
+  })
+}


### PR DESCRIPTION
## Summary

- Keep mobile text inputs, textareas, and selects within their parent width.
- Raise mobile form-control text to the 16px iOS threshold without disabling pinch zoom.
- Add a Playwright regression at 320px, 375px, and 414px that focuses every visible Queue create-form control and verifies both document/root containment and computed font size.

Closes #602

## Validation

Focused browser coverage is included in `frontend/src/test/mobile-form-containment.spec.ts`. The exact branch is ready for the configured CI matrix; this connector runtime cannot execute the local pnpm or browser commands.

This PR is non-draft and must not be merged without Josh's explicit authorization.