### PR TITLE
Recover committed snoozes from failed Roll refreshes (#795)

### DIFF
--- a/frontend/src/hooks/useSnooze.ts
+++ b/frontend/src/hooks/useSnooze.ts
@@ -60,6 +60,10 @@ export function useSnooze() {
 
   const mutate = async (expectedPendingThreadId?: number): Promise<SnoozeResult> => {
     if (inFlightRequest.current) return inFlightRequest.current
+    if (refreshRequest.current) {
+      await refreshRequest.current
+      return undefined
+    }
 
     setIsPending(true)
     setIsError(false)

--- a/frontend/src/hooks/useSnooze.ts
+++ b/frontend/src/hooks/useSnooze.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { snoozeApi } from '../services/api'
 import { getApiErrorDetail } from '../utils/apiError'
 import {
@@ -9,30 +9,66 @@ import {
 
 type SnoozeResult = Awaited<ReturnType<typeof snoozeApi.snooze>> | undefined
 
+const SNOOZE_REFRESH_ATTEMPTS = 2
+
 export function useSnooze() {
   const [isPending, setIsPending] = useState(false)
   const [isError, setIsError] = useState(false)
+  const [refreshError, setRefreshError] = useState<unknown>(null)
   const inFlightRequest = useRef<Promise<SnoozeResult> | null>(null)
+  const refreshRequest = useRef<Promise<boolean> | null>(null)
+
+  const refreshAuthoritativeState = useCallback(async (): Promise<boolean> => {
+    if (refreshRequest.current) return refreshRequest.current
+
+    const request = (async () => {
+      for (let attempt = 1; attempt <= SNOOZE_REFRESH_ATTEMPTS; attempt += 1) {
+        try {
+          await fetchAndPublishRollBootstrap()
+          setRefreshError(null)
+          return true
+        } catch (error: unknown) {
+          if (attempt === SNOOZE_REFRESH_ATTEMPTS) {
+            setRefreshError(error)
+            console.error(
+              'Snooze saved but authoritative Roll state failed to refresh:',
+              getApiErrorDetail(error),
+            )
+            return false
+          }
+        }
+      }
+      return false
+    })()
+
+    refreshRequest.current = request
+    try {
+      return await request
+    } finally {
+      refreshRequest.current = null
+    }
+  }, [])
+
+  const retryRefresh = useCallback(async (): Promise<boolean> => {
+    setIsPending(true)
+    try {
+      return await refreshAuthoritativeState()
+    } finally {
+      setIsPending(false)
+    }
+  }, [refreshAuthoritativeState])
 
   const mutate = async (expectedPendingThreadId?: number): Promise<SnoozeResult> => {
     if (inFlightRequest.current) return inFlightRequest.current
 
     setIsPending(true)
     setIsError(false)
+    setRefreshError(null)
 
     const request: Promise<SnoozeResult> = (async () => {
       try {
         const result = await snoozeApi.snooze()
-
-        try {
-          await fetchAndPublishRollBootstrap()
-        } catch (reconciliationError: unknown) {
-          console.error(
-            'Snooze saved but authoritative Roll state failed to refresh:',
-            getApiErrorDetail(reconciliationError),
-          )
-        }
-
+        await refreshAuthoritativeState()
         return result
       } catch (error: unknown) {
         if (isAmbiguousNetworkFailure(error)) {
@@ -63,7 +99,14 @@ export function useSnooze() {
     }
   }
 
-  return { mutate, isPending, isError }
+  return {
+    mutate,
+    retryRefresh,
+    isPending,
+    isError,
+    refreshError,
+    hasRefreshError: refreshError !== null,
+  }
 }
 
 export function useUnsnooze() {

--- a/frontend/src/unit/useSnooze.test.tsx
+++ b/frontend/src/unit/useSnooze.test.tsx
@@ -89,6 +89,52 @@ describe('snooze hooks', () => {
     expect(snooze.result.current.isError).toBe(false)
   })
 
+  it('retries a failed post-snooze refresh once and publishes authoritative state', async () => {
+    const refreshFailure = new Error('bootstrap unavailable')
+    rollBootstrapApi.get
+      .mockRejectedValueOnce(refreshFailure)
+      .mockResolvedValueOnce(bootstrapState(null, 20))
+    const reconciled = vi.fn()
+    window.addEventListener(ROLL_BOOTSTRAP_RECONCILED_EVENT, reconciled)
+
+    try {
+      const snooze = renderHook(() => useSnooze())
+      await act(async () => await snooze.result.current.mutate(7))
+
+      expect(snoozeApi.snooze).toHaveBeenCalledTimes(1)
+      expect(rollBootstrapApi.get).toHaveBeenCalledTimes(2)
+      expect(reconciled).toHaveBeenCalledTimes(1)
+      expect(snooze.result.current.isError).toBe(false)
+      expect(snooze.result.current.hasRefreshError).toBe(false)
+    } finally {
+      window.removeEventListener(ROLL_BOOTSTRAP_RECONCILED_EVENT, reconciled)
+    }
+  })
+
+  it('exposes exhausted refresh recovery and retries without repeating the snooze', async () => {
+    const refreshFailure = new Error('bootstrap unavailable')
+    rollBootstrapApi.get.mockRejectedValue(refreshFailure)
+    const snooze = renderHook(() => useSnooze())
+
+    await act(async () => await snooze.result.current.mutate(7))
+
+    expect(snoozeApi.snooze).toHaveBeenCalledTimes(1)
+    expect(rollBootstrapApi.get).toHaveBeenCalledTimes(2)
+    expect(snooze.result.current.isError).toBe(false)
+    expect(snooze.result.current.hasRefreshError).toBe(true)
+    expect(snooze.result.current.refreshError).toBe(refreshFailure)
+
+    rollBootstrapApi.get.mockResolvedValue(bootstrapState(null, 20))
+    await act(async () => {
+      await expect(snooze.result.current.retryRefresh()).resolves.toBe(true)
+    })
+
+    expect(snoozeApi.snooze).toHaveBeenCalledTimes(1)
+    expect(rollBootstrapApi.get).toHaveBeenCalledTimes(3)
+    expect(snooze.result.current.hasRefreshError).toBe(false)
+    expect(snooze.result.current.isPending).toBe(false)
+  })
+
   it('reconciles a committed snooze after the delayed response crosses the client timeout', async () => {
     vi.useFakeTimers()
     const timeout = Object.assign(new Error('timeout of 10000ms exceeded'), {

--- a/frontend/src/unit/useSnooze.test.tsx
+++ b/frontend/src/unit/useSnooze.test.tsx
@@ -135,6 +135,38 @@ describe('snooze hooks', () => {
     expect(snooze.result.current.isPending).toBe(false)
   })
 
+  it('blocks duplicate snooze submission while an explicit refresh retry is pending', async () => {
+    const refreshFailure = new Error('bootstrap unavailable')
+    rollBootstrapApi.get.mockRejectedValue(refreshFailure)
+    const snooze = renderHook(() => useSnooze())
+
+    await act(async () => await snooze.result.current.mutate(7))
+
+    let resolveRefresh: ((value: RollBootstrapResponse) => void) | undefined
+    rollBootstrapApi.get.mockReturnValue(new Promise((resolve) => {
+      resolveRefresh = resolve
+    }))
+
+    let retryRequest: Promise<boolean> | undefined
+    let duplicateRequest: Promise<unknown> | undefined
+    act(() => {
+      retryRequest = snooze.result.current.retryRefresh()
+      duplicateRequest = snooze.result.current.mutate(7)
+    })
+
+    expect(snoozeApi.snooze).toHaveBeenCalledTimes(1)
+    expect(snooze.result.current.isPending).toBe(true)
+
+    await act(async () => {
+      resolveRefresh?.(bootstrapState(null, 20))
+      await Promise.all([retryRequest, duplicateRequest])
+    })
+
+    expect(snoozeApi.snooze).toHaveBeenCalledTimes(1)
+    expect(snooze.result.current.isPending).toBe(false)
+    expect(snooze.result.current.hasRefreshError).toBe(false)
+  })
+
   it('reconciles a committed snooze after the delayed response crosses the client timeout', async () => {
     vi.useFakeTimers()
     const timeout = Object.assign(new Error('timeout of 10000ms exceeded'), {


### PR DESCRIPTION
## Summary

Closes #795 by separating a committed snooze from a failed authoritative Roll refresh and giving refresh recovery its own bounded, deduplicated path.

## Implemented

- retries the authoritative post-snooze bootstrap refresh once before surfacing recovery state;
- preserves the successful snooze result even when both refresh attempts fail;
- exposes `hasRefreshError`, `refreshError`, and `retryRefresh` without marking the committed snooze itself failed;
- keeps the recovery refresh deduplicated and keeps `isPending` true while an explicit retry is running;
- clears recovery state after authoritative Roll bootstrap publication succeeds;
- adds focused hook tests for automatic retry success, exhausted recovery, explicit retry, no duplicate snooze mutation, and authoritative event publication.

## Verification

Exact-head CI is the broad validation boundary for this connector-authored branch. The focused tests are `frontend/src/unit/useSnooze.test.tsx`.

Model: chatgpt-factory-5