### PR TITLE
feat(clone): remap retained export graph for local restore (#643)

### DIFF
--- a/scripts/remap_clone_restore.py
+++ b/scripts/remap_clone_restore.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Remap a validated production clone export for safe local insertion."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping
+from copy import deepcopy
+from dataclasses import asdict
+from pathlib import Path
+from typing import Final
+
+from scripts.plan_clone_restore import RestorePlan, RestorePlanError, build_restore_plan
+
+REFERENCE_FIELDS: Final[dict[str, dict[str, str]]] = {
+    "issues": {"thread_id": "threads"},
+    "dependencies": {
+        "thread_id": "threads",
+        "depends_on_thread_id": "threads",
+        "issue_id": "issues",
+        "depends_on_issue_id": "issues",
+    },
+    "reading_order_items": {
+        "reading_order_id": "reading_orders",
+        "thread_id": "threads",
+        "issue_id": "issues",
+    },
+    "events": {
+        "session_id": "sessions",
+        "thread_id": "threads",
+        "selected_thread_id": "threads",
+        "acted_on_thread_id": "threads",
+        "issue_id": "issues",
+    },
+    "snapshots": {
+        "session_id": "sessions",
+        "event_id": "events",
+    },
+}
+USER_OWNED_TABLES: Final = {"threads", "reading_orders", "sessions"}
+
+
+class RestoreRemapError(RestorePlanError):
+    """Raised when an export cannot be remapped without losing references."""
+
+
+def _plan_maps(plan: RestorePlan) -> dict[str, dict[int, int]]:
+    return {table.table: table.id_map for table in plan.tables}
+
+
+def _remap_reference(
+    value: object,
+    *,
+    table: str,
+    field: str,
+    target_table: str,
+    id_maps: Mapping[str, Mapping[int, int]],
+) -> object:
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise RestoreRemapError(f"{table}.{field} must be an integer or null")
+    try:
+        return id_maps[target_table][value]
+    except KeyError as exc:
+        raise RestoreRemapError(
+            f"{table}.{field} references missing {target_table} id {value}"
+        ) from exc
+
+
+def _remap_thread_state_keys(
+    value: object,
+    *,
+    id_maps: Mapping[str, Mapping[int, int]],
+) -> object:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise RestoreRemapError("snapshots.thread_states must be an object or null")
+
+    remapped: dict[str, object] = {}
+    metadata_keys = {"_snapshot_version", "_queue_changes", "_blocked_changes"}
+    for key, nested in value.items():
+        if key in metadata_keys:
+            if key in {"_queue_changes", "_blocked_changes"} and nested is not None:
+                if not isinstance(nested, dict):
+                    raise RestoreRemapError(f"snapshots.thread_states.{key} must be an object")
+                remapped[key] = {
+                    str(_remap_reference(
+                        int(thread_id),
+                        table="snapshots.thread_states",
+                        field=key,
+                        target_table="threads",
+                        id_maps=id_maps,
+                    )): state
+                    for thread_id, state in nested.items()
+                }
+            else:
+                remapped[key] = nested
+            continue
+
+        try:
+            source_thread_id = int(key)
+        except (TypeError, ValueError) as exc:
+            raise RestoreRemapError(
+                f"snapshots.thread_states contains unsupported key {key!r}"
+            ) from exc
+        local_thread_id = _remap_reference(
+            source_thread_id,
+            table="snapshots.thread_states",
+            field="thread_id",
+            target_table="threads",
+            id_maps=id_maps,
+        )
+        remapped[str(local_thread_id)] = nested
+    return remapped
+
+
+def remap_export(
+    document: Mapping[str, object],
+    *,
+    plan: RestorePlan,
+) -> dict[str, object]:
+    """Return a deep-copied export with local IDs and references applied."""
+    id_maps = _plan_maps(plan)
+    remapped = deepcopy(dict(document))
+    source_user = remapped.get("user")
+    if not isinstance(source_user, dict):
+        raise RestoreRemapError("user must be an object")
+    source_user["id"] = plan.local_user_id
+
+    for table_plan in plan.tables:
+        table = table_plan.table
+        rows = remapped.get(table)
+        if not isinstance(rows, list):
+            raise RestoreRemapError(f"{table} must be a list")
+
+        for index, row in enumerate(rows):
+            if not isinstance(row, dict):
+                raise RestoreRemapError(f"{table}[{index}] must be an object")
+            source_id = row.get("id")
+            if not isinstance(source_id, int) or isinstance(source_id, bool):
+                raise RestoreRemapError(f"{table}[{index}].id must be an integer")
+            try:
+                row["id"] = id_maps[table][source_id]
+            except KeyError as exc:
+                raise RestoreRemapError(
+                    f"restore plan has no mapping for {table} id {source_id}"
+                ) from exc
+
+            if table in USER_OWNED_TABLES:
+                row["user_id"] = plan.local_user_id
+
+            for field, target_table in REFERENCE_FIELDS.get(table, {}).items():
+                if field in row:
+                    row[field] = _remap_reference(
+                        row[field],
+                        table=table,
+                        field=field,
+                        target_table=target_table,
+                        id_maps=id_maps,
+                    )
+
+            if table == "sessions":
+                if "pending_thread_id" in row:
+                    row["pending_thread_id"] = _remap_reference(
+                        row["pending_thread_id"],
+                        table=table,
+                        field="pending_thread_id",
+                        target_table="threads",
+                        id_maps=id_maps,
+                    )
+                snoozed = row.get("snoozed_thread_ids")
+                if snoozed is not None:
+                    if not isinstance(snoozed, list):
+                        raise RestoreRemapError(
+                            "sessions.snoozed_thread_ids must be a list or null"
+                        )
+                    row["snoozed_thread_ids"] = [
+                        _remap_reference(
+                            thread_id,
+                            table=table,
+                            field="snoozed_thread_ids",
+                            target_table="threads",
+                            id_maps=id_maps,
+                        )
+                        for thread_id in snoozed
+                    ]
+
+            if table == "snapshots":
+                row["thread_states"] = _remap_thread_state_keys(
+                    row.get("thread_states"), id_maps=id_maps
+                )
+                session_state = row.get("session_state")
+                if isinstance(session_state, dict):
+                    pending = session_state.get("pending_thread_id")
+                    if pending is not None:
+                        session_state["pending_thread_id"] = _remap_reference(
+                            pending,
+                            table="snapshots.session_state",
+                            field="pending_thread_id",
+                            target_table="threads",
+                            id_maps=id_maps,
+                        )
+                    snoozed = session_state.get("snoozed_thread_ids")
+                    if snoozed is not None:
+                        if not isinstance(snoozed, list):
+                            raise RestoreRemapError(
+                                "snapshots.session_state.snoozed_thread_ids must be a list"
+                            )
+                        session_state["snoozed_thread_ids"] = [
+                            _remap_reference(
+                                thread_id,
+                                table="snapshots.session_state",
+                                field="snoozed_thread_ids",
+                                target_table="threads",
+                                id_maps=id_maps,
+                            )
+                            for thread_id in snoozed
+                        ]
+
+    remapped["restore_plan"] = asdict(plan)
+    return remapped
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("file", type=Path)
+    parser.add_argument("--local-user-id", required=True, type=int)
+    parser.add_argument("--next-ids", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+
+    try:
+        document = json.loads(args.file.read_text(encoding="utf-8"))
+        next_ids = json.loads(args.next_ids.read_text(encoding="utf-8"))
+        if not isinstance(document, dict):
+            raise RestoreRemapError("export root must be an object")
+        if not isinstance(next_ids, dict):
+            raise RestoreRemapError("next IDs root must be an object")
+        plan = build_restore_plan(
+            document,
+            local_user_id=args.local_user_id,
+            next_ids=next_ids,
+        )
+        output = remap_export(document, plan=plan)
+        args.output.write_text(
+            json.dumps(output, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    except (OSError, json.JSONDecodeError, RestorePlanError) as exc:
+        parser.exit(1, f"INVALID: {exc}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/remap_clone_restore.py
+++ b/scripts/remap_clone_restore.py
@@ -87,13 +87,15 @@ def _remap_thread_state_keys(
                 if not isinstance(nested, dict):
                     raise RestoreRemapError(f"snapshots.thread_states.{key} must be an object")
                 remapped[key] = {
-                    str(_remap_reference(
-                        int(thread_id),
-                        table="snapshots.thread_states",
-                        field=key,
-                        target_table="threads",
-                        id_maps=id_maps,
-                    )): state
+                    str(
+                        _remap_reference(
+                            int(thread_id),
+                            table="snapshots.thread_states",
+                            field=key,
+                            target_table="threads",
+                            id_maps=id_maps,
+                        )
+                    ): state
                     for thread_id, state in nested.items()
                 }
             else:
@@ -225,6 +227,7 @@ def remap_export(
 
 
 def main() -> int:
+    """Remap a clone-export document and write the local insertion artifact."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("file", type=Path)
     parser.add_argument("--local-user-id", required=True, type=int)

--- a/tests/test_remap_clone_restore.py
+++ b/tests/test_remap_clone_restore.py
@@ -1,14 +1,20 @@
+"""Regression coverage for deterministic retained-export remapping."""
+
 from __future__ import annotations
 
 from copy import deepcopy
+from typing import cast
 
 import pytest
 
 from scripts.plan_clone_restore import TABLE_ORDER, build_restore_plan
 from scripts.remap_clone_restore import RestoreRemapError, remap_export
 
+JsonObject = dict[str, object]
+JsonRows = list[JsonObject]
 
-def sample_document() -> dict[str, object]:
+
+def _sample_document() -> JsonObject:
     return {
         "source_username": "source-user",
         "user": {"id": 7, "username": "source-user"},
@@ -22,81 +28,116 @@ def sample_document() -> dict[str, object]:
         ],
         "dependencies": [{"id": 301, "thread_id": 20, "depends_on_thread_id": 10}],
         "reading_orders": [{"id": 401, "user_id": 7, "name": "Order"}],
-        "reading_order_items": [{"id": 501, "reading_order_id": 401, "thread_id": 20, "issue_id": 102}],
-        "sessions": [{"id": 601, "user_id": 7, "pending_thread_id": 20, "snoozed_thread_ids": [10]}],
-        "events": [{"id": 701, "session_id": 601, "thread_id": 20, "selected_thread_id": 10, "issue_id": 102}],
-        "snapshots": [{
-            "id": 801,
-            "session_id": 601,
-            "event_id": 701,
-            "thread_states": {"10": {"title": "First"}, "_queue_changes": {"20": 2}},
-            "session_state": {"pending_thread_id": 20, "snoozed_thread_ids": [10]},
-        }],
+        "reading_order_items": [
+            {"id": 501, "reading_order_id": 401, "thread_id": 20, "issue_id": 102}
+        ],
+        "sessions": [
+            {
+                "id": 601,
+                "user_id": 7,
+                "pending_thread_id": 20,
+                "snoozed_thread_ids": [10],
+            }
+        ],
+        "events": [
+            {
+                "id": 701,
+                "session_id": 601,
+                "thread_id": 20,
+                "selected_thread_id": 10,
+                "issue_id": 102,
+            }
+        ],
+        "snapshots": [
+            {
+                "id": 801,
+                "session_id": 601,
+                "event_id": 701,
+                "thread_states": {"10": {"title": "First"}, "_queue_changes": {"20": 2}},
+                "session_state": {"pending_thread_id": 20, "snoozed_thread_ids": [10]},
+            }
+        ],
     }
 
 
-def next_ids() -> dict[str, int]:
+def _next_ids() -> dict[str, int]:
     return {table: (index + 1) * 1000 for index, table in enumerate(TABLE_ORDER)}
 
 
+def _object(document: JsonObject, key: str) -> JsonObject:
+    value = document[key]
+    assert isinstance(value, dict)
+    return cast(JsonObject, value)
+
+
+def _rows(document: JsonObject, key: str) -> JsonRows:
+    value = document[key]
+    assert isinstance(value, list)
+    assert all(isinstance(row, dict) for row in value)
+    return cast(JsonRows, value)
+
+
 def test_remap_export_rewrites_graph_without_mutating_input() -> None:
-    document = sample_document()
+    """Remap every retained relationship while preserving source evidence."""
+    document = _sample_document()
     original = deepcopy(document)
-    plan = build_restore_plan(document, local_user_id=42, next_ids=next_ids())
+    plan = build_restore_plan(document, local_user_id=42, next_ids=_next_ids())
 
     result = remap_export(document, plan=plan)
 
     assert document == original
-    assert result["user"]["id"] == 42
-    assert [row["id"] for row in result["threads"]] == [1001, 1000]
-    assert {row["user_id"] for row in result["threads"]} == {42}
-    assert result["issues"] == [
+    assert _object(result, "user")["id"] == 42
+    assert [row["id"] for row in _rows(result, "threads")] == [1001, 1000]
+    assert {row["user_id"] for row in _rows(result, "threads")} == {42}
+    assert _rows(result, "issues") == [
         {"id": 2000, "thread_id": 1000, "issue_number": "1"},
         {"id": 2001, "thread_id": 1001, "issue_number": "2"},
     ]
-    assert result["dependencies"][0]["thread_id"] == 1001
-    assert result["dependencies"][0]["depends_on_thread_id"] == 1000
-    assert result["reading_orders"][0]["user_id"] == 42
-    assert result["reading_order_items"][0] == {
+    assert _rows(result, "dependencies")[0]["thread_id"] == 1001
+    assert _rows(result, "dependencies")[0]["depends_on_thread_id"] == 1000
+    assert _rows(result, "reading_orders")[0]["user_id"] == 42
+    assert _rows(result, "reading_order_items")[0] == {
         "id": 5000,
         "reading_order_id": 4000,
         "thread_id": 1001,
         "issue_id": 2001,
     }
-    assert result["sessions"][0]["pending_thread_id"] == 1001
-    assert result["sessions"][0]["snoozed_thread_ids"] == [1000]
-    assert result["events"][0]["session_id"] == 6000
-    assert result["events"][0]["selected_thread_id"] == 1000
-    assert result["snapshots"][0]["thread_states"] == {
+    assert _rows(result, "sessions")[0]["pending_thread_id"] == 1001
+    assert _rows(result, "sessions")[0]["snoozed_thread_ids"] == [1000]
+    assert _rows(result, "events")[0]["session_id"] == 6000
+    assert _rows(result, "events")[0]["selected_thread_id"] == 1000
+    assert _rows(result, "snapshots")[0]["thread_states"] == {
         "1000": {"title": "First"},
         "_queue_changes": {"1001": 2},
     }
-    assert result["snapshots"][0]["session_state"] == {
+    assert _rows(result, "snapshots")[0]["session_state"] == {
         "pending_thread_id": 1001,
         "snoozed_thread_ids": [1000],
     }
 
 
 def test_remap_export_preserves_nullable_references() -> None:
-    document = sample_document()
-    document["sessions"][0]["pending_thread_id"] = None
-    document["sessions"][0]["snoozed_thread_ids"] = None
-    document["events"][0]["thread_id"] = None
-    document["snapshots"][0]["thread_states"] = None
-    plan = build_restore_plan(document, local_user_id=42, next_ids=next_ids())
+    """Keep nullable references null instead of manufacturing local IDs."""
+    document = _sample_document()
+    _rows(document, "sessions")[0]["pending_thread_id"] = None
+    _rows(document, "sessions")[0]["snoozed_thread_ids"] = None
+    _rows(document, "events")[0]["thread_id"] = None
+    _rows(document, "snapshots")[0]["thread_states"] = None
+    plan = build_restore_plan(document, local_user_id=42, next_ids=_next_ids())
 
     result = remap_export(document, plan=plan)
 
-    assert result["sessions"][0]["pending_thread_id"] is None
-    assert result["sessions"][0]["snoozed_thread_ids"] is None
-    assert result["events"][0]["thread_id"] is None
-    assert result["snapshots"][0]["thread_states"] is None
+    assert _rows(result, "sessions")[0]["pending_thread_id"] is None
+    assert _rows(result, "sessions")[0]["snoozed_thread_ids"] is None
+    assert _rows(result, "events")[0]["thread_id"] is None
+    assert _rows(result, "snapshots")[0]["thread_states"] is None
 
 
 def test_remap_export_fails_closed_for_missing_reference() -> None:
-    document = sample_document()
-    document["events"][0]["selected_thread_id"] = 999
-    plan = build_restore_plan(document, local_user_id=42, next_ids=next_ids())
+    """Reject retained rows whose foreign keys are absent from the plan."""
+    document = _sample_document()
+    _rows(document, "events")[0]["selected_thread_id"] = 999
+    plan = build_restore_plan(document, local_user_id=42, next_ids=_next_ids())
 
     with pytest.raises(RestoreRemapError, match="missing threads id 999"):
         remap_export(document, plan=plan)

--- a/tests/test_remap_clone_restore.py
+++ b/tests/test_remap_clone_restore.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from scripts.plan_clone_restore import TABLE_ORDER, build_restore_plan
+from scripts.remap_clone_restore import RestoreRemapError, remap_export
+
+
+def sample_document() -> dict[str, object]:
+    return {
+        "source_username": "source-user",
+        "user": {"id": 7, "username": "source-user"},
+        "threads": [
+            {"id": 20, "user_id": 7, "title": "Second"},
+            {"id": 10, "user_id": 7, "title": "First"},
+        ],
+        "issues": [
+            {"id": 101, "thread_id": 10, "issue_number": "1"},
+            {"id": 102, "thread_id": 20, "issue_number": "2"},
+        ],
+        "dependencies": [{"id": 301, "thread_id": 20, "depends_on_thread_id": 10}],
+        "reading_orders": [{"id": 401, "user_id": 7, "name": "Order"}],
+        "reading_order_items": [{"id": 501, "reading_order_id": 401, "thread_id": 20, "issue_id": 102}],
+        "sessions": [{"id": 601, "user_id": 7, "pending_thread_id": 20, "snoozed_thread_ids": [10]}],
+        "events": [{"id": 701, "session_id": 601, "thread_id": 20, "selected_thread_id": 10, "issue_id": 102}],
+        "snapshots": [{
+            "id": 801,
+            "session_id": 601,
+            "event_id": 701,
+            "thread_states": {"10": {"title": "First"}, "_queue_changes": {"20": 2}},
+            "session_state": {"pending_thread_id": 20, "snoozed_thread_ids": [10]},
+        }],
+    }
+
+
+def next_ids() -> dict[str, int]:
+    return {table: (index + 1) * 1000 for index, table in enumerate(TABLE_ORDER)}
+
+
+def test_remap_export_rewrites_graph_without_mutating_input() -> None:
+    document = sample_document()
+    original = deepcopy(document)
+    plan = build_restore_plan(document, local_user_id=42, next_ids=next_ids())
+
+    result = remap_export(document, plan=plan)
+
+    assert document == original
+    assert result["user"]["id"] == 42
+    assert [row["id"] for row in result["threads"]] == [1001, 1000]
+    assert {row["user_id"] for row in result["threads"]} == {42}
+    assert result["issues"] == [
+        {"id": 2000, "thread_id": 1000, "issue_number": "1"},
+        {"id": 2001, "thread_id": 1001, "issue_number": "2"},
+    ]
+    assert result["dependencies"][0]["thread_id"] == 1001
+    assert result["dependencies"][0]["depends_on_thread_id"] == 1000
+    assert result["reading_orders"][0]["user_id"] == 42
+    assert result["reading_order_items"][0] == {
+        "id": 5000,
+        "reading_order_id": 4000,
+        "thread_id": 1001,
+        "issue_id": 2001,
+    }
+    assert result["sessions"][0]["pending_thread_id"] == 1001
+    assert result["sessions"][0]["snoozed_thread_ids"] == [1000]
+    assert result["events"][0]["session_id"] == 6000
+    assert result["events"][0]["selected_thread_id"] == 1000
+    assert result["snapshots"][0]["thread_states"] == {
+        "1000": {"title": "First"},
+        "_queue_changes": {"1001": 2},
+    }
+    assert result["snapshots"][0]["session_state"] == {
+        "pending_thread_id": 1001,
+        "snoozed_thread_ids": [1000],
+    }
+
+
+def test_remap_export_preserves_nullable_references() -> None:
+    document = sample_document()
+    document["sessions"][0]["pending_thread_id"] = None
+    document["sessions"][0]["snoozed_thread_ids"] = None
+    document["events"][0]["thread_id"] = None
+    document["snapshots"][0]["thread_states"] = None
+    plan = build_restore_plan(document, local_user_id=42, next_ids=next_ids())
+
+    result = remap_export(document, plan=plan)
+
+    assert result["sessions"][0]["pending_thread_id"] is None
+    assert result["sessions"][0]["snoozed_thread_ids"] is None
+    assert result["events"][0]["thread_id"] is None
+    assert result["snapshots"][0]["thread_states"] is None
+
+
+def test_remap_export_fails_closed_for_missing_reference() -> None:
+    document = sample_document()
+    document["events"][0]["selected_thread_id"] = 999
+    plan = build_restore_plan(document, local_user_id=42, next_ids=next_ids())
+
+    with pytest.raises(RestoreRemapError, match="missing threads id 999"):
+        remap_export(document, plan=plan)


### PR DESCRIPTION
## Summary

Adds the next coherent production-to-local clone stage after the merged dry-run planner: transform a validated retained-data export into a local-insertion document using the planner's deterministic ID maps.

## Implemented

- deep-copies the export rather than mutating source evidence;
- remaps IDs for every retained table in dependency-safe order;
- rewrites ownership to the selected local user;
- rewrites thread, issue, reading-order, session, event, and snapshot references;
- rewrites snoozed and pending thread references in sessions and snapshot session state;
- rewrites thread-keyed snapshot delta metadata;
- fails closed when a reference is absent from the validated restore plan;
- embeds the exact restore plan in the generated artifact for auditability;
- exposes a CLI that writes the remapped JSON document without touching a database;
- adds focused regression coverage for full-graph remapping, nullable references, immutability, and missing-reference rejection.

## Stage scope

This is a substantive import-preparation stage of #643. Transactional database insertion, backup-before-restore, sequence advancement, rollback verification, and full round-trip tests remain open.

## Verification

Exact-head CI is the validation boundary for this connector-authored branch. No merge or auto-merge is authorized.

Model: chatgpt-factory-5