### PR TITLE
Index deterministic latest session action reads (#700)

### DIFF
--- a/alembic/versions/b700c1d2e3f4_add_latest_session_action_index.py
+++ b/alembic/versions/b700c1d2e3f4_add_latest_session_action_index.py
@@ -1,0 +1,32 @@
+"""Add latest session action lookup index.
+
+Revision ID: b700c1d2e3f4
+Revises: a613b7c9d201
+Create Date: 2026-08-04 18:05:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "b700c1d2e3f4"
+down_revision: str | Sequence[str] | None = "a613b7c9d201"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Index deterministic latest-action reads by session."""
+    op.create_index(
+        "ix_event_session_latest_action",
+        "events",
+        ["session_id", op.f("timestamp"), op.f("id")],
+        unique=False,
+        postgresql_ops={"timestamp": "DESC", "id": "DESC"},
+    )
+
+
+def downgrade() -> None:
+    """Remove the latest-action lookup index."""
+    op.drop_index("ix_event_session_latest_action", table_name="events")

--- a/alembic/versions/b700c1d2e3f4_add_latest_session_action_index.py
+++ b/alembic/versions/b700c1d2e3f4_add_latest_session_action_index.py
@@ -9,6 +9,7 @@ Create Date: 2026-08-04 18:05:00.000000
 from collections.abc import Sequence
 
 from alembic import op
+import sqlalchemy as sa
 
 revision: str = "b700c1d2e3f4"
 down_revision: str | Sequence[str] | None = "a613b7c9d201"
@@ -21,9 +22,8 @@ def upgrade() -> None:
     op.create_index(
         "ix_event_session_latest_action",
         "events",
-        ["session_id", op.f("timestamp"), op.f("id")],
+        ["session_id", sa.text("timestamp DESC"), sa.text("id DESC")],
         unique=False,
-        postgresql_ops={"timestamp": "DESC", "id": "DESC"},
     )
 
 

--- a/app/models/event.py
+++ b/app/models/event.py
@@ -86,6 +86,12 @@ class Event(Base):
         Index("ix_event_session_id", "session_id"),
         Index("ix_event_timestamp", "timestamp"),
         Index("ix_event_session_type_timestamp", "session_id", "type", "timestamp"),
+        Index(
+            "ix_event_session_latest_action",
+            "session_id",
+            timestamp.desc(),
+            id.desc(),
+        ),
         Index("ix_event_session_type_die_after", "session_id", "type", "die_after"),
     )
 


### PR DESCRIPTION
## Summary

Adds a database index aligned with the current-session endpoint's deterministic latest-action lookup.

## Implemented

- adds a composite PostgreSQL index on `events(session_id, timestamp DESC, id DESC)`;
- mirrors the index in SQLAlchemy model metadata;
- preserves the endpoint's existing timestamp and event-ID tie-breaking semantics;
- avoids changing payloads, cache behavior, or session mutation behavior.

## Stage scope

Part of #700. This is a bounded query-plan improvement for the current-session read path. Broader event aggregation and History consolidation remain open.

## Verification

Exact-head CI is the validation boundary because the automation runtime cannot resolve `github.com` for a writable checkout. No merge or auto-merge is authorized.

Model: chatgpt-factory-3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved the speed of retrieving the latest actions for a session.
  * Added database indexing to optimize event lookups involving sessions and timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->