### PR TITLE
Fix OpenCode provider rotation exhaustion

### DIFF
--- a/.github/workflows/factory-policy.yml
+++ b/.github/workflows/factory-policy.yml
@@ -17,6 +17,7 @@ on:
       - scripts/tests/test_autonomous_factory_policy.py
       - scripts/tests/test_install_git_hooks.py
       - scripts/tests/test_opencode_model_tools.py
+      - scripts/tests/test_opencode_provider_rotation.py
       - scripts/tests/test_overnight_factory_cli.py
       - .github/workflows/factory-policy.yml
   push:
@@ -37,6 +38,7 @@ on:
       - scripts/tests/test_autonomous_factory_policy.py
       - scripts/tests/test_install_git_hooks.py
       - scripts/tests/test_opencode_model_tools.py
+      - scripts/tests/test_opencode_provider_rotation.py
       - scripts/tests/test_overnight_factory_cli.py
       - .github/workflows/factory-policy.yml
 
@@ -64,6 +66,7 @@ jobs:
             scripts/tests/test_autonomous_factory_policy.py \
             scripts/tests/test_install_git_hooks.py \
             scripts/tests/test_opencode_model_tools.py \
+            scripts/tests/test_opencode_provider_rotation.py \
             scripts/tests/test_overnight_factory_cli.py
       - name: Check canonical factory invariants
         run: python scripts/check-autonomous-factory-policy.py
@@ -72,6 +75,9 @@ jobs:
       - name: Test git hook installer
         run: python -m unittest scripts/tests/test_install_git_hooks.py
       - name: Test model rotation and scout supervision
-        run: python -m unittest scripts/tests/test_opencode_model_tools.py
+        run: >-
+          python -m unittest
+          scripts/tests/test_opencode_model_tools.py
+          scripts/tests/test_opencode_provider_rotation.py
       - name: Test overnight factory CLI
         run: python -m unittest scripts/tests/test_overnight_factory_cli.py

--- a/scripts/comic-pile-opencode-factory.sh
+++ b/scripts/comic-pile-opencode-factory.sh
@@ -216,8 +216,6 @@ while true; do
     continue
   fi
 
-  "$MANIFEST_HELPER" record "$model" "$STATE_DIR" >/dev/null 2>&1 || true
-
   if grep -Fq 'FACTORY_RESULT: changed' "$result_file"; then
     rm -f "$result_file"
     if ((RUN_ONCE == 1)); then

--- a/scripts/comic-pile-opencode-factory.sh
+++ b/scripts/comic-pile-opencode-factory.sh
@@ -10,6 +10,7 @@ set -Eeuo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 HEARTBEAT_RUNNER="$SCRIPT_DIR/comic-pile-opencode-factory-heartbeat.sh"
 MANIFEST_HELPER="$SCRIPT_DIR/opencode-model-manifest.sh"
+MODEL_SCOUT="$SCRIPT_DIR/opencode-model-scout.sh"
 SOURCE_REPO="${COMIC_PILE_REPO:-/mnt/extra/josh/code/comic-pile}"
 STATE_DIR="${COMIC_PILE_FACTORY_STATE_DIR:-}"
 DEFAULT_MODEL="${COMIC_PILE_DEFAULT_MODEL:-deepseek/deepseek-v4-flash}"
@@ -20,6 +21,12 @@ RUN_ONCE=0
 STATE_DIR_EXPLICIT=0
 FORWARD_ARGS=()
 MAX_FAILURES="${FACTORY_MAX_FAILURES:-2}"
+WAIT_FOR_SCOUT="${COMIC_PILE_FACTORY_WAIT_FOR_SCOUT:-0}"
+SCOUT_READY_FILE="${COMIC_PILE_FACTORY_SCOUT_READY_FILE:-}"
+SCOUT_PID_FILE="${COMIC_PILE_FACTORY_SCOUT_PID_FILE:-}"
+AUTO_SCOUT="${COMIC_PILE_FACTORY_AUTO_SCOUT:-1}"
+SCOUT_PARALLEL="${SCOUT_PARALLEL:-4}"
+SCOUT_TIMEOUT="${MODEL_SCOUT_TIMEOUT:-${FACTORY_HEARTBEAT_TIMEOUT:-60}}"
 
 usage() {
   "$HEARTBEAT_RUNNER" --help
@@ -81,14 +88,79 @@ done
 if [[ -z "$STATE_DIR" || "$STATE_DIR_EXPLICIT" == "0" && -z "${COMIC_PILE_FACTORY_STATE_DIR:-}" ]]; then
   STATE_DIR="${SOURCE_REPO%/}-factory-state"
 fi
+[[ -n "$SCOUT_READY_FILE" ]] || SCOUT_READY_FILE="$STATE_DIR/scout-initial-pass.done"
 
 is_nonnegative_integer "$IDLE_SECONDS" || die "FACTORY_IDLE_SECONDS must be an integer"
 is_nonnegative_integer "$MAX_FAILURES" || die "FACTORY_MAX_FAILURES must be an integer"
 ((MAX_FAILURES >= 1)) || die "FACTORY_MAX_FAILURES must be at least 1"
+is_nonnegative_integer "$SCOUT_PARALLEL" || die "SCOUT_PARALLEL must be an integer"
+((SCOUT_PARALLEL >= 1)) || die "SCOUT_PARALLEL must be at least 1"
+[[ "$SCOUT_TIMEOUT" =~ ^[1-9][0-9]*$ ]] || die "MODEL_SCOUT_TIMEOUT must be a positive integer"
+[[ "$AUTO_SCOUT" == "0" || "$AUTO_SCOUT" == "1" ]] || die "COMIC_PILE_FACTORY_AUTO_SCOUT must be 0 or 1"
 [[ -x "$HEARTBEAT_RUNNER" ]] || die "heartbeat runner is not executable: $HEARTBEAT_RUNNER"
 [[ -x "$MANIFEST_HELPER" ]] || die "manifest helper is not executable: $MANIFEST_HELPER"
 mkdir -p "$STATE_DIR"
 "$MANIFEST_HELPER" init "$STATE_DIR"
+
+non_chat_model() {
+  [[ "$1" == *embedding* || "$1" == *rerank* || "$1" == *whisper* || "$1" == *tts* \
+    || "$1" == *-image* || "$1" == *image-* || "$1" == *safeguard* \
+    || "$1" == *content-safety* || "$1" == *cosmos* || "$1" == *riva* \
+    || "$1" == *nemotron-mini* || "$1" == *prompt-guard* || "$1" == *esm* ]]
+}
+
+wait_for_initial_scout() {
+  [[ "$WAIT_FOR_SCOUT" == "1" ]] || return 0
+  printf 'Waiting for the model scout to complete its initial pass...\n'
+  while [[ ! -f "$SCOUT_READY_FILE" ]]; do
+    if [[ -n "$SCOUT_PID_FILE" && -f "$SCOUT_PID_FILE" ]]; then
+      local scout_pid
+      scout_pid="$(cat "$SCOUT_PID_FILE" 2>/dev/null || true)"
+      if [[ "$scout_pid" =~ ^[0-9]+$ ]] && ! kill -0 -- "-$scout_pid" 2>/dev/null; then
+        die "model scout exited before completing its initial pass"
+      fi
+    fi
+    sleep 2
+  done
+  printf 'Model scout initial pass complete; refreshing the complete provider list.\n'
+}
+
+refresh_model_manifest() {
+  local cooldown="${1:-3600}"
+  local candidates_file model
+
+  [[ -z "$PINNED_MODEL" && "$AUTO_SCOUT" == "1" ]] || return 0
+  command -v opencode >/dev/null 2>&1 || return 0
+  [[ -x "$MODEL_SCOUT" ]] || {
+    printf 'WARNING: model scout is not executable: %s\n' "$MODEL_SCOUT" >&2
+    return 1
+  }
+
+  candidates_file="$(mktemp "$STATE_DIR/.model-candidates.XXXXXX")"
+  while IFS= read -r model; do
+    [[ -n "$model" ]] || continue
+    non_chat_model "$model" || printf '%s\n' "$model"
+  done < <(opencode models 2>/dev/null) >"$candidates_file"
+
+  if [[ ! -s "$candidates_file" ]]; then
+    rm -f "$candidates_file"
+    printf 'WARNING: opencode models returned no usable chat models; keeping the existing manifest.\n' >&2
+    return 1
+  fi
+
+  printf 'Refreshing OpenCode model manifest from all available providers...\n'
+  set +e
+  MODEL_SCOUT_FAILURE_COOLDOWN_SECONDS="$cooldown" \
+    "$MODEL_SCOUT" --once \
+    --state-dir "$STATE_DIR" \
+    --parallel "$SCOUT_PARALLEL" \
+    --timeout "$SCOUT_TIMEOUT" \
+    --candidates-file "$candidates_file"
+  local status=$?
+  set -e
+  rm -f "$candidates_file"
+  return "$status"
+}
 
 select_model() {
   if [[ -n "$PINNED_MODEL" ]]; then
@@ -98,7 +170,11 @@ select_model() {
   fi
 }
 
+wait_for_initial_scout
+refresh_model_manifest 3600 || true
+
 heartbeat=0
+recovery_scout_attempted=0
 while true; do
   heartbeat=$((heartbeat + 1))
   model="$(select_model)"
@@ -125,13 +201,22 @@ while true; do
       exit "$status"
     fi
     if ! "$MANIFEST_HELPER" confirmed "$STATE_DIR" | grep -q .; then
-      printf 'Factory stopped: no confirmed models remain after failure of %s.\n' "$model" >&2
-      exit "$status"
+      if ((recovery_scout_attempted == 0)) && [[ "$AUTO_SCOUT" == "1" ]]; then
+        recovery_scout_attempted=1
+        printf 'No confirmed models remain; immediately re-probing every available provider.\n' >&2
+        refresh_model_manifest 0 || true
+      fi
+      if ! "$MANIFEST_HELPER" confirmed "$STATE_DIR" | grep -q .; then
+        printf 'Factory stopped: no confirmed models remain after exhausting all available providers.\n' >&2
+        exit "$status"
+      fi
     fi
     printf 'Heartbeat failed for %s; immediately rotating to the next model (no cooldown).\n' \
       "$model" >&2
     continue
   fi
+
+  "$MANIFEST_HELPER" record "$model" "$STATE_DIR" >/dev/null 2>&1 || true
 
   if grep -Fq 'FACTORY_RESULT: changed' "$result_file"; then
     rm -f "$result_file"

--- a/scripts/tests/test_opencode_provider_rotation.py
+++ b/scripts/tests/test_opencode_provider_rotation.py
@@ -18,6 +18,7 @@ class ProviderRotationTests(unittest.TestCase):
     """Verify direct factory runs discover every usable OpenCode provider."""
 
     def test_direct_run_refreshes_providers_before_rotation(self) -> None:
+        """Refresh live providers and rotate away from a failed Cerebras model."""
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             scripts = root / "scripts"

--- a/scripts/tests/test_opencode_provider_rotation.py
+++ b/scripts/tests/test_opencode_provider_rotation.py
@@ -1,0 +1,144 @@
+"""Regression coverage for live OpenCode provider rotation."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+SOURCE_ROOT = Path(__file__).resolve().parents[2]
+
+
+class ProviderRotationTests(unittest.TestCase):
+    """Verify direct factory runs discover every usable OpenCode provider."""
+
+    def test_direct_run_refreshes_providers_before_rotation(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            scripts = root / "scripts"
+            bin_dir = root / "bin"
+            state = root / "state"
+            scripts.mkdir()
+            bin_dir.mkdir()
+            state.mkdir()
+
+            for name in (
+                "comic-pile-opencode-factory.sh",
+                "opencode-model-manifest.sh",
+            ):
+                target = scripts / name
+                shutil.copy2(SOURCE_ROOT / "scripts" / name, target)
+                target.chmod(0o755)
+
+            scout = scripts / "opencode-model-scout.sh"
+            scout.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    state=""
+                    candidates=""
+                    while (($#)); do
+                      case "$1" in
+                        --state-dir) state="$2"; shift 2 ;;
+                        --candidates-file) candidates="$2"; shift 2 ;;
+                        *) shift ;;
+                      esac
+                    done
+                    while IFS= read -r model; do
+                      [[ -n "$model" ]] || continue
+                      "$(dirname "$0")/opencode-model-manifest.sh" \
+                        set "$model" confirmed yes "$state"
+                    done <"$candidates"
+                    """
+                )
+            )
+            scout.chmod(0o755)
+
+            heartbeat = scripts / "comic-pile-opencode-factory-heartbeat.sh"
+            heartbeat.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    state=""
+                    model=""
+                    while (($#)); do
+                      case "$1" in
+                        --state-dir) state="$2"; shift 2 ;;
+                        --model) model="$2"; shift 2 ;;
+                        --help) exit 0 ;;
+                        *) shift ;;
+                      esac
+                    done
+                    printf '%s\n' "$model" >>"$state/models-used.log"
+                    if [[ "$model" == cerebras/* ]]; then
+                      exit 7
+                    fi
+                    printf 'FACTORY_RESULT: idle\n'
+                    """
+                )
+            )
+            heartbeat.chmod(0o755)
+
+            opencode = bin_dir / "opencode"
+            opencode.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    [[ "${1:-}" == "models" ]] || exit 2
+                    printf '%s\n' \
+                      cerebras/gemma \
+                      deepseek/deepseek-v4-flash \
+                      nvidia/nemotron \
+                      opencode/zen \
+                      nvidia/text-embedding
+                    """
+                )
+            )
+            opencode.chmod(0o755)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "PATH": f"{bin_dir}:{env['PATH']}",
+                    "COMIC_PILE_FACTORY_STATE_DIR": str(state),
+                    "COMIC_PILE_DEFAULT_MODEL": "cerebras/gemma",
+                    "FACTORY_MAX_FAILURES": "1",
+                    "SCOUT_PARALLEL": "1",
+                }
+            )
+            result = subprocess.run(
+                [scripts / "comic-pile-opencode-factory.sh"],
+                cwd=root,
+                env=env,
+                text=True,
+                capture_output=True,
+                timeout=10,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            used = (state / "models-used.log").read_text().splitlines()
+            self.assertEqual(used[0], "cerebras/gemma")
+            self.assertNotEqual(used[1].split("/", 1)[0], "cerebras")
+
+            manifest = (state / "model_manifest.tsv").read_text()
+            self.assertIn("deepseek/deepseek-v4-flash\tconfirmed", manifest)
+            self.assertIn("nvidia/nemotron\tconfirmed", manifest)
+            self.assertIn("opencode/zen\tconfirmed", manifest)
+            self.assertNotIn("nvidia/text-embedding", manifest)
+            self.assertIn(
+                "Refreshing OpenCode model manifest from all available providers",
+                result.stdout,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- refresh the model manifest from the live `opencode models` list before factory rotation
- include usable models from every provider, including `opencode/*` Zen models
- wait for the overnight scout before the wrapper chooses its first model
- re-probe all available providers once when confirmed models are exhausted instead of stopping after Cerebras
- preserve the existing round-robin selection behavior
- add regression coverage proving a Cerebras failure rotates to another provider while NVIDIA, DeepSeek, and Zen are admitted

## Why

The wrapper only selected models already marked `confirmed`. Direct runs did not start the scout, the wrapper selected before the overnight scout completed, and the scout's default discovery excluded `opencode/*`. After the two confirmed Cerebras models failed, the wrapper therefore saw an empty confirmed set and exited even though other providers were available.

## Validation

- shell syntax and canonical factory-policy invariants pass
- existing model rotation and scout supervision tests pass
- new regression proves Cerebras failure rotates to a non-Cerebras provider and admits DeepSeek, NVIDIA, and OpenCode Zen
- full CI passes, including backend, frontend, migrations, Ruff, type checking, and E2E suites