### PR TITLE
feat(thread): preserve visible issue mutation state (#697)

### DIFF
--- a/frontend/src/pages/ThreadDetailView.tsx
+++ b/frontend/src/pages/ThreadDetailView.tsx
@@ -11,6 +11,8 @@ import { getApiErrorDetail } from '../utils/apiError'
 import type { ChangeEvent, FormEvent } from 'react'
 import { DEFAULT_CREATE_STATE, type QueueFormState } from '../pages/QueuePage/types'
 import { IssueToggleList } from '../pages/QueuePage/IssueToggleList'
+import { IssueReadStatusButton } from './thread-detail/IssueReadStatusButton'
+import type { IssueMutationSnapshot } from './thread-detail/issueMutationState'
 
 export default function ThreadDetailView() {
   const { id } = useParams<{ id: string }>()
@@ -105,12 +107,22 @@ export default function ThreadDetailView() {
     }
   }
 
+  function handleIssueSnapshotChange(snapshot: IssueMutationSnapshot) {
+    setIssues(snapshot.issues)
+    setThread(snapshot.thread)
+  }
+
   const handleEditSubmit = async (event: FormEvent) => {
     event.preventDefault()
     const currentThread = thread!
 
     try {
-      const updateData: { title: string; format: string; notes: string | null; issues_remaining?: number } = {
+      const updateData: {
+        title: string
+        format: string
+        notes: string | null
+        issues_remaining?: number
+      } = {
         title: editForm.title,
         format: editForm.format,
         notes: editForm.notes || null,
@@ -176,12 +188,14 @@ export default function ThreadDetailView() {
     return (
       <div className="space-y-6 md:space-y-8 pb-20">
         <header className="px-2">
-          <h1 className="text-2xl md:text-4xl font-black tracking-tighter text-glow mb-1 uppercase">Thread Details</h1>
-          <p className="text-[10px] font-bold text-stone-500 uppercase tracking-widest">View thread information</p>
+          <h1 className="text-2xl md:text-4xl font-black tracking-tighter text-glow mb-1 uppercase">
+            Thread Details
+          </h1>
+          <p className="text-[10px] font-bold text-stone-500 uppercase tracking-widest">
+            View thread information
+          </p>
         </header>
-        <div className="text-center text-stone-500">
-          {error || 'Thread not found'}
-        </div>
+        <div className="text-center text-stone-500">{error || 'Thread not found'}</div>
       </div>
     )
   }
@@ -201,8 +215,12 @@ export default function ThreadDetailView() {
           >
             ← Back to Queue
           </button>
-          <h1 className="text-2xl md:text-4xl font-black tracking-tighter text-glow mb-1 uppercase truncate">{thread.title}</h1>
-          <p className="text-[10px] font-bold text-stone-500 uppercase tracking-widest">{thread.format}</p>
+          <h1 className="text-2xl md:text-4xl font-black tracking-tighter text-glow mb-1 uppercase truncate">
+            {thread.title}
+          </h1>
+          <p className="text-[10px] font-bold text-stone-500 uppercase tracking-widest">
+            {thread.format}
+          </p>
         </div>
         <button
           type="button"
@@ -217,7 +235,9 @@ export default function ThreadDetailView() {
         {progressPercentage && (
           <div className="glass-card p-3 md:p-4 space-y-3">
             <div className="flex justify-between items-center">
-              <span className="text-xs font-black uppercase tracking-widest text-stone-500">Reading Progress</span>
+              <span className="text-xs font-black uppercase tracking-widest text-stone-500">
+                Reading Progress
+              </span>
               <span className="text-sm font-black text-amber-400">{progressPercentage}</span>
             </div>
             <div className="w-full bg-white/10 rounded-full h-2 overflow-hidden">
@@ -232,7 +252,9 @@ export default function ThreadDetailView() {
 
         {thread.notes && (
           <div className="glass-card p-3 md:p-4 space-y-2">
-            <span className="text-xs font-black uppercase tracking-widest text-stone-500">Notes</span>
+            <span className="text-xs font-black uppercase tracking-widest text-stone-500">
+              Notes
+            </span>
             <p className="text-sm text-stone-300 whitespace-pre-wrap">{thread.notes}</p>
           </div>
         )}
@@ -272,7 +294,7 @@ export default function ThreadDetailView() {
                     <button
                       type="button"
                       onClick={() => {
-                        if (thread && thread.total_issues !== null) {
+                        if (thread.total_issues !== null) {
                           setIssues([])
                           setNextPageToken(null)
                           void loadIssuesPage(thread.id, null)
@@ -294,7 +316,7 @@ export default function ThreadDetailView() {
                     {issues.map((issue) => (
                       <div
                         key={issue.id}
-                        className={`flex items-center justify-between p-2 rounded-lg border ${
+                        className={`flex items-center justify-between gap-3 p-2 rounded-lg border ${
                           issue.status === 'read'
                             ? 'bg-green-500/10 border-green-500/20'
                             : 'bg-white/5 border-white/10'
@@ -303,13 +325,20 @@ export default function ThreadDetailView() {
                         <span className="text-sm font-medium text-stone-300">
                           #{issue.issue_number}
                         </span>
-                        <span className="text-xs font-black uppercase tracking-widest">
-                          {issue.status === 'read' ? (
-                            <span className="text-green-400">Read</span>
-                          ) : (
-                            <span className="text-stone-500">Unread</span>
-                          )}
-                        </span>
+                        <div className="flex items-center gap-3">
+                          <span className="text-xs font-black uppercase tracking-widest">
+                            {issue.status === 'read' ? (
+                              <span className="text-green-400">Read</span>
+                            ) : (
+                              <span className="text-stone-500">Unread</span>
+                            )}
+                          </span>
+                          <IssueReadStatusButton
+                            issue={issue}
+                            snapshot={{ issues, thread }}
+                            onSnapshotChange={handleIssueSnapshotChange}
+                          />
+                        </div>
                       </div>
                     ))}
                   </div>
@@ -335,28 +364,42 @@ export default function ThreadDetailView() {
 
         {!isMigrated && (
           <div className="glass-card p-3 md:p-4 space-y-2">
-            <span className="text-xs font-black uppercase tracking-widest text-stone-500">Issues Remaining</span>
+            <span className="text-xs font-black uppercase tracking-widest text-stone-500">
+              Issues Remaining
+            </span>
             <p className="text-sm text-stone-300">{thread.issues_remaining} issues</p>
           </div>
         )}
 
-
         <div className="glass-card p-3 md:p-4 space-y-2">
-          <span className="text-xs font-black uppercase tracking-widest text-stone-500">Queue Position</span>
+          <span className="text-xs font-black uppercase tracking-widest text-stone-500">
+            Queue Position
+          </span>
           <p className="text-sm text-stone-300">Position #{thread.queue_position}</p>
         </div>
 
         <div className="glass-card p-3 md:p-4 space-y-2">
-          <span className="text-xs font-black uppercase tracking-widest text-stone-500">Status</span>
+          <span className="text-xs font-black uppercase tracking-widest text-stone-500">
+            Status
+          </span>
           <p className="text-sm font-black uppercase">{thread.status}</p>
         </div>
       </div>
 
-      <Modal isOpen={isEditOpen} title="Edit Thread" onClose={() => { setIsEditOpen(false) }} overlayClassName="edit-modal__overlay">
+      <Modal
+        isOpen={isEditOpen}
+        title="Edit Thread"
+        onClose={() => {
+          setIsEditOpen(false)
+        }}
+        overlayClassName="edit-modal__overlay"
+      >
         <div className="space-y-4">
           <form id="edit-thread-form" className="space-y-4" onSubmit={handleEditSubmit}>
             <div className="space-y-2">
-              <label className="text-[10px] font-bold uppercase tracking-widest text-stone-500">Title</label>
+              <label className="text-[10px] font-bold uppercase tracking-widest text-stone-500">
+                Title
+              </label>
               <input
                 value={editForm.title}
                 onChange={(event) => setEditForm({ ...editForm, title: event.target.value })}
@@ -366,7 +409,9 @@ export default function ThreadDetailView() {
             </div>
 
             <div className="space-y-2">
-              <label className="text-[10px] font-bold uppercase tracking-widest text-stone-500">Format</label>
+              <label className="text-[10px] font-bold uppercase tracking-widest text-stone-500">
+                Format
+              </label>
               <FormatSelect
                 value={editForm.format}
                 onChange={(value) => setEditForm({ ...editForm, format: value })}
@@ -376,7 +421,9 @@ export default function ThreadDetailView() {
 
             {thread.total_issues === null && (
               <div className="space-y-2">
-                <label className="text-[10px] font-bold uppercase tracking-widest text-stone-500">Issues Remaining</label>
+                <label className="text-[10px] font-bold uppercase tracking-widest text-stone-500">
+                  Issues Remaining
+                </label>
                 <input
                   type="number"
                   min="0"
@@ -393,7 +440,9 @@ export default function ThreadDetailView() {
             )}
 
             <div className="space-y-2">
-              <label className="text-[10px] font-bold uppercase tracking-widest text-stone-500">Notes</label>
+              <label className="text-[10px] font-bold uppercase tracking-widest text-stone-500">
+                Notes
+              </label>
               <textarea
                 value={editForm.notes}
                 onChange={(event) => setEditForm({ ...editForm, notes: event.target.value })}
@@ -402,9 +451,7 @@ export default function ThreadDetailView() {
             </div>
           </form>
 
-          {thread.total_issues !== null && (
-            <IssueToggleList threadId={thread.id} />
-          )}
+          {thread.total_issues !== null && <IssueToggleList threadId={thread.id} />}
 
           <button
             type="submit"

--- a/frontend/src/pages/thread-detail/IssueReadStatusButton.tsx
+++ b/frontend/src/pages/thread-detail/IssueReadStatusButton.tsx
@@ -10,14 +10,14 @@ import {
 
 interface IssueReadStatusButtonProps {
   issue: Issue
-  snapshot: IssueMutationSnapshot
-  onSnapshotChange: (snapshot: IssueMutationSnapshot) => void
+  onSnapshotChange: (
+    update: (snapshot: IssueMutationSnapshot) => IssueMutationSnapshot,
+  ) => void
 }
 
 /** Toggle one visible issue and reconcile only the affected row plus thread summary. */
 export function IssueReadStatusButton({
   issue,
-  snapshot,
   onSnapshotChange,
 }: IssueReadStatusButtonProps) {
   const [isPending, setIsPending] = useState(false)
@@ -46,7 +46,9 @@ export function IssueReadStatusButton({
         next_unread_issue_number: updatedThread.next_unread_issue_number ?? null,
       }
 
-      onSnapshotChange(applyIssueReadStatus(snapshot, issue.id, result))
+      onSnapshotChange((currentSnapshot) =>
+        applyIssueReadStatus(currentSnapshot, issue.id, result),
+      )
     } catch {
       setError('Failed to update issue')
     } finally {

--- a/frontend/src/pages/thread-detail/IssueReadStatusButton.tsx
+++ b/frontend/src/pages/thread-detail/IssueReadStatusButton.tsx
@@ -10,18 +10,22 @@ import {
 
 interface IssueReadStatusButtonProps {
   issue: Issue
-  onSnapshotChange: (
-    update: (snapshot: IssueMutationSnapshot) => IssueMutationSnapshot,
-  ) => void
+  snapshot: IssueMutationSnapshot
+  onSnapshotChange: (snapshot: IssueMutationSnapshot) => void
 }
+
+const latestSnapshots = new Map<number, IssueMutationSnapshot>()
 
 /** Toggle one visible issue and reconcile only the affected row plus thread summary. */
 export function IssueReadStatusButton({
   issue,
+  snapshot,
   onSnapshotChange,
 }: IssueReadStatusButtonProps) {
   const [isPending, setIsPending] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  latestSnapshots.set(issue.thread_id, snapshot)
 
   async function handleToggle() {
     setIsPending(true)
@@ -45,10 +49,11 @@ export function IssueReadStatusButton({
         next_unread_issue_id: updatedThread.next_unread_issue_id ?? null,
         next_unread_issue_number: updatedThread.next_unread_issue_number ?? null,
       }
+      const currentSnapshot = latestSnapshots.get(issue.thread_id) ?? snapshot
+      const nextSnapshot = applyIssueReadStatus(currentSnapshot, issue.id, result)
 
-      onSnapshotChange((currentSnapshot) =>
-        applyIssueReadStatus(currentSnapshot, issue.id, result),
-      )
+      latestSnapshots.set(issue.thread_id, nextSnapshot)
+      onSnapshotChange(nextSnapshot)
     } catch {
       setError('Failed to update issue')
     } finally {

--- a/frontend/src/pages/thread-detail/IssueReadStatusButton.tsx
+++ b/frontend/src/pages/thread-detail/IssueReadStatusButton.tsx
@@ -42,8 +42,8 @@ export function IssueReadStatusButton({
         status: updatedIssue.status,
         read_at: updatedIssue.read_at,
         issues_remaining: updatedThread.issues_remaining,
-        next_unread_issue_id: updatedThread.next_unread_issue_id,
-        next_unread_issue_number: updatedThread.next_unread_issue_number,
+        next_unread_issue_id: updatedThread.next_unread_issue_id ?? null,
+        next_unread_issue_number: updatedThread.next_unread_issue_number ?? null,
       }
 
       onSnapshotChange(applyIssueReadStatus(snapshot, issue.id, result))

--- a/frontend/src/pages/thread-detail/IssueReadStatusButton.tsx
+++ b/frontend/src/pages/thread-detail/IssueReadStatusButton.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react'
+import { threadsApi } from '../../services/api'
+import { issuesApi } from '../../services/api-issues'
+import type { Issue } from '../../types'
+import {
+  applyIssueReadStatus,
+  type IssueMutationSnapshot,
+  type IssueReadStatusResult,
+} from './issueMutationState'
+
+interface IssueReadStatusButtonProps {
+  issue: Issue
+  snapshot: IssueMutationSnapshot
+  onSnapshotChange: (snapshot: IssueMutationSnapshot) => void
+}
+
+/** Toggle one visible issue and reconcile only the affected row plus thread summary. */
+export function IssueReadStatusButton({
+  issue,
+  snapshot,
+  onSnapshotChange,
+}: IssueReadStatusButtonProps) {
+  const [isPending, setIsPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleToggle() {
+    setIsPending(true)
+    setError(null)
+
+    try {
+      if (issue.status === 'read') {
+        await issuesApi.markUnread(issue.id)
+      } else {
+        await issuesApi.markRead(issue.id)
+      }
+
+      const [updatedIssue, updatedThread] = await Promise.all([
+        issuesApi.get(issue.id),
+        threadsApi.get(issue.thread_id),
+      ])
+      const result: IssueReadStatusResult = {
+        status: updatedIssue.status,
+        read_at: updatedIssue.read_at,
+        issues_remaining: updatedThread.issues_remaining,
+        next_unread_issue_id: updatedThread.next_unread_issue_id,
+        next_unread_issue_number: updatedThread.next_unread_issue_number,
+      }
+
+      onSnapshotChange(applyIssueReadStatus(snapshot, issue.id, result))
+    } catch {
+      setError('Failed to update issue')
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {error && <span className="text-xs text-red-400">{error}</span>}
+      <button
+        type="button"
+        onClick={() => void handleToggle()}
+        disabled={isPending}
+        className="text-xs font-black uppercase tracking-widest text-amber-400 hover:text-amber-300 disabled:opacity-50"
+      >
+        {isPending ? 'Saving…' : issue.status === 'read' ? 'Mark unread' : 'Mark read'}
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/pages/thread-detail/issueMutationState.ts
+++ b/frontend/src/pages/thread-detail/issueMutationState.ts
@@ -1,0 +1,43 @@
+import type { Issue, Thread } from '../../types'
+
+export type IssueReadStatus = 'read' | 'unread'
+
+export interface IssueMutationSnapshot {
+  issues: Issue[]
+  thread: Thread
+}
+
+/**
+ * Apply a mark-read or mark-unread result to the currently visible issue page and
+ * thread summary without refetching every loaded issue page.
+ */
+export function applyIssueReadStatus(
+  snapshot: IssueMutationSnapshot,
+  issueId: number,
+  nextStatus: IssueReadStatus,
+): IssueMutationSnapshot {
+  const currentIssue = snapshot.issues.find((issue) => issue.id === issueId)
+  if (!currentIssue || currentIssue.status === nextStatus) {
+    return snapshot
+  }
+
+  const delta = nextStatus === 'read' ? -1 : 1
+  const issuesRemaining = Math.max(0, snapshot.thread.issues_remaining + delta)
+  const issues = snapshot.issues.map((issue) =>
+    issue.id === issueId ? { ...issue, status: nextStatus } : issue,
+  )
+
+  const unreadIssues = issues
+    .filter((issue) => issue.status === 'unread')
+    .sort((left, right) => left.position - right.position)
+
+  return {
+    issues,
+    thread: {
+      ...snapshot.thread,
+      issues_remaining: issuesRemaining,
+      next_unread_issue_number:
+        unreadIssues[0]?.issue_number ?? snapshot.thread.next_unread_issue_number,
+    },
+  }
+}

--- a/frontend/src/pages/thread-detail/issueMutationState.ts
+++ b/frontend/src/pages/thread-detail/issueMutationState.ts
@@ -7,34 +7,52 @@ export interface IssueMutationSnapshot {
   thread: Thread
 }
 
+export interface IssueReadStatusResult {
+  status: IssueReadStatus
+  read_at: string | null
+  issues_remaining: number
+  next_unread_issue_id: number | null
+  next_unread_issue_number: string | null
+}
+
 /**
- * Apply a mark-read or mark-unread result to the currently visible issue page and
- * thread summary without refetching every loaded issue page.
+ * Apply an authoritative mark-read or mark-unread result to the currently visible
+ * issue page and thread summary without refetching every loaded issue page.
  */
 export function applyIssueReadStatus(
   snapshot: IssueMutationSnapshot,
   issueId: number,
-  nextStatus: IssueReadStatus,
+  result: IssueReadStatusResult,
 ): IssueMutationSnapshot {
   const currentIssue = snapshot.issues.find((issue) => issue.id === issueId)
-  if (!currentIssue || currentIssue.status === nextStatus) {
+  if (!currentIssue) {
     return snapshot
   }
 
-  const delta = nextStatus === 'read' ? -1 : 1
-  const issuesRemaining = Math.max(0, snapshot.thread.issues_remaining + delta)
+  const issueIsUnchanged =
+    currentIssue.status === result.status && currentIssue.read_at === result.read_at
+  const threadIsUnchanged =
+    snapshot.thread.issues_remaining === result.issues_remaining &&
+    snapshot.thread.next_unread_issue_id === result.next_unread_issue_id &&
+    snapshot.thread.next_unread_issue_number === result.next_unread_issue_number
+
+  if (issueIsUnchanged && threadIsUnchanged) {
+    return snapshot
+  }
+
   const issues = snapshot.issues.map((issue) =>
-    issue.id === issueId ? { ...issue, status: nextStatus } : issue,
+    issue.id === issueId
+      ? { ...issue, status: result.status, read_at: result.read_at }
+      : issue,
   )
-  const nextUnreadIssue = issues.find((issue) => issue.status === 'unread')
 
   return {
     issues,
     thread: {
       ...snapshot.thread,
-      issues_remaining: issuesRemaining,
-      next_unread_issue_id: nextUnreadIssue?.id ?? null,
-      next_unread_issue_number: nextUnreadIssue?.issue_number ?? null,
+      issues_remaining: result.issues_remaining,
+      next_unread_issue_id: result.next_unread_issue_id,
+      next_unread_issue_number: result.next_unread_issue_number,
     },
   }
 }

--- a/frontend/src/pages/thread-detail/issueMutationState.ts
+++ b/frontend/src/pages/thread-detail/issueMutationState.ts
@@ -26,18 +26,15 @@ export function applyIssueReadStatus(
   const issues = snapshot.issues.map((issue) =>
     issue.id === issueId ? { ...issue, status: nextStatus } : issue,
   )
-
-  const unreadIssues = issues
-    .filter((issue) => issue.status === 'unread')
-    .sort((left, right) => left.position - right.position)
+  const nextUnreadIssue = issues.find((issue) => issue.status === 'unread')
 
   return {
     issues,
     thread: {
       ...snapshot.thread,
       issues_remaining: issuesRemaining,
-      next_unread_issue_number:
-        unreadIssues[0]?.issue_number ?? snapshot.thread.next_unread_issue_number,
+      next_unread_issue_id: nextUnreadIssue?.id ?? null,
+      next_unread_issue_number: nextUnreadIssue?.issue_number ?? null,
     },
   }
 }

--- a/frontend/src/unit/IssueReadStatusButton.test.tsx
+++ b/frontend/src/unit/IssueReadStatusButton.test.tsx
@@ -1,10 +1,11 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useState } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { IssueReadStatusButton } from '../pages/thread-detail/IssueReadStatusButton'
-import { issuesApi } from '../services/api-issues'
-import { threadsApi } from '../services/api'
-import type { Issue, Thread } from '../types'
 import type { IssueMutationSnapshot } from '../pages/thread-detail/issueMutationState'
+import { threadsApi } from '../services/api'
+import { issuesApi } from '../services/api-issues'
+import type { Issue, Thread } from '../types'
 
 vi.mock('../services/api-issues', () => ({
   issuesApi: {
@@ -19,6 +20,49 @@ vi.mock('../services/api', () => ({
     get: vi.fn(),
   },
 }))
+
+interface Deferred<T> {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason?: unknown) => void
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+
+  return { promise, resolve, reject }
+}
+
+interface ControlledIssueButtonsProps {
+  initialSnapshot: IssueMutationSnapshot
+  onSnapshotChange: (snapshot: IssueMutationSnapshot) => void
+}
+
+function ControlledIssueButtons({
+  initialSnapshot,
+  onSnapshotChange,
+}: ControlledIssueButtonsProps) {
+  const [snapshot, setSnapshot] = useState(initialSnapshot)
+
+  function handleSnapshotChange(nextSnapshot: IssueMutationSnapshot) {
+    setSnapshot(nextSnapshot)
+    onSnapshotChange(nextSnapshot)
+  }
+
+  return snapshot.issues.map((currentIssue) => (
+    <IssueReadStatusButton
+      key={currentIssue.id}
+      issue={currentIssue}
+      snapshot={snapshot}
+      onSnapshotChange={handleSnapshotChange}
+    />
+  ))
+}
 
 const issue: Issue = {
   id: 11,
@@ -92,8 +136,8 @@ describe('IssueReadStatusButton', () => {
       id: 12,
       issue_number: '3',
     }
-    const firstIssueRequest = Promise.withResolvers<Issue>()
-    const secondIssueRequest = Promise.withResolvers<Issue>()
+    const firstIssueRequest = createDeferred<Issue>()
+    const secondIssueRequest = createDeferred<Issue>()
     vi.mocked(issuesApi.markRead).mockResolvedValue()
     vi.mocked(issuesApi.get)
       .mockReturnValueOnce(firstIssueRequest.promise)
@@ -121,18 +165,10 @@ describe('IssueReadStatusButton', () => {
     }
 
     render(
-      <>
-        <IssueReadStatusButton
-          issue={issue}
-          snapshot={snapshot}
-          onSnapshotChange={onSnapshotChange}
-        />
-        <IssueReadStatusButton
-          issue={secondIssue}
-          snapshot={snapshot}
-          onSnapshotChange={onSnapshotChange}
-        />
-      </>,
+      <ControlledIssueButtons
+        initialSnapshot={snapshot}
+        onSnapshotChange={onSnapshotChange}
+      />,
     )
 
     const buttons = screen.getAllByRole('button', { name: 'Mark read' })

--- a/frontend/src/unit/IssueReadStatusButton.test.tsx
+++ b/frontend/src/unit/IssueReadStatusButton.test.tsx
@@ -4,6 +4,7 @@ import { IssueReadStatusButton } from '../pages/thread-detail/IssueReadStatusBut
 import { issuesApi } from '../services/api-issues'
 import { threadsApi } from '../services/api'
 import type { Issue, Thread } from '../types'
+import type { IssueMutationSnapshot } from '../pages/thread-detail/issueMutationState'
 
 vi.mock('../services/api-issues', () => ({
   issuesApi: {
@@ -48,7 +49,7 @@ describe('IssueReadStatusButton', () => {
     vi.clearAllMocks()
   })
 
-  it('marks an unread issue read and reconciles the visible snapshot from bounded reads', async () => {
+  it('marks an unread issue read and reconciles the latest visible snapshot', async () => {
     vi.mocked(issuesApi.markRead).mockResolvedValue()
     vi.mocked(issuesApi.get).mockResolvedValue({
       ...issue,
@@ -61,15 +62,14 @@ describe('IssueReadStatusButton', () => {
       next_unread_issue_id: 99,
       next_unread_issue_number: '25',
     })
-    const onSnapshotChange = vi.fn()
-
-    render(
-      <IssueReadStatusButton
-        issue={issue}
-        snapshot={{ issues: [issue], thread }}
-        onSnapshotChange={onSnapshotChange}
-      />,
+    let snapshot: IssueMutationSnapshot = { issues: [issue], thread }
+    const onSnapshotChange = vi.fn(
+      (update: (current: IssueMutationSnapshot) => IssueMutationSnapshot) => {
+        snapshot = update(snapshot)
+      },
     )
+
+    render(<IssueReadStatusButton issue={issue} onSnapshotChange={onSnapshotChange} />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Mark read' }))
 
@@ -77,7 +77,7 @@ describe('IssueReadStatusButton', () => {
     expect(issuesApi.markRead).toHaveBeenCalledWith(11)
     expect(issuesApi.get).toHaveBeenCalledWith(11)
     expect(threadsApi.get).toHaveBeenCalledWith(7)
-    expect(onSnapshotChange).toHaveBeenCalledWith({
+    expect(snapshot).toEqual({
       issues: [{ ...issue, status: 'read', read_at: '2026-08-03T18:30:00Z' }],
       thread: {
         ...thread,
@@ -88,17 +88,52 @@ describe('IssueReadStatusButton', () => {
     })
   })
 
+  it('applies a delayed result without overwriting a newer row transition', async () => {
+    vi.mocked(issuesApi.markRead).mockResolvedValue()
+    vi.mocked(issuesApi.get).mockResolvedValue({
+      ...issue,
+      status: 'read',
+      read_at: '2026-08-03T18:30:00Z',
+    })
+    vi.mocked(threadsApi.get).mockResolvedValue({
+      ...thread,
+      issues_remaining: 0,
+      next_unread_issue_id: null,
+      next_unread_issue_number: null,
+    })
+    const otherIssue: Issue = {
+      ...issue,
+      id: 12,
+      issue_number: '3',
+      status: 'read',
+      read_at: '2026-08-03T18:29:00Z',
+    }
+    let snapshot: IssueMutationSnapshot = {
+      issues: [issue, { ...otherIssue, status: 'unread', read_at: null }],
+      thread,
+    }
+    const onSnapshotChange = (
+      update: (current: IssueMutationSnapshot) => IssueMutationSnapshot,
+    ) => {
+      snapshot = {
+        ...snapshot,
+        issues: snapshot.issues.map((item) => (item.id === 12 ? otherIssue : item)),
+      }
+      snapshot = update(snapshot)
+    }
+
+    render(<IssueReadStatusButton issue={issue} onSnapshotChange={onSnapshotChange} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Mark read' }))
+
+    await waitFor(() => expect(snapshot.issues[0].status).toBe('read'))
+    expect(snapshot.issues[1]).toEqual(otherIssue)
+  })
+
   it('keeps the current snapshot and shows a retryable error when the mutation fails', async () => {
     vi.mocked(issuesApi.markRead).mockRejectedValue(new Error('network'))
     const onSnapshotChange = vi.fn()
 
-    render(
-      <IssueReadStatusButton
-        issue={issue}
-        snapshot={{ issues: [issue], thread }}
-        onSnapshotChange={onSnapshotChange}
-      />,
-    )
+    render(<IssueReadStatusButton issue={issue} onSnapshotChange={onSnapshotChange} />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Mark read' }))
 

--- a/frontend/src/unit/IssueReadStatusButton.test.tsx
+++ b/frontend/src/unit/IssueReadStatusButton.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { IssueReadStatusButton } from '../pages/thread-detail/IssueReadStatusButton'
+import { issuesApi } from '../services/api-issues'
+import { threadsApi } from '../services/api'
+import type { Issue, Thread } from '../types'
+
+vi.mock('../services/api-issues', () => ({
+  issuesApi: {
+    markRead: vi.fn(),
+    markUnread: vi.fn(),
+    get: vi.fn(),
+  },
+}))
+
+vi.mock('../services/api', () => ({
+  threadsApi: {
+    get: vi.fn(),
+  },
+}))
+
+const issue: Issue = {
+  id: 11,
+  thread_id: 7,
+  issue_number: '2',
+  status: 'unread',
+  read_at: null,
+  created_at: '2026-07-02T00:00:00Z',
+}
+
+const thread: Thread = {
+  id: 7,
+  title: 'Test Thread',
+  format: 'single issues',
+  issues_remaining: 2,
+  total_issues: 3,
+  next_unread_issue_id: 11,
+  next_unread_issue_number: '2',
+  queue_position: 1,
+  status: 'active',
+  is_blocked: false,
+  blocking_reasons: [],
+  created_at: '2026-08-03T00:00:00Z',
+}
+
+describe('IssueReadStatusButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('marks an unread issue read and reconciles the visible snapshot from bounded reads', async () => {
+    vi.mocked(issuesApi.markRead).mockResolvedValue()
+    vi.mocked(issuesApi.get).mockResolvedValue({
+      ...issue,
+      status: 'read',
+      read_at: '2026-08-03T18:30:00Z',
+    })
+    vi.mocked(threadsApi.get).mockResolvedValue({
+      ...thread,
+      issues_remaining: 1,
+      next_unread_issue_id: 99,
+      next_unread_issue_number: '25',
+    })
+    const onSnapshotChange = vi.fn()
+
+    render(
+      <IssueReadStatusButton
+        issue={issue}
+        snapshot={{ issues: [issue], thread }}
+        onSnapshotChange={onSnapshotChange}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mark read' }))
+
+    await waitFor(() => expect(onSnapshotChange).toHaveBeenCalledTimes(1))
+    expect(issuesApi.markRead).toHaveBeenCalledWith(11)
+    expect(issuesApi.get).toHaveBeenCalledWith(11)
+    expect(threadsApi.get).toHaveBeenCalledWith(7)
+    expect(onSnapshotChange).toHaveBeenCalledWith({
+      issues: [{ ...issue, status: 'read', read_at: '2026-08-03T18:30:00Z' }],
+      thread: {
+        ...thread,
+        issues_remaining: 1,
+        next_unread_issue_id: 99,
+        next_unread_issue_number: '25',
+      },
+    })
+  })
+
+  it('keeps the current snapshot and shows a retryable error when the mutation fails', async () => {
+    vi.mocked(issuesApi.markRead).mockRejectedValue(new Error('network'))
+    const onSnapshotChange = vi.fn()
+
+    render(
+      <IssueReadStatusButton
+        issue={issue}
+        snapshot={{ issues: [issue], thread }}
+        onSnapshotChange={onSnapshotChange}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mark read' }))
+
+    expect(await screen.findByText('Failed to update issue')).toBeInTheDocument()
+    expect(onSnapshotChange).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/unit/IssueReadStatusButton.test.tsx
+++ b/frontend/src/unit/IssueReadStatusButton.test.tsx
@@ -49,7 +49,7 @@ describe('IssueReadStatusButton', () => {
     vi.clearAllMocks()
   })
 
-  it('marks an unread issue read and reconciles the latest visible snapshot', async () => {
+  it('marks an unread issue read and reconciles the visible snapshot from bounded reads', async () => {
     vi.mocked(issuesApi.markRead).mockResolvedValue()
     vi.mocked(issuesApi.get).mockResolvedValue({
       ...issue,
@@ -62,22 +62,20 @@ describe('IssueReadStatusButton', () => {
       next_unread_issue_id: 99,
       next_unread_issue_number: '25',
     })
-    let snapshot: IssueMutationSnapshot = { issues: [issue], thread }
-    const onSnapshotChange = vi.fn(
-      (update: (current: IssueMutationSnapshot) => IssueMutationSnapshot) => {
-        snapshot = update(snapshot)
-      },
-    )
+    const onSnapshotChange = vi.fn()
 
-    render(<IssueReadStatusButton issue={issue} onSnapshotChange={onSnapshotChange} />)
+    render(
+      <IssueReadStatusButton
+        issue={issue}
+        snapshot={{ issues: [issue], thread }}
+        onSnapshotChange={onSnapshotChange}
+      />,
+    )
 
     fireEvent.click(screen.getByRole('button', { name: 'Mark read' }))
 
     await waitFor(() => expect(onSnapshotChange).toHaveBeenCalledTimes(1))
-    expect(issuesApi.markRead).toHaveBeenCalledWith(11)
-    expect(issuesApi.get).toHaveBeenCalledWith(11)
-    expect(threadsApi.get).toHaveBeenCalledWith(7)
-    expect(snapshot).toEqual({
+    expect(onSnapshotChange).toHaveBeenCalledWith({
       issues: [{ ...issue, status: 'read', read_at: '2026-08-03T18:30:00Z' }],
       thread: {
         ...thread,
@@ -88,52 +86,90 @@ describe('IssueReadStatusButton', () => {
     })
   })
 
-  it('applies a delayed result without overwriting a newer row transition', async () => {
+  it('preserves a newer row transition when an older request finishes later', async () => {
+    const secondIssue: Issue = {
+      ...issue,
+      id: 12,
+      issue_number: '3',
+    }
+    const firstIssueRequest = Promise.withResolvers<Issue>()
+    const secondIssueRequest = Promise.withResolvers<Issue>()
     vi.mocked(issuesApi.markRead).mockResolvedValue()
-    vi.mocked(issuesApi.get).mockResolvedValue({
+    vi.mocked(issuesApi.get)
+      .mockReturnValueOnce(firstIssueRequest.promise)
+      .mockReturnValueOnce(secondIssueRequest.promise)
+    vi.mocked(threadsApi.get)
+      .mockResolvedValueOnce({
+        ...thread,
+        issues_remaining: 0,
+        next_unread_issue_id: null,
+        next_unread_issue_number: null,
+      })
+      .mockResolvedValueOnce({
+        ...thread,
+        issues_remaining: 1,
+        next_unread_issue_id: 12,
+        next_unread_issue_number: '3',
+      })
+
+    let snapshot: IssueMutationSnapshot = {
+      issues: [issue, secondIssue],
+      thread,
+    }
+    const onSnapshotChange = (nextSnapshot: IssueMutationSnapshot) => {
+      snapshot = nextSnapshot
+    }
+
+    render(
+      <>
+        <IssueReadStatusButton
+          issue={issue}
+          snapshot={snapshot}
+          onSnapshotChange={onSnapshotChange}
+        />
+        <IssueReadStatusButton
+          issue={secondIssue}
+          snapshot={snapshot}
+          onSnapshotChange={onSnapshotChange}
+        />
+      </>,
+    )
+
+    const buttons = screen.getAllByRole('button', { name: 'Mark read' })
+    fireEvent.click(buttons[0])
+    fireEvent.click(buttons[1])
+
+    secondIssueRequest.resolve({
+      ...secondIssue,
+      status: 'read',
+      read_at: '2026-08-03T18:29:00Z',
+    })
+    await waitFor(() => expect(snapshot.issues[1].status).toBe('read'))
+
+    firstIssueRequest.resolve({
       ...issue,
       status: 'read',
       read_at: '2026-08-03T18:30:00Z',
     })
-    vi.mocked(threadsApi.get).mockResolvedValue({
-      ...thread,
-      issues_remaining: 0,
-      next_unread_issue_id: null,
-      next_unread_issue_number: null,
-    })
-    const otherIssue: Issue = {
-      ...issue,
-      id: 12,
-      issue_number: '3',
+    await waitFor(() => expect(snapshot.issues[0].status).toBe('read'))
+
+    expect(snapshot.issues[1]).toMatchObject({
       status: 'read',
       read_at: '2026-08-03T18:29:00Z',
-    }
-    let snapshot: IssueMutationSnapshot = {
-      issues: [issue, { ...otherIssue, status: 'unread', read_at: null }],
-      thread,
-    }
-    const onSnapshotChange = (
-      update: (current: IssueMutationSnapshot) => IssueMutationSnapshot,
-    ) => {
-      snapshot = {
-        ...snapshot,
-        issues: snapshot.issues.map((item) => (item.id === 12 ? otherIssue : item)),
-      }
-      snapshot = update(snapshot)
-    }
-
-    render(<IssueReadStatusButton issue={issue} onSnapshotChange={onSnapshotChange} />)
-    fireEvent.click(screen.getByRole('button', { name: 'Mark read' }))
-
-    await waitFor(() => expect(snapshot.issues[0].status).toBe('read'))
-    expect(snapshot.issues[1]).toEqual(otherIssue)
+    })
   })
 
   it('keeps the current snapshot and shows a retryable error when the mutation fails', async () => {
     vi.mocked(issuesApi.markRead).mockRejectedValue(new Error('network'))
     const onSnapshotChange = vi.fn()
 
-    render(<IssueReadStatusButton issue={issue} onSnapshotChange={onSnapshotChange} />)
+    render(
+      <IssueReadStatusButton
+        issue={issue}
+        snapshot={{ issues: [issue], thread }}
+        onSnapshotChange={onSnapshotChange}
+      />,
+    )
 
     fireEvent.click(screen.getByRole('button', { name: 'Mark read' }))
 

--- a/frontend/src/unit/issueMutationState.test.ts
+++ b/frontend/src/unit/issueMutationState.test.ts
@@ -18,54 +18,61 @@ const thread: Thread = {
 }
 
 const issues: Issue[] = [
-  {
-    id: 10,
-    thread_id: 7,
-    issue_number: '1',
-    status: 'read',
-    read_at: '2026-08-01T00:00:00Z',
-    created_at: '2026-07-01T00:00:00Z',
-  },
-  {
-    id: 11,
-    thread_id: 7,
-    issue_number: '2',
-    status: 'unread',
-    read_at: null,
-    created_at: '2026-07-02T00:00:00Z',
-  },
-  {
-    id: 12,
-    thread_id: 7,
-    issue_number: '3',
-    status: 'unread',
-    read_at: null,
-    created_at: '2026-07-03T00:00:00Z',
-  },
+  { id: 10, thread_id: 7, issue_number: '1', status: 'read', read_at: '2026-08-01T00:00:00Z', created_at: '2026-07-01T00:00:00Z' },
+  { id: 11, thread_id: 7, issue_number: '2', status: 'unread', read_at: null, created_at: '2026-07-02T00:00:00Z' },
+  { id: 12, thread_id: 7, issue_number: '3', status: 'unread', read_at: null, created_at: '2026-07-03T00:00:00Z' },
 ]
 
 describe('applyIssueReadStatus', () => {
-  it('marks a visible issue read and advances the thread summary', () => {
-    const result = applyIssueReadStatus({ issues, thread }, 11, 'read')
+  it('uses authoritative thread metadata when marking a visible issue read', () => {
+    const result = applyIssueReadStatus({ issues, thread }, 11, {
+      status: 'read',
+      read_at: '2026-08-03T17:30:00Z',
+      issues_remaining: 1,
+      next_unread_issue_id: 99,
+      next_unread_issue_number: '25',
+    })
 
-    expect(result.issues.map((issue) => issue.status)).toEqual(['read', 'read', 'unread'])
-    expect(result.thread.issues_remaining).toBe(1)
-    expect(result.thread.next_unread_issue_id).toBe(12)
-    expect(result.thread.next_unread_issue_number).toBe('3')
+    expect(result.issues[1]).toMatchObject({ status: 'read', read_at: '2026-08-03T17:30:00Z' })
+    expect(result.thread).toMatchObject({
+      issues_remaining: 1,
+      next_unread_issue_id: 99,
+      next_unread_issue_number: '25',
+    })
   })
 
-  it('marks a visible issue unread and restores it as next unread', () => {
-    const result = applyIssueReadStatus({ issues, thread }, 10, 'unread')
+  it('clears read_at when marking a visible issue unread', () => {
+    const result = applyIssueReadStatus({ issues, thread }, 10, {
+      status: 'unread',
+      read_at: null,
+      issues_remaining: 3,
+      next_unread_issue_id: 10,
+      next_unread_issue_number: '1',
+    })
 
-    expect(result.issues[0]?.status).toBe('unread')
+    expect(result.issues[0]).toMatchObject({ status: 'unread', read_at: null })
     expect(result.thread.issues_remaining).toBe(3)
-    expect(result.thread.next_unread_issue_id).toBe(10)
-    expect(result.thread.next_unread_issue_number).toBe('1')
   })
 
-  it('returns the original snapshot when the requested status is already applied', () => {
+  it('returns the original snapshot when the authoritative result is already applied', () => {
     const snapshot = { issues, thread }
+    expect(applyIssueReadStatus(snapshot, 11, {
+      status: 'unread',
+      read_at: null,
+      issues_remaining: 2,
+      next_unread_issue_id: 11,
+      next_unread_issue_number: '2',
+    })).toBe(snapshot)
+  })
 
-    expect(applyIssueReadStatus(snapshot, 11, 'unread')).toBe(snapshot)
+  it('returns the original snapshot when the issue is not visible', () => {
+    const snapshot = { issues, thread }
+    expect(applyIssueReadStatus(snapshot, 999, {
+      status: 'read',
+      read_at: '2026-08-03T17:30:00Z',
+      issues_remaining: 1,
+      next_unread_issue_id: 12,
+      next_unread_issue_number: '3',
+    })).toBe(snapshot)
   })
 })

--- a/frontend/src/unit/issueMutationState.test.ts
+++ b/frontend/src/unit/issueMutationState.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import type { Issue, Thread } from '../types'
+import { applyIssueReadStatus } from '../pages/thread-detail/issueMutationState'
+
+const thread: Thread = {
+  id: 7,
+  title: 'Test Thread',
+  format: 'single issues',
+  issues_remaining: 2,
+  total_issues: 3,
+  next_unread_issue_id: 11,
+  next_unread_issue_number: '2',
+  queue_position: 1,
+  status: 'active',
+  is_blocked: false,
+  blocking_reasons: [],
+  created_at: '2026-08-03T00:00:00Z',
+}
+
+const issues: Issue[] = [
+  {
+    id: 10,
+    thread_id: 7,
+    issue_number: '1',
+    status: 'read',
+    read_at: '2026-08-01T00:00:00Z',
+    created_at: '2026-07-01T00:00:00Z',
+  },
+  {
+    id: 11,
+    thread_id: 7,
+    issue_number: '2',
+    status: 'unread',
+    read_at: null,
+    created_at: '2026-07-02T00:00:00Z',
+  },
+  {
+    id: 12,
+    thread_id: 7,
+    issue_number: '3',
+    status: 'unread',
+    read_at: null,
+    created_at: '2026-07-03T00:00:00Z',
+  },
+]
+
+describe('applyIssueReadStatus', () => {
+  it('marks a visible issue read and advances the thread summary', () => {
+    const result = applyIssueReadStatus({ issues, thread }, 11, 'read')
+
+    expect(result.issues.map((issue) => issue.status)).toEqual(['read', 'read', 'unread'])
+    expect(result.thread.issues_remaining).toBe(1)
+    expect(result.thread.next_unread_issue_id).toBe(12)
+    expect(result.thread.next_unread_issue_number).toBe('3')
+  })
+
+  it('marks a visible issue unread and restores it as next unread', () => {
+    const result = applyIssueReadStatus({ issues, thread }, 10, 'unread')
+
+    expect(result.issues[0]?.status).toBe('unread')
+    expect(result.thread.issues_remaining).toBe(3)
+    expect(result.thread.next_unread_issue_id).toBe(10)
+    expect(result.thread.next_unread_issue_number).toBe('1')
+  })
+
+  it('returns the original snapshot when the requested status is already applied', () => {
+    const snapshot = { issues, thread }
+
+    expect(applyIssueReadStatus(snapshot, 11, 'unread')).toBe(snapshot)
+  })
+})


### PR DESCRIPTION
## Summary

Completes issue #697 by wiring visible mark-read and mark-unread controls into the incrementally loaded Thread Details issue list without refetching every loaded page.

## Implemented

- Adds a typed `applyIssueReadStatus` transition for visible issue rows.
- Updates `status`, `read_at`, `issues_remaining`, `next_unread_issue_id`, and `next_unread_issue_number` from authoritative API results.
- Integrates per-row read-status controls into `ThreadDetailView`.
- Preserves the current ordered issue page and avoids duplicate network-driven reconstruction.
- Reconciles concurrent row mutations against the latest per-thread snapshot so out-of-order completions cannot erase newer state.
- Treats already-applied statuses and missing rows as no-ops.
- Shows pending and retryable failure states.

## Verification

- Exact-SHA CI run #833 passed for `f3c6bf7bbceecc5a3e67b317bff759c1384969da`.
- Focused regression coverage includes mark-read, mark-unread, authoritative summaries, missing rows, idempotency, failure recovery, and concurrent out-of-order completions.
- All review threads are resolved.

Closes #697.

This PR is non-draft and must not be merged without Josh's explicit authorization.