### PR TITLE
feat(clone): add deterministic restore dry-run planning (#643)

### DIFF
--- a/scripts/plan_clone_restore.py
+++ b/scripts/plan_clone_restore.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Plan a production-to-local clone restore without mutating a database."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Final
+
+TABLE_ORDER: Final = (
+    "threads",
+    "issues",
+    "dependencies",
+    "reading_orders",
+    "reading_order_items",
+    "sessions",
+    "events",
+    "snapshots",
+)
+
+
+class RestorePlanError(ValueError):
+    """Raised when a safe deterministic restore plan cannot be produced."""
+
+
+@dataclass(frozen=True)
+class TableRestorePlan:
+    """Describe one table's deterministic restore work."""
+
+    table: str
+    source_count: int
+    first_local_id: int | None
+    last_local_id: int | None
+    id_map: dict[int, int]
+
+
+@dataclass(frozen=True)
+class RestorePlan:
+    """Describe the complete database-free restore plan."""
+
+    source_username: str
+    local_user_id: int
+    insertion_order: tuple[str, ...]
+    tables: tuple[TableRestorePlan, ...]
+
+
+def _records(document: Mapping[str, object], table: str) -> list[Mapping[str, object]]:
+    value = document.get(table)
+    if not isinstance(value, list):
+        raise RestorePlanError(f"{table} must be a list")
+    records: list[Mapping[str, object]] = []
+    for index, record in enumerate(value):
+        if not isinstance(record, dict):
+            raise RestorePlanError(f"{table}[{index}] must be an object")
+        records.append(record)
+    return records
+
+
+def _source_ids(records: Sequence[Mapping[str, object]], table: str) -> list[int]:
+    source_ids: list[int] = []
+    seen: set[int] = set()
+    for index, record in enumerate(records):
+        source_id = record.get("id")
+        if not isinstance(source_id, int) or isinstance(source_id, bool):
+            raise RestorePlanError(f"{table}[{index}].id must be an integer")
+        if source_id in seen:
+            raise RestorePlanError(f"{table} contains duplicate id {source_id}")
+        seen.add(source_id)
+        source_ids.append(source_id)
+    return sorted(source_ids)
+
+
+def build_restore_plan(
+    document: Mapping[str, object],
+    *,
+    local_user_id: int,
+    next_ids: Mapping[str, int],
+) -> RestorePlan:
+    """Build stable source-to-local ID maps without writing to a database."""
+    if local_user_id <= 0:
+        raise RestorePlanError("local_user_id must be positive")
+
+    source_username = document.get("source_username")
+    if not isinstance(source_username, str) or not source_username.strip():
+        raise RestorePlanError("source_username must be a non-empty string")
+
+    user = document.get("user")
+    if not isinstance(user, dict):
+        raise RestorePlanError("user must be an object")
+    source_user_id = user.get("id")
+    if not isinstance(source_user_id, int) or isinstance(source_user_id, bool):
+        raise RestorePlanError("user.id must be an integer")
+
+    plans: list[TableRestorePlan] = []
+    for table in TABLE_ORDER:
+        records = _records(document, table)
+        source_ids = _source_ids(records, table)
+        start = next_ids.get(table)
+        if not isinstance(start, int) or isinstance(start, bool) or start <= 0:
+            raise RestorePlanError(f"next_ids[{table!r}] must be a positive integer")
+        id_map = {source_id: start + offset for offset, source_id in enumerate(source_ids)}
+        plans.append(
+            TableRestorePlan(
+                table=table,
+                source_count=len(source_ids),
+                first_local_id=start if source_ids else None,
+                last_local_id=start + len(source_ids) - 1 if source_ids else None,
+                id_map=id_map,
+            )
+        )
+
+    thread_ids = {record["id"] for record in _records(document, "threads")}
+    for index, thread in enumerate(_records(document, "threads")):
+        if thread.get("user_id") != source_user_id:
+            raise RestorePlanError(f"threads[{index}].user_id is not owned by export user")
+    for index, order in enumerate(_records(document, "reading_orders")):
+        if order.get("user_id") != source_user_id:
+            raise RestorePlanError(f"reading_orders[{index}].user_id is not owned by export user")
+    for index, session in enumerate(_records(document, "sessions")):
+        if session.get("user_id") != source_user_id:
+            raise RestorePlanError(f"sessions[{index}].user_id is not owned by export user")
+        snoozed = session.get("snoozed_thread_ids")
+        if snoozed is not None:
+            if not isinstance(snoozed, list):
+                raise RestorePlanError(f"sessions[{index}].snoozed_thread_ids must be a list")
+            missing = [thread_id for thread_id in snoozed if thread_id not in thread_ids]
+            if missing:
+                raise RestorePlanError(
+                    f"sessions[{index}].snoozed_thread_ids contains missing thread ids {missing}"
+                )
+
+    return RestorePlan(
+        source_username=source_username,
+        local_user_id=local_user_id,
+        insertion_order=TABLE_ORDER,
+        tables=tuple(plans),
+    )
+
+
+def main() -> int:
+    """Print a machine-readable dry-run restore plan."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("file", type=Path)
+    parser.add_argument("--local-user-id", required=True, type=int)
+    parser.add_argument(
+        "--next-ids",
+        required=True,
+        type=Path,
+        help="JSON object containing the next available ID for every retained table",
+    )
+    args = parser.parse_args()
+
+    try:
+        document = json.loads(args.file.read_text(encoding="utf-8"))
+        next_ids = json.loads(args.next_ids.read_text(encoding="utf-8"))
+        if not isinstance(document, dict):
+            raise RestorePlanError("export root must be an object")
+        if not isinstance(next_ids, dict):
+            raise RestorePlanError("next IDs root must be an object")
+        plan = build_restore_plan(document, local_user_id=args.local_user_id, next_ids=next_ids)
+    except (OSError, json.JSONDecodeError, RestorePlanError) as exc:
+        parser.exit(1, f"INVALID: {exc}\n")
+
+    print(json.dumps(asdict(plan), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_plan_clone_restore.py
+++ b/tests/test_plan_clone_restore.py
@@ -1,0 +1,87 @@
+"""Tests for deterministic clone restore planning."""
+
+from scripts.plan_clone_restore import TABLE_ORDER, RestorePlanError, build_restore_plan
+
+
+def _document() -> dict[str, object]:
+    """Return a minimal valid retained-data export."""
+    return {
+        "source_username": "Josh",
+        "user": {"id": 7},
+        "threads": [{"id": 20, "user_id": 7}, {"id": 10, "user_id": 7}],
+        "issues": [{"id": 30, "thread_id": 10}],
+        "dependencies": [],
+        "reading_orders": [{"id": 40, "user_id": 7}],
+        "reading_order_items": [],
+        "sessions": [{"id": 50, "user_id": 7, "snoozed_thread_ids": [20]}],
+        "events": [],
+        "snapshots": [],
+    }
+
+
+def _next_ids() -> dict[str, int]:
+    """Return deterministic local sequence starts."""
+    return {table: 1000 + index * 100 for index, table in enumerate(TABLE_ORDER)}
+
+
+def test_build_restore_plan_sorts_source_ids_and_allocates_contiguous_local_ids() -> None:
+    """Source row order must not change the resulting ID map."""
+    plan = build_restore_plan(_document(), local_user_id=3, next_ids=_next_ids())
+
+    thread_plan = plan.tables[0]
+    assert plan.source_username == "Josh"
+    assert plan.local_user_id == 3
+    assert plan.insertion_order == TABLE_ORDER
+    assert thread_plan.id_map == {10: 1000, 20: 1001}
+    assert thread_plan.first_local_id == 1000
+    assert thread_plan.last_local_id == 1001
+
+
+def test_build_restore_plan_keeps_empty_tables_explicit() -> None:
+    """Dry-run output should preserve every insertion stage even when empty."""
+    plan = build_restore_plan(_document(), local_user_id=3, next_ids=_next_ids())
+
+    dependency_plan = next(item for item in plan.tables if item.table == "dependencies")
+    assert dependency_plan.source_count == 0
+    assert dependency_plan.first_local_id is None
+    assert dependency_plan.last_local_id is None
+    assert dependency_plan.id_map == {}
+
+
+def test_build_restore_plan_rejects_cross_user_records() -> None:
+    """A restore plan must never silently adopt another user's retained rows."""
+    document = _document()
+    document["reading_orders"] = [{"id": 40, "user_id": 99}]
+
+    try:
+        build_restore_plan(document, local_user_id=3, next_ids=_next_ids())
+    except RestorePlanError as exc:
+        assert "reading_orders[0].user_id" in str(exc)
+    else:
+        raise AssertionError("cross-user record was accepted")
+
+
+def test_build_restore_plan_rejects_missing_snoozed_thread() -> None:
+    """Session thread references must be resolvable before database mutation."""
+    document = _document()
+    document["sessions"] = [{"id": 50, "user_id": 7, "snoozed_thread_ids": [999]}]
+
+    try:
+        build_restore_plan(document, local_user_id=3, next_ids=_next_ids())
+    except RestorePlanError as exc:
+        assert "missing thread ids [999]" in str(exc)
+    else:
+        raise AssertionError("missing snoozed thread was accepted")
+
+
+def test_build_restore_plan_rejects_duplicate_ids() -> None:
+    """Duplicate source IDs would make remapping ambiguous and must fail closed."""
+    document = _document()
+    document["issues"] = [{"id": 30, "thread_id": 10}, {"id": 30, "thread_id": 20}]
+
+    try:
+        build_restore_plan(document, local_user_id=3, next_ids=_next_ids())
+    except RestorePlanError as exc:
+        assert "issues contains duplicate id 30" in str(exc)
+    else:
+        raise AssertionError("duplicate IDs were accepted")


### PR DESCRIPTION
## Summary

Adds a database-free restore planner for production-to-local clone imports so ID allocation and ownership safety can be inspected before any local mutation.

## Implemented

- computes stable source-to-local ID maps independent of export row order;
- preserves explicit dependency-safe table insertion order;
- reports deterministic per-table counts and local ID ranges;
- rejects duplicate IDs, invalid sequence starts, cross-user retained rows, and unresolved snoozed-thread references;
- exposes a JSON CLI suitable for dry-run review and later import-command integration;
- adds focused regression coverage for deterministic remapping and fail-closed ownership/reference behavior.

## Stage scope

This is a coherent import-safety stage of #643. It does not overlap PR #776's export-file validator. Wiring both stages into the transactional local restore command, backup-before-restore, and full round-trip verification remain open.

Part of #643.

Model: chatgpt-factory-5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool to validate exported data and generate a deterministic restore plan.
  * Supports ownership and reference checks, local ID assignment, and JSON output.
  * Reports invalid exports clearly without modifying the database.

* **Tests**
  * Added coverage for ID allocation, empty tables, ownership validation, missing references, and duplicate IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->