### PR TITLE
feat(dependencies): add named group persistence foundation (#613)

### DIFF
--- a/alembic/versions/a613b7c9d201_add_named_dependency_groups.py
+++ b/alembic/versions/a613b7c9d201_add_named_dependency_groups.py
@@ -1,0 +1,84 @@
+"""Add named dependency groups.
+
+Revision ID: a613b7c9d201
+Revises: d85468471b73
+Create Date: 2026-08-04 01:20:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "a613b7c9d201"
+down_revision: str | Sequence[str] | None = "d85468471b73"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create user-owned dependency groups and polymorphic memberships."""
+    op.create_table(
+        "dependency_groups",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "name", name="uq_dependency_groups_user_name"),
+    )
+    op.create_index("ix_dependency_groups_user_id", "dependency_groups", ["user_id"])
+    op.create_table(
+        "dependency_group_memberships",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("group_id", sa.Integer(), nullable=False),
+        sa.Column("thread_id", sa.Integer(), nullable=True),
+        sa.Column("issue_id", sa.Integer(), nullable=True),
+        sa.CheckConstraint(
+            "(thread_id IS NOT NULL AND issue_id IS NULL) OR "
+            "(thread_id IS NULL AND issue_id IS NOT NULL)",
+            name="ck_dependency_group_membership_one_target",
+        ),
+        sa.ForeignKeyConstraint(["group_id"], ["dependency_groups.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["issue_id"], ["issues.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["thread_id"], ["threads.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("group_id", "issue_id", name="uq_dependency_group_issue"),
+        sa.UniqueConstraint("group_id", "thread_id", name="uq_dependency_group_thread"),
+    )
+    op.create_index(
+        "ix_dependency_group_memberships_group_id",
+        "dependency_group_memberships",
+        ["group_id"],
+    )
+    op.create_index(
+        "ix_dependency_group_memberships_issue_id",
+        "dependency_group_memberships",
+        ["issue_id"],
+    )
+    op.create_index(
+        "ix_dependency_group_memberships_thread_id",
+        "dependency_group_memberships",
+        ["thread_id"],
+    )
+
+
+def downgrade() -> None:
+    """Remove named dependency group persistence."""
+    op.drop_index(
+        "ix_dependency_group_memberships_thread_id",
+        table_name="dependency_group_memberships",
+    )
+    op.drop_index(
+        "ix_dependency_group_memberships_issue_id",
+        table_name="dependency_group_memberships",
+    )
+    op.drop_index(
+        "ix_dependency_group_memberships_group_id",
+        table_name="dependency_group_memberships",
+    )
+    op.drop_table("dependency_group_memberships")
+    op.drop_index("ix_dependency_groups_user_id", table_name="dependency_groups")
+    op.drop_table("dependency_groups")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,6 +1,7 @@
 """SQLAlchemy database models."""
 
 from app.models.dependency import Dependency
+from app.models.dependency_group import DependencyGroup, DependencyGroupMembership
 from app.models.event import Event
 from app.models.failed_login_attempt import FailedLoginAttempt
 from app.models.issue import Issue
@@ -13,6 +14,8 @@ from app.models.user import User
 
 __all__ = [
     "Dependency",
+    "DependencyGroup",
+    "DependencyGroupMembership",
     "Event",
     "FailedLoginAttempt",
     "Issue",

--- a/app/models/dependency_group.py
+++ b/app/models/dependency_group.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, UniqueConstraint
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, Integer, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
@@ -58,6 +58,11 @@ class DependencyGroupMembership(Base):
     )
 
     __table_args__ = (
+        CheckConstraint(
+            "(thread_id IS NOT NULL AND issue_id IS NULL) OR "
+            "(thread_id IS NULL AND issue_id IS NOT NULL)",
+            name="ck_dependency_group_membership_one_target",
+        ),
         UniqueConstraint("group_id", "thread_id", name="uq_dependency_group_thread"),
         UniqueConstraint("group_id", "issue_id", name="uq_dependency_group_issue"),
         Index("ix_dependency_group_memberships_group_id", "group_id"),

--- a/app/models/dependency_group.py
+++ b/app/models/dependency_group.py
@@ -1,0 +1,66 @@
+"""Named dependency-group persistence models."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+
+class DependencyGroup(Base):
+    """User-owned name for a set of related dependency participants."""
+
+    __tablename__ = "dependency_groups"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
+
+    memberships: Mapped[list[DependencyGroupMembership]] = relationship(
+        "DependencyGroupMembership",
+        back_populates="group",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "name", name="uq_dependency_groups_user_name"),
+        Index("ix_dependency_groups_user_id", "user_id"),
+    )
+
+
+class DependencyGroupMembership(Base):
+    """Thread- or issue-level membership in a named dependency group."""
+
+    __tablename__ = "dependency_group_memberships"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    group_id: Mapped[int] = mapped_column(
+        ForeignKey("dependency_groups.id", ondelete="CASCADE"), nullable=False
+    )
+    thread_id: Mapped[int | None] = mapped_column(
+        ForeignKey("threads.id", ondelete="CASCADE"), nullable=True
+    )
+    issue_id: Mapped[int | None] = mapped_column(
+        ForeignKey("issues.id", ondelete="CASCADE"), nullable=True
+    )
+
+    group: Mapped[DependencyGroup] = relationship(
+        "DependencyGroup", back_populates="memberships"
+    )
+
+    __table_args__ = (
+        UniqueConstraint("group_id", "thread_id", name="uq_dependency_group_thread"),
+        UniqueConstraint("group_id", "issue_id", name="uq_dependency_group_issue"),
+        Index("ix_dependency_group_memberships_group_id", "group_id"),
+        Index("ix_dependency_group_memberships_thread_id", "thread_id"),
+        Index("ix_dependency_group_memberships_issue_id", "issue_id"),
+    )

--- a/app/models/dependency_group.py
+++ b/app/models/dependency_group.py
@@ -4,7 +4,15 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, Integer, String, UniqueConstraint
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base

--- a/tests/test_dependency_group_model.py
+++ b/tests/test_dependency_group_model.py
@@ -1,0 +1,41 @@
+"""Regression tests for named dependency-group persistence."""
+
+from sqlalchemy import CheckConstraint, UniqueConstraint
+
+from app.models.dependency_group import DependencyGroup, DependencyGroupMembership
+
+
+def test_dependency_group_names_are_unique_per_user() -> None:
+    """Prevent duplicate group names inside one user's namespace."""
+    constraints = {
+        constraint.name
+        for constraint in DependencyGroup.__table__.constraints
+        if isinstance(constraint, UniqueConstraint)
+    }
+
+    assert "uq_dependency_groups_user_name" in constraints
+
+
+def test_dependency_group_membership_requires_exactly_one_target() -> None:
+    """A membership must point to one thread or one issue, never both or neither."""
+    constraints = {
+        constraint.name
+        for constraint in DependencyGroupMembership.__table__.constraints
+        if isinstance(constraint, CheckConstraint)
+    }
+
+    assert "ck_dependency_group_membership_one_target" in constraints
+
+
+def test_dependency_group_memberships_are_unique_by_target() -> None:
+    """Do not allow the same thread or issue to be added twice to one group."""
+    constraints = {
+        constraint.name
+        for constraint in DependencyGroupMembership.__table__.constraints
+        if isinstance(constraint, UniqueConstraint)
+    }
+
+    assert constraints >= {
+        "uq_dependency_group_thread",
+        "uq_dependency_group_issue",
+    }

--- a/tests/test_dependency_group_model.py
+++ b/tests/test_dependency_group_model.py
@@ -1,15 +1,22 @@
 """Regression tests for named dependency-group persistence."""
 
-from sqlalchemy import CheckConstraint, UniqueConstraint
+from typing import cast
+
+from sqlalchemy import CheckConstraint, Table, UniqueConstraint
 
 from app.models.dependency_group import DependencyGroup, DependencyGroupMembership
+
+
+def _model_table(model_table: object) -> Table:
+    """Narrow SQLAlchemy's declarative table attribute for static analysis."""
+    return cast(Table, model_table)
 
 
 def test_dependency_group_names_are_unique_per_user() -> None:
     """Prevent duplicate group names inside one user's namespace."""
     constraints = {
         constraint.name
-        for constraint in DependencyGroup.__table__.constraints
+        for constraint in _model_table(DependencyGroup.__table__).constraints
         if isinstance(constraint, UniqueConstraint)
     }
 
@@ -20,7 +27,7 @@ def test_dependency_group_membership_requires_exactly_one_target() -> None:
     """A membership must point to one thread or one issue, never both or neither."""
     constraints = {
         constraint.name
-        for constraint in DependencyGroupMembership.__table__.constraints
+        for constraint in _model_table(DependencyGroupMembership.__table__).constraints
         if isinstance(constraint, CheckConstraint)
     }
 
@@ -31,7 +38,7 @@ def test_dependency_group_memberships_are_unique_by_target() -> None:
     """Do not allow the same thread or issue to be added twice to one group."""
     constraints = {
         constraint.name
-        for constraint in DependencyGroupMembership.__table__.constraints
+        for constraint in _model_table(DependencyGroupMembership.__table__).constraints
         if isinstance(constraint, UniqueConstraint)
     }
 


### PR DESCRIPTION
## Summary

Adds the durable persistence foundation for explicit user-named dependency groups.

## Implemented

- adds user-owned `DependencyGroup` records with per-user unique names;
- adds memberships that can target either one thread or one issue;
- enforces exactly one target at the database boundary;
- prevents duplicate thread or issue membership inside the same group;
- cascades group and target deletion safely;
- adds a forward and reversible Alembic migration;
- adds focused regression coverage for the ownership namespace and membership invariants.

## Stage scope

This is a coherent persistence stage of #613. The remaining issue contract is CRUD API ownership enforcement, dependency-management UI integration, and displaying group names on the Roll view.

Part of #613.

Model: chatgpt-factory-4