### PR TITLE
Adopt shared overlay lifecycle for Queue position menu (#625)

### DIFF
--- a/frontend/src/components/PositionMenu.tsx
+++ b/frontend/src/components/PositionMenu.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { createPortal } from 'react-dom'
 import type { Thread } from '../types'
 import { usePositionMenu } from '../contexts/usePositionMenu'
+import OverlayPortal from './OverlayPortal'
 
 interface PositionMenuProps {
   thread: Thread
@@ -236,37 +236,38 @@ export default function PositionMenu({ thread, onMoveToFront, onReposition, onMo
       >
         &#x22EE;
       </button>
-      {isOpen && menuPosition && createPortal(
-        <div
-          ref={menuRef}
-          className="fixed w-52 bg-[#1a1410]/95 border border-white/10 rounded-xl shadow-2xl z-[1000] py-1 overflow-hidden"
-          style={menuPosition}
-          role="menu"
-          aria-label="Thread actions"
-        >
-          {menuItems.map((item, index) => (
-            <button
-              key={item.label}
-              ref={(el) => { menuItemsRef.current[index] = el }}
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation()
-                item.action()
-              }}
-              aria-label={item.ariaLabel}
-              className={`w-full px-4 py-3 text-left text-sm transition-colors flex items-center gap-3 focus:outline-none focus-visible:bg-white/10 ${
-                item.destructive
-                  ? 'text-red-400 hover:bg-red-500/10 hover:text-red-300 focus-visible:bg-red-500/10 focus-visible:text-red-300'
-                  : 'text-stone-300 hover:bg-white/10 hover:text-white focus-visible:bg-white/10 focus-visible:text-white'
-              }`}
-              role="menuitem"
-            >
-              <span className="text-base">{item.icon}</span>
-              <span className="font-medium">{item.label}</span>
-            </button>
-          ))}
-        </div>,
-        document.body,
+      {isOpen && menuPosition && (
+        <OverlayPortal>
+          <div
+            ref={menuRef}
+            className="fixed w-52 bg-[#1a1410]/95 border border-white/10 rounded-xl shadow-2xl z-[1000] py-1 overflow-hidden"
+            style={menuPosition}
+            role="menu"
+            aria-label="Thread actions"
+          >
+            {menuItems.map((item, index) => (
+              <button
+                key={item.label}
+                ref={(el) => { menuItemsRef.current[index] = el }}
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  item.action()
+                }}
+                aria-label={item.ariaLabel}
+                className={`w-full px-4 py-3 text-left text-sm transition-colors flex items-center gap-3 focus:outline-none focus-visible:bg-white/10 ${
+                  item.destructive
+                    ? 'text-red-400 hover:bg-red-500/10 hover:text-red-300 focus-visible:bg-red-500/10 focus-visible:text-red-300'
+                    : 'text-stone-300 hover:bg-white/10 hover:text-white focus-visible:bg-white/10 focus-visible:text-white'
+                }`}
+                role="menuitem"
+              >
+                <span className="text-base">{item.icon}</span>
+                <span className="font-medium">{item.label}</span>
+              </button>
+            ))}
+          </div>
+        </OverlayPortal>
       )}
     </div>
   )

--- a/frontend/src/unit/PositionMenu.test.tsx
+++ b/frontend/src/unit/PositionMenu.test.tsx
@@ -86,7 +86,10 @@ describe('PositionMenu', () => {
 
     await user.click(screen.getByRole('button', { name: /thread actions/i }))
 
-    expect(screen.getByRole('menu').parentElement).toBe(document.body)
+    const overlayRoot = document.querySelector('[data-overlay-root="true"]')
+    expect(overlayRoot).not.toBeNull()
+    expect(screen.getByRole('menu').parentElement).toBe(overlayRoot)
+    expect(overlayRoot?.parentElement).toBe(document.body)
   })
 
   it('repositions the portaled menu when the viewport changes', async () => {
@@ -473,107 +476,104 @@ describe('PositionMenu', () => {
     trigger.focus()
     await user.keyboard('{Enter}')
 
-     const menuItems = screen.getAllByRole('menuitem')
-     expect(document.activeElement).toBe(menuItems[0])
- 
-     await user.keyboard('{ArrowDown}')
-     expect(document.activeElement).toBe(menuItems[1])
- 
-     await user.keyboard('{ArrowDown}')
-     expect(document.activeElement).toBe(menuItems[2])
- 
-     await user.keyboard('{ArrowDown}')
-     expect(document.activeElement).toBe(menuItems[3])
- 
-     await user.keyboard('{ArrowDown}')
-     expect(document.activeElement).toBe(menuItems[4])
- 
-     await user.keyboard('{ArrowDown}')
-     expect(document.activeElement).toBe(menuItems[5])
- 
-     await user.keyboard('{ArrowDown}')
-     expect(document.activeElement).toBe(menuItems[0])
-   })
+    const menuItems = screen.getAllByRole('menuitem')
+    expect(document.activeElement).toBe(menuItems[0])
 
-   it('moves focus upward through portaled menu items and back to its trigger', async () => {
-     const user = userEvent.setup()
-     render(
-       <PositionMenu
-         thread={mockThread}
-         onMoveToFront={vi.fn()}
-         onReposition={vi.fn()}
-         onMoveToBack={vi.fn()}
-         onEdit={vi.fn()}
-         onDependencies={vi.fn()}
-         onDelete={vi.fn()}
-       />
-     )
+    await user.keyboard('{ArrowDown}')
+    expect(document.activeElement).toBe(menuItems[1])
 
-     const trigger = screen.getByRole('button', { name: /thread actions/i })
-     await user.click(trigger)
-     const menuItems = screen.getAllByRole('menuitem')
-     menuItems[1].focus()
+    await user.keyboard('{ArrowDown}')
+    expect(document.activeElement).toBe(menuItems[2])
 
-     await user.keyboard('{ArrowUp}')
-     expect(document.activeElement).toBe(menuItems[0])
-     await user.keyboard('{ArrowUp}')
-     expect(document.activeElement).toBe(trigger)
-   })
+    await user.keyboard('{ArrowDown}')
+    expect(document.activeElement).toBe(menuItems[3])
 
-   it('only one overflow menu can be open at a time', async () => {
-     const user = userEvent.setup()
-     const mockThread1 = {
-       ...mockThread,
-       id: 1,
-       title: 'Thread 1',
-     }
-     const mockThread2 = {
-       ...mockThread,
-       id: 2,
-       title: 'Thread 2',
-     }
+    await user.keyboard('{ArrowDown}')
+    expect(document.activeElement).toBe(menuItems[4])
 
-     render(
-       <>
-         <PositionMenu
-           thread={mockThread1}
-           onMoveToFront={vi.fn()}
-           onReposition={vi.fn()}
-            onMoveToBack={vi.fn()}
-            onEdit={vi.fn()}
-            onDependencies={vi.fn()}
-            onDelete={vi.fn()}
-          />
-         <PositionMenu
-           thread={mockThread2}
-           onMoveToFront={vi.fn()}
-           onReposition={vi.fn()}
-            onMoveToBack={vi.fn()}
-            onEdit={vi.fn()}
-            onDependencies={vi.fn()}
-            onDelete={vi.fn()}
-          />
-       </>
-     )
+    await user.keyboard('{ArrowDown}')
+    expect(document.activeElement).toBe(menuItems[5])
 
-     const triggers = screen.getAllByRole('button', { name: /thread actions/i })
+    await user.keyboard('{ArrowDown}')
+    expect(document.activeElement).toBe(menuItems[0])
+  })
 
-     // Open first menu
-     await user.click(triggers[0])
-     expect(screen.getAllByRole('menu')).toHaveLength(1)
-     expect(triggers[0]).toHaveAttribute('aria-expanded', 'true')
-     expect(triggers[1]).toHaveAttribute('aria-expanded', 'false')
+  it('moves focus upward through portaled menu items and back to its trigger', async () => {
+    const user = userEvent.setup()
+    render(
+      <PositionMenu
+        thread={mockThread}
+        onMoveToFront={vi.fn()}
+        onReposition={vi.fn()}
+        onMoveToBack={vi.fn()}
+        onEdit={vi.fn()}
+        onDependencies={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    )
 
-     // Open second menu - first should close automatically
-     await user.click(triggers[1])
-     expect(screen.getAllByRole('menu')).toHaveLength(1)
-     expect(triggers[0]).toHaveAttribute('aria-expanded', 'false')
-     expect(triggers[1]).toHaveAttribute('aria-expanded', 'true')
+    const trigger = screen.getByRole('button', { name: /thread actions/i })
+    await user.click(trigger)
+    const menuItems = screen.getAllByRole('menuitem')
+    menuItems[1].focus()
 
-     // Click first again - second should close
-     await user.click(triggers[0])
-     expect(screen.getAllByRole('menu')).toHaveLength(1)
-     expect(triggers[0]).toHaveAttribute('aria-expanded', 'true')
-     expect(triggers[1]).toHaveAttribute('aria-expanded', 'false')
-   })
- })
+    await user.keyboard('{ArrowUp}')
+    expect(document.activeElement).toBe(menuItems[0])
+    await user.keyboard('{ArrowUp}')
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('only one overflow menu can be open at a time', async () => {
+    const user = userEvent.setup()
+    const mockThread1 = {
+      ...mockThread,
+      id: 1,
+      title: 'Thread 1',
+    }
+    const mockThread2 = {
+      ...mockThread,
+      id: 2,
+      title: 'Thread 2',
+    }
+
+    render(
+      <>
+        <PositionMenu
+          thread={mockThread1}
+          onMoveToFront={vi.fn()}
+          onReposition={vi.fn()}
+          onMoveToBack={vi.fn()}
+          onEdit={vi.fn()}
+          onDependencies={vi.fn()}
+          onDelete={vi.fn()}
+        />
+        <PositionMenu
+          thread={mockThread2}
+          onMoveToFront={vi.fn()}
+          onReposition={vi.fn()}
+          onMoveToBack={vi.fn()}
+          onEdit={vi.fn()}
+          onDependencies={vi.fn()}
+          onDelete={vi.fn()}
+        />
+      </>
+    )
+
+    const triggers = screen.getAllByRole('button', { name: /thread actions/i })
+
+    await user.click(triggers[0])
+    expect(screen.getAllByRole('menu')).toHaveLength(1)
+    expect(triggers[0]).toHaveAttribute('aria-expanded', 'true')
+    expect(triggers[1]).toHaveAttribute('aria-expanded', 'false')
+
+    await user.click(triggers[1])
+    expect(screen.getAllByRole('menu')).toHaveLength(1)
+    expect(triggers[0]).toHaveAttribute('aria-expanded', 'false')
+    expect(triggers[1]).toHaveAttribute('aria-expanded', 'true')
+
+    await user.click(triggers[0])
+    expect(screen.getAllByRole('menu')).toHaveLength(1)
+    expect(triggers[0]).toHaveAttribute('aria-expanded', 'true')
+    expect(triggers[1]).toHaveAttribute('aria-expanded', 'false')
+  })
+})

--- a/frontend/src/unit/PositionMenuOverlayPortal.test.tsx
+++ b/frontend/src/unit/PositionMenuOverlayPortal.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, expect, it, vi } from 'vitest'
+import PositionMenu from '../components/PositionMenu'
+import { PositionMenuProvider } from '../contexts/PositionMenuContext'
+
+const mockThread = {
+  id: 1,
+  title: 'Saga',
+  format: 'Comic',
+  status: 'active' as const,
+  queue_position: 1,
+  issues_remaining: 5,
+  notes: null,
+  total_issues: null,
+  next_unread_issue_id: null,
+  next_unread_issue_number: null,
+  reading_progress: null,
+  blocking_reasons: [],
+  is_blocked: false,
+  created_at: '2024-01-01T00:00:00Z',
+}
+
+function renderMenu() {
+  return render(
+    <PositionMenuProvider>
+      <PositionMenu
+        thread={mockThread}
+        onMoveToFront={vi.fn()}
+        onReposition={vi.fn()}
+        onMoveToBack={vi.fn()}
+        onEdit={vi.fn()}
+        onDependencies={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    </PositionMenuProvider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+it('mounts the position menu inside the shared overlay root', async () => {
+  const user = userEvent.setup()
+  renderMenu()
+
+  await user.click(screen.getByRole('button', { name: 'Thread actions' }))
+
+  const menu = await screen.findByRole('menu', { name: 'Thread actions' })
+  const overlayRoot = document.querySelector('[data-overlay-root="true"]')
+
+  expect(overlayRoot).not.toBeNull()
+  expect(overlayRoot).toContainElement(menu)
+  expect(menu.parentElement).toBe(overlayRoot)
+})
+
+it('releases the shared overlay root after the menu unmounts', async () => {
+  const user = userEvent.setup()
+  const view = renderMenu()
+
+  await user.click(screen.getByRole('button', { name: 'Thread actions' }))
+  await screen.findByRole('menu', { name: 'Thread actions' })
+
+  view.unmount()
+
+  await waitFor(() => {
+    expect(document.querySelector('[data-overlay-root="true"]')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Moves the Queue thread-actions menu off its component-local `document.body` portal and onto the shared `OverlayPortal` lifecycle introduced for #625.

## Implemented

- removes direct `react-dom` portal ownership from `PositionMenu`;
- renders the fixed, collision-aware menu inside the shared document overlay root;
- preserves existing keyboard navigation, outside-click dismissal, focus return, viewport repositioning, and action behavior;
- adds focused regression coverage proving the menu is mounted beneath the shared overlay root and that the root is released when the menu unmounts.

## Stage scope

Part of #625. Swipe containment is handled separately. Modal adoption, overlay z-index tokens, and headed Firefox/WebKit containment evidence remain open.

## Verification

Exact-head CI is the validation boundary for this connector-authored branch. No merge or auto-merge is authorized.

Model: chatgpt-factory-3