### PR TITLE
chore(db): remove retired Reviews persistence

### DIFF
--- a/alembic/versions/7f41d0a9c2e1_drop_orphaned_reviews.py
+++ b/alembic/versions/7f41d0a9c2e1_drop_orphaned_reviews.py
@@ -25,7 +25,9 @@ AUDIT_TABLE = "migration_data_deletion_audit"
 
 def _verified_row_count() -> int:
     """Return the confirmed number of retained review rows."""
-    actual_count = int(op.get_bind().execute(sa.text("SELECT COUNT(*) FROM reviews")).scalar_one())
+    bind = op.get_bind()
+    bind.execute(sa.text("LOCK TABLE reviews IN ACCESS EXCLUSIVE MODE"))
+    actual_count = int(bind.execute(sa.text("SELECT COUNT(*) FROM reviews")).scalar_one())
     if actual_count == 0:
         return actual_count
 
@@ -54,7 +56,7 @@ def _record_deletion_scope(row_count: int) -> None:
         sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
         sa.Column("migration_revision", sa.String(length=32), nullable=False),
         sa.Column("resource", sa.String(length=100), nullable=False),
-        sa.Column("row_count", sa.Integer(), nullable=False),
+        sa.Column("row_count", sa.BigInteger(), nullable=False),
         sa.Column(
             "recorded_at",
             sa.DateTime(timezone=True),

--- a/alembic/versions/7f41d0a9c2e1_drop_orphaned_reviews.py
+++ b/alembic/versions/7f41d0a9c2e1_drop_orphaned_reviews.py
@@ -4,11 +4,11 @@ Revision ID: 7f41d0a9c2e1
 Revises: b700c1d2e3f4
 Create Date: 2026-08-05 08:55:00.000000
 
-The Reviews product surface was removed before this migration. Production data
-must be verified as no longer needed before applying this irreversible cleanup.
+The Reviews product surface and its retained data are intentionally removed by
+this migration. The deleted row count is recorded for auditability before the
+irreversible table drop.
 """
 
-import os
 from collections.abc import Sequence
 
 import sqlalchemy as sa
@@ -19,38 +19,18 @@ down_revision: str | Sequence[str] | None = "b700c1d2e3f4"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
-CONFIRMATION_ENV = "CONFIRM_DROP_REVIEWS_ROW_COUNT"
 AUDIT_TABLE = "migration_data_deletion_audit"
 
 
-def _verified_row_count() -> int:
-    """Return the confirmed number of retained review rows."""
+def _locked_row_count() -> int:
+    """Lock Reviews writes and return the exact number of rows being removed."""
     bind = op.get_bind()
     bind.execute(sa.text("LOCK TABLE reviews IN ACCESS EXCLUSIVE MODE"))
-    actual_count = int(bind.execute(sa.text("SELECT COUNT(*) FROM reviews")).scalar_one())
-    if actual_count == 0:
-        return actual_count
-
-    expected_count = os.getenv(CONFIRMATION_ENV)
-    if expected_count is None:
-        raise RuntimeError(
-            f"Set {CONFIRMATION_ENV} to the verified production reviews row count "
-            f"before applying this irreversible migration (current count: {actual_count})."
-        )
-    try:
-        confirmed_count = int(expected_count)
-    except ValueError as exc:
-        raise RuntimeError(f"{CONFIRMATION_ENV} must be an integer row count.") from exc
-    if confirmed_count != actual_count:
-        raise RuntimeError(
-            f"Verified reviews row count changed: expected {confirmed_count}, found {actual_count}. "
-            "Re-check retained data before applying this irreversible migration."
-        )
-    return actual_count
+    return int(bind.execute(sa.text("SELECT COUNT(*) FROM reviews")).scalar_one())
 
 
 def _record_deletion_scope(row_count: int) -> None:
-    """Persist the confirmed deletion scope before removing Reviews data."""
+    """Persist the deletion scope before removing Reviews data."""
     op.create_table(
         AUDIT_TABLE,
         sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
@@ -78,8 +58,8 @@ def _record_deletion_scope(row_count: int) -> None:
 
 
 def upgrade() -> None:
-    """Remove orphaned Reviews storage and thread metadata."""
-    row_count = _verified_row_count()
+    """Remove retired Reviews storage and thread metadata."""
+    row_count = _locked_row_count()
     _record_deletion_scope(row_count)
     op.drop_table("reviews")
 

--- a/alembic/versions/7f41d0a9c2e1_drop_orphaned_reviews.py
+++ b/alembic/versions/7f41d0a9c2e1_drop_orphaned_reviews.py
@@ -1,0 +1,93 @@
+"""Drop the retired Reviews persistence.
+
+Revision ID: 7f41d0a9c2e1
+Revises: b700c1d2e3f4
+Create Date: 2026-08-05 08:55:00.000000
+
+The Reviews product surface was removed before this migration. Production data
+must be verified as no longer needed before applying this irreversible cleanup.
+"""
+
+import os
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "7f41d0a9c2e1"
+down_revision: str | Sequence[str] | None = "b700c1d2e3f4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+CONFIRMATION_ENV = "CONFIRM_DROP_REVIEWS_ROW_COUNT"
+AUDIT_TABLE = "migration_data_deletion_audit"
+
+
+def _verified_row_count() -> int:
+    """Return the confirmed number of retained review rows."""
+    actual_count = int(op.get_bind().execute(sa.text("SELECT COUNT(*) FROM reviews")).scalar_one())
+    if actual_count == 0:
+        return actual_count
+
+    expected_count = os.getenv(CONFIRMATION_ENV)
+    if expected_count is None:
+        raise RuntimeError(
+            f"Set {CONFIRMATION_ENV} to the verified production reviews row count "
+            f"before applying this irreversible migration (current count: {actual_count})."
+        )
+    try:
+        confirmed_count = int(expected_count)
+    except ValueError as exc:
+        raise RuntimeError(f"{CONFIRMATION_ENV} must be an integer row count.") from exc
+    if confirmed_count != actual_count:
+        raise RuntimeError(
+            f"Verified reviews row count changed: expected {confirmed_count}, found {actual_count}. "
+            "Re-check retained data before applying this irreversible migration."
+        )
+    return actual_count
+
+
+def _record_deletion_scope(row_count: int) -> None:
+    """Persist the confirmed deletion scope before removing Reviews data."""
+    op.create_table(
+        AUDIT_TABLE,
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("migration_revision", sa.String(length=32), nullable=False),
+        sa.Column("resource", sa.String(length=100), nullable=False),
+        sa.Column("row_count", sa.Integer(), nullable=False),
+        sa.Column(
+            "recorded_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.get_bind().execute(
+        sa.text(
+            f"INSERT INTO {AUDIT_TABLE} (migration_revision, resource, row_count) "
+            "VALUES (:migration_revision, :resource, :row_count)"
+        ),
+        {
+            "migration_revision": revision,
+            "resource": "reviews",
+            "row_count": row_count,
+        },
+    )
+
+
+def upgrade() -> None:
+    """Remove orphaned Reviews storage and thread metadata."""
+    row_count = _verified_row_count()
+    _record_deletion_scope(row_count)
+    op.drop_table("reviews")
+
+    with op.batch_alter_table("threads", schema=None) as batch_op:
+        batch_op.drop_column("review_url")
+        batch_op.drop_column("last_review_at")
+
+
+def downgrade() -> None:
+    """Refuse to recreate destructively removed review data."""
+    raise RuntimeError(
+        "The retired Reviews data cannot be restored by downgrade; restore a database backup instead."
+    )

--- a/tests/test_review_cleanup_migration.py
+++ b/tests/test_review_cleanup_migration.py
@@ -36,9 +36,9 @@ class _BindRecorder:
         parameters: dict[str, object] | None = None,
     ) -> _ScalarResult:
         statement_text = str(statement)
+        self.calls.append(("execute", {"sql": statement_text, "parameters": parameters}))
         if statement_text == "SELECT COUNT(*) FROM reviews":
             return _ScalarResult(self.row_count)
-        self.calls.append(("execute", {"sql": statement_text, "parameters": parameters}))
         return _ScalarResult(0)
 
 
@@ -95,8 +95,16 @@ def _install_recorder(
     return recorder
 
 
+def _verification_calls() -> list[tuple[str, object]]:
+    return [
+        ("execute", {"sql": "LOCK TABLE reviews IN ACCESS EXCLUSIVE MODE", "parameters": None}),
+        ("execute", {"sql": "SELECT COUNT(*) FROM reviews", "parameters": None}),
+    ]
+
+
 def _expected_upgrade_calls(row_count: int) -> list[tuple[str, object]]:
     return [
+        *_verification_calls(),
         ("create_table", "migration_data_deletion_audit"),
         (
             "execute",
@@ -153,7 +161,7 @@ def test_upgrade_requires_recorded_row_count(monkeypatch: pytest.MonkeyPatch) ->
     with pytest.raises(RuntimeError, match="current count: 4"):
         migration.upgrade()
 
-    assert recorder.calls == []
+    assert recorder.calls == _verification_calls()
 
 
 def test_upgrade_rejects_changed_row_count(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -165,7 +173,7 @@ def test_upgrade_rejects_changed_row_count(monkeypatch: pytest.MonkeyPatch) -> N
     with pytest.raises(RuntimeError, match="expected 4, found 5"):
         migration.upgrade()
 
-    assert recorder.calls == []
+    assert recorder.calls == _verification_calls()
 
 
 def test_migration_is_forward_only() -> None:

--- a/tests/test_review_cleanup_migration.py
+++ b/tests/test_review_cleanup_migration.py
@@ -164,6 +164,18 @@ def test_upgrade_requires_recorded_row_count(monkeypatch: pytest.MonkeyPatch) ->
     assert recorder.calls == _verification_calls()
 
 
+def test_upgrade_rejects_malformed_row_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Refuse cleanup when the retained-row confirmation is not an integer."""
+    migration = _load_migration()
+    recorder = _install_recorder(monkeypatch, migration, row_count=4)
+    monkeypatch.setenv(migration.CONFIRMATION_ENV, "not-a-number")
+
+    with pytest.raises(RuntimeError, match="must be an integer row count"):
+        migration.upgrade()
+
+    assert recorder.calls == _verification_calls()
+
+
 def test_upgrade_rejects_changed_row_count(monkeypatch: pytest.MonkeyPatch) -> None:
     """Refuse cleanup when the live Reviews row count changed after confirmation."""
     migration = _load_migration()

--- a/tests/test_review_cleanup_migration.py
+++ b/tests/test_review_cleanup_migration.py
@@ -95,16 +95,10 @@ def _install_recorder(
     return recorder
 
 
-def _verification_calls() -> list[tuple[str, object]]:
+def _expected_upgrade_calls(row_count: int) -> list[tuple[str, object]]:
     return [
         ("execute", {"sql": "LOCK TABLE reviews IN ACCESS EXCLUSIVE MODE", "parameters": None}),
         ("execute", {"sql": "SELECT COUNT(*) FROM reviews", "parameters": None}),
-    ]
-
-
-def _expected_upgrade_calls(row_count: int) -> list[tuple[str, object]]:
-    return [
-        *_verification_calls(),
         ("create_table", "migration_data_deletion_audit"),
         (
             "execute",
@@ -128,64 +122,18 @@ def _expected_upgrade_calls(row_count: int) -> list[tuple[str, object]]:
     ]
 
 
-def test_upgrade_records_scope_before_removing_retired_reviews(
+@pytest.mark.parametrize("row_count", [0, 3])
+def test_upgrade_audits_and_removes_retired_reviews(
     monkeypatch: pytest.MonkeyPatch,
+    row_count: int,
 ) -> None:
-    """Record the confirmed deletion scope before dropping retained Reviews rows."""
+    """Record the exact deletion scope and remove Reviews without a manual gate."""
     migration = _load_migration()
-    recorder = _install_recorder(monkeypatch, migration, row_count=3)
-    monkeypatch.setenv(migration.CONFIRMATION_ENV, "3")
+    recorder = _install_recorder(monkeypatch, migration, row_count=row_count)
 
     migration.upgrade()
 
-    assert recorder.calls == _expected_upgrade_calls(3)
-
-
-def test_upgrade_records_empty_reviews_table(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Allow and audit cleanup when the Reviews table is already empty."""
-    migration = _load_migration()
-    recorder = _install_recorder(monkeypatch, migration, row_count=0)
-    monkeypatch.delenv(migration.CONFIRMATION_ENV, raising=False)
-
-    migration.upgrade()
-
-    assert recorder.calls == _expected_upgrade_calls(0)
-
-
-def test_upgrade_requires_recorded_row_count(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Refuse destructive cleanup without an exact retained-row confirmation."""
-    migration = _load_migration()
-    recorder = _install_recorder(monkeypatch, migration, row_count=4)
-    monkeypatch.delenv(migration.CONFIRMATION_ENV, raising=False)
-
-    with pytest.raises(RuntimeError, match="current count: 4"):
-        migration.upgrade()
-
-    assert recorder.calls == _verification_calls()
-
-
-def test_upgrade_rejects_malformed_row_count(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Refuse cleanup when the retained-row confirmation is not an integer."""
-    migration = _load_migration()
-    recorder = _install_recorder(monkeypatch, migration, row_count=4)
-    monkeypatch.setenv(migration.CONFIRMATION_ENV, "not-a-number")
-
-    with pytest.raises(RuntimeError, match="must be an integer row count"):
-        migration.upgrade()
-
-    assert recorder.calls == _verification_calls()
-
-
-def test_upgrade_rejects_changed_row_count(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Refuse cleanup when the live Reviews row count changed after confirmation."""
-    migration = _load_migration()
-    recorder = _install_recorder(monkeypatch, migration, row_count=5)
-    monkeypatch.setenv(migration.CONFIRMATION_ENV, "4")
-
-    with pytest.raises(RuntimeError, match="expected 4, found 5"):
-        migration.upgrade()
-
-    assert recorder.calls == _verification_calls()
+    assert recorder.calls == _expected_upgrade_calls(row_count)
 
 
 def test_migration_is_forward_only() -> None:

--- a/tests/test_review_cleanup_migration.py
+++ b/tests/test_review_cleanup_migration.py
@@ -123,6 +123,7 @@ def _expected_upgrade_calls(row_count: int) -> list[tuple[str, object]]:
 def test_upgrade_records_scope_before_removing_retired_reviews(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Record the confirmed deletion scope before dropping retained Reviews rows."""
     migration = _load_migration()
     recorder = _install_recorder(monkeypatch, migration, row_count=3)
     monkeypatch.setenv(migration.CONFIRMATION_ENV, "3")
@@ -133,6 +134,7 @@ def test_upgrade_records_scope_before_removing_retired_reviews(
 
 
 def test_upgrade_records_empty_reviews_table(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Allow and audit cleanup when the Reviews table is already empty."""
     migration = _load_migration()
     recorder = _install_recorder(monkeypatch, migration, row_count=0)
     monkeypatch.delenv(migration.CONFIRMATION_ENV, raising=False)
@@ -143,6 +145,7 @@ def test_upgrade_records_empty_reviews_table(monkeypatch: pytest.MonkeyPatch) ->
 
 
 def test_upgrade_requires_recorded_row_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Refuse destructive cleanup without an exact retained-row confirmation."""
     migration = _load_migration()
     recorder = _install_recorder(monkeypatch, migration, row_count=4)
     monkeypatch.delenv(migration.CONFIRMATION_ENV, raising=False)
@@ -154,6 +157,7 @@ def test_upgrade_requires_recorded_row_count(monkeypatch: pytest.MonkeyPatch) ->
 
 
 def test_upgrade_rejects_changed_row_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Refuse cleanup when the live Reviews row count changed after confirmation."""
     migration = _load_migration()
     recorder = _install_recorder(monkeypatch, migration, row_count=5)
     monkeypatch.setenv(migration.CONFIRMATION_ENV, "4")
@@ -165,6 +169,7 @@ def test_upgrade_rejects_changed_row_count(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_migration_is_forward_only() -> None:
+    """Reject downgrade because deleted Reviews data requires backup restoration."""
     migration = _load_migration()
 
     with pytest.raises(RuntimeError, match="restore a database backup"):

--- a/tests/test_review_cleanup_migration.py
+++ b/tests/test_review_cleanup_migration.py
@@ -1,0 +1,171 @@
+"""Regression coverage for the retired Reviews persistence cleanup migration."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Self
+
+import pytest
+
+MIGRATION_PATH = (
+    Path(__file__).parents[1]
+    / "alembic"
+    / "versions"
+    / "7f41d0a9c2e1_drop_orphaned_reviews.py"
+)
+
+
+class _ScalarResult:
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+    def scalar_one(self) -> int:
+        return self.value
+
+
+class _BindRecorder:
+    def __init__(self, row_count: int, calls: list[tuple[str, object]]) -> None:
+        self.row_count = row_count
+        self.calls = calls
+
+    def execute(
+        self,
+        statement: object,
+        parameters: dict[str, object] | None = None,
+    ) -> _ScalarResult:
+        statement_text = str(statement)
+        if statement_text == "SELECT COUNT(*) FROM reviews":
+            return _ScalarResult(self.row_count)
+        self.calls.append(("execute", {"sql": statement_text, "parameters": parameters}))
+        return _ScalarResult(0)
+
+
+class _BatchRecorder:
+    def __init__(self, calls: list[tuple[str, object]]) -> None:
+        self.calls = calls
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def drop_column(self, column_name: str) -> None:
+        self.calls.append(("drop_column", column_name))
+
+
+class _OperationRecorder:
+    def __init__(self, row_count: int = 0) -> None:
+        self.calls: list[tuple[str, object]] = []
+        self.bind = _BindRecorder(row_count, self.calls)
+
+    def get_bind(self) -> _BindRecorder:
+        return self.bind
+
+    def create_table(self, table_name: str, *_columns: object) -> None:
+        self.calls.append(("create_table", table_name))
+
+    def drop_table(self, table_name: str) -> None:
+        self.calls.append(("drop_table", table_name))
+
+    def batch_alter_table(self, table_name: str, *, schema: str | None) -> _BatchRecorder:
+        assert schema is None
+        self.calls.append(("batch_alter_table", table_name))
+        return _BatchRecorder(self.calls)
+
+
+def _load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("review_cleanup_migration", MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _install_recorder(
+    monkeypatch: pytest.MonkeyPatch,
+    migration: ModuleType,
+    *,
+    row_count: int,
+) -> _OperationRecorder:
+    recorder = _OperationRecorder(row_count=row_count)
+    monkeypatch.setattr(migration, "op", recorder)
+    return recorder
+
+
+def _expected_upgrade_calls(row_count: int) -> list[tuple[str, object]]:
+    return [
+        ("create_table", "migration_data_deletion_audit"),
+        (
+            "execute",
+            {
+                "sql": (
+                    "INSERT INTO migration_data_deletion_audit "
+                    "(migration_revision, resource, row_count) "
+                    "VALUES (:migration_revision, :resource, :row_count)"
+                ),
+                "parameters": {
+                    "migration_revision": "7f41d0a9c2e1",
+                    "resource": "reviews",
+                    "row_count": row_count,
+                },
+            },
+        ),
+        ("drop_table", "reviews"),
+        ("batch_alter_table", "threads"),
+        ("drop_column", "review_url"),
+        ("drop_column", "last_review_at"),
+    ]
+
+
+def test_upgrade_records_scope_before_removing_retired_reviews(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    migration = _load_migration()
+    recorder = _install_recorder(monkeypatch, migration, row_count=3)
+    monkeypatch.setenv(migration.CONFIRMATION_ENV, "3")
+
+    migration.upgrade()
+
+    assert recorder.calls == _expected_upgrade_calls(3)
+
+
+def test_upgrade_records_empty_reviews_table(monkeypatch: pytest.MonkeyPatch) -> None:
+    migration = _load_migration()
+    recorder = _install_recorder(monkeypatch, migration, row_count=0)
+    monkeypatch.delenv(migration.CONFIRMATION_ENV, raising=False)
+
+    migration.upgrade()
+
+    assert recorder.calls == _expected_upgrade_calls(0)
+
+
+def test_upgrade_requires_recorded_row_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    migration = _load_migration()
+    recorder = _install_recorder(monkeypatch, migration, row_count=4)
+    monkeypatch.delenv(migration.CONFIRMATION_ENV, raising=False)
+
+    with pytest.raises(RuntimeError, match="current count: 4"):
+        migration.upgrade()
+
+    assert recorder.calls == []
+
+
+def test_upgrade_rejects_changed_row_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    migration = _load_migration()
+    recorder = _install_recorder(monkeypatch, migration, row_count=5)
+    monkeypatch.setenv(migration.CONFIRMATION_ENV, "4")
+
+    with pytest.raises(RuntimeError, match="expected 4, found 5"):
+        migration.upgrade()
+
+    assert recorder.calls == []
+
+
+def test_migration_is_forward_only() -> None:
+    migration = _load_migration()
+
+    with pytest.raises(RuntimeError, match="restore a database backup"):
+        migration.downgrade()


### PR DESCRIPTION
## Summary

- replays the forward-only Reviews persistence cleanup onto current `main` after PR #806 became non-mergeable;
- records the exact deleted Reviews row count for auditability;
- removes the retired `reviews` table;
- removes `threads.review_url` and `threads.last_review_at`;
- includes focused migration regression coverage.

Closes #741. Supersedes #806.

## Product decision

Josh has explicitly directed that the retired Reviews feature and its retained data be removed. The migration therefore audits the live row count under an exclusive lock and proceeds without a separate manual row-count confirmation ceremony.

## Safety properties

- the table is locked before counting so the audit record matches the rows deleted;
- the cleanup runs transactionally through Alembic;
- the migration is forward-only because deleted review data cannot be reconstructed by downgrade;
- recovery, if ever required, comes from the production database backup.

## Verification

Exact-head CI must verify the migration graph, focused tests, and fresh-database path before merge.