### PR TITLE
Add typed frontend client for named dependency groups (#613)

### DIFF
--- a/frontend/src/services/api-dependency-groups.ts
+++ b/frontend/src/services/api-dependency-groups.ts
@@ -1,0 +1,67 @@
+import api from './api'
+
+export interface DependencyGroupMember {
+  id: number
+  thread_id: number | null
+  issue_id: number | null
+}
+
+export interface DependencyGroup {
+  id: number
+  name: string
+  created_at: string
+  memberships: DependencyGroupMember[]
+}
+
+export interface DependencyGroupSummary {
+  id: number
+  name: string
+}
+
+export type DependencyGroupMemberTarget =
+  | { thread_id: number; issue_id?: never }
+  | { issue_id: number; thread_id?: never }
+
+export const dependencyGroupsApi = {
+  list: async (): Promise<DependencyGroup[]> => {
+    return api.get<DependencyGroup[]>('/v1/dependencies/reading-order-groups/')
+  },
+
+  create: async (name: string): Promise<DependencyGroup> => {
+    return api.post<DependencyGroup>('/v1/dependencies/reading-order-groups/', { name })
+  },
+
+  get: async (groupId: number): Promise<DependencyGroup> => {
+    return api.get<DependencyGroup>(`/v1/dependencies/reading-order-groups/${groupId}`)
+  },
+
+  rename: async (groupId: number, name: string): Promise<DependencyGroup> => {
+    return api.patch<DependencyGroup>(`/v1/dependencies/reading-order-groups/${groupId}`, { name })
+  },
+
+  delete: async (groupId: number): Promise<void> => {
+    await api.delete(`/v1/dependencies/reading-order-groups/${groupId}`)
+  },
+
+  listForThread: async (threadId: number): Promise<DependencyGroupSummary[]> => {
+    return api.get<DependencyGroupSummary[]>(
+      `/v1/dependencies/reading-order-groups/threads/${threadId}/groups`,
+    )
+  },
+
+  addMember: async (
+    groupId: number,
+    target: DependencyGroupMemberTarget,
+  ): Promise<DependencyGroupMember> => {
+    return api.post<DependencyGroupMember>(
+      `/v1/dependencies/reading-order-groups/${groupId}/members`,
+      target,
+    )
+  },
+
+  removeMember: async (groupId: number, memberId: number): Promise<void> => {
+    await api.delete(
+      `/v1/dependencies/reading-order-groups/${groupId}/members/${memberId}`,
+    )
+  },
+}

--- a/frontend/src/unit/api-dependency-groups.test.ts
+++ b/frontend/src/unit/api-dependency-groups.test.ts
@@ -37,6 +37,22 @@ describe('dependencyGroupsApi', () => {
     )
   })
 
+  it('loads group details', async () => {
+    const group = {
+      id: 3,
+      name: 'Infinity',
+      created_at: '2026-01-01T00:00:00Z',
+      memberships: [],
+    }
+    apiMock.get.mockResolvedValueOnce(group)
+
+    await expect(dependencyGroupsApi.get(3)).resolves.toEqual(group)
+
+    expect(apiMock.get).toHaveBeenCalledWith(
+      '/v1/dependencies/reading-order-groups/3',
+    )
+  })
+
   it('supports group rename and deletion', async () => {
     apiMock.patch.mockResolvedValue({ id: 3, name: 'Infinity', memberships: [] })
     apiMock.delete.mockResolvedValue(undefined)

--- a/frontend/src/unit/api-dependency-groups.test.ts
+++ b/frontend/src/unit/api-dependency-groups.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+}))
+
+vi.mock('axios', () => ({
+  default: {
+    create: vi.fn(() => ({
+      ...apiMock,
+      interceptors: { request: { use: vi.fn() }, response: { use: vi.fn() } },
+    })),
+  },
+}))
+
+import { dependencyGroupsApi } from '../services/api-dependency-groups'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('dependencyGroupsApi', () => {
+  it('uses the ownership-scoped group collection routes', async () => {
+    apiMock.get.mockResolvedValueOnce([])
+    apiMock.post.mockResolvedValueOnce({ id: 1, name: 'Cosmic', memberships: [] })
+
+    await dependencyGroupsApi.list()
+    await dependencyGroupsApi.create('Cosmic')
+
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/dependencies/reading-order-groups/')
+    expect(apiMock.post).toHaveBeenCalledWith(
+      '/v1/dependencies/reading-order-groups/',
+      { name: 'Cosmic' },
+    )
+  })
+
+  it('supports group rename and deletion', async () => {
+    apiMock.patch.mockResolvedValue({ id: 3, name: 'Infinity', memberships: [] })
+    apiMock.delete.mockResolvedValue(undefined)
+
+    await dependencyGroupsApi.rename(3, 'Infinity')
+    await dependencyGroupsApi.delete(3)
+
+    expect(apiMock.patch).toHaveBeenCalledWith(
+      '/v1/dependencies/reading-order-groups/3',
+      { name: 'Infinity' },
+    )
+    expect(apiMock.delete).toHaveBeenCalledWith('/v1/dependencies/reading-order-groups/3')
+  })
+
+  it('loads compact group names for the Roll view', async () => {
+    apiMock.get.mockResolvedValue([{ id: 7, name: 'Annihilation' }])
+
+    await expect(dependencyGroupsApi.listForThread(42)).resolves.toEqual([
+      { id: 7, name: 'Annihilation' },
+    ])
+
+    expect(apiMock.get).toHaveBeenCalledWith(
+      '/v1/dependencies/reading-order-groups/threads/42/groups',
+    )
+  })
+
+  it('adds and removes both supported membership target types', async () => {
+    apiMock.post
+      .mockResolvedValueOnce({ id: 10, thread_id: 42, issue_id: null })
+      .mockResolvedValueOnce({ id: 11, thread_id: null, issue_id: 99 })
+    apiMock.delete.mockResolvedValue(undefined)
+
+    await dependencyGroupsApi.addMember(7, { thread_id: 42 })
+    await dependencyGroupsApi.addMember(7, { issue_id: 99 })
+    await dependencyGroupsApi.removeMember(7, 10)
+
+    expect(apiMock.post).toHaveBeenNthCalledWith(
+      1,
+      '/v1/dependencies/reading-order-groups/7/members',
+      { thread_id: 42 },
+    )
+    expect(apiMock.post).toHaveBeenNthCalledWith(
+      2,
+      '/v1/dependencies/reading-order-groups/7/members',
+      { issue_id: 99 },
+    )
+    expect(apiMock.delete).toHaveBeenCalledWith(
+      '/v1/dependencies/reading-order-groups/7/members/10',
+    )
+  })
+})


### PR DESCRIPTION
## Superseded

Closed because the branch became non-mergeable after `main` advanced.

The exact reviewed implementation, including the resolved group-detail regression test from `8b4fa6b`, has been replayed onto current `main` in #805. Continue review and CI there.

Part of #613.