### PR TITLE
Prevent stale bootstrap requests from overwriting reconciled Roll state (#794)

### DIFF
--- a/frontend/src/hooks/useRollBootstrap.ts
+++ b/frontend/src/hooks/useRollBootstrap.ts
@@ -15,13 +15,16 @@ export function useRollBootstrap() {
   const lastNotifiedSessionIdRef = useRef<number | null>(null);
   const justReconciledRef = useRef<RollBootstrapResponse | null>(null);
   const reconciliationExpiryRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const requestGenerationRef = useRef(0);
 
   const fetchBootstrap = useCallback(async () => {
+    const requestGeneration = ++requestGenerationRef.current;
     setIsPending(true);
     setIsError(false);
     setError(null);
     try {
       const result = await rollBootstrapApi.get();
+      if (requestGeneration !== requestGenerationRef.current) return result;
 
       const currentSessionId = result.session_id;
       const currentUserId = result.user_id ?? 'anonymous';
@@ -57,11 +60,13 @@ export function useRollBootstrap() {
       return result;
     } catch (err: unknown) {
       const normalized = err instanceof Error ? err : new Error('Failed to fetch roll bootstrap');
-      setIsError(true);
-      setError(normalized);
+      if (requestGeneration === requestGenerationRef.current) {
+        setIsError(true);
+        setError(normalized);
+      }
       throw normalized;
     } finally {
-      setIsPending(false);
+      if (requestGeneration === requestGenerationRef.current) setIsPending(false);
     }
   }, [showToast]);
 
@@ -90,6 +95,7 @@ export function useRollBootstrap() {
       const reconciled = (event as CustomEvent<RollBootstrapResponse>).detail;
       if (!reconciled) return;
 
+      requestGenerationRef.current += 1;
       justReconciledRef.current = reconciled;
       if (reconciliationExpiryRef.current) clearTimeout(reconciliationExpiryRef.current);
       reconciliationExpiryRef.current = setTimeout(() => {

--- a/frontend/src/unit/useRollBootstrap.test.tsx
+++ b/frontend/src/unit/useRollBootstrap.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useRollBootstrap } from '../hooks/useRollBootstrap'
+import { ROLL_BOOTSTRAP_RECONCILED_EVENT } from '../hooks/rollMutationReconciliation'
 import { rollBootstrapApi } from '../services/rollBootstrapApi'
 import type { RollBootstrapResponse } from '../types/rollBootstrap'
 import { ToastProvider } from '../contexts/ToastProvider'
@@ -29,6 +30,16 @@ const bootstrapResponse = {
   stale_thread_count: 0,
   stale_thread: null,
 } as RollBootstrapResponse
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+  return { promise, resolve, reject }
+}
 
 function renderBootstrap() {
   return renderHook(() => useRollBootstrap(), {
@@ -211,5 +222,58 @@ describe('useRollBootstrap', () => {
     expect(result.current.data).toBe(bootstrapResponse)
     expect(result.current.isError).toBe(false)
     expect(localStorage.getItem('comic_pile_last_session_id_1')).toBe('1')
+  })
+
+  it('keeps reconciled state when an older bootstrap request resolves later', async () => {
+    const initialRequest = deferred<RollBootstrapResponse>()
+    mockedBootstrap.mockReturnValueOnce(initialRequest.promise)
+    const reconciled = { ...bootstrapResponse, current_die: 8 }
+    const { result } = renderBootstrap()
+
+    await waitFor(() => expect(mockedBootstrap).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(ROLL_BOOTSTRAP_RECONCILED_EVENT, { detail: reconciled }),
+      )
+    })
+
+    expect(result.current.data).toEqual(reconciled)
+    expect(result.current.isPending).toBe(false)
+
+    await act(async () => {
+      initialRequest.resolve(bootstrapResponse)
+      await initialRequest.promise
+    })
+
+    expect(result.current.data).toEqual(reconciled)
+    expect(result.current.isPending).toBe(false)
+    expect(result.current.isError).toBe(false)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('ignores an older bootstrap failure after successful reconciliation', async () => {
+    const initialRequest = deferred<RollBootstrapResponse>()
+    mockedBootstrap.mockReturnValueOnce(initialRequest.promise)
+    const reconciled = { ...bootstrapResponse, current_die: 8 }
+    const { result } = renderBootstrap()
+
+    await waitFor(() => expect(mockedBootstrap).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(ROLL_BOOTSTRAP_RECONCILED_EVENT, { detail: reconciled }),
+      )
+    })
+
+    await act(async () => {
+      initialRequest.reject(new Error('stale bootstrap failure'))
+      await expect(initialRequest.promise).rejects.toThrow('stale bootstrap failure')
+    })
+
+    expect(result.current.data).toEqual(reconciled)
+    expect(result.current.isPending).toBe(false)
+    expect(result.current.isError).toBe(false)
+    expect(result.current.error).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

Closes #794 by adding request-generation protection to `useRollBootstrap`.

## Implemented

- assigns every bootstrap request a monotonically increasing generation;
- advances the generation when authoritative reconciled Roll state is published;
- applies data, error, and pending-state cleanup only for the current generation;
- prevents older successful responses from replacing reconciled state;
- prevents older failures from surfacing after successful reconciliation;
- adds deterministic stale-success and stale-failure hook regressions.

## Verification

Exact-head CI is the broad validation boundary for this connector-authored branch. Focused coverage is in `frontend/src/unit/useRollBootstrap.test.tsx`.

Local focused validation: `pnpm vitest run src/unit/useRollBootstrap.test.tsx` → 10/10 passed. `pnpm run lint` and `pnpm run typecheck` are clean for the changed files.

Model: ollama-cloud/minimax-m3