### PR TITLE
Clarify overnight factory command usage

### DIFF
--- a/.github/workflows/factory-policy.yml
+++ b/.github/workflows/factory-policy.yml
@@ -17,6 +17,7 @@ on:
       - scripts/tests/test_autonomous_factory_policy.py
       - scripts/tests/test_install_git_hooks.py
       - scripts/tests/test_opencode_model_tools.py
+      - scripts/tests/test_overnight_factory_cli.py
       - .github/workflows/factory-policy.yml
   push:
     branches:
@@ -36,6 +37,7 @@ on:
       - scripts/tests/test_autonomous_factory_policy.py
       - scripts/tests/test_install_git_hooks.py
       - scripts/tests/test_opencode_model_tools.py
+      - scripts/tests/test_overnight_factory_cli.py
       - .github/workflows/factory-policy.yml
 
 permissions:
@@ -61,7 +63,8 @@ jobs:
             scripts/check-autonomous-factory-policy.py \
             scripts/tests/test_autonomous_factory_policy.py \
             scripts/tests/test_install_git_hooks.py \
-            scripts/tests/test_opencode_model_tools.py
+            scripts/tests/test_opencode_model_tools.py \
+            scripts/tests/test_overnight_factory_cli.py
       - name: Check canonical factory invariants
         run: python scripts/check-autonomous-factory-policy.py
       - name: Test policy drift detection
@@ -70,3 +73,5 @@ jobs:
         run: python -m unittest scripts/tests/test_install_git_hooks.py
       - name: Test model rotation and scout supervision
         run: python -m unittest scripts/tests/test_opencode_model_tools.py
+      - name: Test overnight factory CLI
+        run: python -m unittest scripts/tests/test_overnight_factory_cli.py

--- a/scripts/comic-pile-opencode-factory-overnight.sh
+++ b/scripts/comic-pile-opencode-factory-overnight.sh
@@ -28,12 +28,13 @@ Environment defaults:
   FACTORY_FAILURE_BACKOFF_SECONDS=30
   FACTORY_MAX_FAILURES=5
 
-Additional arguments are passed to comic-pile-opencode-factory.sh after --watch.
+Additional factory options are passed to comic-pile-opencode-factory.sh after the selected command.
 Examples:
   bash scripts/comic-pile-opencode-factory-overnight.sh start
+  bash scripts/comic-pile-opencode-factory-overnight.sh start --idle-seconds 30
+  bash scripts/comic-pile-opencode-factory-overnight.sh run --idle-seconds 30
   bash scripts/comic-pile-opencode-factory-overnight.sh status
   bash scripts/comic-pile-opencode-factory-overnight.sh stop
-  bash scripts/comic-pile-opencode-factory-overnight.sh run --idle-seconds 30
 USAGE
 }
 

--- a/scripts/tests/test_overnight_factory_cli.py
+++ b/scripts/tests/test_overnight_factory_cli.py
@@ -1,0 +1,59 @@
+"""Regression tests for the overnight factory supervisor CLI."""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "comic-pile-opencode-factory-overnight.sh"
+
+
+class OvernightFactoryCliTest(unittest.TestCase):
+    """Keep the command parser and user-facing help synchronized."""
+
+    def test_help_documents_command_first_factory_options(self) -> None:
+        """Factory options must be shown after start or run, never as commands."""
+        result = subprocess.run(
+            ["bash", str(SCRIPT), "--help"],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertIn(
+            "Additional factory options are passed to "
+            "comic-pile-opencode-factory.sh after the selected command.",
+            result.stdout,
+        )
+        self.assertIn(
+            "comic-pile-opencode-factory-overnight.sh start --idle-seconds 30",
+            result.stdout,
+        )
+        self.assertIn(
+            "comic-pile-opencode-factory-overnight.sh run --idle-seconds 30",
+            result.stdout,
+        )
+        self.assertNotIn("after --watch", result.stdout)
+        self.assertNotIn("comic-pile-opencode-factory-overnight.sh --watch", result.stdout)
+
+    def test_watch_without_command_is_rejected_with_command_usage(self) -> None:
+        """The former ambiguous invocation should fail and show valid commands."""
+        result = subprocess.run(
+            ["bash", str(SCRIPT), "--watch"],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("<start|stop|status|run> [factory options]", result.stderr)
+        self.assertIn("ERROR: unknown command: --watch", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #760

## What changed

- clarifies that factory options follow the required `start` or `run` command
- removes the misleading `after --watch` wording
- adds command-first examples for background and foreground operation
- adds regression tests for the help text and the rejected bare `--watch` invocation
- wires the new test into the Factory Policy workflow

## Validation

- Factory Policy CI runs `bash -n` on the supervisor script
- Factory Policy CI compiles and runs `scripts/tests/test_overnight_factory_cli.py`
