### PR TITLE
feat(ui): add shared document overlay root (#625)

### DIFF
--- a/frontend/src/components/OverlayPortal.tsx
+++ b/frontend/src/components/OverlayPortal.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+interface OverlayPortalProps {
+  children: React.ReactNode
+}
+
+const OVERLAY_ROOT_ID = 'comic-pile-overlay-root'
+
+function getOrCreateOverlayRoot(): HTMLElement {
+  const existingRoot = document.getElementById(OVERLAY_ROOT_ID)
+  if (existingRoot) return existingRoot
+
+  const overlayRoot = document.createElement('div')
+  overlayRoot.id = OVERLAY_ROOT_ID
+  overlayRoot.dataset.overlayRoot = 'true'
+  document.body.appendChild(overlayRoot)
+  return overlayRoot
+}
+
+export default function OverlayPortal({ children }: OverlayPortalProps) {
+  const [overlayRoot, setOverlayRoot] = useState<HTMLElement | null>(null)
+
+  useEffect(() => {
+    const root = getOrCreateOverlayRoot()
+    setOverlayRoot(root)
+
+    return () => {
+      if (root.childElementCount === 0) root.remove()
+    }
+  }, [])
+
+  if (!overlayRoot) return null
+  return createPortal(children, overlayRoot)
+}

--- a/frontend/src/components/OverlayPortal.tsx
+++ b/frontend/src/components/OverlayPortal.tsx
@@ -6,6 +6,7 @@ interface OverlayPortalProps {
 }
 
 const OVERLAY_ROOT_ID = 'comic-pile-overlay-root'
+let mountedPortalCount = 0
 
 function getOrCreateOverlayRoot(): HTMLElement {
   const existingRoot = document.getElementById(OVERLAY_ROOT_ID)
@@ -23,10 +24,12 @@ export default function OverlayPortal({ children }: OverlayPortalProps) {
 
   useEffect(() => {
     const root = getOrCreateOverlayRoot()
+    mountedPortalCount += 1
     setOverlayRoot(root)
 
     return () => {
-      if (root.childElementCount === 0) root.remove()
+      mountedPortalCount -= 1
+      if (mountedPortalCount === 0) root.remove()
     }
   }, [])
 

--- a/frontend/src/unit/OverlayPortal.test.tsx
+++ b/frontend/src/unit/OverlayPortal.test.tsx
@@ -46,3 +46,20 @@ it('shares one overlay root across concurrent overlays', async () => {
   second.unmount()
   expect(document.getElementById('comic-pile-overlay-root')).not.toBeInTheDocument()
 })
+
+it('keeps the shared root connected while a direct text portal remains mounted', async () => {
+  const first = render(<OverlayPortal>First text overlay</OverlayPortal>)
+  const second = render(<OverlayPortal>Second text overlay</OverlayPortal>)
+
+  await screen.findByText('Second text overlay')
+
+  first.unmount()
+
+  const overlayRoot = document.getElementById('comic-pile-overlay-root')
+  expect(overlayRoot).toBeInTheDocument()
+  expect(overlayRoot?.isConnected).toBe(true)
+  expect(overlayRoot).toHaveTextContent('Second text overlay')
+
+  second.unmount()
+  expect(document.getElementById('comic-pile-overlay-root')).not.toBeInTheDocument()
+})

--- a/frontend/src/unit/OverlayPortal.test.tsx
+++ b/frontend/src/unit/OverlayPortal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { afterEach, expect, it } from 'vitest'
 import OverlayPortal from '../components/OverlayPortal'
 
@@ -51,7 +51,11 @@ it('keeps the shared root connected while a direct text portal remains mounted',
   const first = render(<OverlayPortal>First text overlay</OverlayPortal>)
   const second = render(<OverlayPortal>Second text overlay</OverlayPortal>)
 
-  await screen.findByText('Second text overlay')
+  await waitFor(() => {
+    expect(document.getElementById('comic-pile-overlay-root')).toHaveTextContent(
+      'First text overlaySecond text overlay',
+    )
+  })
 
   first.unmount()
 

--- a/frontend/src/unit/OverlayPortal.test.tsx
+++ b/frontend/src/unit/OverlayPortal.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, expect, it } from 'vitest'
+import OverlayPortal from '../components/OverlayPortal'
+
+afterEach(() => {
+  document.getElementById('comic-pile-overlay-root')?.remove()
+})
+
+it('renders overlay content outside the application root', async () => {
+  render(
+    <OverlayPortal>
+      <div role="menu">Actions</div>
+    </OverlayPortal>,
+  )
+
+  const menu = await screen.findByRole('menu')
+  const overlayRoot = document.getElementById('comic-pile-overlay-root')
+
+  expect(overlayRoot).toHaveAttribute('data-overlay-root', 'true')
+  expect(overlayRoot).toContainElement(menu)
+  expect(overlayRoot?.parentElement).toBe(document.body)
+})
+
+it('shares one overlay root across concurrent overlays', async () => {
+  const first = render(
+    <OverlayPortal>
+      <div>First overlay</div>
+    </OverlayPortal>,
+  )
+  const second = render(
+    <OverlayPortal>
+      <div>Second overlay</div>
+    </OverlayPortal>,
+  )
+
+  await screen.findByText('Second overlay')
+
+  expect(document.querySelectorAll('#comic-pile-overlay-root')).toHaveLength(1)
+  expect(document.getElementById('comic-pile-overlay-root')).toHaveTextContent(
+    'First overlaySecond overlay',
+  )
+
+  first.unmount()
+  expect(document.getElementById('comic-pile-overlay-root')).toHaveTextContent('Second overlay')
+
+  second.unmount()
+  expect(document.getElementById('comic-pile-overlay-root')).not.toBeInTheDocument()
+})


### PR DESCRIPTION
## Summary

Introduces the reusable document-level overlay root required by #625 so menus and other floating UI can escape clipped swipe cards and transformed virtual rows through one explicit primitive.

## Implemented

- adds `OverlayPortal`, which lazily creates one `#comic-pile-overlay-root` under `document.body`;
- shares that root across concurrent overlays instead of creating competing portal containers;
- removes the root after the final overlay unmounts;
- adds focused regression coverage for body-level rendering, root reuse, and lifecycle cleanup.

## Stage scope

This establishes the shared overlay boundary. Migrating `PositionMenu`, modal layering, and any remaining ad-hoc overlays remains open under #625 and should use this primitive in follow-up work.

Part of #625.

Model: chatgpt-factory-1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for rendering content in a dedicated overlay layer above the main application interface.
  * Multiple overlays can share the same layer, with automatic cleanup when no overlays remain.

* **Tests**
  * Added coverage for overlay rendering, shared usage, metadata, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->