### PR TITLE
Adopt shared overlay lifecycle for modals (#625)

### DIFF
--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useEffect, useId, useLayoutEffect, useRef, useState } from 'react'
 import OverlayPortal from './OverlayPortal'
 
 interface ModalProps {
@@ -42,6 +42,7 @@ export default function Modal({
   const closeButtonRef = useRef<HTMLButtonElement>(null)
   const previousFocusRef = useRef<HTMLElement | null>(null)
   const onCloseRef = useRef(onClose)
+  const titleId = useId()
 
   const modalIdRef = useRef<number | null>(null)
   if (modalIdRef.current === null) {
@@ -170,13 +171,13 @@ export default function Modal({
           className="relative w-full max-w-lg h-[calc(100dvh-1rem)] md:h-auto modal-card max-h-[calc(100dvh-1rem)] md:max-h-[85vh] flex flex-col overflow-hidden rounded-t-2xl md:rounded-lg animate-slide-up md:animate-fade-in pb-[env(safe-area-inset-bottom)]"
           role="dialog"
           aria-modal="true"
-          aria-labelledby="modal-title"
+          aria-labelledby={titleId}
         >
           <div className="flex justify-center pt-2 pb-1 md:hidden shrink-0">
             <div className="w-10 h-1 bg-white/20 rounded-full" />
           </div>
           <div className="flex items-start justify-between gap-2 md:gap-4 px-4 md:px-6 pt-2 md:pt-0 pb-3 md:pb-4 shrink-0">
-            <h2 id="modal-title" className="min-w-0 flex-1 text-base md:text-xl font-black tracking-tight text-stone-200 uppercase">{title}</h2>
+            <h2 id={titleId} className="min-w-0 flex-1 text-base md:text-xl font-black tracking-tight text-stone-200 uppercase">{title}</h2>
             <button
               ref={closeButtonRef}
               type="button"

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useLayoutEffect, useRef } from 'react'
+import OverlayPortal from './OverlayPortal'
 
 interface ModalProps {
   isOpen: boolean
@@ -87,11 +88,9 @@ export default function Modal({
             e.preventDefault()
             lastElement?.focus()
           }
-        } else {
-          if (document.activeElement === lastElement) {
-            e.preventDefault()
-            firstElement?.focus()
-          }
+        } else if (document.activeElement === lastElement) {
+          e.preventDefault()
+          firstElement?.focus()
         }
       }
     }
@@ -125,14 +124,9 @@ export default function Modal({
   }, [autoFocus, isOpen])
 
   // Lock the #root scroller while a modal is open (fixes iOS scroll-bleed).
-  // This app scrolls via #root, NOT <body> (see src/styles.css: html/body are
-  // overflow:hidden, so locking <body> is a no-op). Use overflow:hidden ONLY on
-  // #root, do NOT set touch-action:none on #root: the modal content is a DOM
-  // descendant of #root (Modal renders inline, no portal), and an ancestor
-  // touch-action:none would disable touch-panning for descendants, breaking
-  // in-modal scrolling on mobile.
-  // Uses a module-level ref count so nested/overlapping modals don't prematurely
-  // unlock #root, the lock is only released when the last modal closes.
+  // The dialog itself is portaled to document.body, so locking #root no longer
+  // affects touch-panning inside modal content. The ref count still protects
+  // nested and overlapping dialogs from prematurely restoring page scrolling.
   useEffect(() => {
     if (!isOpen) return
     const root = document.getElementById('root')
@@ -155,46 +149,48 @@ export default function Modal({
   if (!isOpen) return null
 
   return (
-    <div
-      ref={overlayRef}
-      className={`fixed inset-0 flex items-end md:items-center justify-center md:px-4 ${overlayClassName || ''}`}
-      style={{ zIndex: 60 }}
-    >
+    <OverlayPortal>
       <div
-        className="absolute inset-0 bg-[#110e0a]/60 backdrop-blur-sm touch-none"
-        onClick={() => {
-          if (isTopmostModal(modalIdRef.current!)) onClose()
-        }}
-        aria-hidden="true"
-      ></div>
-      <div
-        ref={modalRef}
-        data-testid={testId}
-        tabIndex={-1}
-        className="relative w-full max-w-lg h-[calc(100dvh-1rem)] md:h-auto modal-card max-h-[calc(100dvh-1rem)] md:max-h-[85vh] flex flex-col overflow-hidden rounded-t-2xl md:rounded-lg animate-slide-up md:animate-fade-in pb-[env(safe-area-inset-bottom)]"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="modal-title"
+        ref={overlayRef}
+        className={`fixed inset-0 flex items-end md:items-center justify-center md:px-4 ${overlayClassName || ''}`}
+        style={{ zIndex: 60 }}
       >
-        <div className="flex justify-center pt-2 pb-1 md:hidden shrink-0">
-          <div className="w-10 h-1 bg-white/20 rounded-full" />
-        </div>
-        <div className="flex items-start justify-between gap-2 md:gap-4 px-4 md:px-6 pt-2 md:pt-0 pb-3 md:pb-4 shrink-0">
-          <h2 id="modal-title" className="min-w-0 flex-1 text-base md:text-xl font-black tracking-tight text-stone-200 uppercase">{title}</h2>
-          <button
-            ref={closeButtonRef}
-            type="button"
-            onClick={onClose}
-            className="text-stone-500 hover:text-stone-300 transition-colors text-2xl leading-none"
-            aria-label="Close modal"
-          >
-            &times;
-          </button>
-        </div>
-        <div className="overflow-y-auto space-y-4 md:space-y-6 min-h-0 px-4 md:px-6 pb-4 md:pb-6 overscroll-contain">
-          {children}
+        <div
+          className="absolute inset-0 bg-[#110e0a]/60 backdrop-blur-sm touch-none"
+          onClick={() => {
+            if (isTopmostModal(modalIdRef.current!)) onClose()
+          }}
+          aria-hidden="true"
+        ></div>
+        <div
+          ref={modalRef}
+          data-testid={testId}
+          tabIndex={-1}
+          className="relative w-full max-w-lg h-[calc(100dvh-1rem)] md:h-auto modal-card max-h-[calc(100dvh-1rem)] md:max-h-[85vh] flex flex-col overflow-hidden rounded-t-2xl md:rounded-lg animate-slide-up md:animate-fade-in pb-[env(safe-area-inset-bottom)]"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="modal-title"
+        >
+          <div className="flex justify-center pt-2 pb-1 md:hidden shrink-0">
+            <div className="w-10 h-1 bg-white/20 rounded-full" />
+          </div>
+          <div className="flex items-start justify-between gap-2 md:gap-4 px-4 md:px-6 pt-2 md:pt-0 pb-3 md:pb-4 shrink-0">
+            <h2 id="modal-title" className="min-w-0 flex-1 text-base md:text-xl font-black tracking-tight text-stone-200 uppercase">{title}</h2>
+            <button
+              ref={closeButtonRef}
+              type="button"
+              onClick={onClose}
+              className="text-stone-500 hover:text-stone-300 transition-colors text-2xl leading-none"
+              aria-label="Close modal"
+            >
+              &times;
+            </button>
+          </div>
+          <div className="overflow-y-auto space-y-4 md:space-y-6 min-h-0 px-4 md:px-6 pb-4 md:pb-6 overscroll-contain">
+            {children}
+          </div>
         </div>
       </div>
-    </div>
+    </OverlayPortal>
   )
 }

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import OverlayPortal from './OverlayPortal'
 
 interface ModalProps {
@@ -37,7 +37,7 @@ export default function Modal({
   overlayClassName,
   autoFocus = true,
 }: ModalProps) {
-  const overlayRef = useRef<HTMLDivElement>(null)
+  const [overlayElement, setOverlayElement] = useState<HTMLDivElement | null>(null)
   const modalRef = useRef<HTMLDivElement>(null)
   const closeButtonRef = useRef<HTMLButtonElement>(null)
   const previousFocusRef = useRef<HTMLElement | null>(null)
@@ -53,20 +53,21 @@ export default function Modal({
     onCloseRef.current = onClose
   })
 
-  // Register and layer open modals before paint so logical dismissal order and
-  // visual stacking cannot diverge when an earlier DOM modal reopens.
+  // OverlayPortal creates its shared root after the parent modal's first commit.
+  // Wait until the portaled overlay node is attached before registering, layering,
+  // or focusing the modal. This avoids dereferencing a ref that cannot exist yet.
   useLayoutEffect(() => {
-    if (!isOpen) return
+    if (!isOpen || !overlayElement || !modalRef.current) return
 
     const modalId = modalIdRef.current!
     // This effect's cleanup always removes its entry before a rerun, so every
     // active modal has exactly one stack entry.
     openModalStack.push(modalId)
-    overlayRef.current!.style.zIndex = String(nextModalLayer++)
+    overlayElement.style.zIndex = String(nextModalLayer++)
 
     previousFocusRef.current = document.activeElement as HTMLElement
 
-    const modal = modalRef.current!
+    const modal = modalRef.current
 
     const focusableElements = modal.querySelectorAll<HTMLElement>(
       'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
@@ -121,7 +122,7 @@ export default function Modal({
         previousFocusRef.current?.focus()
       }
     }
-  }, [autoFocus, isOpen])
+  }, [autoFocus, isOpen, overlayElement])
 
   // Lock the #root scroller while a modal is open (fixes iOS scroll-bleed).
   // The dialog itself is portaled to document.body, so locking #root no longer
@@ -151,7 +152,7 @@ export default function Modal({
   return (
     <OverlayPortal>
       <div
-        ref={overlayRef}
+        ref={setOverlayElement}
         className={`fixed inset-0 flex items-end md:items-center justify-center md:px-4 ${overlayClassName || ''}`}
         style={{ zIndex: 60 }}
       >

--- a/frontend/src/unit/Modal.backdrop-stacking.test.tsx
+++ b/frontend/src/unit/Modal.backdrop-stacking.test.tsx
@@ -8,19 +8,21 @@ it('ignores a lower modal backdrop while a higher modal is open', async () => {
   const lowerOnClose = vi.fn()
   const upperOnClose = vi.fn()
 
-  const lower = render(
+  render(
     <Modal isOpen title="Lower" onClose={lowerOnClose}>
       <button type="button">Lower action</button>
     </Modal>,
   )
-  const upper = render(
+  render(
     <Modal isOpen title="Upper" onClose={upperOnClose}>
       <button type="button">Upper action</button>
     </Modal>,
   )
 
-  const lowerBackdrop = lower.container.querySelector('[aria-hidden="true"]')
-  const upperBackdrop = upper.container.querySelector('[aria-hidden="true"]')
+  const overlayRoot = document.querySelector('[data-overlay-root="true"]')
+  const backdrops = overlayRoot?.querySelectorAll('[aria-hidden="true"]')
+  const lowerBackdrop = backdrops?.[0]
+  const upperBackdrop = backdrops?.[1]
   if (!lowerBackdrop || !upperBackdrop) {
     throw new Error('Expected both modal backdrops to be rendered')
   }

--- a/frontend/src/unit/Modal.test.tsx
+++ b/frontend/src/unit/Modal.test.tsx
@@ -8,7 +8,7 @@ it('renders content and handles close actions', async () => {
   const user = userEvent.setup()
   const handleClose = vi.fn()
 
-  const { container } = render(
+  render(
     <Modal isOpen title="Test Modal" onClose={handleClose}>
       <p>Modal content</p>
     </Modal>
@@ -16,7 +16,7 @@ it('renders content and handles close actions', async () => {
 
   expect(screen.getByText('Modal content')).toBeInTheDocument()
   await user.click(screen.getByRole('button', { name: /close modal/i }))
-  const backdrop = container.querySelector('[aria-hidden="true"]')
+  const backdrop = document.querySelector('[data-overlay-root="true"] [aria-hidden="true"]')
   if (!backdrop) {
     throw new Error('Backdrop not found')
   }
@@ -57,14 +57,14 @@ it('keeps focus on a controlled input while typing across parent rerenders', asy
 })
 
 it('uses a translucent modal surface with a softened overlay', () => {
-  const { container } = render(
+  render(
     <Modal isOpen title="Translucent Modal" onClose={() => {}}>
       <p>Modal content</p>
     </Modal>
   )
 
   const dialog = screen.getByRole('dialog', { name: 'Translucent Modal' })
-  const overlay = container.querySelector('[aria-hidden="true"]')
+  const overlay = document.querySelector('[data-overlay-root="true"] [aria-hidden="true"]')
 
   expect(dialog).toHaveClass('modal-card')
   expect(dialog.className).toContain('modal-card')
@@ -144,14 +144,14 @@ it('uses the close button as the autofocus fallback', () => {
 
 it('does not wrap focus when tabbing from a middle focusable element', () => {
   // Covers the false arms of the shift/non-shift focus-wrap guards in the keydown handler
-  const { container } = render(
+  render(
     <Modal isOpen title="Focus Wrap" onClose={() => {}}>
       <input aria-label="First field" />
       <input aria-label="Middle field" />
       <button type="button">Last</button>
     </Modal>,
   )
-  const middle = container.querySelectorAll('input')[1] as HTMLElement
+  const middle = screen.getByLabelText('Middle field')
   middle.focus()
   // shift+tab from a non-first element: activeElement !== firstElement -> no wrap
   fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
@@ -186,7 +186,7 @@ it('backdrop click on the topmost overlapping modal closes only it', async () =>
   const firstOnClose = vi.fn()
   const secondOnClose = vi.fn()
 
-  const { container } = render(
+  render(
     <Modal isOpen title="One" onClose={firstOnClose}>
       <button type="button">One action</button>
     </Modal>,
@@ -197,7 +197,7 @@ it('backdrop click on the topmost overlapping modal closes only it', async () =>
     </Modal>,
   )
 
-  const backdrops = container.parentElement!.querySelectorAll('[aria-hidden="true"]')
+  const backdrops = document.querySelectorAll('[data-overlay-root="true"] [aria-hidden="true"]')
   const topmostBackdrop = backdrops[backdrops.length - 1]
   await user.click(topmostBackdrop as HTMLElement)
   expect(secondOnClose).toHaveBeenCalledTimes(1)

--- a/frontend/src/unit/ModalOverlayPortal.test.tsx
+++ b/frontend/src/unit/ModalOverlayPortal.test.tsx
@@ -1,0 +1,94 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, expect, it, vi } from 'vitest'
+import Modal from '../components/Modal'
+
+afterEach(() => {
+  cleanup()
+})
+
+it('mounts an open modal beneath the shared document overlay root', async () => {
+  render(
+    <Modal isOpen title="Edit thread" onClose={vi.fn()}>
+      <button type="button">Save</button>
+    </Modal>,
+  )
+
+  const dialog = await screen.findByRole('dialog', { name: 'Edit thread' })
+  const overlayRoot = document.querySelector('[data-overlay-root="true"]')
+
+  expect(overlayRoot).not.toBeNull()
+  expect(overlayRoot?.parentElement).toBe(document.body)
+  expect(overlayRoot?.contains(dialog)).toBe(true)
+})
+
+it('keeps the shared root until the last overlapping modal unmounts', async () => {
+  const { rerender } = render(
+    <>
+      <Modal isOpen title="First modal" onClose={vi.fn()}>
+        First
+      </Modal>
+      <Modal isOpen title="Second modal" onClose={vi.fn()}>
+        Second
+      </Modal>
+    </>,
+  )
+
+  await screen.findByRole('dialog', { name: 'Second modal' })
+  expect(document.querySelector('[data-overlay-root="true"]')).not.toBeNull()
+
+  rerender(
+    <>
+      <Modal isOpen={false} title="First modal" onClose={vi.fn()}>
+        First
+      </Modal>
+      <Modal isOpen title="Second modal" onClose={vi.fn()}>
+        Second
+      </Modal>
+    </>,
+  )
+
+  expect(document.querySelector('[data-overlay-root="true"]')).not.toBeNull()
+
+  rerender(
+    <>
+      <Modal isOpen={false} title="First modal" onClose={vi.fn()}>
+        First
+      </Modal>
+      <Modal isOpen={false} title="Second modal" onClose={vi.fn()}>
+        Second
+      </Modal>
+    </>,
+  )
+
+  await waitFor(() => {
+    expect(document.querySelector('[data-overlay-root="true"]')).toBeNull()
+  })
+})
+
+it('preserves topmost backdrop dismissal after portaling', async () => {
+  const user = userEvent.setup()
+  const closeFirst = vi.fn()
+  const closeSecond = vi.fn()
+
+  render(
+    <>
+      <Modal isOpen title="First modal" onClose={closeFirst}>
+        First
+      </Modal>
+      <Modal isOpen title="Second modal" onClose={closeSecond}>
+        Second
+      </Modal>
+    </>,
+  )
+
+  const dialogs = await screen.findAllByRole('dialog')
+  const firstBackdrop = dialogs[0].previousElementSibling as HTMLElement
+  const secondBackdrop = dialogs[1].previousElementSibling as HTMLElement
+
+  await user.click(firstBackdrop)
+  expect(closeFirst).not.toHaveBeenCalled()
+
+  await user.click(secondBackdrop)
+  expect(closeSecond).toHaveBeenCalledTimes(1)
+})


### PR DESCRIPTION
## Summary

Moves the shared `Modal` primitive out of route/component stacking contexts and into the document-level `OverlayPortal` lifecycle established for #625.

## Implemented

- renders every open dialog beneath the canonical shared overlay root;
- preserves topmost-modal layering, Escape/backdrop ownership, focus trapping, focus restoration, and nested-modal scroll locking;
- updates the scroll-lock contract now that modal touch content is no longer a descendant of the locked `#root` scroller;
- adds focused regression coverage for shared-root containment, overlapping modal lifecycle, and topmost backdrop dismissal.

## Stage scope

Part of #625. This branch owns only `Modal.tsx` and its focused portal tests. It does not overlap the green PositionMenu adoption PR. Swipe tuning, tooltip behavior, shared z-index tokens, and headed Firefox/WebKit containment evidence remain open.

## Verification

Exact-head CI is the validation boundary for this connector-authored branch because the runtime cannot resolve `github.com` for a local checkout. No merge or auto-merge is authorized.

Model: chatgpt-factory-3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved modal rendering and overlay behavior, including focus management, stacking, backdrop handling, and scroll locking.
  - Ensured only the topmost modal can be dismissed by clicking its backdrop.
  - Improved cleanup when multiple overlapping modals are closed.

- **Tests**
  - Added coverage for modal portal mounting, overlapping modals, dismissal behavior, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->