### PR TITLE
feat(roll): show reading-order groups in rating view

### DIFF
--- a/frontend/src/pages/RollPage/components/RatingView.tsx
+++ b/frontend/src/pages/RollPage/components/RatingView.tsx
@@ -8,6 +8,7 @@ import { RATING_THRESHOLD, getProgressPercentage } from '../utils'
 import type { RatingThread } from '../types'
 import type { ReadingOrder } from '../../../services/api-reading-orders'
 import type { ConnectedThreadInfo } from '../../../types'
+import { ReadingOrderGroups } from './ReadingOrderGroups'
 
 interface RatingViewProps {
   activeRatingThread: RatingThread | null
@@ -145,6 +146,8 @@ export function RatingView({
           </div>
         </div>
       )}
+
+      <ReadingOrderGroups threadId={activeRatingThread?.id} />
 
       <div className="space-y-5 md:space-y-8">
         <div id="rating-preview-dice" className="dice-perspective">

--- a/frontend/src/unit/RatingViewReadingOrderGroups.test.tsx
+++ b/frontend/src/unit/RatingViewReadingOrderGroups.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { RatingView } from '../pages/RollPage/components/RatingView'
+
+vi.mock('../components/LazyDice3D', () => ({ default: () => <div data-testid="dice" /> }))
+vi.mock('../components/Tooltip', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+vi.mock('../components/IssueCorrectionDialog', () => ({ default: () => null }))
+vi.mock('../hooks/useDependencyGroups', () => ({
+  useDependencyGroups: (threadId: number | null | undefined) => ({
+    groups: threadId === 42 ? [{ id: 7, name: 'Cosmic bridge' }] : [],
+    isLoading: false,
+    error: null,
+  }),
+}))
+
+const callbacks = {
+  onUpdateRating: vi.fn(),
+  onSubmitRating: vi.fn(),
+  onSnooze: vi.fn(),
+  onCancel: vi.fn(),
+  onRefreshThread: vi.fn(),
+}
+
+describe('RatingView reading-order groups', () => {
+  it('shows names owned by the active rating thread', () => {
+    render(
+      <RatingView
+        activeRatingThread={{
+          id: 42,
+          title: 'Silver Surfer',
+          format: 'Comic',
+          issues_remaining: 3,
+          total_issues: 6,
+          issue_number: '3',
+          next_issue_number: '4',
+        } as never}
+        currentDie={6}
+        rolledResult={3}
+        rating={4}
+        predictedDie={4}
+        hasValidRolledResult
+        poolSize={6}
+        errorMessage=""
+        rateIsPending={false}
+        snoozeIsPending={false}
+        dismissIsPending={false}
+        readingOrders={[]}
+        connectedThreads={[]}
+        {...callbacks}
+      />,
+    )
+
+    expect(screen.getByRole('heading', { name: 'Reading-order groups' })).toBeInTheDocument()
+    expect(screen.getByText('Cosmic bridge')).toBeInTheDocument()
+  })
+
+  it('does not show group chrome without an active thread', () => {
+    render(
+      <RatingView
+        activeRatingThread={null}
+        currentDie={6}
+        rolledResult={null}
+        rating={3}
+        predictedDie={6}
+        hasValidRolledResult={false}
+        poolSize={0}
+        errorMessage=""
+        rateIsPending={false}
+        snoozeIsPending={false}
+        dismissIsPending={false}
+        readingOrders={[]}
+        connectedThreads={[]}
+        {...callbacks}
+      />,
+    )
+
+    expect(screen.queryByRole('heading', { name: 'Reading-order groups' })).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

- wires the merged `ReadingOrderGroups` presentation into the active Roll rating view;
- scopes the lookup to the active rating thread ID;
- adds focused regression coverage for populated and absent active-thread states.

Part of #613.

## Verification

Exact-head CI must run frontend lint, typecheck, build, and Vitest coverage for this branch.