### PR TITLE
Instrument current-session and History read phases (#700)

### DIFF
--- a/app/middleware/security_headers.py
+++ b/app/middleware/security_headers.py
@@ -1,32 +1,106 @@
-"""Security headers middleware for FastAPI application."""
+"""Security headers and targeted session-read diagnostics middleware."""
 
+import logging
 import os
+import time
 
 from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 
+from app.performance_diagnostics import get_request_diagnostics
+
+logger = logging.getLogger(__name__)
+
+
+def _session_read_operation(path: str, method: str) -> str | None:
+    """Classify current-session and History list reads.
+
+    Args:
+        path: Request URL path.
+        method: HTTP request method.
+
+    Returns:
+        Stable operation name for instrumented reads, otherwise ``None``.
+    """
+    if method != "GET":
+        return None
+
+    normalized_path = path.rstrip("/")
+    prefixes = ("/api/sessions", "/api/v1/sessions")
+    for prefix in prefixes:
+        if normalized_path == f"{prefix}/current":
+            return "current-session"
+        if normalized_path == prefix:
+            return "history-list"
+    return None
+
+
+def _add_session_read_diagnostics(
+    request: Request,
+    response: Response,
+    operation: str,
+    total_ms: float,
+) -> None:
+    """Expose and log bounded read-pipeline timing and query-count evidence.
+
+    Args:
+        request: Completed HTTP request.
+        response: Response receiving diagnostic headers.
+        operation: Stable session-read operation name.
+        total_ms: Total elapsed middleware time in milliseconds.
+    """
+    diagnostics = get_request_diagnostics()
+    application_ms = max(
+        total_ms - diagnostics.database_time_ms - diagnostics.cache_time_ms,
+        0.0,
+    )
+
+    response.headers["X-Session-Read-Operation"] = operation
+    response.headers["X-Session-Read-Total-Ms"] = f"{total_ms:.2f}"
+    response.headers["X-Session-Read-App-Ms"] = f"{application_ms:.2f}"
+    response.headers["X-Session-Read-DB-Ms"] = f"{diagnostics.database_time_ms:.2f}"
+    response.headers["X-Session-Read-DB-Queries"] = str(diagnostics.database_queries)
+    response.headers["X-Session-Read-Cache-Ms"] = f"{diagnostics.cache_time_ms:.2f}"
+    response.headers["X-Session-Read-Cache-Calls"] = str(diagnostics.cache_calls)
+
+    logger.warning(
+        "Session read diagnostics: %s completed in %.2f ms",
+        operation,
+        total_ms,
+        extra={
+            "event": "session_read_diagnostics",
+            "operation": operation,
+            "path": request.url.path,
+            "request_id": getattr(request.state, "request_id", None),
+            "status_code": response.status_code,
+            "total_time_ms": round(total_ms, 2),
+            "application_time_ms": round(application_ms, 2),
+            "database_time_ms": round(diagnostics.database_time_ms, 2),
+            "database_queries": diagnostics.database_queries,
+            "cache_time_ms": round(diagnostics.cache_time_ms, 2),
+            "cache_calls": diagnostics.cache_calls,
+            "cache_status": diagnostics.cache_status,
+        },
+    )
+
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
-    """Middleware to add security headers to all responses.
-
-    Adds the following security headers:
-    - Content-Security-Policy (CSP): Prevents XSS attacks
-    - Strict-Transport-Security (HSTS): Enforces HTTPS
-    - X-Content-Type-Options: Prevents MIME sniffing
-    - X-Frame-Options: Prevents clickjacking
-    """
+    """Middleware to add security headers and targeted read diagnostics."""
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
-        """Add security headers to the response.
+        """Add security headers and session-read diagnostics to the response.
 
         Args:
             request: The incoming HTTP request.
             call_next: The next middleware or route handler.
 
         Returns:
-            The HTTP response with security headers added.
+            The HTTP response with security and optional diagnostics headers added.
         """
+        operation = _session_read_operation(request.url.path, request.method)
+        started_at = time.perf_counter()
         response = await call_next(request)
+        total_ms = (time.perf_counter() - started_at) * 1000
 
         csp_header = (
             "default-src 'self'; "
@@ -55,5 +129,8 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers["X-XSS-Protection"] = "1; mode=block"
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()"
+
+        if operation is not None and response.status_code < 500:
+            _add_session_read_diagnostics(request, response, operation, total_ms)
 
         return response

--- a/tests/test_session_read_observability.py
+++ b/tests/test_session_read_observability.py
@@ -1,0 +1,99 @@
+"""Tests for current-session and History read diagnostics."""
+
+import logging
+
+import pytest
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from app.middleware.security_headers import SecurityHeadersMiddleware, _session_read_operation
+from app.performance_diagnostics import (
+    begin_request_diagnostics,
+    end_request_diagnostics,
+    record_cache_operation,
+    record_database_query,
+)
+
+
+def _request(path: str, method: str = "GET") -> Request:
+    """Build a minimal Starlette request for middleware tests."""
+    return Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": method,
+            "scheme": "https",
+            "path": path,
+            "raw_path": path.encode(),
+            "query_string": b"",
+            "headers": [],
+            "client": ("127.0.0.1", 1234),
+            "server": ("testserver", 443),
+        }
+    )
+
+
+def test_session_read_operation_classifies_only_bounded_list_reads() -> None:
+    """Current-session and History lists are instrumented without detail noise."""
+    assert _session_read_operation("/api/sessions/current/", "GET") == "current-session"
+    assert _session_read_operation("/api/v1/sessions/current", "GET") == "current-session"
+    assert _session_read_operation("/api/sessions/", "GET") == "history-list"
+    assert _session_read_operation("/api/v1/sessions", "GET") == "history-list"
+    assert _session_read_operation("/api/sessions/42", "GET") is None
+    assert _session_read_operation("/api/sessions/current/", "POST") is None
+
+
+@pytest.mark.asyncio
+async def test_current_session_response_exposes_phase_and_query_diagnostics(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Successful current-session reads expose structured timing evidence."""
+    middleware = SecurityHeadersMiddleware(app=lambda scope, receive, send: None)
+    request = _request("/api/sessions/current/")
+    request.state.request_id = "request-123"
+    token = begin_request_diagnostics()
+
+    async def call_next(_request: Request) -> JSONResponse:
+        record_database_query(12.5)
+        record_database_query(7.5)
+        record_cache_operation("hit", 2.0)
+        return JSONResponse({"id": 1})
+
+    try:
+        with caplog.at_level(logging.WARNING):
+            response = await middleware.dispatch(request, call_next)
+    finally:
+        end_request_diagnostics(token)
+
+    assert response.headers["X-Session-Read-Operation"] == "current-session"
+    assert response.headers["X-Session-Read-DB-Ms"] == "20.00"
+    assert response.headers["X-Session-Read-DB-Queries"] == "2"
+    assert response.headers["X-Session-Read-Cache-Ms"] == "2.00"
+    assert response.headers["X-Session-Read-Cache-Calls"] == "1"
+    assert float(response.headers["X-Session-Read-Total-Ms"]) >= 0
+    assert float(response.headers["X-Session-Read-App-Ms"]) >= 0
+    assert "Session read diagnostics: current-session" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_history_detail_response_does_not_emit_list_diagnostics(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Session details keep ordinary headers without list-pipeline diagnostics."""
+    middleware = SecurityHeadersMiddleware(app=lambda scope, receive, send: None)
+    request = _request("/api/sessions/42/")
+    token = begin_request_diagnostics()
+
+    async def call_next(_request: Request) -> JSONResponse:
+        record_database_query(1.0)
+        return JSONResponse({"id": 42})
+
+    try:
+        with caplog.at_level(logging.WARNING):
+            response = await middleware.dispatch(request, call_next)
+    finally:
+        end_request_diagnostics(token)
+
+    assert "X-Session-Read-Operation" not in response.headers
+    assert "Session read diagnostics" not in caplog.text
+    assert response.headers["X-Content-Type-Options"] == "nosniff"


### PR DESCRIPTION
## Summary

Adds targeted successful-read diagnostics for the bounded current-session and History list pipelines.

Part of #700 and #687.

## Implemented

- classifies only `GET /api[/v1]/sessions/current` and the History list route, excluding session detail and mutations;
- emits stable response headers for operation, total time, derived application time, database time/query count, and cache time/call count;
- writes one structured diagnostic event containing the same phase and query-count evidence plus request ID, status, and cache outcome;
- preserves all existing security headers and response payloads;
- adds focused middleware tests for legacy/v1 route classification, metrics, structured logging, and detail-route exclusion.

## Remaining work

- Record comparable cold and warm production samples after deployment.
- Use those samples to set explicit current-session and History budgets before closing #700.

## Verification

Connector-only runtime could not execute the test suite because `github.com` DNS resolution prevents a writable checkout. Exact-head CI is the validation boundary for this branch.

No merge or auto-merge is authorized.