### PR TITLE
feat(openapi): add deterministic schema export contract (#639)

### DIFF
--- a/scripts/export_openapi_schema.py
+++ b/scripts/export_openapi_schema.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Export ComicPile's OpenAPI schema deterministically for generated clients."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+DEFAULT_OUTPUT = Path("frontend/src/generated/openapi.json")
+
+
+def render_openapi_schema(schema: dict[str, Any]) -> str:
+    """Render an OpenAPI document with stable ordering and formatting.
+
+    Args:
+        schema: OpenAPI document returned by FastAPI.
+
+    Returns:
+        Deterministic JSON text ending in one newline.
+    """
+    return json.dumps(schema, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+def write_schema(output: Path, rendered: str, *, check: bool) -> bool:
+    """Write generated schema text or verify that checked-in output is current.
+
+    Args:
+        output: Generated schema destination.
+        rendered: Deterministically rendered schema text.
+        check: Whether to compare without modifying the file.
+
+    Returns:
+        True when the destination is current or was written successfully.
+    """
+    if check:
+        return output.exists() and output.read_text(encoding="utf-8") == rendered
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(rendered, encoding="utf-8")
+    return True
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="fail when the checked-in schema differs instead of rewriting it",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Export the application OpenAPI schema or verify generated output."""
+    args = _parse_args()
+
+    from app.main import app
+
+    rendered = render_openapi_schema(app.openapi())
+    if write_schema(args.output, rendered, check=args.check):
+        action = "Verified" if args.check else "Wrote"
+        print(f"{action} deterministic OpenAPI schema: {args.output}")
+        return 0
+
+    print(
+        f"Generated OpenAPI schema is stale: {args.output}\n"
+        "Run `python scripts/export_openapi_schema.py` and commit the result."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cancel_stale_ci_runs.py
+++ b/tests/test_cancel_stale_ci_runs.py
@@ -4,6 +4,7 @@ from scripts.cancel_stale_ci_runs import select_superseded_runs
 
 
 def test_selects_only_older_active_runs_for_same_pull_request_branch() -> None:
+    """Select older active pull-request runs only from the matching branch."""
     runs = [
         {
             "id": 10,
@@ -66,6 +67,7 @@ def test_selects_only_older_active_runs_for_same_pull_request_branch() -> None:
 
 
 def test_accepts_all_github_active_run_states_and_orders_by_run_id() -> None:
+    """Recognize every active GitHub state and return runs in stable order."""
     runs = [
         {
             "id": run_id,
@@ -94,6 +96,7 @@ def test_accepts_all_github_active_run_states_and_orders_by_run_id() -> None:
 
 
 def test_ignores_malformed_workflow_run_payloads() -> None:
+    """Ignore incomplete workflow-run records instead of selecting them."""
     selected = select_superseded_runs(
         [
             {},

--- a/tests/test_export_openapi_schema.py
+++ b/tests/test_export_openapi_schema.py
@@ -1,0 +1,49 @@
+"""Regression tests for deterministic OpenAPI schema generation."""
+
+from pathlib import Path
+
+from scripts.export_openapi_schema import render_openapi_schema, write_schema
+
+
+def test_render_openapi_schema_is_stable_and_newline_terminated() -> None:
+    """Sort nested keys and emit exactly one trailing newline."""
+    schema = {
+        "paths": {"/z": {"get": {}}, "/a": {"post": {}}},
+        "info": {"version": "1", "title": "ComicPile"},
+    }
+
+    rendered = render_openapi_schema(schema)
+
+    assert rendered.endswith("\n")
+    assert not rendered.endswith("\n\n")
+    assert rendered.index('"info"') < rendered.index('"paths"')
+    assert rendered.index('"/a"') < rendered.index('"/z"')
+
+
+def test_write_schema_creates_parent_directory_and_file(tmp_path: Path) -> None:
+    """Create a missing generated directory and write the rendered schema."""
+    output = tmp_path / "generated" / "openapi.json"
+
+    assert write_schema(output, '{"openapi":"3.1.0"}\n', check=False)
+    assert output.read_text(encoding="utf-8") == '{"openapi":"3.1.0"}\n'
+
+
+def test_check_mode_accepts_current_output_without_rewriting(tmp_path: Path) -> None:
+    """Return success when checked-in output exactly matches generation."""
+    output = tmp_path / "openapi.json"
+    output.write_text("current\n", encoding="utf-8")
+    original_mtime = output.stat().st_mtime_ns
+
+    assert write_schema(output, "current\n", check=True)
+    assert output.stat().st_mtime_ns == original_mtime
+
+
+def test_check_mode_rejects_missing_or_stale_output(tmp_path: Path) -> None:
+    """Reject absent and changed generated schemas without modifying them."""
+    output = tmp_path / "openapi.json"
+
+    assert not write_schema(output, "current\n", check=True)
+
+    output.write_text("stale\n", encoding="utf-8")
+    assert not write_schema(output, "current\n", check=True)
+    assert output.read_text(encoding="utf-8") == "stale\n"


### PR DESCRIPTION
## Summary

Adds the deterministic backend contract needed before generated frontend API types can be checked in safely.

## Implemented

- adds `scripts/export_openapi_schema.py`, which exports `app.openapi()` with stable recursive key ordering, UTF-8 output, consistent two-space formatting, and exactly one trailing newline;
- writes to `frontend/src/generated/openapi.json` by default while allowing an explicit output path;
- adds `--check` mode that never rewrites files and exits nonzero when the generated schema is missing or stale;
- creates missing generated directories only during write mode;
- adds focused regression coverage for deterministic ordering, newline stability, parent-directory creation, no-write check mode, and stale/missing output rejection.

## Scope truth

This materially advances #639 by establishing a reproducible OpenAPI artifact and stale-output primitive. The next issue work remains to choose and pin the TypeScript generator, check in generated TypeScript output, wire the stale check into CI, and migrate a low-risk resource pilot.

## Validation

Focused coverage is in `tests/test_export_openapi_schema.py`. Exact-SHA CI is the broad validation source for this connector runtime.

Part of #639.

Model: chatgpt-factory-5