### PR TITLE
feat(query): replay targeted rating cache contract on current main

### DIFF
--- a/frontend/src/hooks/useQueue.ts
+++ b/frontend/src/hooks/useQueue.ts
@@ -1,4 +1,6 @@
 import { useCallback, useState } from 'react'
+import { invalidateAfterQueueMovement } from '../query/cacheEffects'
+import { queryClient } from '../query/queryClient'
 import { queueApi } from '../services/api'
 import { getApiErrorDetail } from '../utils/apiError'
 import type { MoveToPositionPayload } from '../types'
@@ -12,6 +14,7 @@ export function useMoveToPosition() {
       setIsPending(true)
       setIsError(false)
       await queueApi.moveToPosition(id, position)
+      await invalidateAfterQueueMovement(queryClient)
     } catch (error: unknown) {
       setIsError(true)
       console.error('Failed to move thread to position:', getApiErrorDetail(error))
@@ -33,6 +36,7 @@ export function useMoveToFront() {
       setIsPending(true)
       setIsError(false)
       await queueApi.moveToFront(id)
+      await invalidateAfterQueueMovement(queryClient)
     } catch (error: unknown) {
       setIsError(true)
       console.error('Failed to move thread to front:', getApiErrorDetail(error))
@@ -54,6 +58,7 @@ export function useMoveToBack() {
       setIsPending(true)
       setIsError(false)
       await queueApi.moveToBack(id)
+      await invalidateAfterQueueMovement(queryClient)
     } catch (error: unknown) {
       setIsError(true)
       console.error('Failed to move thread to back:', getApiErrorDetail(error))
@@ -75,6 +80,7 @@ export function useShuffleQueue() {
       setIsPending(true)
       setIsError(false)
       await queueApi.shuffle()
+      await invalidateAfterQueueMovement(queryClient)
     } catch (error: unknown) {
       setIsError(true)
       console.error('Failed to shuffle queue:', getApiErrorDetail(error))

--- a/frontend/src/hooks/useRate.ts
+++ b/frontend/src/hooks/useRate.ts
@@ -1,4 +1,6 @@
 import { useState } from 'react'
+import { applyRatedThreadCache } from '../query/cacheEffects'
+import { queryClient } from '../query/queryClient'
 import { rateApi } from '../services/api'
 import { getApiErrorDetail } from '../utils/apiError'
 import type { RatePayload } from '../types'
@@ -11,7 +13,9 @@ export function useRate() {
     setIsPending(true)
     setIsError(false)
     try {
-      return await rateApi.rate(data)
+      const thread = await rateApi.rate(data)
+      await applyRatedThreadCache(queryClient, thread)
+      return thread
     } catch (error: unknown) {
       setIsError(true)
       console.error('Failed to rate thread:', getApiErrorDetail(error))

--- a/frontend/src/hooks/useSnooze.ts
+++ b/frontend/src/hooks/useSnooze.ts
@@ -1,4 +1,6 @@
 import { useState } from 'react'
+import { invalidateCurrentSessionAfterSnooze } from '../query/cacheEffects'
+import { queryClient } from '../query/queryClient'
 import { snoozeApi } from '../services/api'
 import { getApiErrorDetail } from '../utils/apiError'
 
@@ -11,6 +13,7 @@ export function useSnooze() {
     setIsError(false)
     try {
       await snoozeApi.snooze()
+      await invalidateCurrentSessionAfterSnooze(queryClient)
     } catch (error: unknown) {
       setIsError(true)
       console.error('Failed to snooze thread:', getApiErrorDetail(error))
@@ -32,6 +35,7 @@ export function useUnsnooze() {
     setIsError(false)
     try {
       await snoozeApi.unsnooze(threadId)
+      await invalidateCurrentSessionAfterSnooze(queryClient)
     } catch (error: unknown) {
       setIsError(true)
       console.error('Failed to unsnooze thread:', getApiErrorDetail(error))

--- a/frontend/src/query/cacheEffects.ts
+++ b/frontend/src/query/cacheEffects.ts
@@ -2,6 +2,40 @@ import type { QueryClient } from '@tanstack/react-query'
 import type { Thread } from '../types'
 import { queryKeys } from './queryKeys'
 
+export type ThreadCacheRollback = () => void
+
+export function optimisticallyUpdateThreadCache(
+  client: QueryClient,
+  threadId: number,
+  update: (thread: Thread) => Thread,
+): ThreadCacheRollback {
+  const detailKey = queryKeys.thread.detail(threadId)
+  const summaryKey = queryKeys.thread.summary(threadId)
+  const previousDetail = client.getQueryData<Thread>(detailKey)
+  const previousSummary = client.getQueryData<Thread>(summaryKey)
+
+  if (previousDetail) {
+    client.setQueryData(detailKey, update(previousDetail))
+  }
+  if (previousSummary) {
+    client.setQueryData(summaryKey, update(previousSummary))
+  }
+
+  return () => {
+    if (previousDetail) {
+      client.setQueryData(detailKey, previousDetail)
+    } else {
+      client.removeQueries({ queryKey: detailKey, exact: true })
+    }
+
+    if (previousSummary) {
+      client.setQueryData(summaryKey, previousSummary)
+    } else {
+      client.removeQueries({ queryKey: summaryKey, exact: true })
+    }
+  }
+}
+
 export async function applyRatedThreadCache(
   client: QueryClient,
   thread: Thread,

--- a/frontend/src/query/cacheEffects.ts
+++ b/frontend/src/query/cacheEffects.ts
@@ -1,0 +1,84 @@
+import type { QueryClient } from '@tanstack/react-query'
+import type { Thread } from '../types'
+import { queryKeys } from './queryKeys'
+
+export async function applyRatedThreadCache(
+  client: QueryClient,
+  thread: Thread,
+): Promise<void> {
+  client.setQueryData(queryKeys.thread.detail(thread.id), thread)
+  client.setQueryData(queryKeys.thread.summary(thread.id), thread)
+
+  await client.invalidateQueries({
+    queryKey: queryKeys.session.current(),
+    exact: true,
+  })
+}
+
+export async function applyUpdatedThreadCache(
+  client: QueryClient,
+  thread: Thread,
+): Promise<void> {
+  client.setQueryData(queryKeys.thread.detail(thread.id), thread)
+  client.setQueryData(queryKeys.thread.summary(thread.id), thread)
+
+  await Promise.all([
+    client.invalidateQueries({ queryKey: queryKeys.queue.pages() }),
+    client.invalidateQueries({
+      queryKey: queryKeys.session.current(),
+      exact: true,
+    }),
+    client.invalidateQueries({
+      queryKey: queryKeys.roll.bootstrap(),
+      exact: true,
+    }),
+  ])
+}
+
+export async function invalidateAfterIssueEdit(
+  client: QueryClient,
+  threadId: number,
+): Promise<void> {
+  await Promise.all([
+    client.invalidateQueries({
+      queryKey: queryKeys.thread.issuePages(threadId),
+    }),
+    client.invalidateQueries({
+      queryKey: queryKeys.thread.detail(threadId),
+      exact: true,
+    }),
+    client.invalidateQueries({
+      queryKey: queryKeys.thread.summary(threadId),
+      exact: true,
+    }),
+    client.invalidateQueries({
+      queryKey: queryKeys.session.current(),
+      exact: true,
+    }),
+  ])
+}
+
+export async function invalidateCurrentSessionAfterSnooze(
+  client: QueryClient,
+): Promise<void> {
+  await client.invalidateQueries({
+    queryKey: queryKeys.session.current(),
+    exact: true,
+  })
+}
+
+export async function invalidateAfterQueueMovement(
+  client: QueryClient,
+): Promise<void> {
+  await Promise.all([
+    client.invalidateQueries({ queryKey: queryKeys.queue.pages() }),
+    client.invalidateQueries({
+      queryKey: queryKeys.session.current(),
+      exact: true,
+    }),
+    client.invalidateQueries({
+      queryKey: queryKeys.roll.bootstrap(),
+      exact: true,
+    }),
+  ])
+}

--- a/frontend/src/query/queryKeys.ts
+++ b/frontend/src/query/queryKeys.ts
@@ -1,0 +1,85 @@
+export type QueueSort = 'position' | 'alphabetical' | 'created'
+
+export interface QueuePageKeyOptions {
+  search?: string
+  sort: QueueSort
+  pageToken?: string | null
+  pageSize: number
+}
+
+export interface SessionPageKeyOptions {
+  pageToken?: string | null
+  pageSize: number
+}
+
+export interface ThreadIssuePageKeyOptions {
+  pageToken?: string | null
+  pageSize: number
+  status?: 'read' | 'unread'
+}
+
+function normalizedSearch(search?: string): string | null {
+  const value = search?.trim()
+  return value ? value : null
+}
+
+export const queryKeys = {
+  session: {
+    all: ['session'] as const,
+    current: () => ['session', 'current'] as const,
+    pages: () => ['session', 'pages'] as const,
+    page: ({ pageToken, pageSize }: SessionPageKeyOptions) =>
+      ['session', 'pages', { pageToken: pageToken ?? null, pageSize }] as const,
+    detail: (sessionId: number) => ['session', 'detail', sessionId] as const,
+  },
+  queue: {
+    all: ['queue'] as const,
+    pages: () => ['queue', 'pages'] as const,
+    page: ({ search, sort, pageToken, pageSize }: QueuePageKeyOptions) =>
+      [
+        'queue',
+        'pages',
+        {
+          search: normalizedSearch(search),
+          sort,
+          pageToken: pageToken ?? null,
+          pageSize,
+        },
+      ] as const,
+  },
+  roll: {
+    all: ['roll'] as const,
+    bootstrap: () => ['roll', 'bootstrap'] as const,
+  },
+  thread: {
+    all: ['thread'] as const,
+    summaries: () => ['thread', 'summary'] as const,
+    summary: (threadId: number) => ['thread', 'summary', threadId] as const,
+    details: () => ['thread', 'detail'] as const,
+    detail: (threadId: number) => ['thread', 'detail', threadId] as const,
+    issuePages: (threadId: number) => ['thread', threadId, 'issues'] as const,
+    issuePage: (
+      threadId: number,
+      { pageToken, pageSize, status }: ThreadIssuePageKeyOptions,
+    ) =>
+      [
+        'thread',
+        threadId,
+        'issues',
+        {
+          pageToken: pageToken ?? null,
+          pageSize,
+          status: status ?? null,
+        },
+      ] as const,
+  },
+  dependencies: {
+    all: ['dependencies'] as const,
+    forThread: (threadId: number) => ['dependencies', 'thread', threadId] as const,
+    blocking: (threadId: number) => ['dependencies', 'blocking', threadId] as const,
+  },
+  analytics: {
+    all: ['analytics'] as const,
+    overview: () => ['analytics', 'overview'] as const,
+  },
+} as const

--- a/frontend/src/unit/queryCacheContract.test.ts
+++ b/frontend/src/unit/queryCacheContract.test.ts
@@ -1,0 +1,224 @@
+import { QueryClient } from '@tanstack/react-query'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  applyRatedThreadCache,
+  applyUpdatedThreadCache,
+  invalidateAfterIssueEdit,
+  invalidateAfterQueueMovement,
+  invalidateCurrentSessionAfterSnooze,
+} from '../query/cacheEffects'
+import { queryKeys } from '../query/queryKeys'
+import type { Thread } from '../types'
+
+const thread: Thread = {
+  id: 7,
+  title: 'Mister Miracle',
+  format: 'issue',
+  issues_remaining: 4,
+  total_issues: 12,
+  queue_position: 3,
+  status: 'active',
+  is_blocked: false,
+  blocking_reasons: [],
+  created_at: '2026-08-03T00:00:00Z',
+}
+
+function createSpiedClient() {
+  const client = new QueryClient()
+  const setQueryData = vi.spyOn(client, 'setQueryData')
+  const invalidateQueries = vi.spyOn(client, 'invalidateQueries').mockResolvedValue()
+
+  return { client, setQueryData, invalidateQueries }
+}
+
+describe('canonical query keys', () => {
+  it('represents every retained resource dimension without a Collections family', () => {
+    expect(queryKeys).not.toHaveProperty('collections')
+
+    expect(queryKeys.session.all).toEqual(['session'])
+    expect(queryKeys.session.current()).toEqual(['session', 'current'])
+    expect(queryKeys.session.pages()).toEqual(['session', 'pages'])
+    expect(queryKeys.session.page({ pageSize: 20 })).toEqual([
+      'session',
+      'pages',
+      { pageToken: null, pageSize: 20 },
+    ])
+    expect(queryKeys.session.page({ pageToken: 'next', pageSize: 10 })).toEqual([
+      'session',
+      'pages',
+      { pageToken: 'next', pageSize: 10 },
+    ])
+    expect(queryKeys.session.detail(9)).toEqual(['session', 'detail', 9])
+
+    expect(queryKeys.queue.all).toEqual(['queue'])
+    expect(queryKeys.queue.pages()).toEqual(['queue', 'pages'])
+    expect(
+      queryKeys.queue.page({
+        search: '   ',
+        sort: 'position',
+        pageSize: 25,
+      }),
+    ).toEqual([
+      'queue',
+      'pages',
+      { search: null, sort: 'position', pageToken: null, pageSize: 25 },
+    ])
+    expect(
+      queryKeys.queue.page({
+        search: '  Batman  ',
+        sort: 'alphabetical',
+        pageToken: 'page-2',
+        pageSize: 50,
+      }),
+    ).toEqual([
+      'queue',
+      'pages',
+      {
+        search: 'Batman',
+        sort: 'alphabetical',
+        pageToken: 'page-2',
+        pageSize: 50,
+      },
+    ])
+
+    expect(queryKeys.roll.all).toEqual(['roll'])
+    expect(queryKeys.roll.bootstrap()).toEqual(['roll', 'bootstrap'])
+
+    expect(queryKeys.thread.all).toEqual(['thread'])
+    expect(queryKeys.thread.summaries()).toEqual(['thread', 'summary'])
+    expect(queryKeys.thread.summary(7)).toEqual(['thread', 'summary', 7])
+    expect(queryKeys.thread.details()).toEqual(['thread', 'detail'])
+    expect(queryKeys.thread.detail(7)).toEqual(['thread', 'detail', 7])
+    expect(queryKeys.thread.issuePages(7)).toEqual(['thread', 7, 'issues'])
+    expect(queryKeys.thread.issuePage(7, { pageSize: 30 })).toEqual([
+      'thread',
+      7,
+      'issues',
+      { pageToken: null, pageSize: 30, status: null },
+    ])
+    expect(
+      queryKeys.thread.issuePage(7, {
+        pageToken: 'issues-2',
+        pageSize: 15,
+        status: 'unread',
+      }),
+    ).toEqual([
+      'thread',
+      7,
+      'issues',
+      { pageToken: 'issues-2', pageSize: 15, status: 'unread' },
+    ])
+
+    expect(queryKeys.dependencies.all).toEqual(['dependencies'])
+    expect(queryKeys.dependencies.forThread(7)).toEqual([
+      'dependencies',
+      'thread',
+      7,
+    ])
+    expect(queryKeys.dependencies.blocking(7)).toEqual([
+      'dependencies',
+      'blocking',
+      7,
+    ])
+    expect(queryKeys.analytics.all).toEqual(['analytics'])
+    expect(queryKeys.analytics.overview()).toEqual(['analytics', 'overview'])
+  })
+})
+
+describe('targeted cache effects', () => {
+  it('uses an authoritative rating response and invalidates only current session', async () => {
+    const { client, setQueryData, invalidateQueries } = createSpiedClient()
+
+    await applyRatedThreadCache(client, thread)
+
+    expect(setQueryData).toHaveBeenNthCalledWith(
+      1,
+      queryKeys.thread.detail(thread.id),
+      thread,
+    )
+    expect(setQueryData).toHaveBeenNthCalledWith(
+      2,
+      queryKeys.thread.summary(thread.id),
+      thread,
+    )
+    expect(invalidateQueries).toHaveBeenCalledOnce()
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.session.current(),
+      exact: true,
+    })
+  })
+
+  it('updates a thread and narrowly refreshes queue, current session, and roll state', async () => {
+    const { client, setQueryData, invalidateQueries } = createSpiedClient()
+
+    await applyUpdatedThreadCache(client, thread)
+
+    expect(setQueryData).toHaveBeenCalledTimes(2)
+    expect(invalidateQueries).toHaveBeenCalledTimes(3)
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.queue.pages(),
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.session.current(),
+      exact: true,
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.roll.bootstrap(),
+      exact: true,
+    })
+  })
+
+  it('invalidates only the edited thread issue, detail, summary, and session keys', async () => {
+    const { client, invalidateQueries } = createSpiedClient()
+
+    await invalidateAfterIssueEdit(client, thread.id)
+
+    expect(invalidateQueries).toHaveBeenCalledTimes(4)
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.thread.issuePages(thread.id),
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.thread.detail(thread.id),
+      exact: true,
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.thread.summary(thread.id),
+      exact: true,
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.session.current(),
+      exact: true,
+    })
+  })
+
+  it('limits snooze reconciliation to the exact current session key', async () => {
+    const { client, invalidateQueries } = createSpiedClient()
+
+    await invalidateCurrentSessionAfterSnooze(client)
+
+    expect(invalidateQueries).toHaveBeenCalledOnce()
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.session.current(),
+      exact: true,
+    })
+  })
+
+  it('limits queue movement refreshes to queue pages, current session, and roll state', async () => {
+    const { client, invalidateQueries } = createSpiedClient()
+
+    await invalidateAfterQueueMovement(client)
+
+    expect(invalidateQueries).toHaveBeenCalledTimes(3)
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.queue.pages(),
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.session.current(),
+      exact: true,
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.roll.bootstrap(),
+      exact: true,
+    })
+  })
+})

--- a/frontend/src/unit/threadCacheRollback.test.ts
+++ b/frontend/src/unit/threadCacheRollback.test.ts
@@ -1,0 +1,86 @@
+import { QueryClient } from '@tanstack/react-query'
+import { describe, expect, it } from 'vitest'
+import { optimisticallyUpdateThreadCache } from '../query/cacheEffects'
+import { queryKeys } from '../query/queryKeys'
+import type { Thread } from '../types'
+
+const thread: Thread = {
+  id: 7,
+  title: 'Mister Miracle',
+  format: 'issue',
+  issues_remaining: 4,
+  total_issues: 12,
+  queue_position: 3,
+  status: 'active',
+  is_blocked: false,
+  blocking_reasons: [],
+  created_at: '2026-08-03T00:00:00Z',
+}
+
+describe('optimistic thread cache rollback', () => {
+  it('updates detail and summary together and restores both snapshots', () => {
+    const client = new QueryClient()
+    const detailKey = queryKeys.thread.detail(thread.id)
+    const summaryKey = queryKeys.thread.summary(thread.id)
+    client.setQueryData(detailKey, thread)
+    client.setQueryData(summaryKey, thread)
+
+    const rollback = optimisticallyUpdateThreadCache(client, thread.id, (current) => ({
+      ...current,
+      title: 'Mister Miracle: The Source of Freedom',
+    }))
+
+    expect(client.getQueryData<Thread>(detailKey)?.title).toBe(
+      'Mister Miracle: The Source of Freedom',
+    )
+    expect(client.getQueryData<Thread>(summaryKey)?.title).toBe(
+      'Mister Miracle: The Source of Freedom',
+    )
+
+    rollback()
+
+    expect(client.getQueryData(detailKey)).toEqual(thread)
+    expect(client.getQueryData(summaryKey)).toEqual(thread)
+  })
+
+  it('does not manufacture missing cache entries and rollback keeps them absent', () => {
+    const client = new QueryClient()
+    const detailKey = queryKeys.thread.detail(thread.id)
+    const summaryKey = queryKeys.thread.summary(thread.id)
+
+    const rollback = optimisticallyUpdateThreadCache(client, thread.id, (current) => ({
+      ...current,
+      title: 'Unused optimistic title',
+    }))
+
+    expect(client.getQueryData(detailKey)).toBeUndefined()
+    expect(client.getQueryData(summaryKey)).toBeUndefined()
+
+    rollback()
+
+    expect(client.getQueryData(detailKey)).toBeUndefined()
+    expect(client.getQueryData(summaryKey)).toBeUndefined()
+  })
+
+  it('rolls back each cache entry to its own authoritative snapshot', () => {
+    const client = new QueryClient()
+    const detailKey = queryKeys.thread.detail(thread.id)
+    const summaryKey = queryKeys.thread.summary(thread.id)
+    const summary = { ...thread, title: 'Compact summary title' }
+    client.setQueryData(detailKey, thread)
+    client.setQueryData(summaryKey, summary)
+
+    const rollback = optimisticallyUpdateThreadCache(client, thread.id, (current) => ({
+      ...current,
+      issues_remaining: current.issues_remaining - 1,
+    }))
+
+    expect(client.getQueryData<Thread>(detailKey)?.issues_remaining).toBe(3)
+    expect(client.getQueryData<Thread>(summaryKey)?.issues_remaining).toBe(3)
+
+    rollback()
+
+    expect(client.getQueryData(detailKey)).toEqual(thread)
+    expect(client.getQueryData(summaryKey)).toEqual(summary)
+  })
+})

--- a/frontend/src/unit/useQueue.test.tsx
+++ b/frontend/src/unit/useQueue.test.tsx
@@ -1,6 +1,8 @@
 import { act, renderHook } from '@testing-library/react'
 import { beforeEach, expect, it, vi } from 'vitest'
 import { useMoveToBack, useMoveToFront, useMoveToPosition, useShuffleQueue } from '../hooks/useQueue'
+import { invalidateAfterQueueMovement } from '../query/cacheEffects'
+import { queryClient } from '../query/queryClient'
 import { queueApi } from '../services/api'
 
 vi.mock('../services/api', () => ({
@@ -12,16 +14,23 @@ vi.mock('../services/api', () => ({
   },
 }))
 
+vi.mock('../query/cacheEffects', () => ({
+  invalidateAfterQueueMovement: vi.fn(),
+}))
+
 const mockedQueueApi = vi.mocked(queueApi)
+const mockedInvalidateAfterQueueMovement = vi.mocked(invalidateAfterQueueMovement)
 
 beforeEach(() => {
+  vi.clearAllMocks()
   mockedQueueApi.moveToPosition.mockResolvedValue(undefined as never)
   mockedQueueApi.moveToFront.mockResolvedValue(undefined as never)
   mockedQueueApi.moveToBack.mockResolvedValue(undefined as never)
   mockedQueueApi.shuffle.mockResolvedValue(undefined as never)
+  mockedInvalidateAfterQueueMovement.mockResolvedValue()
 })
 
-it('moves queue position', async () => {
+it('moves queue position and reconciles only queue-owned read models', async () => {
   const { result } = renderHook(() => useMoveToPosition())
 
   await act(async () => {
@@ -29,9 +38,10 @@ it('moves queue position', async () => {
   })
 
   expect(mockedQueueApi.moveToPosition).toHaveBeenCalledWith(4, 2)
+  expect(mockedInvalidateAfterQueueMovement).toHaveBeenCalledWith(queryClient)
 })
 
-it('moves thread to front and back', async () => {
+it('moves thread to front and back and reconciles after each mutation', async () => {
   const { result: frontResult } = renderHook(() => useMoveToFront())
   await act(async () => {
     await frontResult.current.mutate(8)
@@ -44,9 +54,12 @@ it('moves thread to front and back', async () => {
 
   expect(mockedQueueApi.moveToFront).toHaveBeenCalledWith(8)
   expect(mockedQueueApi.moveToBack).toHaveBeenCalledWith(9)
+  expect(mockedInvalidateAfterQueueMovement).toHaveBeenCalledTimes(2)
+  expect(mockedInvalidateAfterQueueMovement).toHaveBeenNthCalledWith(1, queryClient)
+  expect(mockedInvalidateAfterQueueMovement).toHaveBeenNthCalledWith(2, queryClient)
 })
 
-it('shuffles the queue', async () => {
+it('shuffles the queue and reconciles queue-owned read models', async () => {
   const { result } = renderHook(() => useShuffleQueue())
 
   await act(async () => {
@@ -54,4 +67,18 @@ it('shuffles the queue', async () => {
   })
 
   expect(mockedQueueApi.shuffle).toHaveBeenCalled()
+  expect(mockedInvalidateAfterQueueMovement).toHaveBeenCalledWith(queryClient)
+})
+
+it('does not invalidate cache when a queue mutation fails', async () => {
+  mockedQueueApi.moveToFront.mockRejectedValueOnce(new Error('move failed'))
+  const { result } = renderHook(() => useMoveToFront())
+
+  await expect(
+    act(async () => {
+      await result.current.mutate(8)
+    }),
+  ).rejects.toThrow('move failed')
+
+  expect(mockedInvalidateAfterQueueMovement).not.toHaveBeenCalled()
 })

--- a/frontend/src/unit/useRate.test.tsx
+++ b/frontend/src/unit/useRate.test.tsx
@@ -24,7 +24,18 @@ beforeEach(() => {
 })
 
 it('applies the authoritative rating response to targeted caches', async () => {
-  const thread = { id: 1, rating: 4 } as Thread
+  const thread: Thread = {
+    id: 1,
+    title: 'Saga',
+    format: 'issue',
+    issues_remaining: 3,
+    total_issues: 10,
+    queue_position: 2,
+    status: 'active',
+    is_blocked: false,
+    blocking_reasons: [],
+    created_at: '2026-08-03T00:00:00Z',
+  }
   mockedRateApi.rate.mockResolvedValue(thread)
   mockedApplyRatedThreadCache.mockResolvedValue()
   const { result } = renderHook(() => useRate())

--- a/frontend/src/unit/useRate.test.tsx
+++ b/frontend/src/unit/useRate.test.tsx
@@ -1,8 +1,10 @@
 import { act, renderHook } from '@testing-library/react'
 import { beforeEach, expect, it, vi } from 'vitest'
 import { useRate } from '../hooks/useRate'
+import { applyRatedThreadCache } from '../query/cacheEffects'
+import { queryClient } from '../query/queryClient'
 import { rateApi } from '../services/api'
-import type { RatePayload } from '../types'
+import type { RatePayload, Thread } from '../types'
 
 vi.mock('../services/api', () => ({
   rateApi: {
@@ -10,19 +12,30 @@ vi.mock('../services/api', () => ({
   },
 }))
 
+vi.mock('../query/cacheEffects', () => ({
+  applyRatedThreadCache: vi.fn(),
+}))
+
 const mockedRateApi = vi.mocked(rateApi)
+const mockedApplyRatedThreadCache = vi.mocked(applyRatedThreadCache)
 
 beforeEach(() => {
-  mockedRateApi.rate.mockResolvedValue(undefined as never)
+  vi.clearAllMocks()
 })
 
-it('submits ratings', async () => {
+it('applies the authoritative rating response to targeted caches', async () => {
+  const thread = { id: 1, rating: 4 } as Thread
+  mockedRateApi.rate.mockResolvedValue(thread)
+  mockedApplyRatedThreadCache.mockResolvedValue()
   const { result } = renderHook(() => useRate())
   const payload: RatePayload = { thread_id: 1, rating: 4 }
 
+  let response: Thread | undefined
   await act(async () => {
-    await result.current.mutate(payload)
+    response = await result.current.mutate(payload)
   })
 
   expect(mockedRateApi.rate).toHaveBeenCalledWith(payload)
+  expect(mockedApplyRatedThreadCache).toHaveBeenCalledWith(queryClient, thread)
+  expect(response).toBe(thread)
 })

--- a/frontend/src/unit/useSnooze.test.tsx
+++ b/frontend/src/unit/useSnooze.test.tsx
@@ -2,28 +2,45 @@ import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const snoozeApi = vi.hoisted(() => ({ snooze: vi.fn(), unsnooze: vi.fn() }))
+const invalidateCurrentSessionAfterSnooze = vi.hoisted(() => vi.fn())
 vi.mock('../services/api', () => ({ snoozeApi }))
+vi.mock('../query/cacheEffects', () => ({ invalidateCurrentSessionAfterSnooze }))
 
 import { useSnooze, useUnsnooze } from '../hooks/useSnooze'
+import { queryClient } from '../query/queryClient'
 
 describe('snooze hooks', () => {
   beforeEach(() => {
     snoozeApi.snooze.mockReset()
     snoozeApi.unsnooze.mockReset()
+    invalidateCurrentSessionAfterSnooze.mockReset()
   })
 
-  it('snoozes and unsnoozes successfully', async () => {
+  it('snoozes and narrowly invalidates the current session', async () => {
     snoozeApi.snooze.mockResolvedValue(undefined)
-    snoozeApi.unsnooze.mockResolvedValue(undefined)
+    invalidateCurrentSessionAfterSnooze.mockResolvedValue(undefined)
     const snooze = renderHook(() => useSnooze())
+
     await act(async () => await snooze.result.current.mutate())
+
     expect(snooze.result.current.isError).toBe(false)
-    const unsnooze = renderHook(() => useUnsnooze())
-    await act(async () => await unsnooze.result.current.mutate(7))
-    expect(snoozeApi.unsnooze).toHaveBeenCalledWith(7)
+    expect(snoozeApi.snooze).toHaveBeenCalledOnce()
+    expect(invalidateCurrentSessionAfterSnooze).toHaveBeenCalledWith(queryClient)
   })
 
-  it('tracks and rethrows failures', async () => {
+  it('unsnoozes and narrowly invalidates the current session', async () => {
+    snoozeApi.unsnooze.mockResolvedValue(undefined)
+    invalidateCurrentSessionAfterSnooze.mockResolvedValue(undefined)
+    const unsnooze = renderHook(() => useUnsnooze())
+
+    await act(async () => await unsnooze.result.current.mutate(7))
+
+    expect(unsnooze.result.current.isError).toBe(false)
+    expect(snoozeApi.unsnooze).toHaveBeenCalledWith(7)
+    expect(invalidateCurrentSessionAfterSnooze).toHaveBeenCalledWith(queryClient)
+  })
+
+  it('tracks and rethrows failures without invalidating cache state', async () => {
     snoozeApi.snooze.mockRejectedValueOnce(new Error('snooze failed'))
     const snooze = renderHook(() => useSnooze())
     await act(async () => await expect(snooze.result.current.mutate()).rejects.toThrow('snooze failed'))
@@ -33,5 +50,7 @@ describe('snooze hooks', () => {
     const unsnooze = renderHook(() => useUnsnooze())
     await act(async () => await expect(unsnooze.result.current.mutate(7)).rejects.toThrow('unsnooze failed'))
     await waitFor(() => expect(unsnooze.result.current.isError).toBe(true))
+
+    expect(invalidateCurrentSessionAfterSnooze).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

Replays the conflict-safe targeted cache contract for #702 from current `main` after PR #732 diverged.

Part of #702.

## Implemented

- Restores centralized typed query-key factories without a Collections key family.
- Restores retained mutation cache-effect helpers, including issue-edit and thread-edit contracts.
- Wires rating mutations to use the authoritative returned thread for exact detail and summary cache updates.
- Limits rating invalidation to the exact current-session key.
- Routes Queue move-to-position, move-to-front, move-to-back, and shuffle mutations through the targeted Queue/session/Roll reconciliation contract.
- Routes snooze and unsnooze through exact current-session reconciliation.
- Adds optimistic thread detail and summary updates with independent snapshots, exact rollback, and absent-cache preservation.
- Adds focused regression coverage for exact keys, success paths, failure paths, and rollback behavior.

## Branch repair context

PR #732 is non-mergeable and substantially behind `main`. This PR is a fresh current-main semantic replay rather than a force rebase or full-file overwrite of stale frontend files.

## Closure status

Issue #702 remains open. The remaining contract includes wiring thread edits and issue edits into the retained helpers, migrating active read callers, removing the old custom `invalidateQueries()` plumbing when unused, cross-route/navigation evidence, and request-count evidence.

## Verification

Exact-SHA CI run #839 passed for `0f997811687e31e24b129a2636bdd960a150f2e9`.

This PR is non-draft and must not be merged without Josh's explicit authorization.