### PR TITLE
Add ownership-scoped named dependency group API (#613)

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,8 +1,10 @@
 """API route handlers."""
 
 from app.api import dependency as dependency
+from app.api import dependency_group as dependency_group
 from app.api import issue_dependency_batch as issue_dependency_batch
 
 dependency.router.include_router(issue_dependency_batch.router)
+dependency.router.include_router(dependency_group.router)
 
-__all__ = ["dependency", "issue_dependency_batch"]
+__all__ = ["dependency", "dependency_group", "issue_dependency_batch"]

--- a/app/api/dependency_group.py
+++ b/app/api/dependency_group.py
@@ -50,7 +50,15 @@ async def list_groups(
     current_user: Annotated[User, Depends(get_current_user)],
     db: AsyncSession = Depends(get_db),
 ) -> list[DependencyGroup]:
-    """List the current user's groups and memberships."""
+    """List the current user's groups and memberships.
+
+    Args:
+        current_user: The authenticated owner of the requested groups.
+        db: The asynchronous database session.
+
+    Returns:
+        The user's groups with eagerly loaded memberships.
+    """
     result = await db.execute(
         select(DependencyGroup)
         .options(selectinload(DependencyGroup.memberships))
@@ -66,7 +74,16 @@ async def create_group(
     current_user: Annotated[User, Depends(get_current_user)],
     db: AsyncSession = Depends(get_db),
 ) -> DependencyGroup:
-    """Create a user-owned named group."""
+    """Create a user-owned named group.
+
+    Args:
+        payload: The validated group creation request.
+        current_user: The authenticated group owner.
+        db: The asynchronous database session.
+
+    Returns:
+        The newly created group with memberships loaded.
+    """
     group = DependencyGroup(user_id=current_user.id, name=_normalize_name(payload.name))
     db.add(group)
     try:
@@ -83,7 +100,16 @@ async def get_group(
     current_user: Annotated[User, Depends(get_current_user)],
     db: AsyncSession = Depends(get_db),
 ) -> DependencyGroup:
-    """Return one owned group."""
+    """Return one owned group.
+
+    Args:
+        group_id: The dependency group identifier.
+        current_user: The authenticated group owner.
+        db: The asynchronous database session.
+
+    Returns:
+        The requested owned group with memberships loaded.
+    """
     return await _owned_group(db, group_id, current_user.id)
 
 
@@ -94,7 +120,17 @@ async def update_group(
     current_user: Annotated[User, Depends(get_current_user)],
     db: AsyncSession = Depends(get_db),
 ) -> DependencyGroup:
-    """Rename one owned group."""
+    """Rename one owned group.
+
+    Args:
+        group_id: The dependency group identifier.
+        payload: The validated group rename request.
+        current_user: The authenticated group owner.
+        db: The asynchronous database session.
+
+    Returns:
+        The renamed group with memberships loaded.
+    """
     group = await _owned_group(db, group_id, current_user.id)
     group.name = _normalize_name(payload.name)
     try:
@@ -111,7 +147,16 @@ async def delete_group(
     current_user: Annotated[User, Depends(get_current_user)],
     db: AsyncSession = Depends(get_db),
 ) -> Response:
-    """Delete one owned group and its memberships."""
+    """Delete one owned group and its memberships.
+
+    Args:
+        group_id: The dependency group identifier.
+        current_user: The authenticated group owner.
+        db: The asynchronous database session.
+
+    Returns:
+        An empty HTTP 204 response.
+    """
     group = await _owned_group(db, group_id, current_user.id)
     await db.delete(group)
     await db.commit()
@@ -129,7 +174,17 @@ async def add_member(
     current_user: Annotated[User, Depends(get_current_user)],
     db: AsyncSession = Depends(get_db),
 ) -> DependencyGroupMembership:
-    """Add one owned thread or issue to an owned group."""
+    """Add one owned thread or issue to an owned group.
+
+    Args:
+        group_id: The dependency group identifier.
+        payload: The validated thread or issue membership request.
+        current_user: The authenticated owner of the group and target.
+        db: The asynchronous database session.
+
+    Returns:
+        The newly persisted group membership.
+    """
     await _owned_group(db, group_id, current_user.id)
     if payload.thread_id is not None:
         target = await db.get(Thread, payload.thread_id)
@@ -162,7 +217,17 @@ async def remove_member(
     current_user: Annotated[User, Depends(get_current_user)],
     db: AsyncSession = Depends(get_db),
 ) -> Response:
-    """Remove one membership from an owned group."""
+    """Remove one membership from an owned group.
+
+    Args:
+        group_id: The dependency group identifier.
+        member_id: The membership identifier to remove.
+        current_user: The authenticated group owner.
+        db: The asynchronous database session.
+
+    Returns:
+        An empty HTTP 204 response.
+    """
     await _owned_group(db, group_id, current_user.id)
     member = await db.get(DependencyGroupMembership, member_id)
     if member is None or member.group_id != group_id:
@@ -178,7 +243,16 @@ async def list_thread_groups(
     current_user: Annotated[User, Depends(get_current_user)],
     db: AsyncSession = Depends(get_db),
 ) -> list[DependencyGroupSummary]:
-    """List groups containing an owned thread or any of its owned issues."""
+    """List groups containing an owned thread or any of its owned issues.
+
+    Args:
+        thread_id: The owned thread identifier used for the lookup.
+        current_user: The authenticated thread and group owner.
+        db: The asynchronous database session.
+
+    Returns:
+        Distinct group summaries ordered by name and identifier.
+    """
     thread = await db.get(Thread, thread_id)
     if thread is None or thread.user_id != current_user.id:
         raise HTTPException(status_code=404, detail=f"Thread {thread_id} not found")

--- a/app/api/dependency_group.py
+++ b/app/api/dependency_group.py
@@ -94,6 +94,42 @@ async def create_group(
     return await _owned_group(db, group.id, current_user.id)
 
 
+@router.get("/threads/{thread_id}/groups", response_model=list[DependencyGroupSummary])
+async def list_thread_groups(
+    thread_id: int,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: AsyncSession = Depends(get_db),
+) -> list[DependencyGroupSummary]:
+    """List groups containing an owned thread or any of its owned issues.
+
+    Args:
+        thread_id: The owned thread identifier used for the lookup.
+        current_user: The authenticated thread and group owner.
+        db: The asynchronous database session.
+
+    Returns:
+        Distinct group summaries ordered by name and identifier.
+    """
+    thread = await db.get(Thread, thread_id)
+    if thread is None or thread.user_id != current_user.id:
+        raise HTTPException(status_code=404, detail=f"Thread {thread_id} not found")
+    issue_ids = select(Issue.id).where(Issue.thread_id == thread_id)
+    result = await db.execute(
+        select(DependencyGroup.id, DependencyGroup.name)
+        .join(DependencyGroupMembership)
+        .where(
+            DependencyGroup.user_id == current_user.id,
+            or_(
+                DependencyGroupMembership.thread_id == thread_id,
+                DependencyGroupMembership.issue_id.in_(issue_ids),
+            ),
+        )
+        .distinct()
+        .order_by(DependencyGroup.name, DependencyGroup.id)
+    )
+    return [DependencyGroupSummary(id=row.id, name=row.name) for row in result]
+
+
 @router.get("/{group_id}", response_model=DependencyGroupResponse)
 async def get_group(
     group_id: int,
@@ -235,39 +271,3 @@ async def remove_member(
     await db.delete(member)
     await db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
-
-
-@router.get("/threads/{thread_id}/groups", response_model=list[DependencyGroupSummary])
-async def list_thread_groups(
-    thread_id: int,
-    current_user: Annotated[User, Depends(get_current_user)],
-    db: AsyncSession = Depends(get_db),
-) -> list[DependencyGroupSummary]:
-    """List groups containing an owned thread or any of its owned issues.
-
-    Args:
-        thread_id: The owned thread identifier used for the lookup.
-        current_user: The authenticated thread and group owner.
-        db: The asynchronous database session.
-
-    Returns:
-        Distinct group summaries ordered by name and identifier.
-    """
-    thread = await db.get(Thread, thread_id)
-    if thread is None or thread.user_id != current_user.id:
-        raise HTTPException(status_code=404, detail=f"Thread {thread_id} not found")
-    issue_ids = select(Issue.id).where(Issue.thread_id == thread_id)
-    result = await db.execute(
-        select(DependencyGroup.id, DependencyGroup.name)
-        .join(DependencyGroupMembership)
-        .where(
-            DependencyGroup.user_id == current_user.id,
-            or_(
-                DependencyGroupMembership.thread_id == thread_id,
-                DependencyGroupMembership.issue_id.in_(issue_ids),
-            ),
-        )
-        .distinct()
-        .order_by(DependencyGroup.name, DependencyGroup.id)
-    )
-    return [DependencyGroupSummary(id=row.id, name=row.name) for row in result]

--- a/app/api/dependency_group.py
+++ b/app/api/dependency_group.py
@@ -1,0 +1,199 @@
+"""Authenticated API for user-owned named dependency groups."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy import or_, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.auth import get_current_user
+from app.database import get_db
+from app.models import DependencyGroup, DependencyGroupMembership, Issue, Thread
+from app.models.user import User
+from app.schemas.dependency_group import (
+    DependencyGroupCreate,
+    DependencyGroupMemberCreate,
+    DependencyGroupMemberResponse,
+    DependencyGroupResponse,
+    DependencyGroupSummary,
+    DependencyGroupUpdate,
+)
+
+router = APIRouter(prefix="/reading-order-groups", tags=["reading-order-groups"])
+
+
+def _normalize_name(name: str) -> str:
+    normalized = name.strip()
+    if not normalized:
+        raise HTTPException(status_code=422, detail="Group name must not be blank")
+    return normalized
+
+
+async def _owned_group(
+    db: AsyncSession, group_id: int, user_id: int
+) -> DependencyGroup:
+    result = await db.execute(
+        select(DependencyGroup)
+        .options(selectinload(DependencyGroup.memberships))
+        .where(DependencyGroup.id == group_id, DependencyGroup.user_id == user_id)
+    )
+    group = result.scalar_one_or_none()
+    if group is None:
+        raise HTTPException(status_code=404, detail=f"Group {group_id} not found")
+    return group
+
+
+@router.get("/", response_model=list[DependencyGroupResponse])
+async def list_groups(
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: AsyncSession = Depends(get_db),
+) -> list[DependencyGroup]:
+    """List the current user's groups and memberships."""
+    result = await db.execute(
+        select(DependencyGroup)
+        .options(selectinload(DependencyGroup.memberships))
+        .where(DependencyGroup.user_id == current_user.id)
+        .order_by(DependencyGroup.name, DependencyGroup.id)
+    )
+    return list(result.scalars().unique())
+
+
+@router.post("/", response_model=DependencyGroupResponse, status_code=201)
+async def create_group(
+    payload: DependencyGroupCreate,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: AsyncSession = Depends(get_db),
+) -> DependencyGroup:
+    """Create a user-owned named group."""
+    group = DependencyGroup(user_id=current_user.id, name=_normalize_name(payload.name))
+    db.add(group)
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="A group with this name already exists") from exc
+    return await _owned_group(db, group.id, current_user.id)
+
+
+@router.get("/{group_id}", response_model=DependencyGroupResponse)
+async def get_group(
+    group_id: int,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: AsyncSession = Depends(get_db),
+) -> DependencyGroup:
+    """Return one owned group."""
+    return await _owned_group(db, group_id, current_user.id)
+
+
+@router.patch("/{group_id}", response_model=DependencyGroupResponse)
+async def update_group(
+    group_id: int,
+    payload: DependencyGroupUpdate,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: AsyncSession = Depends(get_db),
+) -> DependencyGroup:
+    """Rename one owned group."""
+    group = await _owned_group(db, group_id, current_user.id)
+    group.name = _normalize_name(payload.name)
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="A group with this name already exists") from exc
+    return await _owned_group(db, group_id, current_user.id)
+
+
+@router.delete("/{group_id}", status_code=204)
+async def delete_group(
+    group_id: int,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Delete one owned group and its memberships."""
+    group = await _owned_group(db, group_id, current_user.id)
+    await db.delete(group)
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post(
+    "/{group_id}/members",
+    response_model=DependencyGroupMemberResponse,
+    status_code=201,
+)
+async def add_member(
+    group_id: int,
+    payload: DependencyGroupMemberCreate,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: AsyncSession = Depends(get_db),
+) -> DependencyGroupMembership:
+    """Add one owned thread or issue to an owned group."""
+    await _owned_group(db, group_id, current_user.id)
+    if payload.thread_id is not None:
+        target = await db.get(Thread, payload.thread_id)
+        if target is None or target.user_id != current_user.id:
+            raise HTTPException(status_code=404, detail=f"Thread {payload.thread_id} not found")
+    else:
+        issue = await db.get(Issue, payload.issue_id)
+        thread = await db.get(Thread, issue.thread_id) if issue else None
+        if issue is None or thread is None or thread.user_id != current_user.id:
+            raise HTTPException(status_code=404, detail=f"Issue {payload.issue_id} not found")
+    member = DependencyGroupMembership(
+        group_id=group_id,
+        thread_id=payload.thread_id,
+        issue_id=payload.issue_id,
+    )
+    db.add(member)
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="This member is already in the group") from exc
+    await db.refresh(member)
+    return member
+
+
+@router.delete("/{group_id}/members/{member_id}", status_code=204)
+async def remove_member(
+    group_id: int,
+    member_id: int,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Remove one membership from an owned group."""
+    await _owned_group(db, group_id, current_user.id)
+    member = await db.get(DependencyGroupMembership, member_id)
+    if member is None or member.group_id != group_id:
+        raise HTTPException(status_code=404, detail=f"Member {member_id} not found")
+    await db.delete(member)
+    await db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get("/threads/{thread_id}/groups", response_model=list[DependencyGroupSummary])
+async def list_thread_groups(
+    thread_id: int,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: AsyncSession = Depends(get_db),
+) -> list[DependencyGroupSummary]:
+    """List groups containing an owned thread or any of its owned issues."""
+    thread = await db.get(Thread, thread_id)
+    if thread is None or thread.user_id != current_user.id:
+        raise HTTPException(status_code=404, detail=f"Thread {thread_id} not found")
+    issue_ids = select(Issue.id).where(Issue.thread_id == thread_id)
+    result = await db.execute(
+        select(DependencyGroup.id, DependencyGroup.name)
+        .join(DependencyGroupMembership)
+        .where(
+            DependencyGroup.user_id == current_user.id,
+            or_(
+                DependencyGroupMembership.thread_id == thread_id,
+                DependencyGroupMembership.issue_id.in_(issue_ids),
+            ),
+        )
+        .distinct()
+        .order_by(DependencyGroup.name, DependencyGroup.id)
+    )
+    return [DependencyGroupSummary(id=row.id, name=row.name) for row in result]

--- a/app/schemas/dependency_group.py
+++ b/app/schemas/dependency_group.py
@@ -1,0 +1,59 @@
+"""Schemas for user-owned named dependency groups."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class DependencyGroupCreate(BaseModel):
+    """Create a named dependency group."""
+
+    name: str = Field(min_length=1, max_length=120)
+
+
+class DependencyGroupUpdate(BaseModel):
+    """Rename a named dependency group."""
+
+    name: str = Field(min_length=1, max_length=120)
+
+
+class DependencyGroupMemberCreate(BaseModel):
+    """Add exactly one thread or issue to a group."""
+
+    thread_id: int | None = Field(default=None, gt=0)
+    issue_id: int | None = Field(default=None, gt=0)
+
+    @model_validator(mode="after")
+    def validate_one_target(self) -> "DependencyGroupMemberCreate":
+        """Require exactly one membership target."""
+        if (self.thread_id is None) == (self.issue_id is None):
+            raise ValueError("Exactly one of thread_id or issue_id is required")
+        return self
+
+
+class DependencyGroupMemberResponse(BaseModel):
+    """One persisted group membership."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    thread_id: int | None
+    issue_id: int | None
+
+
+class DependencyGroupResponse(BaseModel):
+    """A named dependency group with its members."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    created_at: datetime
+    memberships: list[DependencyGroupMemberResponse]
+
+
+class DependencyGroupSummary(BaseModel):
+    """Compact group metadata for the Roll view."""
+
+    id: int
+    name: str

--- a/app/schemas/dependency_group.py
+++ b/app/schemas/dependency_group.py
@@ -24,7 +24,7 @@ class DependencyGroupMemberCreate(BaseModel):
     issue_id: int | None = Field(default=None, gt=0)
 
     @model_validator(mode="after")
-    def validate_one_target(self) -> "DependencyGroupMemberCreate":
+    def validate_one_target(self) -> DependencyGroupMemberCreate:
         """Require exactly one membership target."""
         if (self.thread_id is None) == (self.issue_id is None):
             raise ValueError("Exactly one of thread_id or issue_id is required")

--- a/app/schemas/dependency_group.py
+++ b/app/schemas/dependency_group.py
@@ -25,7 +25,14 @@ class DependencyGroupMemberCreate(BaseModel):
 
     @model_validator(mode="after")
     def validate_one_target(self) -> DependencyGroupMemberCreate:
-        """Require exactly one membership target."""
+        """Require exactly one membership target.
+
+        Args:
+            self: The membership request model being validated.
+
+        Returns:
+            The validated membership request model.
+        """
         if (self.thread_id is None) == (self.issue_id is None):
             raise ValueError("Exactly one of thread_id or issue_id is required")
         return self

--- a/tests/test_dependency_group_route_order.py
+++ b/tests/test_dependency_group_route_order.py
@@ -27,4 +27,4 @@ def test_thread_group_lookup_is_not_shadowed_by_group_id_route() -> None:
     ]
 
     assert full_matches
-    assert full_matches[0].name == "list_thread_groups"
+    assert getattr(full_matches[0], "name", None) == "list_thread_groups"

--- a/tests/test_dependency_group_route_order.py
+++ b/tests/test_dependency_group_route_order.py
@@ -1,0 +1,30 @@
+"""Regression coverage for dependency-group route precedence."""
+
+from starlette.routing import Match
+
+from app.api.dependency_group import router
+
+
+def test_thread_group_lookup_is_not_shadowed_by_group_id_route() -> None:
+    """Route the Roll lookup to its static endpoint before dynamic group IDs."""
+    scope = {
+        "type": "http",
+        "path": "/reading-order-groups/threads/42/groups",
+        "method": "GET",
+        "headers": [],
+        "query_string": b"",
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "client": ("testclient", 50000),
+        "root_path": "",
+        "http_version": "1.1",
+    }
+
+    full_matches = [
+        route
+        for route in router.routes
+        if route.matches(scope)[0] is Match.FULL
+    ]
+
+    assert full_matches
+    assert full_matches[0].name == "list_thread_groups"


### PR DESCRIPTION
## Summary

Adds the backend API foundation for explicit user-owned named reading-order groups using the persistence model and migration already present on `main`.

## Implemented

- adds validated create/update/member request schemas and group/member responses;
- exposes authenticated list, create, read, rename, and delete routes;
- supports thread-level and issue-level memberships with exactly-one-target validation;
- enforces current-user ownership for groups, threads, issues, and membership removal;
- returns conflict responses for duplicate names and duplicate memberships;
- adds one bounded Roll-view lookup returning groups containing the thread or any of its issues;
- registers the routes beneath the existing `/api/v1` dependency router.

## Stage scope

Part of #613. This is a coherent backend API stage. Frontend management controls, Roll rendering, and their browser/unit coverage remain open, so this PR does not close the issue.

## Verification

Exact-head CI is the validation boundary for this connector-authored branch. No merge or auto-merge is authorized.

Model: chatgpt-factory-3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reading-order dependency groups for organizing threads and issues.
  * Users can create, rename, view, list, and delete their groups.
  * Added the ability to add or remove threads and issues as group members.
  * Added group listings for threads and their associated issues.
  * Added validation for group names, memberships, duplicate entries, and access permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->