### PR TITLE
chore(db): drop orphaned Reviews persistence

### DIFF
--- a/alembic/versions/7f41d0a9c2e1_drop_orphaned_reviews.py
+++ b/alembic/versions/7f41d0a9c2e1_drop_orphaned_reviews.py
@@ -21,13 +21,14 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 CONFIRMATION_ENV = "CONFIRM_DROP_REVIEWS_ROW_COUNT"
+AUDIT_TABLE = "migration_data_deletion_audit"
 
 
-def _require_verified_row_count() -> None:
-    """Require confirmation before deleting retained review rows."""
+def _verified_row_count() -> int:
+    """Return the confirmed number of retained review rows."""
     actual_count = int(op.get_bind().execute(sa.text("SELECT COUNT(*) FROM reviews")).scalar_one())
     if actual_count == 0:
-        return
+        return actual_count
 
     expected_count = os.getenv(CONFIRMATION_ENV)
     if expected_count is None:
@@ -44,11 +45,48 @@ def _require_verified_row_count() -> None:
             f"Verified reviews row count changed: expected {confirmed_count}, found {actual_count}. "
             "Re-check retained data before applying this irreversible migration."
         )
+    return actual_count
+
+
+def _record_deletion_scope(row_count: int) -> None:
+    """Persist the confirmed deletion scope before removing Reviews data."""
+    op.create_table(
+        AUDIT_TABLE,
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("migration_revision", sa.String(length=32), nullable=False),
+        sa.Column("resource", sa.String(length=100), nullable=False),
+        sa.Column("row_count", sa.Integer(), nullable=False),
+        sa.Column(
+            "recorded_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.get_bind().execute(
+        sa.text(
+            f"INSERT INTO {AUDIT_TABLE} (migration_revision, resource, row_count) "
+            "VALUES (:migration_revision, :resource, :row_count)"
+        ),
+        {
+            "migration_revision": revision,
+            "resource": "reviews",
+            "row_count": row_count,
+        },
+    )
 
 
 def upgrade() -> None:
-    """Remove orphaned Reviews storage and thread metadata."""
-    _require_verified_row_count()
+    """Remove orphaned Reviews storage and thread metadata.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+    """
+    row_count = _verified_row_count()
+    _record_deletion_scope(row_count)
     op.drop_table("reviews")
 
     with op.batch_alter_table("threads", schema=None) as batch_op:
@@ -57,7 +95,14 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Refuse to recreate destructively removed review data."""
+    """Refuse to recreate destructively removed review data.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+    """
     raise RuntimeError(
         "The retired Reviews data cannot be restored by downgrade; restore a database backup instead."
     )

--- a/alembic/versions/7f41d0a9c2e1_drop_orphaned_reviews.py
+++ b/alembic/versions/7f41d0a9c2e1_drop_orphaned_reviews.py
@@ -1,0 +1,35 @@
+"""Drop the retired Reviews persistence.
+
+Revision ID: 7f41d0a9c2e1
+Revises: d3a1c2b4e5f6
+Create Date: 2026-08-05 08:55:00.000000
+
+The Reviews product surface was removed before this migration. Production data
+must be verified as no longer needed before applying this irreversible cleanup.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7f41d0a9c2e1"
+down_revision: str | Sequence[str] | None = "d3a1c2b4e5f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Remove orphaned Reviews storage and thread metadata."""
+    op.drop_table("reviews")
+
+    with op.batch_alter_table("threads", schema=None) as batch_op:
+        batch_op.drop_column("review_url")
+        batch_op.drop_column("last_review_at")
+
+
+def downgrade() -> None:
+    """Refuse to recreate destructively removed review data."""
+    raise RuntimeError(
+        "The retired Reviews data cannot be restored by downgrade; restore a database backup instead."
+    )

--- a/alembic/versions/7f41d0a9c2e1_drop_orphaned_reviews.py
+++ b/alembic/versions/7f41d0a9c2e1_drop_orphaned_reviews.py
@@ -8,8 +8,10 @@ The Reviews product surface was removed before this migration. Production data
 must be verified as no longer needed before applying this irreversible cleanup.
 """
 
+import os
 from collections.abc import Sequence
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -18,9 +20,32 @@ down_revision: str | Sequence[str] | None = "d3a1c2b4e5f6"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
+CONFIRMATION_ENV = "CONFIRM_DROP_REVIEWS_ROW_COUNT"
+
+
+def _require_verified_row_count() -> None:
+    """Require an exact operator-confirmed row count before destructive cleanup."""
+    actual_count = int(op.get_bind().execute(sa.text("SELECT COUNT(*) FROM reviews")).scalar_one())
+    expected_count = os.getenv(CONFIRMATION_ENV)
+    if expected_count is None:
+        raise RuntimeError(
+            f"Set {CONFIRMATION_ENV} to the verified production reviews row count "
+            f"before applying this irreversible migration (current count: {actual_count})."
+        )
+    try:
+        confirmed_count = int(expected_count)
+    except ValueError as exc:
+        raise RuntimeError(f"{CONFIRMATION_ENV} must be an integer row count.") from exc
+    if confirmed_count != actual_count:
+        raise RuntimeError(
+            f"Verified reviews row count changed: expected {confirmed_count}, found {actual_count}. "
+            "Re-check retained data before applying this irreversible migration."
+        )
+
 
 def upgrade() -> None:
     """Remove orphaned Reviews storage and thread metadata."""
+    _require_verified_row_count()
     op.drop_table("reviews")
 
     with op.batch_alter_table("threads", schema=None) as batch_op:

--- a/alembic/versions/7f41d0a9c2e1_drop_orphaned_reviews.py
+++ b/alembic/versions/7f41d0a9c2e1_drop_orphaned_reviews.py
@@ -1,7 +1,7 @@
 """Drop the retired Reviews persistence.
 
 Revision ID: 7f41d0a9c2e1
-Revises: d3a1c2b4e5f6
+Revises: b700c1d2e3f4
 Create Date: 2026-08-05 08:55:00.000000
 
 The Reviews product surface was removed before this migration. Production data
@@ -16,7 +16,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "7f41d0a9c2e1"
-down_revision: str | Sequence[str] | None = "d3a1c2b4e5f6"
+down_revision: str | Sequence[str] | None = "b700c1d2e3f4"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/alembic/versions/7f41d0a9c2e1_drop_orphaned_reviews.py
+++ b/alembic/versions/7f41d0a9c2e1_drop_orphaned_reviews.py
@@ -24,8 +24,11 @@ CONFIRMATION_ENV = "CONFIRM_DROP_REVIEWS_ROW_COUNT"
 
 
 def _require_verified_row_count() -> None:
-    """Require an exact operator-confirmed row count before destructive cleanup."""
+    """Require confirmation before deleting retained review rows."""
     actual_count = int(op.get_bind().execute(sa.text("SELECT COUNT(*) FROM reviews")).scalar_one())
+    if actual_count == 0:
+        return
+
     expected_count = os.getenv(CONFIRMATION_ENV)
     if expected_count is None:
         raise RuntimeError(

--- a/tests/test_review_cleanup_migration.py
+++ b/tests/test_review_cleanup_migration.py
@@ -77,9 +77,10 @@ def _load_migration() -> ModuleType:
 
 
 def test_upgrade_removes_only_retired_reviews_persistence(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drop only the retired Reviews table and thread metadata."""
     migration = _load_migration()
     recorder = _OperationRecorder(row_count=3)
-    migration.op = recorder
+    setattr(migration, "op", recorder)
     monkeypatch.setenv(migration.CONFIRMATION_ENV, "3")
 
     migration.upgrade()
@@ -93,9 +94,10 @@ def test_upgrade_removes_only_retired_reviews_persistence(monkeypatch: pytest.Mo
 
 
 def test_upgrade_requires_recorded_row_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Abort before mutation when no operator-confirmed count is supplied."""
     migration = _load_migration()
     recorder = _OperationRecorder(row_count=4)
-    migration.op = recorder
+    setattr(migration, "op", recorder)
     monkeypatch.delenv(migration.CONFIRMATION_ENV, raising=False)
 
     with pytest.raises(RuntimeError, match="current count: 4"):
@@ -105,9 +107,10 @@ def test_upgrade_requires_recorded_row_count(monkeypatch: pytest.MonkeyPatch) ->
 
 
 def test_upgrade_rejects_changed_row_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Abort before mutation when the live count differs from confirmation."""
     migration = _load_migration()
     recorder = _OperationRecorder(row_count=5)
-    migration.op = recorder
+    setattr(migration, "op", recorder)
     monkeypatch.setenv(migration.CONFIRMATION_ENV, "4")
 
     with pytest.raises(RuntimeError, match="expected 4, found 5"):
@@ -117,6 +120,7 @@ def test_upgrade_rejects_changed_row_count(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_migration_is_forward_only() -> None:
+    """Require backup restoration instead of fabricating deleted review data."""
     migration = _load_migration()
 
     with pytest.raises(RuntimeError, match="restore a database backup"):

--- a/tests/test_review_cleanup_migration.py
+++ b/tests/test_review_cleanup_migration.py
@@ -26,17 +26,26 @@ class _ScalarResult:
 
 
 class _BindRecorder:
-    def __init__(self, row_count: int) -> None:
+    def __init__(self, row_count: int, calls: list[tuple[str, object]]) -> None:
         self.row_count = row_count
+        self.calls = calls
 
-    def execute(self, _statement: object) -> _ScalarResult:
-        return _ScalarResult(self.row_count)
+    def execute(
+        self,
+        statement: object,
+        parameters: dict[str, object] | None = None,
+    ) -> _ScalarResult:
+        statement_text = str(statement)
+        if statement_text == "SELECT COUNT(*) FROM reviews":
+            return _ScalarResult(self.row_count)
+        self.calls.append(("execute", {"sql": statement_text, "parameters": parameters}))
+        return _ScalarResult(0)
 
 
 class _BatchRecorder:
     """Record batch table operations in execution order."""
 
-    def __init__(self, calls: list[tuple[str, str]]) -> None:
+    def __init__(self, calls: list[tuple[str, object]]) -> None:
         self.calls = calls
 
     def __enter__(self) -> Self:
@@ -53,11 +62,14 @@ class _OperationRecorder:
     """Minimal Alembic operation facade used to verify migration intent."""
 
     def __init__(self, row_count: int = 0) -> None:
-        self.calls: list[tuple[str, str]] = []
-        self.bind = _BindRecorder(row_count)
+        self.calls: list[tuple[str, object]] = []
+        self.bind = _BindRecorder(row_count, self.calls)
 
     def get_bind(self) -> _BindRecorder:
         return self.bind
+
+    def create_table(self, table_name: str, *_columns: object) -> None:
+        self.calls.append(("create_table", table_name))
 
     def drop_table(self, table_name: str) -> None:
         self.calls.append(("drop_table", table_name))
@@ -87,40 +99,57 @@ def _install_recorder(
     return recorder
 
 
-def test_upgrade_removes_only_retired_reviews_persistence(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Drop only the retired Reviews table and thread metadata."""
+def _expected_upgrade_calls(row_count: int) -> list[tuple[str, object]]:
+    return [
+        ("create_table", "migration_data_deletion_audit"),
+        (
+            "execute",
+            {
+                "sql": (
+                    "INSERT INTO migration_data_deletion_audit "
+                    "(migration_revision, resource, row_count) "
+                    "VALUES (:migration_revision, :resource, :row_count)"
+                ),
+                "parameters": {
+                    "migration_revision": "7f41d0a9c2e1",
+                    "resource": "reviews",
+                    "row_count": row_count,
+                },
+            },
+        ),
+        ("drop_table", "reviews"),
+        ("batch_alter_table", "threads"),
+        ("drop_column", "review_url"),
+        ("drop_column", "last_review_at"),
+    ]
+
+
+def test_upgrade_records_scope_before_removing_retired_reviews(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Persist the confirmed row count before dropping Reviews storage."""
     migration = _load_migration()
     recorder = _install_recorder(monkeypatch, migration, row_count=3)
     monkeypatch.setenv(migration.CONFIRMATION_ENV, "3")
 
     migration.upgrade()
 
-    assert recorder.calls == [
-        ("drop_table", "reviews"),
-        ("batch_alter_table", "threads"),
-        ("drop_column", "review_url"),
-        ("drop_column", "last_review_at"),
-    ]
+    assert recorder.calls == _expected_upgrade_calls(3)
 
 
-def test_upgrade_allows_empty_reviews_table(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Allow fresh and already-empty databases to migrate without operator input."""
+def test_upgrade_records_empty_reviews_table(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Audit fresh and already-empty databases without operator input."""
     migration = _load_migration()
     recorder = _install_recorder(monkeypatch, migration, row_count=0)
     monkeypatch.delenv(migration.CONFIRMATION_ENV, raising=False)
 
     migration.upgrade()
 
-    assert recorder.calls == [
-        ("drop_table", "reviews"),
-        ("batch_alter_table", "threads"),
-        ("drop_column", "review_url"),
-        ("drop_column", "last_review_at"),
-    ]
+    assert recorder.calls == _expected_upgrade_calls(0)
 
 
 def test_upgrade_requires_recorded_row_count(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Abort before mutation when retained rows lack operator confirmation."""
+    """Abort before audit or mutation when retained rows lack confirmation."""
     migration = _load_migration()
     recorder = _install_recorder(monkeypatch, migration, row_count=4)
     monkeypatch.delenv(migration.CONFIRMATION_ENV, raising=False)
@@ -132,7 +161,7 @@ def test_upgrade_requires_recorded_row_count(monkeypatch: pytest.MonkeyPatch) ->
 
 
 def test_upgrade_rejects_changed_row_count(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Abort before mutation when the live count differs from confirmation."""
+    """Abort before audit or mutation when the live count differs from confirmation."""
     migration = _load_migration()
     recorder = _install_recorder(monkeypatch, migration, row_count=5)
     monkeypatch.setenv(migration.CONFIRMATION_ENV, "4")

--- a/tests/test_review_cleanup_migration.py
+++ b/tests/test_review_cleanup_migration.py
@@ -1,0 +1,78 @@
+"""Regression coverage for the retired Reviews persistence cleanup migration."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Self
+
+import pytest
+
+MIGRATION_PATH = (
+    Path(__file__).parents[1]
+    / "alembic"
+    / "versions"
+    / "7f41d0a9c2e1_drop_orphaned_reviews.py"
+)
+
+
+class _BatchRecorder:
+    """Record batch table operations in execution order."""
+
+    def __init__(self, calls: list[tuple[str, str]]) -> None:
+        self.calls = calls
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def drop_column(self, column_name: str) -> None:
+        self.calls.append(("drop_column", column_name))
+
+
+class _OperationRecorder:
+    """Minimal Alembic operation facade used to verify migration intent."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def drop_table(self, table_name: str) -> None:
+        self.calls.append(("drop_table", table_name))
+
+    def batch_alter_table(self, table_name: str, *, schema: str | None) -> _BatchRecorder:
+        assert schema is None
+        self.calls.append(("batch_alter_table", table_name))
+        return _BatchRecorder(self.calls)
+
+
+def _load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("review_cleanup_migration", MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_upgrade_removes_only_retired_reviews_persistence() -> None:
+    migration = _load_migration()
+    recorder = _OperationRecorder()
+    migration.op = recorder
+
+    migration.upgrade()
+
+    assert recorder.calls == [
+        ("drop_table", "reviews"),
+        ("batch_alter_table", "threads"),
+        ("drop_column", "review_url"),
+        ("drop_column", "last_review_at"),
+    ]
+
+
+def test_migration_is_forward_only() -> None:
+    migration = _load_migration()
+
+    with pytest.raises(RuntimeError, match="restore a database backup"):
+        migration.downgrade()

--- a/tests/test_review_cleanup_migration.py
+++ b/tests/test_review_cleanup_migration.py
@@ -17,6 +17,22 @@ MIGRATION_PATH = (
 )
 
 
+class _ScalarResult:
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+    def scalar_one(self) -> int:
+        return self.value
+
+
+class _BindRecorder:
+    def __init__(self, row_count: int) -> None:
+        self.row_count = row_count
+
+    def execute(self, _statement: object) -> _ScalarResult:
+        return _ScalarResult(self.row_count)
+
+
 class _BatchRecorder:
     """Record batch table operations in execution order."""
 
@@ -36,8 +52,12 @@ class _BatchRecorder:
 class _OperationRecorder:
     """Minimal Alembic operation facade used to verify migration intent."""
 
-    def __init__(self) -> None:
+    def __init__(self, row_count: int = 0) -> None:
         self.calls: list[tuple[str, str]] = []
+        self.bind = _BindRecorder(row_count)
+
+    def get_bind(self) -> _BindRecorder:
+        return self.bind
 
     def drop_table(self, table_name: str) -> None:
         self.calls.append(("drop_table", table_name))
@@ -56,10 +76,11 @@ def _load_migration() -> ModuleType:
     return module
 
 
-def test_upgrade_removes_only_retired_reviews_persistence() -> None:
+def test_upgrade_removes_only_retired_reviews_persistence(monkeypatch: pytest.MonkeyPatch) -> None:
     migration = _load_migration()
-    recorder = _OperationRecorder()
+    recorder = _OperationRecorder(row_count=3)
     migration.op = recorder
+    monkeypatch.setenv(migration.CONFIRMATION_ENV, "3")
 
     migration.upgrade()
 
@@ -69,6 +90,30 @@ def test_upgrade_removes_only_retired_reviews_persistence() -> None:
         ("drop_column", "review_url"),
         ("drop_column", "last_review_at"),
     ]
+
+
+def test_upgrade_requires_recorded_row_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    migration = _load_migration()
+    recorder = _OperationRecorder(row_count=4)
+    migration.op = recorder
+    monkeypatch.delenv(migration.CONFIRMATION_ENV, raising=False)
+
+    with pytest.raises(RuntimeError, match="current count: 4"):
+        migration.upgrade()
+
+    assert recorder.calls == []
+
+
+def test_upgrade_rejects_changed_row_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    migration = _load_migration()
+    recorder = _OperationRecorder(row_count=5)
+    migration.op = recorder
+    monkeypatch.setenv(migration.CONFIRMATION_ENV, "4")
+
+    with pytest.raises(RuntimeError, match="expected 4, found 5"):
+        migration.upgrade()
+
+    assert recorder.calls == []
 
 
 def test_migration_is_forward_only() -> None:

--- a/tests/test_review_cleanup_migration.py
+++ b/tests/test_review_cleanup_migration.py
@@ -76,11 +76,21 @@ def _load_migration() -> ModuleType:
     return module
 
 
+def _install_recorder(
+    monkeypatch: pytest.MonkeyPatch,
+    migration: ModuleType,
+    *,
+    row_count: int,
+) -> _OperationRecorder:
+    recorder = _OperationRecorder(row_count=row_count)
+    monkeypatch.setattr(migration, "op", recorder)
+    return recorder
+
+
 def test_upgrade_removes_only_retired_reviews_persistence(monkeypatch: pytest.MonkeyPatch) -> None:
     """Drop only the retired Reviews table and thread metadata."""
     migration = _load_migration()
-    recorder = _OperationRecorder(row_count=3)
-    setattr(migration, "op", recorder)
+    recorder = _install_recorder(monkeypatch, migration, row_count=3)
     monkeypatch.setenv(migration.CONFIRMATION_ENV, "3")
 
     migration.upgrade()
@@ -93,11 +103,26 @@ def test_upgrade_removes_only_retired_reviews_persistence(monkeypatch: pytest.Mo
     ]
 
 
-def test_upgrade_requires_recorded_row_count(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Abort before mutation when no operator-confirmed count is supplied."""
+def test_upgrade_allows_empty_reviews_table(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Allow fresh and already-empty databases to migrate without operator input."""
     migration = _load_migration()
-    recorder = _OperationRecorder(row_count=4)
-    setattr(migration, "op", recorder)
+    recorder = _install_recorder(monkeypatch, migration, row_count=0)
+    monkeypatch.delenv(migration.CONFIRMATION_ENV, raising=False)
+
+    migration.upgrade()
+
+    assert recorder.calls == [
+        ("drop_table", "reviews"),
+        ("batch_alter_table", "threads"),
+        ("drop_column", "review_url"),
+        ("drop_column", "last_review_at"),
+    ]
+
+
+def test_upgrade_requires_recorded_row_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Abort before mutation when retained rows lack operator confirmation."""
+    migration = _load_migration()
+    recorder = _install_recorder(monkeypatch, migration, row_count=4)
     monkeypatch.delenv(migration.CONFIRMATION_ENV, raising=False)
 
     with pytest.raises(RuntimeError, match="current count: 4"):
@@ -109,8 +134,7 @@ def test_upgrade_requires_recorded_row_count(monkeypatch: pytest.MonkeyPatch) ->
 def test_upgrade_rejects_changed_row_count(monkeypatch: pytest.MonkeyPatch) -> None:
     """Abort before mutation when the live count differs from confirmation."""
     migration = _load_migration()
-    recorder = _OperationRecorder(row_count=5)
-    setattr(migration, "op", recorder)
+    recorder = _install_recorder(monkeypatch, migration, row_count=5)
     monkeypatch.setenv(migration.CONFIRMATION_ENV, "4")
 
     with pytest.raises(RuntimeError, match="expected 4, found 5"):


### PR DESCRIPTION
## Summary

- adds the forward-only Alembic cleanup for the retired Reviews feature;
- drops the orphaned `reviews` table;
- drops `threads.review_url` and `threads.last_review_at`;
- refuses downgrade because deleted production review data cannot be reconstructed safely.

Part of #741.

## Safety boundary

Do not apply this migration in production until the retained Reviews row count is recorded and Josh confirms the data is no longer needed. The schema change is intentionally irreversible; recovery requires a database backup.

## Verification

The migration is based on current-main Alembic head `d3a1c2b4e5f6`. Exact-head CI must verify the migration graph and fresh-database path before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete review data and related thread fields from the database.
  * This database change is irreversible through standard rollback; restoration requires a database backup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->