### PR TITLE
Reconcile delayed Roll mutations after committed writes (#783)

### DIFF
--- a/frontend/src/hooks/rollMutationReconciliation.ts
+++ b/frontend/src/hooks/rollMutationReconciliation.ts
@@ -1,0 +1,52 @@
+import { rollBootstrapApi } from '../services/rollBootstrapApi'
+import type { RollBootstrapResponse } from '../types/rollBootstrap'
+
+export const ROLL_BOOTSTRAP_RECONCILED_EVENT = 'comic-pile:roll-bootstrap-reconciled'
+
+function normalizePendingThreadId(
+  value: number | string | null | undefined,
+): number | null {
+  if (value === null || value === undefined) return null
+  const normalized = Number(value)
+  return Number.isFinite(normalized) ? normalized : null
+}
+
+export function isAmbiguousNetworkFailure(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+
+  const candidate = error as { code?: string; message?: string; response?: unknown }
+  if (candidate.response) return false
+
+  return candidate.code === 'ECONNABORTED'
+    || candidate.code === 'ETIMEDOUT'
+    || candidate.message?.toLowerCase().includes('timeout') === true
+    || candidate.message === 'Network Error'
+}
+
+export function publishRollBootstrap(state: RollBootstrapResponse): void {
+  if (typeof window === 'undefined' || typeof CustomEvent === 'undefined') return
+
+  window.dispatchEvent(new CustomEvent<RollBootstrapResponse>(
+    ROLL_BOOTSTRAP_RECONCILED_EVENT,
+    { detail: state },
+  ))
+}
+
+export async function fetchAndPublishRollBootstrap(): Promise<RollBootstrapResponse> {
+  const state = await rollBootstrapApi.get()
+  publishRollBootstrap(state)
+  return state
+}
+
+export async function reconcileAmbiguousRollMutation(
+  expectedPendingThreadId?: number,
+): Promise<boolean> {
+  const state = await fetchAndPublishRollBootstrap()
+  const pendingThreadId = normalizePendingThreadId(state.pending_thread_id)
+
+  if (expectedPendingThreadId === undefined) {
+    return pendingThreadId === null
+  }
+
+  return pendingThreadId !== expectedPendingThreadId
+}

--- a/frontend/src/hooks/useRate.ts
+++ b/frontend/src/hooks/useRate.ts
@@ -1,22 +1,14 @@
 import { useRef, useState } from 'react'
 import { rateApi } from '../services/api'
-import { rollBootstrapApi } from '../services/rollBootstrapApi'
 import { getApiErrorDetail } from '../utils/apiError'
 import type { RatePayload } from '../types'
+import {
+  fetchAndPublishRollBootstrap,
+  isAmbiguousNetworkFailure,
+  reconcileAmbiguousRollMutation,
+} from './rollMutationReconciliation'
 
 type RateResult = Awaited<ReturnType<typeof rateApi.rate>> | undefined
-
-function isAmbiguousNetworkFailure(error: unknown): boolean {
-  if (!error || typeof error !== 'object') return false
-
-  const candidate = error as { code?: string; message?: string; response?: unknown }
-  if (candidate.response) return false
-
-  return candidate.code === 'ECONNABORTED'
-    || candidate.code === 'ETIMEDOUT'
-    || candidate.message?.toLowerCase().includes('timeout') === true
-    || candidate.message === 'Network Error'
-}
 
 export function useRate() {
   const [isPending, setIsPending] = useState(false)
@@ -31,23 +23,23 @@ export function useRate() {
 
     const request: Promise<RateResult> = (async () => {
       try {
-        return await rateApi.rate(data)
+        const result = await rateApi.rate(data)
+
+        try {
+          await fetchAndPublishRollBootstrap()
+        } catch (reconciliationError: unknown) {
+          console.error(
+            'Rating saved but authoritative Roll state failed to refresh:',
+            getApiErrorDetail(reconciliationError),
+          )
+        }
+
+        return result
       } catch (error: unknown) {
         if (isAmbiguousNetworkFailure(error)) {
           try {
-            const authoritativeState = await rollBootstrapApi.get()
-            const pendingThreadId = authoritativeState.pending_thread_id === null
-              || authoritativeState.pending_thread_id === undefined
-              ? null
-              : Number(authoritativeState.pending_thread_id)
-
-            if (pendingThreadId !== data.thread_id) {
-              // The write may have committed even though the client timed out.
-              // Reloading is intentionally conservative: it replaces every stale
-              // rating, queue, and die snapshot with the authoritative bootstrap.
-              globalThis.location.reload()
-              return undefined
-            }
+            const committed = await reconcileAmbiguousRollMutation(data.thread_id)
+            if (committed) return undefined
           } catch (reconciliationError: unknown) {
             console.error(
               'Failed to reconcile ambiguous rating result:',

--- a/frontend/src/hooks/useRate.ts
+++ b/frontend/src/hooks/useRate.ts
@@ -1,27 +1,69 @@
 import { useRef, useState } from 'react'
 import { rateApi } from '../services/api'
+import { rollBootstrapApi } from '../services/rollBootstrapApi'
 import { getApiErrorDetail } from '../utils/apiError'
 import type { RatePayload } from '../types'
+
+function isAmbiguousNetworkFailure(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+
+  const candidate = error as { code?: string; message?: string; response?: unknown }
+  if (candidate.response) return false
+
+  return candidate.code === 'ECONNABORTED'
+    || candidate.code === 'ETIMEDOUT'
+    || candidate.message?.toLowerCase().includes('timeout') === true
+    || candidate.message === 'Network Error'
+}
 
 export function useRate() {
   const [isPending, setIsPending] = useState(false)
   const [isError, setIsError] = useState(false)
-  const inFlightRequest = useRef<ReturnType<typeof rateApi.rate> | null>(null)
+  const inFlightRequest = useRef<Promise<unknown> | null>(null)
 
   const mutate = async (data: RatePayload) => {
     if (inFlightRequest.current) return inFlightRequest.current
 
     setIsPending(true)
     setIsError(false)
-    const request = rateApi.rate(data)
+
+    const request = (async () => {
+      try {
+        return await rateApi.rate(data)
+      } catch (error: unknown) {
+        if (isAmbiguousNetworkFailure(error)) {
+          try {
+            const authoritativeState = await rollBootstrapApi.get()
+            const pendingThreadId = authoritativeState.pending_thread_id === null
+              || authoritativeState.pending_thread_id === undefined
+              ? null
+              : Number(authoritativeState.pending_thread_id)
+
+            if (pendingThreadId !== data.thread_id) {
+              // The write may have committed even though the client timed out.
+              // Reloading is intentionally conservative: it replaces every stale
+              // rating, queue, and die snapshot with the authoritative bootstrap.
+              globalThis.location.reload()
+              return undefined
+            }
+          } catch (reconciliationError: unknown) {
+            console.error(
+              'Failed to reconcile ambiguous rating result:',
+              getApiErrorDetail(reconciliationError),
+            )
+          }
+        }
+
+        setIsError(true)
+        console.error('Failed to rate thread:', getApiErrorDetail(error))
+        throw error
+      }
+    })()
+
     inFlightRequest.current = request
 
     try {
       return await request
-    } catch (error: unknown) {
-      setIsError(true)
-      console.error('Failed to rate thread:', getApiErrorDetail(error))
-      throw error
     } finally {
       inFlightRequest.current = null
       setIsPending(false)

--- a/frontend/src/hooks/useRate.ts
+++ b/frontend/src/hooks/useRate.ts
@@ -4,6 +4,8 @@ import { rollBootstrapApi } from '../services/rollBootstrapApi'
 import { getApiErrorDetail } from '../utils/apiError'
 import type { RatePayload } from '../types'
 
+type RateResult = Awaited<ReturnType<typeof rateApi.rate>> | undefined
+
 function isAmbiguousNetworkFailure(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false
 
@@ -19,15 +21,15 @@ function isAmbiguousNetworkFailure(error: unknown): boolean {
 export function useRate() {
   const [isPending, setIsPending] = useState(false)
   const [isError, setIsError] = useState(false)
-  const inFlightRequest = useRef<Promise<unknown> | null>(null)
+  const inFlightRequest = useRef<Promise<RateResult> | null>(null)
 
-  const mutate = async (data: RatePayload) => {
+  const mutate = async (data: RatePayload): Promise<RateResult> => {
     if (inFlightRequest.current) return inFlightRequest.current
 
     setIsPending(true)
     setIsError(false)
 
-    const request = (async () => {
+    const request: Promise<RateResult> = (async () => {
       try {
         return await rateApi.rate(data)
       } catch (error: unknown) {

--- a/frontend/src/hooks/useRollBootstrap.ts
+++ b/frontend/src/hooks/useRollBootstrap.ts
@@ -13,6 +13,8 @@ export function useRollBootstrap() {
   const [error, setError] = useState<Error | null>(null);
   const { showToast } = useToast();
   const lastNotifiedSessionIdRef = useRef<number | null>(null);
+  const justReconciledRef = useRef<RollBootstrapResponse | null>(null);
+  const reconciliationExpiryRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const fetchBootstrap = useCallback(async () => {
     setIsPending(true);
@@ -63,6 +65,20 @@ export function useRollBootstrap() {
     }
   }, [showToast]);
 
+  const refetchBootstrap = useCallback(async () => {
+    const reconciled = justReconciledRef.current;
+    if (reconciled) {
+      justReconciledRef.current = null;
+      if (reconciliationExpiryRef.current) {
+        clearTimeout(reconciliationExpiryRef.current);
+        reconciliationExpiryRef.current = null;
+      }
+      return reconciled;
+    }
+
+    return fetchBootstrap();
+  }, [fetchBootstrap]);
+
   useEffect(() => {
     // Defer the request by one microtask so consumers can reliably observe the
     // initial loading state before even an already-resolved test or cache value settles.
@@ -74,6 +90,13 @@ export function useRollBootstrap() {
       const reconciled = (event as CustomEvent<RollBootstrapResponse>).detail;
       if (!reconciled) return;
 
+      justReconciledRef.current = reconciled;
+      if (reconciliationExpiryRef.current) clearTimeout(reconciliationExpiryRef.current);
+      reconciliationExpiryRef.current = setTimeout(() => {
+        if (justReconciledRef.current === reconciled) justReconciledRef.current = null;
+        reconciliationExpiryRef.current = null;
+      }, 0);
+
       setData(reconciled);
       setIsPending(false);
       setIsError(false);
@@ -83,8 +106,9 @@ export function useRollBootstrap() {
     window.addEventListener(ROLL_BOOTSTRAP_RECONCILED_EVENT, handleReconciledBootstrap);
     return () => {
       window.removeEventListener(ROLL_BOOTSTRAP_RECONCILED_EVENT, handleReconciledBootstrap);
+      if (reconciliationExpiryRef.current) clearTimeout(reconciliationExpiryRef.current);
     };
   }, []);
 
-  return { data, isPending, isError, error, refetch: fetchBootstrap };
+  return { data, isPending, isError, error, refetch: refetchBootstrap };
 }

--- a/frontend/src/hooks/useRollBootstrap.ts
+++ b/frontend/src/hooks/useRollBootstrap.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { RollBootstrapResponse } from '../types/rollBootstrap';
 import { rollBootstrapApi } from '../services/rollBootstrapApi';
 import { useToast } from '../contexts/useToast';
+import { ROLL_BOOTSTRAP_RECONCILED_EVENT } from './rollMutationReconciliation';
 
 const STORAGE_KEY_PREFIX = 'comic_pile_last_session_id';
 
@@ -67,6 +68,23 @@ export function useRollBootstrap() {
     // initial loading state before even an already-resolved test or cache value settles.
     void Promise.resolve().then(fetchBootstrap).catch(() => undefined);
   }, [fetchBootstrap]);
+
+  useEffect(() => {
+    const handleReconciledBootstrap = (event: Event) => {
+      const reconciled = (event as CustomEvent<RollBootstrapResponse>).detail;
+      if (!reconciled) return;
+
+      setData(reconciled);
+      setIsPending(false);
+      setIsError(false);
+      setError(null);
+    };
+
+    window.addEventListener(ROLL_BOOTSTRAP_RECONCILED_EVENT, handleReconciledBootstrap);
+    return () => {
+      window.removeEventListener(ROLL_BOOTSTRAP_RECONCILED_EVENT, handleReconciledBootstrap);
+    };
+  }, []);
 
   return { data, isPending, isError, error, refetch: fetchBootstrap };
 }

--- a/frontend/src/hooks/useSnooze.ts
+++ b/frontend/src/hooks/useSnooze.ts
@@ -1,21 +1,64 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { snoozeApi } from '../services/api'
 import { getApiErrorDetail } from '../utils/apiError'
+import {
+  fetchAndPublishRollBootstrap,
+  isAmbiguousNetworkFailure,
+  reconcileAmbiguousRollMutation,
+} from './rollMutationReconciliation'
+
+type SnoozeResult = Awaited<ReturnType<typeof snoozeApi.snooze>> | undefined
 
 export function useSnooze() {
   const [isPending, setIsPending] = useState(false)
   const [isError, setIsError] = useState(false)
+  const inFlightRequest = useRef<Promise<SnoozeResult> | null>(null)
 
-  const mutate = async () => {
+  const mutate = async (expectedPendingThreadId?: number): Promise<SnoozeResult> => {
+    if (inFlightRequest.current) return inFlightRequest.current
+
     setIsPending(true)
     setIsError(false)
+
+    const request: Promise<SnoozeResult> = (async () => {
+      try {
+        const result = await snoozeApi.snooze()
+
+        try {
+          await fetchAndPublishRollBootstrap()
+        } catch (reconciliationError: unknown) {
+          console.error(
+            'Snooze saved but authoritative Roll state failed to refresh:',
+            getApiErrorDetail(reconciliationError),
+          )
+        }
+
+        return result
+      } catch (error: unknown) {
+        if (isAmbiguousNetworkFailure(error)) {
+          try {
+            const committed = await reconcileAmbiguousRollMutation(expectedPendingThreadId)
+            if (committed) return undefined
+          } catch (reconciliationError: unknown) {
+            console.error(
+              'Failed to reconcile ambiguous snooze result:',
+              getApiErrorDetail(reconciliationError),
+            )
+          }
+        }
+
+        setIsError(true)
+        console.error('Failed to snooze thread:', getApiErrorDetail(error))
+        throw error
+      }
+    })()
+
+    inFlightRequest.current = request
+
     try {
-      await snoozeApi.snooze()
-    } catch (error: unknown) {
-      setIsError(true)
-      console.error('Failed to snooze thread:', getApiErrorDetail(error))
-      throw error
+      return await request
     } finally {
+      inFlightRequest.current = null
       setIsPending(false)
     }
   }

--- a/frontend/src/unit/rollMutationReconciliation.test.tsx
+++ b/frontend/src/unit/rollMutationReconciliation.test.tsx
@@ -1,7 +1,12 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
-import { beforeEach, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ToastProvider } from '../contexts/ToastProvider'
-import { publishRollBootstrap } from '../hooks/rollMutationReconciliation'
+import {
+  isAmbiguousNetworkFailure,
+  publishRollBootstrap,
+  reconcileAmbiguousRollMutation,
+  ROLL_BOOTSTRAP_RECONCILED_EVENT,
+} from '../hooks/rollMutationReconciliation'
 import { useRollBootstrap } from '../hooks/useRollBootstrap'
 import { rollBootstrapApi } from '../services/rollBootstrapApi'
 import type { RollBootstrapResponse } from '../types/rollBootstrap'
@@ -39,27 +44,78 @@ beforeEach(() => {
   localStorage.clear()
 })
 
-it('replaces mounted Roll bootstrap state when a mutation publishes reconciliation', async () => {
-  const initial = bootstrapState(6, 7)
-  const reconciled = bootstrapState(8, null)
-  mockedBootstrap.mockResolvedValue(initial)
-
-  const { result } = renderHook(() => useRollBootstrap(), {
-    wrapper: ({ children }: { children: React.ReactNode }) => (
-      <ToastProvider>{children}</ToastProvider>
-    ),
+describe('Roll mutation reconciliation', () => {
+  it('classifies only response-less timeout and network failures as ambiguous', () => {
+    expect(isAmbiguousNetworkFailure(null)).toBe(false)
+    expect(isAmbiguousNetworkFailure('timeout')).toBe(false)
+    expect(isAmbiguousNetworkFailure({ response: { status: 500 }, code: 'ECONNABORTED' })).toBe(false)
+    expect(isAmbiguousNetworkFailure({ code: 'ECONNABORTED' })).toBe(true)
+    expect(isAmbiguousNetworkFailure({ code: 'ETIMEDOUT' })).toBe(true)
+    expect(isAmbiguousNetworkFailure(new Error('request timeout'))).toBe(true)
+    expect(isAmbiguousNetworkFailure(new Error('Network Error'))).toBe(true)
+    expect(isAmbiguousNetworkFailure(new Error('ordinary failure'))).toBe(false)
   })
 
-  await waitFor(() => expect(result.current.data).toBe(initial))
+  it('distinguishes committed and still-pending mutations with and without an expected thread', async () => {
+    mockedBootstrap
+      .mockResolvedValueOnce(bootstrapState(12, null))
+      .mockResolvedValueOnce(bootstrapState(12, 7))
+      .mockResolvedValueOnce(bootstrapState(12, 7))
+      .mockResolvedValueOnce(bootstrapState(12, 9))
+      .mockResolvedValueOnce({
+        ...bootstrapState(12, null),
+        pending_thread_id: 'invalid' as unknown as number,
+      })
 
-  act(() => {
-    publishRollBootstrap(reconciled)
+    await expect(reconcileAmbiguousRollMutation()).resolves.toBe(true)
+    await expect(reconcileAmbiguousRollMutation()).resolves.toBe(false)
+    await expect(reconcileAmbiguousRollMutation(7)).resolves.toBe(false)
+    await expect(reconcileAmbiguousRollMutation(7)).resolves.toBe(true)
+    await expect(reconcileAmbiguousRollMutation()).resolves.toBe(true)
+    expect(mockedBootstrap).toHaveBeenCalledTimes(5)
   })
 
-  expect(result.current.data).toBe(reconciled)
-  expect(result.current.data?.current_die).toBe(8)
-  expect(result.current.data?.pending_thread_id).toBeNull()
-  expect(result.current.isPending).toBe(false)
-  expect(result.current.isError).toBe(false)
-  expect(result.current.error).toBeNull()
+  it('does not publish when the browser CustomEvent API is unavailable', () => {
+    const reconciled = vi.fn()
+    window.addEventListener(ROLL_BOOTSTRAP_RECONCILED_EVENT, reconciled)
+    vi.stubGlobal('CustomEvent', undefined)
+
+    try {
+      publishRollBootstrap(bootstrapState(8, null))
+      expect(reconciled).not.toHaveBeenCalled()
+    } finally {
+      vi.unstubAllGlobals()
+      window.removeEventListener(ROLL_BOOTSTRAP_RECONCILED_EVENT, reconciled)
+    }
+  })
+
+  it('replaces mounted Roll bootstrap state when a mutation publishes reconciliation', async () => {
+    const initial = bootstrapState(6, 7)
+    const reconciled = bootstrapState(8, null)
+    mockedBootstrap.mockResolvedValue(initial)
+
+    const { result } = renderHook(() => useRollBootstrap(), {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <ToastProvider>{children}</ToastProvider>
+      ),
+    })
+
+    await waitFor(() => expect(result.current.data).toBe(initial))
+
+    act(() => {
+      window.dispatchEvent(new Event(ROLL_BOOTSTRAP_RECONCILED_EVENT))
+    })
+    expect(result.current.data).toBe(initial)
+
+    act(() => {
+      publishRollBootstrap(reconciled)
+    })
+
+    expect(result.current.data).toBe(reconciled)
+    expect(result.current.data?.current_die).toBe(8)
+    expect(result.current.data?.pending_thread_id).toBeNull()
+    expect(result.current.isPending).toBe(false)
+    expect(result.current.isError).toBe(false)
+    expect(result.current.error).toBeNull()
+  })
 })

--- a/frontend/src/unit/rollMutationReconciliation.test.tsx
+++ b/frontend/src/unit/rollMutationReconciliation.test.tsx
@@ -18,6 +18,9 @@ vi.mock('../services/rollBootstrapApi', () => ({
 }))
 
 const mockedBootstrap = vi.mocked(rollBootstrapApi.get)
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ToastProvider>{children}</ToastProvider>
+)
 
 const bootstrapState = (
   currentDie: RollBootstrapResponse['current_die'],
@@ -89,17 +92,12 @@ describe('Roll mutation reconciliation', () => {
     }
   })
 
-  it('replaces mounted Roll bootstrap state when a mutation publishes reconciliation', async () => {
+  it('replaces mounted state and reuses it for the caller immediate refetch', async () => {
     const initial = bootstrapState(6, 7)
     const reconciled = bootstrapState(8, null)
     mockedBootstrap.mockResolvedValue(initial)
 
-    const { result } = renderHook(() => useRollBootstrap(), {
-      wrapper: ({ children }: { children: React.ReactNode }) => (
-        <ToastProvider>{children}</ToastProvider>
-      ),
-    })
-
+    const { result } = renderHook(() => useRollBootstrap(), { wrapper })
     await waitFor(() => expect(result.current.data).toBe(initial))
 
     act(() => {
@@ -109,13 +107,65 @@ describe('Roll mutation reconciliation', () => {
 
     act(() => {
       publishRollBootstrap(reconciled)
+      publishRollBootstrap(reconciled)
     })
 
+    let reused: RollBootstrapResponse | undefined
+    await act(async () => {
+      reused = await result.current.refetch()
+    })
+
+    expect(reused).toBe(reconciled)
+    expect(mockedBootstrap).toHaveBeenCalledTimes(1)
     expect(result.current.data).toBe(reconciled)
     expect(result.current.data?.current_die).toBe(8)
     expect(result.current.data?.pending_thread_id).toBeNull()
     expect(result.current.isPending).toBe(false)
     expect(result.current.isError).toBe(false)
     expect(result.current.error).toBeNull()
+  })
+
+  it('expires reconciled reuse before a later independent refetch', async () => {
+    const initial = bootstrapState(6, 7)
+    const reconciled = bootstrapState(8, null)
+    const later = bootstrapState(10, 9)
+    mockedBootstrap.mockResolvedValueOnce(initial).mockResolvedValueOnce(later)
+
+    const { result } = renderHook(() => useRollBootstrap(), { wrapper })
+    await waitFor(() => expect(result.current.data).toBe(initial))
+
+    vi.useFakeTimers()
+    try {
+      act(() => {
+        publishRollBootstrap(reconciled)
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0)
+      })
+
+      let refreshed: RollBootstrapResponse | undefined
+      await act(async () => {
+        refreshed = await result.current.refetch()
+      })
+
+      expect(refreshed).toBe(later)
+      expect(mockedBootstrap).toHaveBeenCalledTimes(2)
+      expect(result.current.data).toBe(later)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('clears a pending reconciliation expiry when the hook unmounts', async () => {
+    const initial = bootstrapState(6, 7)
+    mockedBootstrap.mockResolvedValue(initial)
+
+    const { result, unmount } = renderHook(() => useRollBootstrap(), { wrapper })
+    await waitFor(() => expect(result.current.data).toBe(initial))
+
+    act(() => {
+      publishRollBootstrap(bootstrapState(8, null))
+    })
+    expect(() => unmount()).not.toThrow()
   })
 })

--- a/frontend/src/unit/rollMutationReconciliation.test.tsx
+++ b/frontend/src/unit/rollMutationReconciliation.test.tsx
@@ -1,0 +1,65 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, expect, it, vi } from 'vitest'
+import { ToastProvider } from '../contexts/ToastProvider'
+import { publishRollBootstrap } from '../hooks/rollMutationReconciliation'
+import { useRollBootstrap } from '../hooks/useRollBootstrap'
+import { rollBootstrapApi } from '../services/rollBootstrapApi'
+import type { RollBootstrapResponse } from '../types/rollBootstrap'
+
+vi.mock('../services/rollBootstrapApi', () => ({
+  rollBootstrapApi: {
+    get: vi.fn(),
+  },
+}))
+
+const mockedBootstrap = vi.mocked(rollBootstrapApi.get)
+
+const bootstrapState = (
+  currentDie: RollBootstrapResponse['current_die'],
+  pendingThreadId: number | null,
+): RollBootstrapResponse => ({
+  session_id: 1,
+  user_id: 1,
+  current_die: currentDie,
+  manual_die: null,
+  pending_thread_id: pendingThreadId,
+  last_rolled_result: pendingThreadId === null ? null : 1,
+  active_thread: null,
+  roll_pool: [],
+  snoozed_threads: [],
+  snoozed_count: 0,
+  blocked_count: 0,
+  blocked_threads: [],
+  stale_thread_count: 0,
+  stale_thread: null,
+})
+
+beforeEach(() => {
+  mockedBootstrap.mockReset()
+  localStorage.clear()
+})
+
+it('replaces mounted Roll bootstrap state when a mutation publishes reconciliation', async () => {
+  const initial = bootstrapState(6, 7)
+  const reconciled = bootstrapState(8, null)
+  mockedBootstrap.mockResolvedValue(initial)
+
+  const { result } = renderHook(() => useRollBootstrap(), {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <ToastProvider>{children}</ToastProvider>
+    ),
+  })
+
+  await waitFor(() => expect(result.current.data).toBe(initial))
+
+  act(() => {
+    publishRollBootstrap(reconciled)
+  })
+
+  expect(result.current.data).toBe(reconciled)
+  expect(result.current.data?.current_die).toBe(8)
+  expect(result.current.data?.pending_thread_id).toBeNull()
+  expect(result.current.isPending).toBe(false)
+  expect(result.current.isError).toBe(false)
+  expect(result.current.error).toBeNull()
+})

--- a/frontend/src/unit/useRate.test.tsx
+++ b/frontend/src/unit/useRate.test.tsx
@@ -33,7 +33,9 @@ beforeEach(() => {
     active_thread: null,
     roll_pool: [],
     blocked_threads: [],
+    blocked_count: 0,
     snoozed_threads: [],
+    snoozed_count: 0,
     stale_thread: null,
     stale_thread_count: 0,
   })
@@ -93,7 +95,9 @@ it('reconciles a timeout that committed and prevents a second rating request', a
     active_thread: null,
     roll_pool: [],
     blocked_threads: [],
+    blocked_count: 0,
     snoozed_threads: [],
+    snoozed_count: 0,
     stale_thread: null,
     stale_thread_count: 0,
   })

--- a/frontend/src/unit/useRate.test.tsx
+++ b/frontend/src/unit/useRate.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook } from '@testing-library/react'
 import { beforeEach, expect, it, vi } from 'vitest'
 import { useRate } from '../hooks/useRate'
+import { ROLL_BOOTSTRAP_RECONCILED_EVENT } from '../hooks/rollMutationReconciliation'
 import { rateApi } from '../services/api'
 import { rollBootstrapApi } from '../services/rollBootstrapApi'
 import type { RatePayload } from '../types'
@@ -20,36 +21,48 @@ vi.mock('../services/rollBootstrapApi', () => ({
 const mockedRateApi = vi.mocked(rateApi)
 const mockedRollBootstrapApi = vi.mocked(rollBootstrapApi)
 
+const bootstrapState = (pendingThreadId: number | null, currentDie = 8) => ({
+  session_id: 1,
+  user_id: 1,
+  current_die: currentDie,
+  manual_die: null,
+  pending_thread_id: pendingThreadId,
+  last_rolled_result: pendingThreadId === null ? null : 1,
+  active_thread: null,
+  roll_pool: [],
+  blocked_threads: [],
+  blocked_count: 0,
+  snoozed_threads: [],
+  snoozed_count: 0,
+  stale_thread: null,
+  stale_thread_count: 0,
+})
+
 beforeEach(() => {
   vi.clearAllMocks()
   mockedRateApi.rate.mockResolvedValue(undefined as never)
-  mockedRollBootstrapApi.get.mockResolvedValue({
-    session_id: 1,
-    user_id: 1,
-    current_die: 8,
-    manual_die: null,
-    pending_thread_id: 1,
-    last_rolled_result: 1,
-    active_thread: null,
-    roll_pool: [],
-    blocked_threads: [],
-    blocked_count: 0,
-    snoozed_threads: [],
-    snoozed_count: 0,
-    stale_thread: null,
-    stale_thread_count: 0,
-  })
+  mockedRollBootstrapApi.get.mockResolvedValue(bootstrapState(null))
 })
 
-it('submits ratings', async () => {
-  const { result } = renderHook(() => useRate())
-  const payload: RatePayload = { thread_id: 1, rating: 4 }
+it('submits ratings and publishes authoritative Roll state', async () => {
+  const reconciled = vi.fn()
+  window.addEventListener(ROLL_BOOTSTRAP_RECONCILED_EVENT, reconciled)
 
-  await act(async () => {
-    await result.current.mutate(payload)
-  })
+  try {
+    const { result } = renderHook(() => useRate())
+    const payload: RatePayload = { thread_id: 1, rating: 4 }
 
-  expect(mockedRateApi.rate).toHaveBeenCalledWith(payload)
+    await act(async () => {
+      await result.current.mutate(payload)
+    })
+
+    expect(mockedRateApi.rate).toHaveBeenCalledWith(payload)
+    expect(mockedRollBootstrapApi.get).toHaveBeenCalledTimes(1)
+    expect(reconciled).toHaveBeenCalledTimes(1)
+    expect(result.current.isError).toBe(false)
+  } finally {
+    window.removeEventListener(ROLL_BOOTSTRAP_RECONCILED_EVENT, reconciled)
+  }
 })
 
 it('shares one in-flight request across repeated submissions', async () => {
@@ -76,68 +89,72 @@ it('shares one in-flight request across repeated submissions', async () => {
     await Promise.all([firstRequest, secondRequest])
   })
 
+  expect(mockedRollBootstrapApi.get).toHaveBeenCalledTimes(1)
   expect(result.current.isPending).toBe(false)
   expect(result.current.isError).toBe(false)
 })
 
-it('reconciles a timeout that committed and prevents a second rating request', async () => {
+it('reconciles a committed rating after the delayed response crosses the client timeout', async () => {
+  vi.useFakeTimers()
   const timeout = Object.assign(new Error('timeout of 10000ms exceeded'), {
     code: 'ECONNABORTED',
   })
-  mockedRateApi.rate.mockRejectedValue(timeout)
-  mockedRollBootstrapApi.get.mockResolvedValue({
-    session_id: 1,
-    user_id: 1,
-    current_die: 10,
-    manual_die: null,
-    pending_thread_id: null,
-    last_rolled_result: null,
-    active_thread: null,
-    roll_pool: [],
-    blocked_threads: [],
-    blocked_count: 0,
-    snoozed_threads: [],
-    snoozed_count: 0,
-    stale_thread: null,
-    stale_thread_count: 0,
-  })
-  const reload = vi.fn()
-  vi.stubGlobal('location', { reload })
+  mockedRateApi.rate.mockImplementation(() => new Promise((_, reject) => {
+    setTimeout(() => reject(timeout), 10_000)
+  }))
+  mockedRollBootstrapApi.get.mockResolvedValue(bootstrapState(null, 10))
 
-  const { result } = renderHook(() => useRate())
-  const payload: RatePayload = { thread_id: 1, rating: 3 }
-  let firstRequest: Promise<unknown> | undefined
-  let secondRequest: Promise<unknown> | undefined
+  try {
+    const { result } = renderHook(() => useRate())
+    const payload: RatePayload = { thread_id: 1, rating: 3 }
+    let firstRequest: Promise<unknown> | undefined
+    let secondRequest: Promise<unknown> | undefined
 
-  await act(async () => {
-    firstRequest = result.current.mutate(payload)
-    secondRequest = result.current.mutate(payload)
-    await Promise.all([firstRequest, secondRequest])
-  })
+    act(() => {
+      firstRequest = result.current.mutate(payload)
+      secondRequest = result.current.mutate(payload)
+    })
 
-  expect(mockedRateApi.rate).toHaveBeenCalledTimes(1)
-  expect(mockedRollBootstrapApi.get).toHaveBeenCalledTimes(1)
-  expect(reload).toHaveBeenCalledTimes(1)
-  expect(result.current.isError).toBe(false)
-  expect(result.current.isPending).toBe(false)
+    expect(mockedRateApi.rate).toHaveBeenCalledTimes(1)
+    expect(result.current.isPending).toBe(true)
 
-  vi.unstubAllGlobals()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000)
+      await Promise.all([firstRequest, secondRequest])
+    })
+
+    expect(mockedRollBootstrapApi.get).toHaveBeenCalledTimes(1)
+    expect(result.current.isError).toBe(false)
+    expect(result.current.isPending).toBe(false)
+  } finally {
+    vi.useRealTimers()
+  }
 })
 
-it('surfaces a timeout when authoritative state still has the same pending thread', async () => {
+it('surfaces a delayed timeout when authoritative state still has the same pending thread', async () => {
+  vi.useFakeTimers()
   const timeout = Object.assign(new Error('timeout of 10000ms exceeded'), {
     code: 'ECONNABORTED',
   })
-  mockedRateApi.rate.mockRejectedValue(timeout)
+  mockedRateApi.rate.mockImplementation(() => new Promise((_, reject) => {
+    setTimeout(() => reject(timeout), 10_000)
+  }))
+  mockedRollBootstrapApi.get.mockResolvedValue(bootstrapState(1))
 
-  const { result } = renderHook(() => useRate())
-  const payload: RatePayload = { thread_id: 1, rating: 3 }
+  try {
+    const { result } = renderHook(() => useRate())
+    const payload: RatePayload = { thread_id: 1, rating: 3 }
+    const request = result.current.mutate(payload)
 
-  await act(async () => {
-    await expect(result.current.mutate(payload)).rejects.toBe(timeout)
-  })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000)
+      await expect(request).rejects.toBe(timeout)
+    })
 
-  expect(mockedRollBootstrapApi.get).toHaveBeenCalledTimes(1)
-  expect(result.current.isError).toBe(true)
-  expect(result.current.isPending).toBe(false)
+    expect(mockedRollBootstrapApi.get).toHaveBeenCalledTimes(1)
+    expect(result.current.isError).toBe(true)
+    expect(result.current.isPending).toBe(false)
+  } finally {
+    vi.useRealTimers()
+  }
 })

--- a/frontend/src/unit/useRate.test.tsx
+++ b/frontend/src/unit/useRate.test.tsx
@@ -148,15 +148,16 @@ it('surfaces a delayed timeout when authoritative state still has the same pendi
   try {
     const { result } = renderHook(() => useRate())
     const payload: RatePayload = { thread_id: 1, rating: 3 }
-    let request: Promise<unknown> | undefined
+    let request!: Promise<unknown>
 
     act(() => {
       request = result.current.mutate(payload)
     })
 
+    const rejection = expect(request).rejects.toBe(timeout)
     await act(async () => {
       await vi.advanceTimersByTimeAsync(10_000)
-      await expect(request).rejects.toBe(timeout)
+      await rejection
     })
 
     expect(mockedRollBootstrapApi.get).toHaveBeenCalledTimes(1)

--- a/frontend/src/unit/useRate.test.tsx
+++ b/frontend/src/unit/useRate.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react'
 import { beforeEach, expect, it, vi } from 'vitest'
 import { useRate } from '../hooks/useRate'
 import { rateApi } from '../services/api'
+import { rollBootstrapApi } from '../services/rollBootstrapApi'
 import type { RatePayload } from '../types'
 
 vi.mock('../services/api', () => ({
@@ -10,11 +11,32 @@ vi.mock('../services/api', () => ({
   },
 }))
 
+vi.mock('../services/rollBootstrapApi', () => ({
+  rollBootstrapApi: {
+    get: vi.fn(),
+  },
+}))
+
 const mockedRateApi = vi.mocked(rateApi)
+const mockedRollBootstrapApi = vi.mocked(rollBootstrapApi)
 
 beforeEach(() => {
   vi.clearAllMocks()
   mockedRateApi.rate.mockResolvedValue(undefined as never)
+  mockedRollBootstrapApi.get.mockResolvedValue({
+    session_id: 1,
+    user_id: 1,
+    current_die: 8,
+    manual_die: null,
+    pending_thread_id: 1,
+    last_rolled_result: 1,
+    active_thread: null,
+    roll_pool: [],
+    blocked_threads: [],
+    snoozed_threads: [],
+    stale_thread: null,
+    stale_thread_count: 0,
+  })
 })
 
 it('submits ratings', async () => {
@@ -54,4 +76,64 @@ it('shares one in-flight request across repeated submissions', async () => {
 
   expect(result.current.isPending).toBe(false)
   expect(result.current.isError).toBe(false)
+})
+
+it('reconciles a timeout that committed and prevents a second rating request', async () => {
+  const timeout = Object.assign(new Error('timeout of 10000ms exceeded'), {
+    code: 'ECONNABORTED',
+  })
+  mockedRateApi.rate.mockRejectedValue(timeout)
+  mockedRollBootstrapApi.get.mockResolvedValue({
+    session_id: 1,
+    user_id: 1,
+    current_die: 10,
+    manual_die: null,
+    pending_thread_id: null,
+    last_rolled_result: null,
+    active_thread: null,
+    roll_pool: [],
+    blocked_threads: [],
+    snoozed_threads: [],
+    stale_thread: null,
+    stale_thread_count: 0,
+  })
+  const reload = vi.fn()
+  vi.stubGlobal('location', { reload })
+
+  const { result } = renderHook(() => useRate())
+  const payload: RatePayload = { thread_id: 1, rating: 3 }
+  let firstRequest: Promise<unknown> | undefined
+  let secondRequest: Promise<unknown> | undefined
+
+  await act(async () => {
+    firstRequest = result.current.mutate(payload)
+    secondRequest = result.current.mutate(payload)
+    await Promise.all([firstRequest, secondRequest])
+  })
+
+  expect(mockedRateApi.rate).toHaveBeenCalledTimes(1)
+  expect(mockedRollBootstrapApi.get).toHaveBeenCalledTimes(1)
+  expect(reload).toHaveBeenCalledTimes(1)
+  expect(result.current.isError).toBe(false)
+  expect(result.current.isPending).toBe(false)
+
+  vi.unstubAllGlobals()
+})
+
+it('surfaces a timeout when authoritative state still has the same pending thread', async () => {
+  const timeout = Object.assign(new Error('timeout of 10000ms exceeded'), {
+    code: 'ECONNABORTED',
+  })
+  mockedRateApi.rate.mockRejectedValue(timeout)
+
+  const { result } = renderHook(() => useRate())
+  const payload: RatePayload = { thread_id: 1, rating: 3 }
+
+  await act(async () => {
+    await expect(result.current.mutate(payload)).rejects.toBe(timeout)
+  })
+
+  expect(mockedRollBootstrapApi.get).toHaveBeenCalledTimes(1)
+  expect(result.current.isError).toBe(true)
+  expect(result.current.isPending).toBe(false)
 })

--- a/frontend/src/unit/useRate.test.tsx
+++ b/frontend/src/unit/useRate.test.tsx
@@ -5,6 +5,7 @@ import { ROLL_BOOTSTRAP_RECONCILED_EVENT } from '../hooks/rollMutationReconcilia
 import { rateApi } from '../services/api'
 import { rollBootstrapApi } from '../services/rollBootstrapApi'
 import type { RatePayload } from '../types'
+import type { RollBootstrapResponse } from '../types/rollBootstrap'
 
 vi.mock('../services/api', () => ({
   rateApi: {
@@ -21,7 +22,10 @@ vi.mock('../services/rollBootstrapApi', () => ({
 const mockedRateApi = vi.mocked(rateApi)
 const mockedRollBootstrapApi = vi.mocked(rollBootstrapApi)
 
-const bootstrapState = (pendingThreadId: number | null, currentDie = 8) => ({
+const bootstrapState = (
+  pendingThreadId: number | null,
+  currentDie: RollBootstrapResponse['current_die'] = 8,
+): RollBootstrapResponse => ({
   session_id: 1,
   user_id: 1,
   current_die: currentDie,
@@ -144,7 +148,11 @@ it('surfaces a delayed timeout when authoritative state still has the same pendi
   try {
     const { result } = renderHook(() => useRate())
     const payload: RatePayload = { thread_id: 1, rating: 3 }
-    const request = result.current.mutate(payload)
+    let request: Promise<unknown> | undefined
+
+    act(() => {
+      request = result.current.mutate(payload)
+    })
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(10_000)

--- a/frontend/src/unit/useSnooze.test.tsx
+++ b/frontend/src/unit/useSnooze.test.tsx
@@ -22,7 +22,9 @@ const bootstrapState = (
   last_rolled_result: pendingThreadId === null ? null : 1,
   active_thread: null,
   roll_pool: [],
-  snoozed_threads: pendingThreadId === null ? [{ id: 7, title: 'Doom Patrol' }] : [],
+  snoozed_threads: pendingThreadId === null
+    ? [{ id: 7, title: 'Doom Patrol', format: 'series' }]
+    : [],
   snoozed_count: pendingThreadId === null ? 1 : 0,
   blocked_count: 0,
   blocked_threads: [],
@@ -99,7 +101,11 @@ describe('snooze hooks', () => {
 
     try {
       const snooze = renderHook(() => useSnooze())
-      const request = snooze.result.current.mutate(7)
+      let request: Promise<unknown> | undefined
+
+      act(() => {
+        request = snooze.result.current.mutate(7)
+      })
 
       await act(async () => {
         await vi.advanceTimersByTimeAsync(10_000)
@@ -127,7 +133,11 @@ describe('snooze hooks', () => {
 
     try {
       const snooze = renderHook(() => useSnooze())
-      const request = snooze.result.current.mutate(7)
+      let request: Promise<unknown> | undefined
+
+      act(() => {
+        request = snooze.result.current.mutate(7)
+      })
 
       await act(async () => {
         await vi.advanceTimersByTimeAsync(10_000)

--- a/frontend/src/unit/useSnooze.test.tsx
+++ b/frontend/src/unit/useSnooze.test.tsx
@@ -1,32 +1,151 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSnooze, useUnsnooze } from '../hooks/useSnooze'
+import { ROLL_BOOTSTRAP_RECONCILED_EVENT } from '../hooks/rollMutationReconciliation'
+import type { RollBootstrapResponse } from '../types/rollBootstrap'
 
 const snoozeApi = vi.hoisted(() => ({ snooze: vi.fn(), unsnooze: vi.fn() }))
-vi.mock('../services/api', () => ({ snoozeApi }))
+const rollBootstrapApi = vi.hoisted(() => ({ get: vi.fn() }))
 
-import { useSnooze, useUnsnooze } from '../hooks/useSnooze'
+vi.mock('../services/api', () => ({ snoozeApi }))
+vi.mock('../services/rollBootstrapApi', () => ({ rollBootstrapApi }))
+
+const bootstrapState = (
+  pendingThreadId: number | null,
+  currentDie = 12,
+): RollBootstrapResponse => ({
+  session_id: 1,
+  user_id: 1,
+  current_die: currentDie as RollBootstrapResponse['current_die'],
+  manual_die: null,
+  pending_thread_id: pendingThreadId,
+  last_rolled_result: pendingThreadId === null ? null : 1,
+  active_thread: null,
+  roll_pool: [],
+  snoozed_threads: pendingThreadId === null ? [{ id: 7, title: 'Doom Patrol' }] : [],
+  snoozed_count: pendingThreadId === null ? 1 : 0,
+  blocked_count: 0,
+  blocked_threads: [],
+  stale_thread_count: 0,
+  stale_thread: null,
+})
 
 describe('snooze hooks', () => {
   beforeEach(() => {
-    snoozeApi.snooze.mockReset()
-    snoozeApi.unsnooze.mockReset()
-  })
-
-  it('snoozes and unsnoozes successfully', async () => {
+    vi.clearAllMocks()
     snoozeApi.snooze.mockResolvedValue(undefined)
     snoozeApi.unsnooze.mockResolvedValue(undefined)
-    const snooze = renderHook(() => useSnooze())
-    await act(async () => await snooze.result.current.mutate())
-    expect(snooze.result.current.isError).toBe(false)
-    const unsnooze = renderHook(() => useUnsnooze())
-    await act(async () => await unsnooze.result.current.mutate(7))
-    expect(snoozeApi.unsnooze).toHaveBeenCalledWith(7)
+    rollBootstrapApi.get.mockResolvedValue(bootstrapState(null))
   })
 
-  it('tracks and rethrows failures', async () => {
+  it('snoozes, publishes authoritative Roll state, and unsnoozes successfully', async () => {
+    const reconciled = vi.fn()
+    window.addEventListener(ROLL_BOOTSTRAP_RECONCILED_EVENT, reconciled)
+
+    try {
+      const snooze = renderHook(() => useSnooze())
+      await act(async () => await snooze.result.current.mutate(7))
+
+      expect(snoozeApi.snooze).toHaveBeenCalledTimes(1)
+      expect(rollBootstrapApi.get).toHaveBeenCalledTimes(1)
+      expect(reconciled).toHaveBeenCalledTimes(1)
+      expect(snooze.result.current.isError).toBe(false)
+
+      const unsnooze = renderHook(() => useUnsnooze())
+      await act(async () => await unsnooze.result.current.mutate(7))
+      expect(snoozeApi.unsnooze).toHaveBeenCalledWith(7)
+    } finally {
+      window.removeEventListener(ROLL_BOOTSTRAP_RECONCILED_EVENT, reconciled)
+    }
+  })
+
+  it('shares one in-flight snooze request across repeated submissions', async () => {
+    let resolveRequest: (() => void) | undefined
+    snoozeApi.snooze.mockReturnValue(new Promise((resolve) => {
+      resolveRequest = () => resolve(undefined)
+    }))
+
+    const snooze = renderHook(() => useSnooze())
+    let firstRequest: Promise<unknown> | undefined
+    let secondRequest: Promise<unknown> | undefined
+
+    act(() => {
+      firstRequest = snooze.result.current.mutate(7)
+      secondRequest = snooze.result.current.mutate(7)
+    })
+
+    expect(snoozeApi.snooze).toHaveBeenCalledTimes(1)
+    expect(snooze.result.current.isPending).toBe(true)
+
+    await act(async () => {
+      resolveRequest?.()
+      await Promise.all([firstRequest, secondRequest])
+    })
+
+    expect(rollBootstrapApi.get).toHaveBeenCalledTimes(1)
+    expect(snooze.result.current.isPending).toBe(false)
+    expect(snooze.result.current.isError).toBe(false)
+  })
+
+  it('reconciles a committed snooze after the delayed response crosses the client timeout', async () => {
+    vi.useFakeTimers()
+    const timeout = Object.assign(new Error('timeout of 10000ms exceeded'), {
+      code: 'ECONNABORTED',
+    })
+    snoozeApi.snooze.mockImplementation(() => new Promise((_, reject) => {
+      setTimeout(() => reject(timeout), 10_000)
+    }))
+    rollBootstrapApi.get.mockResolvedValue(bootstrapState(null, 20))
+
+    try {
+      const snooze = renderHook(() => useSnooze())
+      const request = snooze.result.current.mutate(7)
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000)
+        await request
+      })
+
+      expect(snoozeApi.snooze).toHaveBeenCalledTimes(1)
+      expect(rollBootstrapApi.get).toHaveBeenCalledTimes(1)
+      expect(snooze.result.current.isError).toBe(false)
+      expect(snooze.result.current.isPending).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('surfaces a delayed timeout when the same thread is still pending', async () => {
+    vi.useFakeTimers()
+    const timeout = Object.assign(new Error('timeout of 10000ms exceeded'), {
+      code: 'ECONNABORTED',
+    })
+    snoozeApi.snooze.mockImplementation(() => new Promise((_, reject) => {
+      setTimeout(() => reject(timeout), 10_000)
+    }))
+    rollBootstrapApi.get.mockResolvedValue(bootstrapState(7, 10))
+
+    try {
+      const snooze = renderHook(() => useSnooze())
+      const request = snooze.result.current.mutate(7)
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000)
+        await expect(request).rejects.toBe(timeout)
+      })
+
+      expect(rollBootstrapApi.get).toHaveBeenCalledTimes(1)
+      expect(snooze.result.current.isError).toBe(true)
+      expect(snooze.result.current.isPending).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('tracks and rethrows ordinary failures', async () => {
     snoozeApi.snooze.mockRejectedValueOnce(new Error('snooze failed'))
     const snooze = renderHook(() => useSnooze())
-    await act(async () => await expect(snooze.result.current.mutate()).rejects.toThrow('snooze failed'))
+    await act(async () => await expect(snooze.result.current.mutate(7)).rejects.toThrow('snooze failed'))
     await waitFor(() => expect(snooze.result.current.isError).toBe(true))
 
     snoozeApi.unsnooze.mockRejectedValueOnce(new Error('unsnooze failed'))

--- a/frontend/src/unit/useSnooze.test.tsx
+++ b/frontend/src/unit/useSnooze.test.tsx
@@ -133,15 +133,16 @@ describe('snooze hooks', () => {
 
     try {
       const snooze = renderHook(() => useSnooze())
-      let request: Promise<unknown> | undefined
+      let request!: Promise<unknown>
 
       act(() => {
         request = snooze.result.current.mutate(7)
       })
 
+      const rejection = expect(request).rejects.toBe(timeout)
       await act(async () => {
         await vi.advanceTimersByTimeAsync(10_000)
-        await expect(request).rejects.toBe(timeout)
+        await rejection
       })
 
       expect(rollBootstrapApi.get).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## Summary

Fixes the shared Roll mutation failure mode reproduced in production for both **rating** and **snoozing**: the backend commits successfully, but response-tail or scale-to-zero latency crosses the frontend's 10-second timeout and leaves the UI showing obsolete state.

Addresses #779, #780, #781, #782, and #783.

## Implemented

- adds one shared Roll mutation reconciliation module for timeout/network classification, authoritative bootstrap fetching, and state publication;
- makes successful ratings fetch and publish authoritative Roll state before returning, fixing stale die/pool rendering even when no timeout occurs;
- reconciles ambiguous rating timeouts against the submitted pending thread and treats a changed/cleared pending thread as committed;
- applies the same successful-write and ambiguous-timeout behavior to snooze;
- deduplicates repeated in-flight snooze submissions, matching the rating safety contract;
- lets the mounted `useRollBootstrap` instance consume reconciled state immediately, without a full-page reload;
- preserves genuine failure behavior when authoritative state still contains the same pending thread or reconciliation cannot prove the write committed.

## Deterministic production-latency tests

The tests do not add slow real sleeps to CI. Fake timers model the production sequence at the real 10-second boundary:

1. submit rating or snooze;
2. hold the mocked response;
3. advance the fake clock to the Axios timeout;
4. return authoritative state showing either a committed mutation or a genuinely pending mutation;
5. assert committed writes recover without an error or duplicate request;
6. assert genuine failures remain visible;
7. assert reconciled bootstrap state replaces the mounted Roll state, including the new die and cleared pending thread.

## Production evidence

Neon session `2208` showed:

- rating event `7386` committed `d8 -> d10` about 10 seconds before the browser surfaced its timeout;
- snooze event `7388` committed `d10 -> d12`;
- snooze event `7390` committed `d12 -> d20`;
- subsequent rolls used the advanced dice correctly;
- the flaky behavior was stale client state after successful commits, not incorrect persistence.

## Verification

Exact-head CI is the validation boundary for this connector-authored branch. No merge or auto-merge is authorized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of rating and snooze operations through automatic state reconciliation after mutations are committed
  * Enhanced handling of ambiguous network failures with intelligent recovery and reconciliation mechanisms
  * Better error detection ensures failures are properly surfaced to users when appropriate while suppressing transient issues

* **Tests**
  * Expanded test coverage for mutation reconciliation scenarios and timeout handling outcomes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->