### PR TITLE
fix(rate): prevent duplicate rating submissions (#771)

### DIFF
--- a/frontend/src/hooks/useRate.ts
+++ b/frontend/src/hooks/useRate.ts
@@ -23,10 +23,8 @@ export function useRate() {
       console.error('Failed to rate thread:', getApiErrorDetail(error))
       throw error
     } finally {
-      if (inFlightRequest.current === request) {
-        inFlightRequest.current = null
-        setIsPending(false)
-      }
+      inFlightRequest.current = null
+      setIsPending(false)
     }
   }
 

--- a/frontend/src/hooks/useRate.ts
+++ b/frontend/src/hooks/useRate.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { rateApi } from '../services/api'
 import { getApiErrorDetail } from '../utils/apiError'
 import type { RatePayload } from '../types'
@@ -6,18 +6,27 @@ import type { RatePayload } from '../types'
 export function useRate() {
   const [isPending, setIsPending] = useState(false)
   const [isError, setIsError] = useState(false)
+  const inFlightRequest = useRef<ReturnType<typeof rateApi.rate> | null>(null)
 
   const mutate = async (data: RatePayload) => {
+    if (inFlightRequest.current) return inFlightRequest.current
+
     setIsPending(true)
     setIsError(false)
+    const request = rateApi.rate(data)
+    inFlightRequest.current = request
+
     try {
-      return await rateApi.rate(data)
+      return await request
     } catch (error: unknown) {
       setIsError(true)
       console.error('Failed to rate thread:', getApiErrorDetail(error))
       throw error
     } finally {
-      setIsPending(false)
+      if (inFlightRequest.current === request) {
+        inFlightRequest.current = null
+        setIsPending(false)
+      }
     }
   }
 

--- a/frontend/src/unit/useRate.test.tsx
+++ b/frontend/src/unit/useRate.test.tsx
@@ -13,6 +13,7 @@ vi.mock('../services/api', () => ({
 const mockedRateApi = vi.mocked(rateApi)
 
 beforeEach(() => {
+  vi.clearAllMocks()
   mockedRateApi.rate.mockResolvedValue(undefined as never)
 })
 
@@ -25,4 +26,32 @@ it('submits ratings', async () => {
   })
 
   expect(mockedRateApi.rate).toHaveBeenCalledWith(payload)
+})
+
+it('shares one in-flight request across repeated submissions', async () => {
+  let resolveRequest: (() => void) | undefined
+  mockedRateApi.rate.mockReturnValue(new Promise((resolve) => {
+    resolveRequest = () => resolve(undefined as never)
+  }))
+
+  const { result } = renderHook(() => useRate())
+  const payload: RatePayload = { thread_id: 1, rating: 4 }
+  let firstRequest: Promise<unknown> | undefined
+  let secondRequest: Promise<unknown> | undefined
+
+  act(() => {
+    firstRequest = result.current.mutate(payload)
+    secondRequest = result.current.mutate(payload)
+  })
+
+  expect(mockedRateApi.rate).toHaveBeenCalledTimes(1)
+  expect(result.current.isPending).toBe(true)
+
+  await act(async () => {
+    resolveRequest?.()
+    await Promise.all([firstRequest, secondRequest])
+  })
+
+  expect(result.current.isPending).toBe(false)
+  expect(result.current.isError).toBe(false)
 })


### PR DESCRIPTION
## Summary

Prevents repeated taps on the rating action from issuing multiple concurrent API requests for the same pending thread.

## Implemented

- keeps the current rating request in a ref inside `useRate`;
- returns the existing in-flight request when the user taps again before completion;
- preserves the existing pending and error state contract;
- adds focused regression coverage proving repeated submissions produce exactly one API call and settle both callers.

## Why

The reported mobile failure showed one rating request clearing the active thread, followed by another request receiving `400 No active thread`. Sharing the in-flight request removes that race while keeping the rating view's existing loading state.

Closes #771.

Model: chatgpt-factory-4