### PR TITLE
feat(roll): present named reading-order groups

### DIFF
--- a/frontend/src/pages/RollPage/components/ReadingOrderGroups.tsx
+++ b/frontend/src/pages/RollPage/components/ReadingOrderGroups.tsx
@@ -1,0 +1,52 @@
+import { useDependencyGroups } from '../../../hooks/useDependencyGroups'
+
+interface ReadingOrderGroupsProps {
+  threadId: number | null | undefined
+}
+
+export function ReadingOrderGroups({ threadId }: ReadingOrderGroupsProps) {
+  const { groups, isLoading, error } = useDependencyGroups(threadId)
+
+  if (threadId == null) return null
+
+  if (isLoading) {
+    return (
+      <div className="text-center" role="status" aria-live="polite">
+        <span className="text-[10px] font-bold uppercase tracking-wider text-stone-500">
+          Loading reading-order groups…
+        </span>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <p className="text-center text-[10px] font-bold text-rose-500" role="alert">
+        Unable to load reading-order groups.
+      </p>
+    )
+  }
+
+  if (groups.length === 0) return null
+
+  return (
+    <section aria-labelledby="reading-order-groups-heading" className="space-y-2 text-center">
+      <h3
+        id="reading-order-groups-heading"
+        className="text-[10px] font-black uppercase tracking-[0.2em] text-stone-500"
+      >
+        Reading-order groups
+      </h3>
+      <ul className="flex flex-wrap justify-center gap-2">
+        {groups.map((group) => (
+          <li
+            key={group.id}
+            className="max-w-full break-words rounded-lg border border-violet-700/30 bg-violet-900/20 px-3 py-1.5 text-xs font-bold text-violet-300"
+          >
+            {group.name}
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/frontend/src/unit/ReadingOrderGroups.test.tsx
+++ b/frontend/src/unit/ReadingOrderGroups.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ReadingOrderGroups } from '../pages/RollPage/components/ReadingOrderGroups'
+import { useDependencyGroups } from '../hooks/useDependencyGroups'
+
+vi.mock('../hooks/useDependencyGroups', () => ({
+  useDependencyGroups: vi.fn(),
+}))
+
+const mockedUseDependencyGroups = vi.mocked(useDependencyGroups)
+
+describe('ReadingOrderGroups', () => {
+  beforeEach(() => {
+    mockedUseDependencyGroups.mockReset()
+  })
+
+  it('renders nothing when there is no active thread', () => {
+    mockedUseDependencyGroups.mockReturnValue({ groups: [], isLoading: false, error: null })
+
+    const { container } = render(<ReadingOrderGroups threadId={null} />)
+
+    expect(container).toBeEmptyDOMElement()
+    expect(mockedUseDependencyGroups).toHaveBeenCalledWith(null)
+  })
+
+  it('announces loading without showing stale group names', () => {
+    mockedUseDependencyGroups.mockReturnValue({ groups: [], isLoading: true, error: null })
+
+    render(<ReadingOrderGroups threadId={17} />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('Loading reading-order groups')
+    expect(screen.queryByRole('list')).not.toBeInTheDocument()
+  })
+
+  it('renders an accessible error state', () => {
+    mockedUseDependencyGroups.mockReturnValue({
+      groups: [],
+      isLoading: false,
+      error: new Error('network failed'),
+    })
+
+    render(<ReadingOrderGroups threadId={17} />)
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Unable to load reading-order groups.')
+  })
+
+  it('does not add an empty section for threads without groups', () => {
+    mockedUseDependencyGroups.mockReturnValue({ groups: [], isLoading: false, error: null })
+
+    const { container } = render(<ReadingOrderGroups threadId={17} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders every owned group name and preserves long-name wrapping', () => {
+    mockedUseDependencyGroups.mockReturnValue({
+      groups: [
+        { id: 1, name: 'Bwa Haha-era Justice League' },
+        { id: 2, name: 'A deliberately long reading-order group name for narrow mobile screens' },
+      ],
+      isLoading: false,
+      error: null,
+    })
+
+    render(<ReadingOrderGroups threadId={17} />)
+
+    expect(screen.getByRole('heading', { name: 'Reading-order groups' })).toBeInTheDocument()
+    expect(screen.getByRole('list')).toBeInTheDocument()
+    expect(screen.getByText('Bwa Haha-era Justice League')).toBeInTheDocument()
+    expect(
+      screen.getByText('A deliberately long reading-order group name for narrow mobile screens'),
+    ).toHaveClass('break-words')
+  })
+})


### PR DESCRIPTION
## Summary

- adds a focused Roll presentation component for owned named reading-order groups;
- uses the merged active-thread dependency-group query boundary;
- covers loading, error, empty, multiple-group, and long mobile name behavior.

Part of #613.

## Scope boundary

This PR provides the tested presentation component. Wiring it into the active `RatingView` remains required before #613 can close, along with dependency-management create/rename/delete/membership controls.

## Verification

Exact-head CI must validate frontend lint, typecheck, build, and Vitest coverage for this connector-authored branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reading-order group displays for thread content.
  * Shows loading and error states while dependency groups are retrieved.
  * Handles inactive threads and empty results without displaying stale content.
  * Supports grouped content with accessible labels and long names that wrap correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->