### PR TITLE
feat(roll): load named reading-order groups for active threads

### DIFF
--- a/frontend/src/hooks/useDependencyGroups.ts
+++ b/frontend/src/hooks/useDependencyGroups.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react'
+import {
+  dependencyGroupsApi,
+  type DependencyGroupSummary,
+} from '../services/api-dependency-groups'
+
+interface DependencyGroupsState {
+  groups: DependencyGroupSummary[]
+  isLoading: boolean
+  error: Error | null
+}
+
+const EMPTY_STATE: DependencyGroupsState = {
+  groups: [],
+  isLoading: false,
+  error: null,
+}
+
+export function useDependencyGroups(threadId: number | null | undefined): DependencyGroupsState {
+  const [state, setState] = useState<DependencyGroupsState>(EMPTY_STATE)
+
+  useEffect(() => {
+    if (threadId == null) {
+      setState(EMPTY_STATE)
+      return
+    }
+
+    let isCurrent = true
+    setState({ groups: [], isLoading: true, error: null })
+
+    dependencyGroupsApi.listForThread(threadId).then(
+      (groups) => {
+        if (isCurrent) {
+          setState({ groups, isLoading: false, error: null })
+        }
+      },
+      (reason: unknown) => {
+        if (isCurrent) {
+          const error = reason instanceof Error ? reason : new Error('Unable to load reading-order groups')
+          setState({ groups: [], isLoading: false, error })
+        }
+      },
+    )
+
+    return () => {
+      isCurrent = false
+    }
+  }, [threadId])
+
+  return state
+}

--- a/frontend/src/unit/useDependencyGroups.test.tsx
+++ b/frontend/src/unit/useDependencyGroups.test.tsx
@@ -60,6 +60,32 @@ describe('useDependencyGroups', () => {
     expect(result.current.groups).toEqual([{ id: 9, name: 'Infinity' }])
   })
 
+  it('ignores stale errors while preserving the current Error instance', async () => {
+    let rejectFirst: ((reason: Error) => void) | undefined
+    mockedDependencyGroupsApi.listForThread
+      .mockImplementationOnce(
+        () => new Promise((_, reject) => {
+          rejectFirst = reject
+        }),
+      )
+      .mockRejectedValueOnce(new Error('current request failed'))
+
+    const { result, rerender } = renderHook(
+      ({ threadId }) => useDependencyGroups(threadId),
+      { initialProps: { threadId: 42 } },
+    )
+
+    rerender({ threadId: 99 })
+    await waitFor(() => expect(result.current.error?.message).toBe('current request failed'))
+
+    rejectFirst?.(new Error('stale request failed'))
+    await Promise.resolve()
+
+    expect(result.current.error?.message).toBe('current request failed')
+    expect(result.current.groups).toEqual([])
+    expect(result.current.isLoading).toBe(false)
+  })
+
   it('returns a normalized error when loading fails', async () => {
     mockedDependencyGroupsApi.listForThread.mockRejectedValue('offline')
 

--- a/frontend/src/unit/useDependencyGroups.test.tsx
+++ b/frontend/src/unit/useDependencyGroups.test.tsx
@@ -1,0 +1,72 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useDependencyGroups } from '../hooks/useDependencyGroups'
+import { dependencyGroupsApi } from '../services/api-dependency-groups'
+
+vi.mock('../services/api-dependency-groups', () => ({
+  dependencyGroupsApi: {
+    listForThread: vi.fn(),
+  },
+}))
+
+const mockedDependencyGroupsApi = vi.mocked(dependencyGroupsApi)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('useDependencyGroups', () => {
+  it('does not request groups without an active thread', () => {
+    const { result } = renderHook(() => useDependencyGroups(null))
+
+    expect(result.current).toEqual({ groups: [], isLoading: false, error: null })
+    expect(mockedDependencyGroupsApi.listForThread).not.toHaveBeenCalled()
+  })
+
+  it('loads owned groups for the active thread', async () => {
+    mockedDependencyGroupsApi.listForThread.mockResolvedValue([
+      { id: 7, name: 'Annihilation' },
+    ])
+
+    const { result } = renderHook(() => useDependencyGroups(42))
+
+    expect(result.current.isLoading).toBe(true)
+    await waitFor(() => expect(result.current.groups).toEqual([{ id: 7, name: 'Annihilation' }]))
+    expect(result.current.isLoading).toBe(false)
+    expect(mockedDependencyGroupsApi.listForThread).toHaveBeenCalledWith(42)
+  })
+
+  it('clears stale group responses when the active thread changes', async () => {
+    let resolveFirst: ((value: { id: number; name: string }[]) => void) | undefined
+    mockedDependencyGroupsApi.listForThread
+      .mockImplementationOnce(
+        () => new Promise((resolve) => {
+          resolveFirst = resolve
+        }),
+      )
+      .mockResolvedValueOnce([{ id: 9, name: 'Infinity' }])
+
+    const { result, rerender } = renderHook(
+      ({ threadId }) => useDependencyGroups(threadId),
+      { initialProps: { threadId: 42 } },
+    )
+
+    rerender({ threadId: 99 })
+    await waitFor(() => expect(result.current.groups).toEqual([{ id: 9, name: 'Infinity' }]))
+
+    resolveFirst?.([{ id: 7, name: 'Annihilation' }])
+    await Promise.resolve()
+
+    expect(result.current.groups).toEqual([{ id: 9, name: 'Infinity' }])
+  })
+
+  it('returns a normalized error when loading fails', async () => {
+    mockedDependencyGroupsApi.listForThread.mockRejectedValue('offline')
+
+    const { result } = renderHook(() => useDependencyGroups(42))
+
+    await waitFor(() => expect(result.current.error?.message).toBe('Unable to load reading-order groups'))
+    expect(result.current.groups).toEqual([])
+    expect(result.current.isLoading).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- adds a bounded ownership-scoped hook for loading named reading-order groups for the active Roll thread;
- clears state when no thread is active;
- ignores stale responses after thread changes;
- normalizes failed requests for a safe Roll integration boundary;
- adds focused Vitest coverage for loading, empty, error, and stale-response behavior.

Part of #613.

## Scope

This PR provides the tested query boundary required before rendering group names in the Roll view. Dependency-management controls and final Roll presentation remain required before #613 can close.

## Verification

Exact-head CI must run frontend lint, typecheck, build, and Vitest for `088dbbca5b03431627eb73c7ae3bc999a7668229`.