### PR TITLE
Index deterministic latest session action reads (#700)

### DIFF
--- a/alembic/versions/b700c1d2e3f4_add_latest_session_action_index.py
+++ b/alembic/versions/b700c1d2e3f4_add_latest_session_action_index.py
@@ -18,7 +18,7 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    """Index deterministic latest-action reads by session.
+    """Index deterministic latest-action reads by session without blocking writes.
 
     Args:
         None.
@@ -26,16 +26,18 @@ def upgrade() -> None:
     Returns:
         None.
     """
-    op.create_index(
-        "ix_event_session_latest_action",
-        "events",
-        ["session_id", sa.text("timestamp DESC"), sa.text("id DESC")],
-        unique=False,
-    )
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_event_session_latest_action",
+            "events",
+            ["session_id", sa.text("timestamp DESC"), sa.text("id DESC")],
+            unique=False,
+            postgresql_concurrently=True,
+        )
 
 
 def downgrade() -> None:
-    """Remove the latest-action lookup index.
+    """Remove the latest-action lookup index without blocking writes.
 
     Args:
         None.
@@ -43,4 +45,9 @@ def downgrade() -> None:
     Returns:
         None.
     """
-    op.drop_index("ix_event_session_latest_action", table_name="events")
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_event_session_latest_action",
+            table_name="events",
+            postgresql_concurrently=True,
+        )

--- a/alembic/versions/b700c1d2e3f4_add_latest_session_action_index.py
+++ b/alembic/versions/b700c1d2e3f4_add_latest_session_action_index.py
@@ -1,0 +1,46 @@
+"""Add latest session action lookup index.
+
+Revision ID: b700c1d2e3f4
+Revises: a613b7c9d201
+Create Date: 2026-08-04 18:05:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "b700c1d2e3f4"
+down_revision: str | Sequence[str] | None = "a613b7c9d201"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Index deterministic latest-action reads by session.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+    """
+    op.create_index(
+        "ix_event_session_latest_action",
+        "events",
+        ["session_id", sa.text("timestamp DESC"), sa.text("id DESC")],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Remove the latest-action lookup index.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+    """
+    op.drop_index("ix_event_session_latest_action", table_name="events")

--- a/app/models/event.py
+++ b/app/models/event.py
@@ -86,6 +86,12 @@ class Event(Base):
         Index("ix_event_session_id", "session_id"),
         Index("ix_event_timestamp", "timestamp"),
         Index("ix_event_session_type_timestamp", "session_id", "type", "timestamp"),
+        Index(
+            "ix_event_session_latest_action",
+            "session_id",
+            timestamp.desc(),
+            id.desc(),
+        ),
         Index("ix_event_session_type_die_after", "session_id", "type", "die_after"),
     )
 


### PR DESCRIPTION
## Summary

Replays the non-mergeable PR #791 index change from current `main` after the dependency-group migration advanced the branch base.

## Implemented

- adds a composite PostgreSQL index on `events(session_id, timestamp DESC, id DESC)`;
- mirrors the index in SQLAlchemy model metadata;
- preserves the current-session endpoint's existing deterministic `timestamp DESC, id DESC` consumer ordering;
- includes the required migration docstring sections identified during review.

## Review accounting

The prior review request to add the event-ID tie-breaker to `get_active_thread()` does not apply to the indexed production consumer. `/api/sessions/current/` calls `get_session_with_thread_safe()`, whose latest-action query already orders by `Event.timestamp.desc(), Event.id.desc()`. The legacy `get_active_thread()` helper is not used by that route.

## Scope

Part of #700. Broader event aggregation and History consolidation remain open.

## Verification

Exact-head CI is the configured validation boundary for this connector-only runtime. This PR is non-draft and must pass fresh exact-head CI and review accounting before merge.

Supersedes #791.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved retrieval of the latest actions within a session.
  * Added database indexing to make session event lookups faster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->