### PR TITLE
ci: gate stale generated OpenAPI types

### DIFF
--- a/.github/workflows/openapi-generated-types.yml
+++ b/.github/workflows/openapi-generated-types.yml
@@ -41,4 +41,6 @@ jobs:
           pnpm --version
 
       - name: Verify deterministic OpenAPI schema and TypeScript output
+        env:
+          PYTHONPATH: .
         run: uv run python scripts/generate_openapi_types.py --check

--- a/.github/workflows/openapi-generated-types.yml
+++ b/.github/workflows/openapi-generated-types.yml
@@ -1,0 +1,44 @@
+name: OpenAPI Generated Types
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: openapi-generated-types-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  generated-types-current:
+    name: Generated OpenAPI types are current
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+
+      - name: Install uv
+        run: python -m pip install --disable-pip-version-check uv
+
+      - name: Restore locked Python environment
+        run: uv sync --frozen
+
+      - name: Enable pinned pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.15.0 --activate
+          pnpm --version
+
+      - name: Verify deterministic OpenAPI schema and TypeScript output
+        run: uv run python scripts/generate_openapi_types.py --check

--- a/.github/workflows/openapi-generated-types.yml
+++ b/.github/workflows/openapi-generated-types.yml
@@ -40,7 +40,20 @@ jobs:
           corepack prepare pnpm@10.15.0 --activate
           pnpm --version
 
-      - name: Verify deterministic OpenAPI schema and TypeScript output
+      - name: Regenerate deterministic OpenAPI schema and TypeScript output
         env:
           PYTHONPATH: .
-        run: uv run python scripts/generate_openapi_types.py --check
+        run: uv run python scripts/generate_openapi_types.py
+
+      - name: Upload regenerated artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: generated-openapi-types
+          path: |
+            frontend/src/generated/openapi.json
+            frontend/src/generated/openapi.ts
+          if-no-files-found: error
+
+      - name: Verify generated artifacts are committed
+        run: git diff --exit-code -- frontend/src/generated/openapi.json frontend/src/generated/openapi.ts


### PR DESCRIPTION
## Summary

- adds a dedicated pull-request and main-branch CI gate for the existing deterministic OpenAPI export and generated TypeScript artifacts;
- restores the locked Python environment under Python 3.14;
- uses the repository-pinned pnpm version before invoking the pinned `openapi-typescript` generator;
- fails when either `frontend/src/generated/openapi.json` or `frontend/src/generated/openapi.ts` is stale.

Part of #639.

## Verification

Exact-head GitHub Actions must execute `uv run python scripts/generate_openapi_types.py --check`. No local execution is claimed because the available runtime cannot reach GitHub or install repository dependencies.