### PR TITLE
feat(history): render coherent session event records (#609)

### DIFF
--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -4,6 +4,79 @@ import { useUndo } from '../hooks/useUndo'
 import { formatDateTime } from '../utils/dateFormat'
 import LoadingSpinner from '../components/LoadingSpinner'
 
+type DisplayEvent = {
+  id: number
+  timestamp: string
+  type: string
+  thread_title?: string | null
+  rating?: number | null
+  result?: number | null
+  die?: number | null
+  queue_move?: string | null
+  issues_read?: number | null
+  die_after?: number | null
+  selection_method?: string | null
+  issue_number?: string | null
+}
+
+const EVENT_LABELS: Record<string, string> = {
+  roll: 'Rolled',
+  rate: 'Rated',
+  snooze: 'Snoozed',
+  unsnooze: 'Unsnoozed',
+  skip: 'Skipped',
+  complete: 'Completed',
+  completion: 'Completed',
+  undo: 'Restored',
+  restore: 'Restored',
+  move: 'Moved',
+  shuffle: 'Shuffled',
+}
+
+function eventLabel(type: string): string {
+  return EVENT_LABELS[type] ?? type.replaceAll('_', ' ').replace(/^./, (letter) => letter.toUpperCase())
+}
+
+function EventRecord({ event }: { event: DisplayEvent }) {
+  const metadata = [
+    event.issue_number ? `Issue ${event.issue_number}` : null,
+    event.issues_read != null ? `${event.issues_read} ${event.issues_read === 1 ? 'issue' : 'issues'} read` : null,
+    event.die != null ? `d${event.die}` : null,
+    event.result != null ? `Rolled ${event.result}` : null,
+    event.die_after != null ? `Die after: d${event.die_after}` : null,
+    event.rating != null ? `Rating ${event.rating}` : null,
+    event.selection_method ? `Selected by ${event.selection_method.replaceAll('_', ' ')}` : null,
+  ].filter((value): value is string => value !== null)
+
+  return (
+    <article className="min-w-0 bg-white/5 border border-white/10 rounded-xl px-3 md:px-4 py-2.5 md:py-3">
+      <div className="flex items-center gap-2 flex-wrap mb-2">
+        <span className="text-[10px] font-bold uppercase tracking-widest text-stone-500">
+          {formatDateTime(event.timestamp)}
+        </span>
+        <span className="text-[10px] font-black uppercase tracking-widest text-amber-500">
+          {eventLabel(event.type)}
+        </span>
+      </div>
+      <p className="min-w-0 break-words text-sm font-bold text-stone-200">
+        {event.thread_title || 'Thread unavailable'}
+      </p>
+      {metadata.length > 0 ? (
+        <ul className="mt-2 flex min-w-0 flex-wrap gap-x-3 gap-y-1 text-xs text-stone-400" aria-label="Event details">
+          {metadata.map((item) => (
+            <li key={item} className="break-words">{item}</li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-1 text-xs text-stone-500">No additional event details recorded.</p>
+      )}
+      {event.queue_move && (
+        <p className="mt-1 break-words text-xs text-stone-500">Queue move: {event.queue_move}</p>
+      )}
+    </article>
+  )
+}
+
 export default function SessionPage() {
   const { id } = useParams()
   const { data: details, isPending, refetch: refetchDetails } = useSessionDetails(id)
@@ -55,12 +128,12 @@ export default function SessionPage() {
         </div>
         <div className="grid gap-3 md:gap-4 md:grid-cols-3">
           {Object.entries(details.narrative_summary || {}).map(([key, values]) => (
-            <div key={key} className="space-y-2">
+            <div key={key} className="space-y-2 min-w-0">
               <p className="text-[10px] font-bold uppercase tracking-widest text-stone-500">{key}</p>
               {values && values.length > 0 ? (
                 <ul className="space-y-1 text-xs text-stone-300">
                   {values.map((value) => (
-                    <li key={value}>{value}</li>
+                    <li key={value} className="break-words">{value}</li>
                   ))}
                 </ul>
               ) : (
@@ -93,7 +166,7 @@ export default function SessionPage() {
               return (
                 <div key={snapshot.id} className="flex items-center justify-between gap-2 md:gap-4 bg-white/5 border border-white/10 rounded-xl px-3 md:px-4 py-2.5 md:py-3">
                   <div className="min-w-0">
-                    <p className="text-xs md:text-sm font-bold text-stone-300">{snapshot.description || 'Snapshot'}</p>
+                    <p className="break-words text-xs md:text-sm font-bold text-stone-300">{snapshot.description || 'Snapshot'}</p>
                     <p className="text-[10px] font-bold uppercase tracking-widest text-stone-500">{formatDateTime(snapshot.created_at)}</p>
                   </div>
                   {canUndo ? (
@@ -123,30 +196,14 @@ export default function SessionPage() {
         )}
       </div>
 
-      <div className="glass-card p-4 md:p-6 space-y-4">
+      <div className="glass-card p-4 md:p-6 space-y-4 min-w-0">
         <h2 className="text-lg font-black uppercase text-stone-200">Event Timeline</h2>
         {details.events.length === 0 ? (
           <p className="text-xs text-stone-500">No events recorded.</p>
         ) : (
-          <div className="space-y-3">
+          <div className="space-y-3 min-w-0">
             {details.events.map((event) => (
-              <div key={event.id} className="bg-white/5 border border-white/10 rounded-xl px-3 md:px-4 py-2.5 md:py-3">
-                <div className="flex items-center gap-2 flex-wrap mb-1">
-                  <span className="text-[10px] font-bold uppercase tracking-widest text-stone-500">
-                    {formatDateTime(event.timestamp)}
-                  </span>
-                  <span className="text-[10px] font-black uppercase tracking-widest text-amber-500">{event.type}</span>
-                </div>
-                <p className="text-sm text-stone-300">
-                  {event.thread_title || 'Thread'}
-                  {event.rating ? ` • Rated ${event.rating}` : ''}
-                  {event.result ? ` • Rolled ${event.result}` : ''}
-                  {event.die ? ` • d${event.die}` : ''}
-                </p>
-                {event.queue_move && (
-                  <p className="text-xs text-stone-500">Queue move: {event.queue_move}</p>
-                )}
-              </div>
+              <EventRecord key={event.id} event={event as DisplayEvent} />
             ))}
           </div>
         )}

--- a/frontend/src/unit/SessionPage.test.tsx
+++ b/frontend/src/unit/SessionPage.test.tsx
@@ -43,7 +43,7 @@ beforeEach(() => {
         { id: 1, timestamp: '2024-05-01T10:15:00Z', type: 'roll', thread_title: 'Saga', result: 3, die: 6 },
       ],
     },
-    isLoading: false,
+    isPending: false,
     refetch: refetchDetailsSpy,
   })
   mockedUseSessionSnapshots.mockReturnValue({
@@ -119,8 +119,11 @@ it('renders fallback labels for sparse summaries and events', () => {
   })
   render(<MemoryRouter><SessionPage /></MemoryRouter>)
   expect(screen.getAllByText('None').length).toBeGreaterThan(0)
-  expect(screen.getByText('Thread')).toBeInTheDocument()
+  expect(screen.getByText('Thread unavailable')).toBeInTheDocument()
   expect(screen.getByText('Snapshot')).toBeInTheDocument()
+  expect(screen.getByText('Rating 0')).toBeInTheDocument()
+  expect(screen.getByText('Rolled 0')).toBeInTheDocument()
+  expect(screen.getByText('d0')).toBeInTheDocument()
 })
 
 it('shows session-start snapshots as history instead of rating undo targets', () => {
@@ -151,4 +154,51 @@ it('renders pending restore state and optional event metadata', () => {
   render(<MemoryRouter><SessionPage /></MemoryRouter>)
   expect(screen.getByRole('button', { name: 'Restoring...' })).toBeDisabled()
   expect(screen.getByText('Queue move: front')).toBeInTheDocument()
+})
+
+it('renders a complete rate event as one labeled record', () => {
+  mockedUseSessionDetails.mockReturnValue({ data: {
+    session_id: 16, started_at: '2024-01-01', ended_at: '2024-01-02', start_die: 6, current_die: 8,
+    ladder_path: 'd6 → d8', narrative_summary: {},
+    events: [{
+      id: 7,
+      timestamp: '2024-01-01',
+      type: 'rate',
+      thread_title: 'A Very Long Saga Title That Must Wrap Safely On Mobile',
+      issue_number: '5',
+      issues_read: 1,
+      rating: 4,
+      die: 6,
+      die_after: 8,
+      selection_method: 'dice_roll',
+    }],
+  }, isPending: false, refetch: refetchDetailsSpy })
+
+  render(<MemoryRouter><SessionPage /></MemoryRouter>)
+
+  expect(screen.getByText('Rated')).toBeInTheDocument()
+  expect(screen.getByText('Issue 5')).toBeInTheDocument()
+  expect(screen.getByText('1 issue read')).toBeInTheDocument()
+  expect(screen.getByText('Rating 4')).toBeInTheDocument()
+  expect(screen.getByText('d6')).toBeInTheDocument()
+  expect(screen.getByText('Die after: d8')).toBeInTheDocument()
+  expect(screen.getByText('Selected by dice roll')).toBeInTheDocument()
+})
+
+it('uses human labels and explicit fallback text for sparse events', () => {
+  mockedUseSessionDetails.mockReturnValue({ data: {
+    session_id: 17, started_at: '2024-01-01', ended_at: null, start_die: 4, current_die: 4,
+    ladder_path: 'd4', narrative_summary: {},
+    events: [
+      { id: 8, timestamp: '2024-01-01', type: 'snooze', thread_title: 'Saga' },
+      { id: 9, timestamp: '2024-01-01', type: 'undo', thread_title: null },
+    ],
+  }, isPending: false, refetch: refetchDetailsSpy })
+
+  render(<MemoryRouter><SessionPage /></MemoryRouter>)
+
+  expect(screen.getByText('Snoozed')).toBeInTheDocument()
+  expect(screen.getByText('Restored')).toBeInTheDocument()
+  expect(screen.getByText('Thread unavailable')).toBeInTheDocument()
+  expect(screen.getAllByText('No additional event details recorded.')).toHaveLength(2)
 })

--- a/frontend/src/unit/SessionPage.test.tsx
+++ b/frontend/src/unit/SessionPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { beforeEach, expect, it, vi } from 'vitest'
@@ -176,13 +176,14 @@ it('renders a complete rate event as one labeled record', () => {
 
   render(<MemoryRouter><SessionPage /></MemoryRouter>)
 
+  const eventDetails = within(screen.getByRole('list', { name: 'Event details' }))
   expect(screen.getByText('Rated')).toBeInTheDocument()
-  expect(screen.getByText('Issue 5')).toBeInTheDocument()
-  expect(screen.getByText('1 issue read')).toBeInTheDocument()
-  expect(screen.getByText('Rating 4')).toBeInTheDocument()
-  expect(screen.getByText('d6')).toBeInTheDocument()
-  expect(screen.getByText('Die after: d8')).toBeInTheDocument()
-  expect(screen.getByText('Selected by dice roll')).toBeInTheDocument()
+  expect(eventDetails.getByText('Issue 5')).toBeInTheDocument()
+  expect(eventDetails.getByText('1 issue read')).toBeInTheDocument()
+  expect(eventDetails.getByText('Rating 4')).toBeInTheDocument()
+  expect(eventDetails.getByText('d6')).toBeInTheDocument()
+  expect(eventDetails.getByText('Die after: d8')).toBeInTheDocument()
+  expect(eventDetails.getByText('Selected by dice roll')).toBeInTheDocument()
 })
 
 it('uses human labels and explicit fallback text for sparse events', () => {


### PR DESCRIPTION
## Summary

Makes the Session Details timeline read as coherent event records instead of raw event names plus a truthy-value sentence.

## Implemented

- human-readable labels for roll, rate, snooze, unsnooze, skip, completion, restore, move, and shuffle events;
- one structured record per event with thread context, issue context when supplied, issues read, die, result, post-event die, rating, selection method, queue movement, and timestamp;
- nullish checks so recorded zero values are not silently hidden;
- explicit sparse-event fallback instead of inventing missing metadata;
- `min-w-0`, wrapping, and `break-words` containment for long thread titles, snapshot labels, narrative values, and metadata on narrow screens;
- focused unit regressions for complete rating events, sparse events, human labels, zero-valued metadata, and mobile-safe long titles.

## Scope truth

This PR materially advances #609 on the current frontend response contract. The additive backend exposure of `issue_number` and richer historical snooze metadata remains necessary where older events do not already provide those optional fields, so this PR references rather than closes #609.

## Validation

Focused tests were added in `frontend/src/unit/SessionPage.test.tsx`. Exact-SHA CI is the broad validation source for this connector runtime.

Part of #609.

Model: chatgpt-factory-3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved session timelines with clearer event labels and detailed metadata.
  * Added readable details for issues, dice, ratings, selections, queues, and rate events.
  * Added fallback text and explicit zero values for incomplete event data.
  * Improved wrapping for narrative content, snapshots, and timeline entries.
* **Bug Fixes**
  * Preserved empty-state handling when no session events are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->