### PR TITLE
fix(queue): keep completed threads collapsed by default (#655)

### DIFF
--- a/frontend/src/pages/QueuePage/CompletedThreadsSection.tsx
+++ b/frontend/src/pages/QueuePage/CompletedThreadsSection.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react'
+
+interface CompletedThread {
+  id: number
+  title: string
+  format: string
+  notes?: string | null
+}
+
+interface CompletedThreadsSectionProps {
+  threads: CompletedThread[]
+  onReactivate: (thread: CompletedThread | null) => void
+}
+
+export default function CompletedThreadsSection({
+  threads,
+  onReactivate,
+}: CompletedThreadsSectionProps) {
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  if (threads.length === 0) return null
+
+  const handleReactivate = (thread: CompletedThread | null) => {
+    setIsExpanded(false)
+    onReactivate(thread)
+  }
+
+  return (
+    <section className="space-y-4" aria-labelledby="completed-threads-heading">
+      <header className="flex items-center justify-between gap-3 px-2">
+        <div className="min-w-0">
+          <h2
+            id="completed-threads-heading"
+            className="text-lg md:text-xl font-black uppercase text-stone-300"
+          >
+            Completed Threads
+          </h2>
+          <p className="text-[10px] font-bold text-stone-500 uppercase tracking-widest">
+            {threads.length} finished series hidden from the queue
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setIsExpanded((expanded) => !expanded)}
+          aria-expanded={isExpanded}
+          aria-controls="completed-thread-list"
+          className="h-8 md:h-10 px-3 md:px-4 bg-white/5 border border-white/10 rounded-xl text-[10px] font-black uppercase tracking-widest text-stone-300 hover:bg-white/10"
+        >
+          {isExpanded ? 'Hide Completed' : `Show Completed (${threads.length})`}
+        </button>
+      </header>
+
+      {isExpanded && (
+        <div id="completed-thread-list" className="space-y-4">
+          <div className="flex justify-end px-2">
+            <button
+              type="button"
+              onClick={() => handleReactivate(null)}
+              aria-label="Choose completed thread to reactivate"
+              className="h-8 md:h-10 px-3 md:px-4 bg-white/5 border border-white/10 rounded-xl text-[10px] font-black uppercase tracking-widest text-stone-300 hover:bg-white/10"
+            >
+              Reactivate
+            </button>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {threads.map((thread) => (
+              <div key={thread.id} className="glass-card p-4 space-y-2">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-sm font-black text-stone-300 truncate">{thread.title}</p>
+                    <p className="text-[8px] font-black text-stone-500 uppercase tracking-widest">
+                      {thread.format}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleReactivate(thread)}
+                    aria-label={`Reactivate ${thread.title}`}
+                    className="px-3 py-1 bg-white/5 border border-white/10 rounded-lg text-[9px] font-black uppercase tracking-widest text-stone-300 hover:bg-white/10"
+                  >
+                    Reactivate
+                  </button>
+                </div>
+                {thread.notes && <p className="text-xs text-stone-500">{thread.notes}</p>}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/pages/QueuePage/CompletedThreadsSection.tsx
+++ b/frontend/src/pages/QueuePage/CompletedThreadsSection.tsx
@@ -7,20 +7,20 @@ interface CompletedThread {
   notes?: string | null
 }
 
-interface CompletedThreadsSectionProps {
-  threads: CompletedThread[]
-  onReactivate: (thread: CompletedThread | null) => void
+interface CompletedThreadsSectionProps<T extends CompletedThread> {
+  threads: T[]
+  onReactivate: (thread: T | null) => void
 }
 
-export default function CompletedThreadsSection({
+export default function CompletedThreadsSection<T extends CompletedThread>({
   threads,
   onReactivate,
-}: CompletedThreadsSectionProps) {
+}: CompletedThreadsSectionProps<T>) {
   const [isExpanded, setIsExpanded] = useState(false)
 
   if (threads.length === 0) return null
 
-  const handleReactivate = (thread: CompletedThread | null) => {
+  const handleReactivate = (thread: T | null) => {
     setIsExpanded(false)
     onReactivate(thread)
   }

--- a/frontend/src/pages/QueuePage/CompletedThreadsSection.tsx
+++ b/frontend/src/pages/QueuePage/CompletedThreadsSection.tsx
@@ -59,33 +59,31 @@ export default function CompletedThreadsSection<T extends CompletedThread>({
         </div>
       </header>
 
-      {isExpanded && (
-        <div id="completed-thread-list" className="space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {threads.map((thread) => (
-              <div key={thread.id} className="glass-card p-4 space-y-2">
-                <div className="flex items-center justify-between gap-3">
-                  <div className="min-w-0">
-                    <p className="text-sm font-black text-stone-300 truncate">{thread.title}</p>
-                    <p className="text-[8px] font-black text-stone-500 uppercase tracking-widest">
-                      {thread.format}
-                    </p>
-                  </div>
-                  <button
-                    type="button"
-                    onClick={() => handleReactivate(thread)}
-                    aria-label={`Reactivate ${thread.title}`}
-                    className="px-3 py-1 bg-white/5 border border-white/10 rounded-lg text-[9px] font-black uppercase tracking-widest text-stone-300 hover:bg-white/10"
-                  >
-                    Reactivate
-                  </button>
+      <div id="completed-thread-list" className="space-y-4" hidden={!isExpanded}>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {threads.map((thread) => (
+            <div key={thread.id} className="glass-card p-4 space-y-2">
+              <div className="flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-sm font-black text-stone-300 truncate">{thread.title}</p>
+                  <p className="text-[8px] font-black text-stone-500 uppercase tracking-widest">
+                    {thread.format}
+                  </p>
                 </div>
-                {thread.notes && <p className="text-xs text-stone-500">{thread.notes}</p>}
+                <button
+                  type="button"
+                  onClick={() => handleReactivate(thread)}
+                  aria-label={`Reactivate ${thread.title}`}
+                  className="px-3 py-1 bg-white/5 border border-white/10 rounded-lg text-[9px] font-black uppercase tracking-widest text-stone-300 hover:bg-white/10"
+                >
+                  Reactivate
+                </button>
               </div>
-            ))}
-          </div>
+              {thread.notes && <p className="text-xs text-stone-500">{thread.notes}</p>}
+            </div>
+          ))}
         </div>
-      )}
+      </div>
     </section>
   )
 }

--- a/frontend/src/pages/QueuePage/CompletedThreadsSection.tsx
+++ b/frontend/src/pages/QueuePage/CompletedThreadsSection.tsx
@@ -39,29 +39,28 @@ export default function CompletedThreadsSection<T extends CompletedThread>({
             {threads.length} finished series hidden from the queue
           </p>
         </div>
-        <button
-          type="button"
-          onClick={() => setIsExpanded((expanded) => !expanded)}
-          aria-expanded={isExpanded}
-          aria-controls="completed-thread-list"
-          className="h-8 md:h-10 px-3 md:px-4 bg-white/5 border border-white/10 rounded-xl text-[10px] font-black uppercase tracking-widest text-stone-300 hover:bg-white/10"
-        >
-          {isExpanded ? 'Hide Completed' : `Show Completed (${threads.length})`}
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => handleReactivate(null)}
+            className="h-8 md:h-10 px-3 md:px-4 bg-white/5 border border-white/10 rounded-xl text-[10px] font-black uppercase tracking-widest text-stone-300 hover:bg-white/10"
+          >
+            Reactivate
+          </button>
+          <button
+            type="button"
+            onClick={() => setIsExpanded((expanded) => !expanded)}
+            aria-expanded={isExpanded}
+            aria-controls="completed-thread-list"
+            className="h-8 md:h-10 px-3 md:px-4 bg-white/5 border border-white/10 rounded-xl text-[10px] font-black uppercase tracking-widest text-stone-300 hover:bg-white/10"
+          >
+            {isExpanded ? 'Hide Completed' : `Show Completed (${threads.length})`}
+          </button>
+        </div>
       </header>
 
       {isExpanded && (
         <div id="completed-thread-list" className="space-y-4">
-          <div className="flex justify-end px-2">
-            <button
-              type="button"
-              onClick={() => handleReactivate(null)}
-              aria-label="Choose completed thread to reactivate"
-              className="h-8 md:h-10 px-3 md:px-4 bg-white/5 border border-white/10 rounded-xl text-[10px] font-black uppercase tracking-widest text-stone-300 hover:bg-white/10"
-            >
-              Reactivate
-            </button>
-          </div>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {threads.map((thread) => (
               <div key={thread.id} className="glass-card p-4 space-y-2">

--- a/frontend/src/pages/QueuePage/QueuePage.tsx
+++ b/frontend/src/pages/QueuePage/QueuePage.tsx
@@ -18,6 +18,7 @@ import type { Thread } from '../../types'
 import { getApiErrorDetail } from '../../utils/apiError'
 import { FormatSelect } from './FormatSelect'
 import { IssueToggleList } from './IssueToggleList'
+import CompletedThreadsSection from './CompletedThreadsSection'
 import QueueThreadCard from './QueueThreadCard'
 import VirtualizedThreadList, { VIRTUALIZATION_THRESHOLD } from './VirtualizedThreadList'
 import { DEFAULT_CREATE_STATE, type QueueFormState } from './types'
@@ -602,43 +603,10 @@ export default function QueuePage() {
         </>
       )}
 
-      {completedThreads.length > 0 && (
-      <section className="space-y-4">
-        <header className="flex items-center justify-between px-2">
-          <div>
-            <h2 className="text-lg md:text-xl font-black uppercase text-stone-300">Completed Threads</h2>
-            <p className="text-[10px] font-bold text-stone-500 uppercase tracking-widest">Reactivate finished series</p>
-          </div>
-          <button
-            type="button"
-            onClick={() => openReactivateModal(null)}
-            className="h-8 md:h-10 px-3 md:px-4 bg-white/5 border border-white/10 rounded-xl text-[10px] font-black uppercase tracking-widest text-stone-300 hover:bg-white/10"
-          >
-            Reactivate
-          </button>
-        </header>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {completedThreads.map((thread) => (
-            <div key={thread.id} className="glass-card p-4 space-y-2">
-              <div className="flex items-center justify-between gap-3">
-                <div className="min-w-0">
-                  <p className="text-sm font-black text-stone-300 truncate">{thread.title}</p>
-                  <p className="text-[8px] font-black text-stone-500 uppercase tracking-widest">{thread.format}</p>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => openReactivateModal(thread)}
-                  className="px-3 py-1 bg-white/5 border border-white/10 rounded-lg text-[9px] font-black uppercase tracking-widest text-stone-300 hover:bg-white/10"
-                >
-                  Reactivate
-                </button>
-              </div>
-              {thread.notes && <p className="text-xs text-stone-500">{thread.notes}</p>}
-            </div>
-          ))}
-        </div>
-      </section>
-      )}
+      <CompletedThreadsSection
+        threads={completedThreads}
+        onReactivate={openReactivateModal}
+      />
 
   {/* Create Thread Modal */}
   <Modal isOpen={isCreateOpen} title="Create Thread" onClose={closeCreateModal}>

--- a/frontend/src/unit/CompletedThreadsSection.test.tsx
+++ b/frontend/src/unit/CompletedThreadsSection.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import CompletedThreadsSection from '../pages/QueuePage/CompletedThreadsSection'
+
+const completedThreads = [
+  {
+    id: 2,
+    title: 'Descender',
+    format: 'Comic',
+    notes: 'Finished the main series',
+  },
+  {
+    id: 3,
+    title: 'Paper Girls',
+    format: 'Trade',
+    notes: null,
+  },
+]
+
+describe('CompletedThreadsSection', () => {
+  it('keeps completed thread cards hidden until the user opts in', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <CompletedThreadsSection
+        threads={completedThreads}
+        onReactivate={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('heading', { name: 'Completed Threads' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Show Completed (2)' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    )
+    expect(screen.queryByText('Descender')).not.toBeInTheDocument()
+    expect(screen.queryByText('Paper Girls')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Show Completed (2)' }))
+
+    expect(screen.getByRole('button', { name: 'Hide Completed' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    )
+    expect(screen.getByText('Descender')).toBeInTheDocument()
+    expect(screen.getByText('Paper Girls')).toBeInTheDocument()
+  })
+
+  it('preserves distinct reactivation paths and collapses after each selection', async () => {
+    const user = userEvent.setup()
+    const onReactivate = vi.fn()
+
+    render(
+      <CompletedThreadsSection
+        threads={completedThreads}
+        onReactivate={onReactivate}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Show Completed (2)' }))
+    await user.click(
+      screen.getByRole('button', { name: 'Choose completed thread to reactivate' }),
+    )
+
+    expect(onReactivate).toHaveBeenNthCalledWith(1, null)
+    expect(screen.getByRole('button', { name: 'Show Completed (2)' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    )
+    expect(screen.queryByText('Descender')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Show Completed (2)' }))
+    await user.click(screen.getByRole('button', { name: 'Reactivate Descender' }))
+
+    expect(onReactivate).toHaveBeenNthCalledWith(2, completedThreads[0])
+    expect(screen.getByRole('button', { name: 'Show Completed (2)' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    )
+    expect(screen.queryByRole('button', { name: 'Reactivate Paper Girls' })).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when there are no completed threads', () => {
+    const { container } = render(
+      <CompletedThreadsSection
+        threads={[]}
+        onReactivate={vi.fn()}
+      />,
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/frontend/src/unit/CompletedThreadsSection.test.tsx
+++ b/frontend/src/unit/CompletedThreadsSection.test.tsx
@@ -34,8 +34,8 @@ describe('CompletedThreadsSection', () => {
       'aria-expanded',
       'false',
     )
-    expect(screen.queryByText('Descender')).not.toBeInTheDocument()
-    expect(screen.queryByText('Paper Girls')).not.toBeInTheDocument()
+    expect(screen.getByText('Descender')).not.toBeVisible()
+    expect(screen.getByText('Paper Girls')).not.toBeVisible()
 
     await user.click(screen.getByRole('button', { name: 'Show Completed (2)' }))
 
@@ -43,8 +43,8 @@ describe('CompletedThreadsSection', () => {
       'aria-expanded',
       'true',
     )
-    expect(screen.getByText('Descender')).toBeInTheDocument()
-    expect(screen.getByText('Paper Girls')).toBeInTheDocument()
+    expect(screen.getByText('Descender')).toBeVisible()
+    expect(screen.getByText('Paper Girls')).toBeVisible()
   })
 
   it('preserves distinct reactivation paths and collapses after each selection', async () => {
@@ -65,7 +65,7 @@ describe('CompletedThreadsSection', () => {
       'aria-expanded',
       'false',
     )
-    expect(screen.queryByText('Descender')).not.toBeInTheDocument()
+    expect(screen.getByText('Descender')).not.toBeVisible()
 
     await user.click(screen.getByRole('button', { name: 'Show Completed (2)' }))
     await user.click(screen.getByRole('button', { name: 'Reactivate Descender' }))

--- a/frontend/src/unit/CompletedThreadsSection.test.tsx
+++ b/frontend/src/unit/CompletedThreadsSection.test.tsx
@@ -58,10 +58,7 @@ describe('CompletedThreadsSection', () => {
       />,
     )
 
-    await user.click(screen.getByRole('button', { name: 'Show Completed (2)' }))
-    await user.click(
-      screen.getByRole('button', { name: 'Choose completed thread to reactivate' }),
-    )
+    await user.click(screen.getByRole('button', { name: 'Reactivate' }))
 
     expect(onReactivate).toHaveBeenNthCalledWith(1, null)
     expect(screen.getByRole('button', { name: 'Show Completed (2)' })).toHaveAttribute(


### PR DESCRIPTION
## Summary

- keeps completed threads out of the normal Queue scroll until the user explicitly expands them;
- shows the completed count while collapsed;
- preserves both picker-based and per-thread reactivation paths;
- collapses the section after a reactivation choice;
- adds focused component regression coverage.

Closes #655.

## Verification

- The focused component implementation and tests were replayed from previously green component-only work.
- This branch also performs the missing integration into the exact current-main `QueuePage.tsx`.
- No local test execution is claimed because this runtime could not clone the repository; exact-head CI is required before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a collapsible section for completed threads.
  * View thread details and notes when expanded.
  * Reactivate all completed threads or select an individual thread for reactivation.
  * The section automatically collapses after reactivation.
  * Added an empty state when no completed threads are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->