### PR TITLE
ci: restore full cross-browser Playwright matrix (#679)

### DIFF
--- a/.github/workflows/browser-e2e.yml
+++ b/.github/workflows/browser-e2e.yml
@@ -1,0 +1,189 @@
+name: Browser E2E
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: browser-e2e-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/${{ github.event.repository.name }}
+
+jobs:
+  build:
+    name: Build browser-test image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image-ref: ${{ steps.outputs.outputs.image-ref }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set lowercase image name
+        id: lowercase
+        shell: bash
+        run: echo "image-name=${IMAGE_NAME,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish browser-test image
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile.ci
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ steps.lowercase.outputs.image-name }}:browser-${{ github.sha }}
+          cache-from: type=gha,scope=browser-e2e
+          cache-to: type=gha,mode=max,scope=browser-e2e
+
+      - name: Publish immutable image reference
+        id: outputs
+        run: |
+          echo "image-ref=${{ env.REGISTRY }}/${{ steps.lowercase.outputs.image-name }}@${{ steps.build.outputs.digest }}" >> "$GITHUB_OUTPUT"
+
+  playwright:
+    name: Playwright (${{ matrix.browser }}, shard ${{ matrix.shardIndex }}/${{ matrix.totalShards }})
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 45
+    container:
+      image: ${{ needs.build.outputs.image-ref }}
+      options: >-
+        --shm-size=2gb
+        --memory=8gb
+        --cpus=4
+    strategy:
+      fail-fast: false
+      matrix:
+        browser:
+          - firefox
+          - webkit
+          - chromium
+        shardIndex:
+          - 1
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+        totalShards:
+          - 6
+    env:
+      CI: true
+      HOME: /root
+      TEST_ENVIRONMENT: "true"
+      SECRET_KEY: test-secret-key-for-testing-only
+      DATABASE_URL: postgresql+asyncpg://postgres:postgres@postgres:5432/comic_pile_test
+      TEST_DATABASE_URL: postgresql+asyncpg://postgres:postgres@postgres:5432/comic_pile_test
+      REDIS_URL: redis://redis:6379/0
+      PGUSER: postgres
+      PATH: /workspace/.venv/bin:/usr/local/bin:/usr/bin:/bin
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: comic_pile_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Remove local environment overrides
+        run: rm -f .env .env.test .env.backup .envrc .env.local .env.production
+
+      - name: Wait for PostgreSQL
+        shell: bash
+        run: |
+          for attempt in $(seq 1 30); do
+            if pg_isready -h postgres -p 5432 -U postgres; then
+              echo "PostgreSQL is ready"
+              exit 0
+            fi
+            echo "Waiting for PostgreSQL... (${attempt}/30)"
+            sleep 2
+          done
+          echo "PostgreSQL failed to start"
+          exit 1
+
+      - name: Restore frontend toolchain from CI image
+        run: |
+          mkdir -p static
+          rm -rf frontend/node_modules static/react
+          cp -a /opt/ci-assets/static/react static/react
+          pnpm install --frozen-lockfile
+
+      - name: Start backend server
+        shell: bash
+        run: |
+          export AUTO_BACKUP_ENABLED=false
+          python -m uvicorn app.main:app \
+            --host 0.0.0.0 \
+            --port 9000 \
+            --workers 1 \
+            --log-level warning \
+            > /tmp/backend.log 2>&1 &
+          echo $! > /tmp/backend.pid
+
+      - name: Wait for backend
+        shell: bash
+        run: |
+          for attempt in $(seq 1 30); do
+            if curl --fail --silent http://localhost:9000/health > /dev/null; then
+              echo "Backend is ready"
+              exit 0
+            fi
+            echo "Waiting for backend... (${attempt}/30)"
+            sleep 2
+          done
+          echo "Backend failed to start"
+          cat /tmp/backend.log || true
+          exit 1
+
+      - name: Run Playwright shard
+        working-directory: frontend
+        env:
+          REUSE_EXISTING_SERVER: "true"
+          BASE_URL: http://localhost:9000
+        run: >-
+          pnpm exec playwright test
+          --project=${{ matrix.browser }}
+          --shard=${{ matrix.shardIndex }}/${{ matrix.totalShards }}
+
+      - name: Print backend log after failure
+        if: failure()
+        run: cat /tmp/backend.log || true

--- a/frontend/src/test/mobile-form-containment.spec.ts
+++ b/frontend/src/test/mobile-form-containment.spec.ts
@@ -1,10 +1,12 @@
 import { expect, test } from '@playwright/test'
+import { setupAuthenticatedPage } from './helpers'
 
 const MOBILE_WIDTHS = [320, 375, 414] as const
 
 for (const width of MOBILE_WIDTHS) {
   test(`mobile form controls remain contained at ${width}px`, async ({ page }) => {
     await page.setViewportSize({ width, height: 812 })
+    await setupAuthenticatedPage(page)
     await page.goto('/queue')
     await expect(page.getByRole('heading', { name: 'Read Queue' })).toBeVisible()
 


### PR DESCRIPTION
## Summary

Restores the full Firefox, WebKit, and Chromium Playwright release matrix that was paused during the Vercel performance investigation.

## Implemented

- adds a standalone required browser-E2E workflow for pull requests, `main`, and manual dispatch;
- runs all three supported browsers across six shards each;
- builds and publishes one immutable CI image per commit, then reuses it across the 18 browser shards;
- preserves the Firefox container `HOME=/root` requirement;
- provisions isolated PostgreSQL and Redis services for every shard;
- starts the production-style FastAPI test server on port 9000;
- restores the frontend production build and Playwright toolchain from the CI image;
- cancels stale browser runs only for the same PR or ref;
- prints backend logs on failures for actionable diagnostics.

## Scope

Closes #679. This restores browser coverage without rewriting the active general CI workflow while PR #761 is changing its approval/gating contract.

## Verification

The workflow is exercised by this pull request at exact head. No merge or auto-merge is authorized.

Model: chatgpt-factory-5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated browser end-to-end testing for pull requests, main-branch updates, and manual runs.
  * Tests now run across Chromium, Firefox, and WebKit with parallelized execution.
  * Added PostgreSQL and Redis service support for comprehensive test coverage.
  * Improved failure diagnostics by displaying backend logs when tests fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->