### PR TITLE
fix(factory): refresh worktree to origin/main and expand free-model pool

### DIFF
--- a/scripts/comic-pile-opencode-factory-heartbeat.sh
+++ b/scripts/comic-pile-opencode-factory-heartbeat.sh
@@ -127,6 +127,15 @@ mkdir -p "$WORKTREE/.opencode_logs" "$WORKTREE/.opencode_handoff"
 exec 9>"$WORKTREE/.comic-pile-factory.lock"
 flock -n 9 || die "another local factory process already holds the factory lock"
 
+# Every heartbeat runs against a fresh origin/main checkout so merged factory
+# tooling and policy land before the next heartbeat selects work. Without this a
+# long-lived worktree silently goes stale after each merge to main.
+printf 'Refreshing factory worktree to latest origin/main...\n'
+git -C "$SOURCE_REPO" fetch --prune origin
+git -C "$WORKTREE" switch -f --detach origin/main
+printf 'Factory worktree is now at %s (%s).\n' \
+  "$(git -C "$WORKTREE" rev-parse --short origin/main)" "$(git -C "$WORKTREE" log -1 --format='%s' origin/main)"
+
 FACTORY_PROMPT="$(cat <<'PROMPT'
 Act as one high-ownership local factory heartbeat for JoshCLWren/comic-pile.
 Durable worker ID: `__WORKER_ID__`.

--- a/scripts/comic-pile-opencode-factory.sh
+++ b/scripts/comic-pile-opencode-factory.sh
@@ -27,7 +27,10 @@ SCOUT_PID_FILE="${COMIC_PILE_FACTORY_SCOUT_PID_FILE:-}"
 AUTO_SCOUT="${COMIC_PILE_FACTORY_AUTO_SCOUT:-1}"
 SCOUT_PARALLEL="${SCOUT_PARALLEL:-4}"
 SCOUT_TIMEOUT="${MODEL_SCOUT_TIMEOUT:-${FACTORY_HEARTBEAT_TIMEOUT:-60}}"
-ALLOWED_PROVIDERS="${COMIC_PILE_FACTORY_ALLOWED_PROVIDERS:-opencode nvidia fcm-nvidia openrouter}"
+ALLOWED_PROVIDERS="${COMIC_PILE_FACTORY_ALLOWED_PROVIDERS:-opencode nvidia fcm-nvidia openrouter google}"
+# Only these Google models are verified free on the free tier; probing the whole
+# google/ prefix would otherwise probe paid pro models.
+GOOGLE_FREE_MODELS="${COMIC_PILE_GOOGLE_FREE_MODELS:-google/gemini-3.1-flash-lite google/gemini-2.5-flash-lite}"
 FAILURE_THRESHOLD="${FACTORY_FAILURE_THRESHOLD:-2}"
 
 usage() {
@@ -147,9 +150,14 @@ refresh_model_manifest() {
     for provider in $ALLOWED_PROVIDERS; do
       [[ "$model" == "$provider/"* ]] || continue
       # OpenRouter exposes paid models alongside :free ones; only free routes
-      # belong in the curated pool.
+      # and the free router belong in the curated pool.
       if [[ "$provider" == "openrouter" ]]; then
-        [[ "$model" == *:free ]] || continue
+        [[ "$model" == *:free || "$model" == "openrouter/openrouter/free" ]] || continue
+      fi
+      # Google free-tier models are curated per-model so the prefix filter does
+      # not probe paid pro models.
+      if [[ "$provider" == "google" ]]; then
+        [[ " $GOOGLE_FREE_MODELS " == *" $model "* ]] || continue
       fi
       printf '%s\n' "$model"
       break

--- a/scripts/opencode-model-scout.sh
+++ b/scripts/opencode-model-scout.sh
@@ -14,7 +14,10 @@ PARALLEL="${MODEL_SCOUT_PARALLEL:-4}"
 TIMEOUT="${MODEL_SCOUT_TIMEOUT:-900}"
 WATCHDOG_POLL_SECONDS="${MODEL_SCOUT_WATCHDOG_POLL_SECONDS:-15}"
 FAILURE_COOLDOWN_SECONDS="${MODEL_SCOUT_FAILURE_COOLDOWN_SECONDS:-3600}"
-ALLOWED_PROVIDERS="${COMIC_PILE_FACTORY_ALLOWED_PROVIDERS:-opencode nvidia fcm-nvidia openrouter}"
+ALLOWED_PROVIDERS="${COMIC_PILE_FACTORY_ALLOWED_PROVIDERS:-opencode nvidia fcm-nvidia openrouter google}"
+# Only these Google models are verified free on the free tier; probing the whole
+# google/ prefix would otherwise probe paid pro models.
+GOOGLE_FREE_MODELS="${COMIC_PILE_GOOGLE_FREE_MODELS:-google/gemini-3.1-flash-lite google/gemini-2.5-flash-lite}"
 WATCH=0
 RECHECK_SECONDS=600
 FORCE=0
@@ -160,9 +163,14 @@ discover_candidates() {
     for provider in $ALLOWED_PROVIDERS; do
       [[ "$candidate" == "$provider/"* ]] || continue
       # OpenRouter exposes paid models alongside :free ones; only free routes
-      # belong in the curated pool.
+      # and the free router belong in the curated pool.
       if [[ "$provider" == "openrouter" ]]; then
-        [[ "$candidate" == *:free ]] || continue
+        [[ "$candidate" == *:free || "$candidate" == "openrouter/openrouter/free" ]] || continue
+      fi
+      # Google free-tier models are curated per-model so the prefix filter does
+      # not probe paid pro models.
+      if [[ "$provider" == "google" ]]; then
+        [[ " $GOOGLE_FREE_MODELS " == *" $candidate "* ]] || continue
       fi
       printf '%s\n' "$candidate"
       break

--- a/scripts/tests/test_opencode_model_tools.py
+++ b/scripts/tests/test_opencode_model_tools.py
@@ -432,6 +432,104 @@ class ModelToolTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("FACTORY_HEARTBEAT_TIMEOUT", result.stderr)
 
+    def test_heartbeat_refreshes_worktree_to_origin_main(self) -> None:
+        """Re-point a stale worktree to origin/main before each heartbeat."""
+        state = self.root / "state"
+        state.mkdir()
+        bare = self.root / "origin.git"
+        repo = self.root / "repo"
+        worktree = self.root / "factory"
+        bare.mkdir()
+        repo.mkdir()
+        worktree.mkdir()
+
+        subprocess.run(["git", "init", "-q", "--bare", str(bare)], check=True)
+        subprocess.run(["git", "init", "-q", str(repo)], check=True)
+        subprocess.run(["git", "-C", str(repo), "config", "user.email", "test@example.com"], check=True)
+        subprocess.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True)
+        subprocess.run(["git", "-C", str(repo), "remote", "add", "origin", str(bare)], check=True)
+        (repo / "code.txt").write_text("v1\n")
+        subprocess.run(["git", "-C", str(repo), "add", "code.txt"], check=True)
+        subprocess.run(["git", "-C", str(repo), "commit", "-qm", "initial"], check=True)
+        subprocess.run(["git", "-C", str(repo), "branch", "-M", "main"], check=True)
+        subprocess.run(["git", "-C", str(repo), "push", "-qu", "origin", "main"], check=True)
+
+        subprocess.run(["git", "-C", str(repo), "worktree", "add", "--detach", str(worktree), "origin/main"], check=True)
+
+        (repo / "code.txt").write_text("v2\n")
+        subprocess.run(["git", "-C", str(repo), "add", "code.txt"], check=True)
+        subprocess.run(["git", "-C", str(repo), "commit", "-qm", "second"], check=True)
+        subprocess.run(["git", "-C", str(repo), "push", "-qu", "origin", "main"], check=True)
+
+        (worktree / "code.txt").write_text("stale\n")
+
+        # Install a fake opencode and gh so the heartbeat's model-existence and
+        # auth checks pass without real credentials.
+        bin_dir = self.root / "bin"
+        bin_dir.mkdir()
+        opencode = bin_dir / "opencode"
+        opencode.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                [[ "${1:-}" == "models" ]] || exit 2
+                printf 'some/model\\n'
+                """
+            )
+        )
+        opencode.chmod(0o755)
+        gh = bin_dir / "gh"
+        gh.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                exit 0
+                """
+            )
+        )
+        gh.chmod(0o755)
+
+        # Keep the real heartbeat bootstrap (including the worktree refresh) but
+        # stub out the agent execution after the prompt is built. The marker is
+        # consumed by the split, so re-add it and close the here-doc.
+        heartbeat = self.scripts / "comic-pile-opencode-factory-heartbeat.sh"
+        real = heartbeat.read_text()
+        marker = 'FACTORY_PROMPT="$(cat <<'
+        head, _tail = real.split(marker, 1)
+        heartbeat.write_text(
+            head
+            + marker
+            + "'PROMPT'\n"
+            + "PROMPT\n"
+            + ')"\n'
+            + '\n'
+            + 'printf \'REFRESHED:%s\\n\' "$(git -C "$WORKTREE" rev-parse --short HEAD)" >>"$STATE_DIR/log"\n'
+            + 'printf \'FACTORY_RESULT: idle\\n\'\n'
+            + 'exit 0\n'
+        )
+
+        result = self.run_command(
+            str(heartbeat),
+            "--repo",
+            str(repo),
+            "--worktree",
+            str(worktree),
+            "--state-dir",
+            str(state),
+            "--model",
+            "some/model",
+            env={
+                "PATH": f"{bin_dir}:{os.environ['PATH']}",
+                "COMIC_PILE_FACTORY_AUTO_SCOUT": "0",
+            },
+            timeout=15,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Refreshing factory worktree to latest origin/main", result.stdout)
+        self.assertEqual((worktree / "code.txt").read_text(), "v2\n")
+        self.assertIn("REFRESHED:", (state / "log").read_text())
+
     def test_heartbeat_rejects_nonnumeric_heartbeat_timeout(self) -> None:
         """Reject a nonnumeric FACTORY_HEARTBEAT_TIMEOUT before starting any heartbeat."""
         state = self.root / "state"

--- a/scripts/tests/test_opencode_provider_rotation.py
+++ b/scripts/tests/test_opencode_provider_rotation.py
@@ -102,6 +102,10 @@ class ProviderRotationTests(unittest.TestCase):
                       fcm-nvidia/step \
                       openrouter/vendor/free-model:free \
                       openrouter/vendor/paid-model \
+                      openrouter/openrouter/free \
+                      google/gemini-3.1-flash-lite \
+                      google/gemini-2.5-flash-lite \
+                      google/gemini-2.5-pro \
                       nvidia/text-embedding
                     """
                 )
@@ -139,12 +143,16 @@ class ProviderRotationTests(unittest.TestCase):
                 "opencode/zen\tconfirmed",
                 "fcm-nvidia/step\tconfirmed",
                 "openrouter/vendor/free-model:free\tconfirmed",
+                "openrouter/openrouter/free\tconfirmed",
+                "google/gemini-3.1-flash-lite\tconfirmed",
+                "google/gemini-2.5-flash-lite\tconfirmed",
             ):
                 self.assertIn(curated, manifest)
             for excluded in (
                 "cerebras/gemma",
                 "deepseek/deepseek-v4-flash",
                 "openrouter/vendor/paid-model",
+                "google/gemini-2.5-pro",
                 "nvidia/text-embedding",
             ):
                 self.assertNotIn(excluded, manifest)


### PR DESCRIPTION
- Every heartbeat re-fetches origin and re-points the factory worktree to origin/main so merged tooling and policy land before the next heartbeat selects work. A long-lived worktree silently went stale after each merge, leaving agents reading old scripts and policies.
- Add google to the curated provider list with a per-model allowlist (gemini-3.1-flash-lite, gemini-2.5-flash-lite) so the prefix filter does not probe paid pro models.
- Admit the openrouter/openrouter/free router alongside :free routes.
- Regression tests cover worktree refresh and the expanded provider filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Google as an available model provider, with a curated selection of verified free models.
  - Expanded OpenRouter support to include its free model routing option.
  - Provider discovery and selection now consistently apply free-model availability rules.

- **Bug Fixes**
  - Automated factory runs now refresh their workspace to the latest main revision before execution, reducing stale-run issues.

- **Tests**
  - Added coverage for workspace refresh behavior and expanded provider/model selection validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->