### PR TITLE
fix(factory): rotate on transient heartbeat failures without retiring…

### DIFF
--- a/scripts/comic-pile-opencode-factory.sh
+++ b/scripts/comic-pile-opencode-factory.sh
@@ -27,6 +27,8 @@ SCOUT_PID_FILE="${COMIC_PILE_FACTORY_SCOUT_PID_FILE:-}"
 AUTO_SCOUT="${COMIC_PILE_FACTORY_AUTO_SCOUT:-1}"
 SCOUT_PARALLEL="${SCOUT_PARALLEL:-4}"
 SCOUT_TIMEOUT="${MODEL_SCOUT_TIMEOUT:-${FACTORY_HEARTBEAT_TIMEOUT:-60}}"
+ALLOWED_PROVIDERS="${COMIC_PILE_FACTORY_ALLOWED_PROVIDERS:-opencode nvidia fcm-nvidia openrouter}"
+FAILURE_THRESHOLD="${FACTORY_FAILURE_THRESHOLD:-2}"
 
 usage() {
   "$HEARTBEAT_RUNNER" --help
@@ -96,6 +98,8 @@ is_nonnegative_integer "$MAX_FAILURES" || die "FACTORY_MAX_FAILURES must be an i
 is_nonnegative_integer "$SCOUT_PARALLEL" || die "SCOUT_PARALLEL must be an integer"
 ((SCOUT_PARALLEL >= 1)) || die "SCOUT_PARALLEL must be at least 1"
 [[ "$SCOUT_TIMEOUT" =~ ^[1-9][0-9]*$ ]] || die "MODEL_SCOUT_TIMEOUT must be a positive integer"
+is_nonnegative_integer "$FAILURE_THRESHOLD" || die "FACTORY_FAILURE_THRESHOLD must be an integer"
+((FAILURE_THRESHOLD >= 1)) || die "FACTORY_FAILURE_THRESHOLD must be at least 1"
 [[ "$AUTO_SCOUT" == "0" || "$AUTO_SCOUT" == "1" ]] || die "COMIC_PILE_FACTORY_AUTO_SCOUT must be 0 or 1"
 [[ -x "$HEARTBEAT_RUNNER" ]] || die "heartbeat runner is not executable: $HEARTBEAT_RUNNER"
 [[ -x "$MANIFEST_HELPER" ]] || die "manifest helper is not executable: $MANIFEST_HELPER"
@@ -139,7 +143,17 @@ refresh_model_manifest() {
   candidates_file="$(mktemp "$STATE_DIR/.model-candidates.XXXXXX")"
   while IFS= read -r model; do
     [[ -n "$model" ]] || continue
-    non_chat_model "$model" || printf '%s\n' "$model"
+    non_chat_model "$model" && continue
+    for provider in $ALLOWED_PROVIDERS; do
+      [[ "$model" == "$provider/"* ]] || continue
+      # OpenRouter exposes paid models alongside :free ones; only free routes
+      # belong in the curated pool.
+      if [[ "$provider" == "openrouter" ]]; then
+        [[ "$model" == *:free ]] || continue
+      fi
+      printf '%s\n' "$model"
+      break
+    done
   done < <(opencode models 2>/dev/null) >"$candidates_file"
 
   if [[ ! -s "$candidates_file" ]]; then
@@ -170,6 +184,10 @@ select_model() {
   fi
 }
 
+failure_count_file() {
+  printf '%s\n' "$STATE_DIR/model-failures/$(printf '%s' "$1" | tr '/:@._ ' '______')"
+}
+
 wait_for_initial_scout
 refresh_model_manifest 3600 || true
 
@@ -191,10 +209,34 @@ while true; do
   # process lifetime. Remove completed files so they cannot accumulate forever.
   rm -f "$STATE_DIR"/heartbeats/factory_heartbeat_*.hb 2>/dev/null || true
 
+  if ((status == 0)); then
+    rm -f -- "$(failure_count_file "$model")"
+  fi
+
   if ((status != 0)); then
-    # Retire this model from confirmed rotation so the next heartbeat gets a
-    # different known-good candidate. Keep the failure in the manifest.
+    # A watchdog kill (token-per-minute limit or heartbeat silence timeout) is a
+    # transient interruption, not evidence the model is broken. Productive runs
+    # are frequently silent for long stretches (long test suites, git push
+    # hooks), so rotate away without retiring the model.
+    if grep -Eiq 'WATCHDOG:|tokens per minute' "$result_file"; then
+      printf 'Heartbeat for %s was interrupted by the watchdog; rotating without retiring.\n' "$model" >&2
+      rm -f "$result_file"
+      continue
+    fi
+    # Genuine failures retire a model only after FACTORY_FAILURE_THRESHOLD
+    # consecutive wrapper heartbeats, so a single bad run cannot drain the
+    # manifest of verified models.
+    mkdir -p "$STATE_DIR/model-failures"
+    fail_file="$(failure_count_file "$model")"
+    fail_count=$(( $(cat "$fail_file" 2>/dev/null || printf 0) + 1 ))
+    printf '%s\n' "$fail_count" >"$fail_file"
+    if ((fail_count < FAILURE_THRESHOLD)); then
+      printf 'Heartbeat failed for %s (%d/%d); rotating without retiring.\n' "$model" "$fail_count" "$FAILURE_THRESHOLD" >&2
+      rm -f "$result_file"
+      continue
+    fi
     "$MANIFEST_HELPER" fail "$model" "$STATE_DIR" >/dev/null 2>&1 || true
+    rm -f -- "$fail_file"
     rm -f "$result_file"
     if [[ -n "$PINNED_MODEL" ]]; then
       printf 'Factory stopped after failure of pinned model %s.\n' "$model" >&2

--- a/scripts/opencode-model-scout.sh
+++ b/scripts/opencode-model-scout.sh
@@ -14,6 +14,7 @@ PARALLEL="${MODEL_SCOUT_PARALLEL:-4}"
 TIMEOUT="${MODEL_SCOUT_TIMEOUT:-900}"
 WATCHDOG_POLL_SECONDS="${MODEL_SCOUT_WATCHDOG_POLL_SECONDS:-15}"
 FAILURE_COOLDOWN_SECONDS="${MODEL_SCOUT_FAILURE_COOLDOWN_SECONDS:-3600}"
+ALLOWED_PROVIDERS="${COMIC_PILE_FACTORY_ALLOWED_PROVIDERS:-opencode nvidia fcm-nvidia openrouter}"
 WATCH=0
 RECHECK_SECONDS=600
 FORCE=0
@@ -144,6 +145,7 @@ non_chat() {
 }
 
 discover_candidates() {
+  local provider candidate
   if ((${#EXPLICIT_MODELS[@]} > 0)); then
     printf '%s\n' "${EXPLICIT_MODELS[@]}"
     return
@@ -153,8 +155,18 @@ discover_candidates() {
     grep -v '^[[:space:]]*#' "$CANDIDATES_FILE" | grep -v '^[[:space:]]*$'
     return
   fi
-  opencode models 2>/dev/null | grep -vE '^opencode/' | while IFS= read -r candidate; do
-    non_chat "$candidate" || printf '%s\n' "$candidate"
+  opencode models 2>/dev/null | while IFS= read -r candidate; do
+    non_chat "$candidate" && continue
+    for provider in $ALLOWED_PROVIDERS; do
+      [[ "$candidate" == "$provider/"* ]] || continue
+      # OpenRouter exposes paid models alongside :free ones; only free routes
+      # belong in the curated pool.
+      if [[ "$provider" == "openrouter" ]]; then
+        [[ "$candidate" == *:free ]] || continue
+      fi
+      printf '%s\n' "$candidate"
+      break
+    done
   done
 }
 

--- a/scripts/tests/test_opencode_model_tools.py
+++ b/scripts/tests/test_opencode_model_tools.py
@@ -116,6 +116,7 @@ class ModelToolTests(unittest.TestCase):
             str(self.scripts / "comic-pile-opencode-factory.sh"),
             "--state-dir",
             str(state),
+            env={"COMIC_PILE_FACTORY_AUTO_SCOUT": "0"},
             timeout=10,
         )
 
@@ -157,7 +158,11 @@ class ModelToolTests(unittest.TestCase):
             str(self.scripts / "comic-pile-opencode-factory.sh"),
             "--state-dir",
             str(state),
-            env={"FACTORY_FAILURE_BACKOFF_SECONDS": "30"},
+            env={
+                "FACTORY_FAILURE_BACKOFF_SECONDS": "30",
+                "FACTORY_FAILURE_THRESHOLD": "1",
+                "COMIC_PILE_FACTORY_AUTO_SCOUT": "0",
+            },
             timeout=10,
         )
 
@@ -203,7 +208,7 @@ class ModelToolTests(unittest.TestCase):
             str(self.scripts / "comic-pile-opencode-factory.sh"),
             "--state-dir",
             str(state),
-            env={"FACTORY_FAILURE_BACKOFF_SECONDS": "30", "FACTORY_MAX_FAILURES": "1"},
+            env={"FACTORY_FAILURE_BACKOFF_SECONDS": "30", "FACTORY_MAX_FAILURES": "1", "COMIC_PILE_FACTORY_AUTO_SCOUT": "0"},
             timeout=3,
         )
 
@@ -405,6 +410,7 @@ class ModelToolTests(unittest.TestCase):
             str(self.scripts / "comic-pile-opencode-factory.sh"),
             "--state-dir",
             str(state),
+            env={"COMIC_PILE_FACTORY_AUTO_SCOUT": "0"},
             timeout=10,
         )
 

--- a/scripts/tests/test_opencode_provider_rotation.py
+++ b/scripts/tests/test_opencode_provider_rotation.py
@@ -18,7 +18,7 @@ class ProviderRotationTests(unittest.TestCase):
     """Verify direct factory runs discover every usable OpenCode provider."""
 
     def test_direct_run_refreshes_providers_before_rotation(self) -> None:
-        """Refresh live providers and rotate away from a failed Cerebras model."""
+        """Refresh only curated free-model providers before rotating heartbeats."""
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             scripts = root / "scripts"
@@ -99,6 +99,9 @@ class ProviderRotationTests(unittest.TestCase):
                       deepseek/deepseek-v4-flash \
                       nvidia/nemotron \
                       opencode/zen \
+                      fcm-nvidia/step \
+                      openrouter/vendor/free-model:free \
+                      openrouter/vendor/paid-model \
                       nvidia/text-embedding
                     """
                 )
@@ -127,14 +130,24 @@ class ProviderRotationTests(unittest.TestCase):
 
             self.assertEqual(result.returncode, 0, result.stderr)
             used = (state / "models-used.log").read_text().splitlines()
-            self.assertEqual(used[0], "cerebras/gemma")
-            self.assertNotEqual(used[1].split("/", 1)[0], "cerebras")
+            self.assertEqual(used, ["fcm-nvidia/step"])
+            self.assertNotIn("cerebras/gemma", used)
 
             manifest = (state / "model_manifest.tsv").read_text()
-            self.assertIn("deepseek/deepseek-v4-flash\tconfirmed", manifest)
-            self.assertIn("nvidia/nemotron\tconfirmed", manifest)
-            self.assertIn("opencode/zen\tconfirmed", manifest)
-            self.assertNotIn("nvidia/text-embedding", manifest)
+            for curated in (
+                "nvidia/nemotron\tconfirmed",
+                "opencode/zen\tconfirmed",
+                "fcm-nvidia/step\tconfirmed",
+                "openrouter/vendor/free-model:free\tconfirmed",
+            ):
+                self.assertIn(curated, manifest)
+            for excluded in (
+                "cerebras/gemma",
+                "deepseek/deepseek-v4-flash",
+                "openrouter/vendor/paid-model",
+                "nvidia/text-embedding",
+            ):
+                self.assertNotIn(excluded, manifest)
             self.assertIn(
                 "Refreshing OpenCode model manifest from all available providers",
                 result.stdout,


### PR DESCRIPTION
… models

The overnight factory drained its entire confirmed-model manifest because the wrapper retired a model on ANY non-zero heartbeat status. Watchdog kills (60s output silence during long productive runs like git push) and token-per-minute rate limits are transient interruptions, not evidence a model is broken; big-pickle did real work (venv fix, E2E, push) then was permanently retired on a watchdog kill.

Retire a model only after FACTORY_FAILURE_THRESHOLD consecutive genuine failures (default 2). Watchdog and token-per-minute kills rotate to the next confirmed model via the round-robin cursor without retiring.

Also constrain the curated model pool to verified free providers (opencode, nvidia, fcm-nvidia, openrouter :free) in both the factory manifest refresh and the model scout so re-probing cannot re-add non-free or unverified providers that then drain the manifest.