### PR TITLE
feat(queue): replay opt-in completed threads section (#655)

### DIFF
--- a/frontend/src/pages/QueuePage/CompletedThreadsSection.tsx
+++ b/frontend/src/pages/QueuePage/CompletedThreadsSection.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react'
+
+interface CompletedThread {
+  id: number
+  title: string
+  format: string
+  notes?: string | null
+}
+
+interface CompletedThreadsSectionProps {
+  threads: CompletedThread[]
+  onReactivate: (thread: CompletedThread | null) => void
+}
+
+export default function CompletedThreadsSection({
+  threads,
+  onReactivate,
+}: CompletedThreadsSectionProps) {
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  if (threads.length === 0) return null
+
+  const handleReactivate = (thread: CompletedThread | null) => {
+    setIsExpanded(false)
+    onReactivate(thread)
+  }
+
+  return (
+    <section className="space-y-4" aria-labelledby="completed-threads-heading">
+      <header className="flex items-center justify-between gap-3 px-2">
+        <div className="min-w-0">
+          <h2
+            id="completed-threads-heading"
+            className="text-lg md:text-xl font-black uppercase text-stone-300"
+          >
+            Completed Threads
+          </h2>
+          <p className="text-[10px] font-bold text-stone-500 uppercase tracking-widest">
+            {threads.length} finished series hidden from the queue
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setIsExpanded((expanded) => !expanded)}
+          aria-expanded={isExpanded}
+          aria-controls="completed-thread-list"
+          className="h-8 md:h-10 px-3 md:px-4 bg-white/5 border border-white/10 rounded-xl text-[10px] font-black uppercase tracking-widest text-stone-300 hover:bg-white/10"
+        >
+          {isExpanded ? 'Hide Completed' : `Show Completed (${threads.length})`}
+        </button>
+      </header>
+
+      {isExpanded && (
+        <div id="completed-thread-list" className="space-y-4">
+          <div className="flex justify-end px-2">
+            <button
+              type="button"
+              onClick={() => handleReactivate(null)}
+              aria-label="Choose completed thread to reactivate"
+              className="h-8 md:h-10 px-3 md:px-4 bg-white/5 border border-white/10 rounded-xl text-[10px] font-black uppercase tracking-widest text-stone-300 hover:bg-white/10"
+            >
+              Reactivate
+            </button>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {threads.map((thread) => (
+              <div key={thread.id} className="glass-card p-4 space-y-2">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-sm font-black text-stone-300 truncate">{thread.title}</p>
+                    <p className="text-[8px] font-black text-stone-500 uppercase tracking-widest">
+                      {thread.format}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleReactivate(thread)}
+                    aria-label={`Reactivate ${thread.title}`}
+                    className="px-3 py-1 bg-white/5 border border-white/10 rounded-lg text-[9px] font-black uppercase tracking-widest text-stone-300 hover:bg-white/10"
+                  >
+                    Reactivate
+                  </button>
+                </div>
+                {thread.notes && <p className="text-xs text-stone-500">{thread.notes}</p>}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/unit/CompletedThreadsSection.test.tsx
+++ b/frontend/src/unit/CompletedThreadsSection.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import CompletedThreadsSection from '../pages/QueuePage/CompletedThreadsSection'
+
+const completedThreads = [
+  {
+    id: 2,
+    title: 'Descender',
+    format: 'Comic',
+    notes: 'Finished the main series',
+  },
+  {
+    id: 3,
+    title: 'Paper Girls',
+    format: 'Trade',
+    notes: null,
+  },
+]
+
+describe('CompletedThreadsSection', () => {
+  it('keeps completed thread cards hidden until the user opts in', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <CompletedThreadsSection
+        threads={completedThreads}
+        onReactivate={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('heading', { name: 'Completed Threads' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Show Completed (2)' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    )
+    expect(screen.queryByText('Descender')).not.toBeInTheDocument()
+    expect(screen.queryByText('Paper Girls')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Show Completed (2)' }))
+
+    expect(screen.getByRole('button', { name: 'Hide Completed' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    )
+    expect(screen.getByText('Descender')).toBeInTheDocument()
+    expect(screen.getByText('Paper Girls')).toBeInTheDocument()
+  })
+
+  it('preserves distinct reactivation paths and collapses after each selection', async () => {
+    const user = userEvent.setup()
+    const onReactivate = vi.fn()
+
+    render(
+      <CompletedThreadsSection
+        threads={completedThreads}
+        onReactivate={onReactivate}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Show Completed (2)' }))
+    await user.click(
+      screen.getByRole('button', { name: 'Choose completed thread to reactivate' }),
+    )
+
+    expect(onReactivate).toHaveBeenNthCalledWith(1, null)
+    expect(screen.getByRole('button', { name: 'Show Completed (2)' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    )
+    expect(screen.queryByText('Descender')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Show Completed (2)' }))
+    await user.click(screen.getByRole('button', { name: 'Reactivate Descender' }))
+
+    expect(onReactivate).toHaveBeenNthCalledWith(2, completedThreads[0])
+    expect(screen.getByRole('button', { name: 'Show Completed (2)' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    )
+    expect(screen.queryByRole('button', { name: 'Reactivate Paper Girls' })).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when there are no completed threads', () => {
+    const { container } = render(
+      <CompletedThreadsSection
+        threads={[]}
+        onReactivate={vi.fn()}
+      />,
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})


### PR DESCRIPTION
## Summary

Replays the tested completed-thread section from stale PR #753 onto current `main` without carrying its merge conflict.

Part of #655.

## Implemented

- completed threads remain collapsed by default;
- the hidden count is visible before expansion;
- both picker-based and targeted reactivation paths remain available;
- focused unit coverage verifies default-hidden behavior, expansion, both reactivation paths, and the empty state.

## Supersedes

Supersedes #753, whose branch became non-mergeable after `main` advanced.

## Verification

Exact-SHA CI is expected to run for this non-draft replacement PR. No merge or auto-merge is authorized.