### PR TITLE
feat(factory): add GitHub visibility labels

### DIFF
--- a/.github/workflows/factory-visibility.yml
+++ b/.github/workflows/factory-visibility.yml
@@ -1,0 +1,294 @@
+name: Factory visibility
+
+on:
+  issue_comment:
+    types: [created, edited]
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  label-factory-work:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Synchronize factory owner and stage labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = {
+              factory: { color: '5319E7', description: 'Work owned or produced by an autonomous ComicPile factory' },
+              'factory:1': { color: '0366D6', description: 'Current next-action owner is ComicPile Factory 1' },
+              'factory:2': { color: '0366D6', description: 'Current next-action owner is ComicPile Factory 2' },
+              'factory:3': { color: '0366D6', description: 'Current next-action owner is ComicPile Factory 3' },
+              'factory:4': { color: '0366D6', description: 'Current next-action owner is ComicPile Factory 4' },
+              'factory:5': { color: '0366D6', description: 'Current next-action owner is ComicPile Factory 5' },
+              'factory:local': { color: '0366D6', description: 'Current next-action owner is the local OpenCode factory' },
+              'factory:unowned': { color: 'BFDADC', description: 'Factory work has no current next-action owner' },
+              'factory:building': { color: 'FBCA04', description: 'A factory is actively implementing or repairing this work' },
+              'factory:review': { color: 'D4C5F9', description: 'The exact current head needs review or re-review' },
+              'factory:changes-requested': { color: 'D73A4A', description: 'Actionable review findings currently block progress' },
+              'factory:ci': { color: '1D76DB', description: 'Review passed and required exact-head checks are being verified' },
+              'factory:ready': { color: '0E8A16', description: 'All exact-head factory merge gates are satisfied' },
+              'factory:blocked': { color: 'B60205', description: 'A genuine human, credential, or external blocker remains' },
+            };
+
+            const ownerLabels = [
+              'factory:1',
+              'factory:2',
+              'factory:3',
+              'factory:4',
+              'factory:5',
+              'factory:local',
+              'factory:unowned',
+            ];
+            const stageLabels = [
+              'factory:building',
+              'factory:review',
+              'factory:changes-requested',
+              'factory:ci',
+              'factory:ready',
+              'factory:blocked',
+            ];
+
+            async function ensureLabels() {
+              const existing = await github.paginate(github.rest.issues.listLabelsForRepo, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100,
+              });
+              const existingByName = new Map(existing.map((label) => [label.name, label]));
+
+              for (const [name, definition] of Object.entries(labels)) {
+                const current = existingByName.get(name);
+                if (!current) {
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name,
+                    ...definition,
+                  });
+                  continue;
+                }
+
+                if (
+                  current.color.toUpperCase() !== definition.color.toUpperCase()
+                  || (current.description || '') !== definition.description
+                ) {
+                  await github.rest.issues.updateLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name,
+                    new_name: name,
+                    ...definition,
+                  });
+                }
+              }
+            }
+
+            async function getCurrentLabelNames(number) {
+              const current = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: number,
+                per_page: 100,
+              });
+              return new Set(current.map((label) => label.name));
+            }
+
+            async function replaceLabelGroup(number, group, nextLabel) {
+              const current = await getCurrentLabelNames(number);
+              for (const label of group) {
+                if (label !== nextLabel && current.has(label)) {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: number,
+                    name: label,
+                  });
+                }
+              }
+              if (nextLabel && !current.has(nextLabel)) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                  labels: [nextLabel],
+                });
+              }
+            }
+
+            async function markFactory(number) {
+              const current = await getCurrentLabelNames(number);
+              if (!current.has('factory')) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                  labels: ['factory'],
+                });
+              }
+            }
+
+            function ownerLabelForWorker(worker) {
+              const scheduled = worker.match(/^chatgpt-factory-([1-5])$/);
+              if (scheduled) {
+                return `factory:${scheduled[1]}`;
+              }
+              if (worker.startsWith('local-opencode-') || worker === 'local-opencode') {
+                return 'factory:local';
+              }
+              return 'factory:unowned';
+            }
+
+            function extractWorker(body) {
+              const patterns = [
+                /comic-pile-factory-implement-(?:claim|progress)-v\d+:issue-\d+:([^:\s>]+):/,
+                /comic-pile-factory-review-claim-v\d+:[^:\s>]+:([^:\s>]+):/,
+                /comic-pile-factory-fix-(?:claim|progress)-v\d+:[^:\s>]+:([^:\s>]+):/,
+                /comic-pile-factory-claim-released-v\d+:[^:\s>]+:([^:\s>]+):/,
+              ];
+              for (const pattern of patterns) {
+                const match = body.match(pattern);
+                if (match) {
+                  return match[1];
+                }
+              }
+              return null;
+            }
+
+            function stageFromMarker(body) {
+              if (/comic-pile-factory-needs-human-v\d+:/.test(body)) {
+                return 'factory:blocked';
+              }
+              if (/comic-pile-factory-ready-v\d+:/.test(body)) {
+                return 'factory:ready';
+              }
+              if (/comic-pile-factory-review-v\d+:[^:\s>]+:changes-required/.test(body)) {
+                return 'factory:changes-requested';
+              }
+              if (/comic-pile-factory-review-v\d+:[^:\s>]+:pass/.test(body)) {
+                return 'factory:ci';
+              }
+              if (/comic-pile-factory-review-claim-v\d+:/.test(body)) {
+                return 'factory:review';
+              }
+              if (
+                /comic-pile-factory-implement-(?:claim|progress)-v\d+:/.test(body)
+                || /comic-pile-factory-fix-(?:claim|progress)-v\d+:/.test(body)
+              ) {
+                return 'factory:building';
+              }
+              return null;
+            }
+
+            async function findOwnerFromLinkedIssue(pr) {
+              const branchMatch = pr.head.ref.match(/^factory\/(\d+)(?:-|$)/);
+              const bodyMatch = (pr.body || '').match(
+                /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/i,
+              );
+              const issueNumber = Number(branchMatch?.[1] || bodyMatch?.[1] || 0);
+              if (!issueNumber) {
+                return 'factory:unowned';
+              }
+
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                per_page: 100,
+              });
+              comments.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+              for (const comment of comments) {
+                const body = comment.body || '';
+                if (/comic-pile-factory-claim-released-v\d+:/.test(body)) {
+                  return 'factory:unowned';
+                }
+                const worker = extractWorker(body);
+                if (worker) {
+                  return ownerLabelForWorker(worker);
+                }
+              }
+              return 'factory:unowned';
+            }
+
+            await ensureLabels();
+
+            if (context.eventName === 'issue_comment') {
+              const body = context.payload.comment?.body || '';
+              if (!body.includes('comic-pile-factory-')) {
+                return;
+              }
+
+              const number = context.payload.issue.number;
+              await markFactory(number);
+
+              if (/comic-pile-factory-claim-released-v\d+:/.test(body)) {
+                await replaceLabelGroup(number, ownerLabels, 'factory:unowned');
+              } else {
+                const worker = extractWorker(body);
+                if (worker) {
+                  await replaceLabelGroup(number, ownerLabels, ownerLabelForWorker(worker));
+                }
+              }
+
+              const stage = stageFromMarker(body);
+              if (stage) {
+                await replaceLabelGroup(number, stageLabels, stage);
+              }
+              return;
+            }
+
+            if (context.eventName === 'pull_request_target') {
+              const pr = context.payload.pull_request;
+              const number = pr.number;
+              const isFactory = pr.head.ref.startsWith('factory/')
+                || (pr.body || '').includes('comic-pile-factory-')
+                || (pr.labels || []).some((label) => label.name === 'factory');
+              if (!isFactory) {
+                return;
+              }
+
+              await markFactory(number);
+              if (['opened', 'reopened', 'ready_for_review'].includes(context.payload.action)) {
+                await replaceLabelGroup(number, ownerLabels, await findOwnerFromLinkedIssue(pr));
+              }
+              await replaceLabelGroup(number, stageLabels, 'factory:review');
+              return;
+            }
+
+            if (context.eventName === 'pull_request_review') {
+              const pr = context.payload.pull_request;
+              const number = pr.number;
+              const current = await getCurrentLabelNames(number);
+              const isFactory = pr.head.ref.startsWith('factory/') || current.has('factory');
+              if (!isFactory) {
+                return;
+              }
+
+              await markFactory(number);
+              if (context.payload.action === 'dismissed') {
+                await replaceLabelGroup(number, stageLabels, 'factory:review');
+                return;
+              }
+
+              const review = context.payload.review;
+              const state = (review.state || '').toUpperCase();
+              const body = review.body || '';
+              if (state === 'CHANGES_REQUESTED') {
+                await replaceLabelGroup(number, stageLabels, 'factory:changes-requested');
+              } else if (state === 'APPROVED') {
+                await replaceLabelGroup(number, stageLabels, 'factory:ci');
+              } else if (/Actionable comments posted:\s*[1-9]\d*/i.test(body)) {
+                await replaceLabelGroup(number, stageLabels, 'factory:changes-requested');
+              } else {
+                await replaceLabelGroup(number, stageLabels, 'factory:review');
+              }
+            }

--- a/.github/workflows/factory-visibility.yml
+++ b/.github/workflows/factory-visibility.yml
@@ -22,206 +22,156 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const labels = {
-              factory: { color: '5319E7', description: 'Work owned or produced by an autonomous ComicPile factory' },
-              'factory:1': { color: '0366D6', description: 'Current next-action owner is ComicPile Factory 1' },
-              'factory:2': { color: '0366D6', description: 'Current next-action owner is ComicPile Factory 2' },
-              'factory:3': { color: '0366D6', description: 'Current next-action owner is ComicPile Factory 3' },
-              'factory:4': { color: '0366D6', description: 'Current next-action owner is ComicPile Factory 4' },
-              'factory:5': { color: '0366D6', description: 'Current next-action owner is ComicPile Factory 5' },
-              'factory:local': { color: '0366D6', description: 'Current next-action owner is the local OpenCode factory' },
-              'factory:unowned': { color: 'BFDADC', description: 'Factory work has no current next-action owner' },
-              'factory:building': { color: 'FBCA04', description: 'A factory is actively implementing or repairing this work' },
-              'factory:review': { color: 'D4C5F9', description: 'The exact current head needs review or re-review' },
-              'factory:changes-requested': { color: 'D73A4A', description: 'Actionable review findings currently block progress' },
-              'factory:ci': { color: '1D76DB', description: 'Review passed and required exact-head checks are being verified' },
-              'factory:ready': { color: '0E8A16', description: 'All exact-head factory merge gates are satisfied' },
-              'factory:blocked': { color: 'B60205', description: 'A genuine human, credential, or external blocker remains' },
+            const definitions = {
+              factory: ['5319E7', 'Work owned or produced by an autonomous ComicPile factory'],
+              'factory:1': ['0366D6', 'Current next-action owner is ComicPile Factory 1'],
+              'factory:2': ['0366D6', 'Current next-action owner is ComicPile Factory 2'],
+              'factory:3': ['0366D6', 'Current next-action owner is ComicPile Factory 3'],
+              'factory:4': ['0366D6', 'Current next-action owner is ComicPile Factory 4'],
+              'factory:5': ['0366D6', 'Current next-action owner is ComicPile Factory 5'],
+              'factory:local': ['0366D6', 'Current next-action owner is the local OpenCode factory'],
+              'factory:unowned': ['BFDADC', 'Factory work has no current next-action owner'],
+              'factory:building': ['FBCA04', 'A factory is actively implementing or repairing this work'],
+              'factory:review': ['D4C5F9', 'The exact current head needs review or re-review'],
+              'factory:changes-requested': ['D73A4A', 'Actionable review findings currently block progress'],
+              'factory:ci': ['1D76DB', 'Review passed and required exact-head checks are being verified'],
+              'factory:ready': ['0E8A16', 'All exact-head factory merge gates are satisfied'],
+              'factory:blocked': ['B60205', 'A genuine human, credential, or external blocker remains'],
             };
-
             const ownerLabels = [
-              'factory:1',
-              'factory:2',
-              'factory:3',
-              'factory:4',
-              'factory:5',
-              'factory:local',
-              'factory:unowned',
+              'factory:1', 'factory:2', 'factory:3', 'factory:4',
+              'factory:5', 'factory:local', 'factory:unowned',
             ];
             const stageLabels = [
-              'factory:building',
-              'factory:review',
-              'factory:changes-requested',
-              'factory:ci',
-              'factory:ready',
-              'factory:blocked',
+              'factory:building', 'factory:review', 'factory:changes-requested',
+              'factory:ci', 'factory:ready', 'factory:blocked',
             ];
             const trustedAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
 
-            function isTrustedActor(login, association) {
+            function trusted(login, association) {
               return trustedAssociations.has(association)
                 || login === 'coderabbitai[bot]'
                 || login === 'coderabbitai';
             }
 
-            async function ensureLabels() {
-              const existing = await github.paginate(github.rest.issues.listLabelsForRepo, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                per_page: 100,
-              });
-              const existingByName = new Map(existing.map((label) => [label.name, label]));
-
-              for (const [name, definition] of Object.entries(labels)) {
-                const current = existingByName.get(name);
-                if (!current) {
-                  await github.rest.issues.createLabel({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    name,
-                    ...definition,
-                  });
-                  continue;
-                }
-
-                if (
-                  current.color.toUpperCase() !== definition.color.toUpperCase()
-                  || (current.description || '') !== definition.description
-                ) {
-                  await github.rest.issues.updateLabel({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    name,
-                    new_name: name,
-                    ...definition,
-                  });
-                }
+            function workerFrom(body) {
+              for (const pattern of [
+                /comic-pile-factory-implement-(?:claim|progress)-v\d+:issue-\d+:([^:\s>]+):/,
+                /comic-pile-factory-review-claim-v\d+:[^:\s>]+:([^:\s>]+):/,
+                /comic-pile-factory-fix-(?:claim|progress)-v\d+:[^:\s>]+:([^:\s>]+):/,
+                /comic-pile-factory-claim-released-v\d+:[^:\s>]+:([^:\s>]+):/,
+              ]) {
+                const match = body.match(pattern);
+                if (match) return match[1];
               }
+              return null;
             }
 
-            async function getCurrentLabelNames(number) {
-              const current = await github.paginate(github.rest.issues.listLabelsOnIssue, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: number,
-                per_page: 100,
-              });
-              return new Set(current.map((label) => label.name));
-            }
-
-            async function replaceLabelGroup(number, group, nextLabel) {
-              const current = await getCurrentLabelNames(number);
-              for (const label of group) {
-                if (label !== nextLabel && current.has(label)) {
-                  await github.rest.issues.removeLabel({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: number,
-                    name: label,
-                  });
-                }
-              }
-              if (nextLabel && !current.has(nextLabel)) {
-                await github.rest.issues.addLabels({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: number,
-                  labels: [nextLabel],
-                });
-              }
-            }
-
-            async function markFactory(number) {
-              const current = await getCurrentLabelNames(number);
-              if (!current.has('factory')) {
-                await github.rest.issues.addLabels({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: number,
-                  labels: ['factory'],
-                });
-              }
-            }
-
-            function ownerLabelForWorker(worker) {
-              const scheduled = worker.match(/^chatgpt-factory-([1-5])$/);
-              if (scheduled) {
-                return `factory:${scheduled[1]}`;
-              }
-              if (worker.startsWith('local-opencode-') || worker === 'local-opencode') {
+            function ownerFor(worker) {
+              const scheduled = worker?.match(/^chatgpt-factory-([1-5])$/);
+              if (scheduled) return `factory:${scheduled[1]}`;
+              if (worker?.startsWith('local-opencode-') || worker === 'local-opencode') {
                 return 'factory:local';
               }
               return 'factory:unowned';
             }
 
-            function extractWorker(body) {
-              const patterns = [
-                /comic-pile-factory-implement-(?:claim|progress)-v\d+:issue-\d+:([^:\s>]+):/,
-                /comic-pile-factory-review-claim-v\d+:[^:\s>]+:([^:\s>]+):/,
-                /comic-pile-factory-fix-(?:claim|progress)-v\d+:[^:\s>]+:([^:\s>]+):/,
-                /comic-pile-factory-claim-released-v\d+:[^:\s>]+:([^:\s>]+):/,
-              ];
-              for (const pattern of patterns) {
-                const match = body.match(pattern);
-                if (match) {
-                  return match[1];
-                }
-              }
-              return null;
-            }
-
-            function stageFromMarker(body) {
-              if (/comic-pile-factory-needs-human-v\d+:/.test(body)) {
-                return 'factory:blocked';
-              }
-              if (/comic-pile-factory-ready-v\d+:/.test(body)) {
-                return 'factory:ready';
-              }
+            function stageFrom(body) {
+              if (/comic-pile-factory-needs-human-v\d+:/.test(body)) return 'factory:blocked';
+              if (/comic-pile-factory-ready-v\d+:/.test(body)) return 'factory:ready';
               if (/comic-pile-factory-review-v\d+:[^:\s>]+:changes-required/.test(body)) {
                 return 'factory:changes-requested';
               }
-              if (/comic-pile-factory-review-v\d+:[^:\s>]+:pass/.test(body)) {
-                return 'factory:ci';
-              }
-              if (/comic-pile-factory-review-claim-v\d+:/.test(body)) {
-                return 'factory:review';
-              }
+              if (/comic-pile-factory-review-v\d+:[^:\s>]+:pass/.test(body)) return 'factory:ci';
+              if (/comic-pile-factory-review-claim-v\d+:/.test(body)) return 'factory:review';
               if (
                 /comic-pile-factory-implement-(?:claim|progress)-v\d+:/.test(body)
                 || /comic-pile-factory-fix-(?:claim|progress)-v\d+:/.test(body)
-              ) {
-                return 'factory:building';
-              }
+              ) return 'factory:building';
               return null;
             }
 
-            async function findOwnerFromLinkedIssue(pr) {
-              const branchMatch = pr.head.ref.match(/^factory\/(\d+)(?:-|$)/);
-              const bodyMatch = (pr.body || '').match(
+            async function ensureLabels() {
+              const existing = await github.paginate(github.rest.issues.listLabelsForRepo, {
+                owner: context.repo.owner, repo: context.repo.repo, per_page: 100,
+              });
+              const byName = new Map(existing.map((label) => [label.name, label]));
+              for (const [name, [color, description]] of Object.entries(definitions)) {
+                const current = byName.get(name);
+                if (!current) {
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner, repo: context.repo.repo,
+                    name, color, description,
+                  });
+                } else if (
+                  current.color.toUpperCase() !== color
+                  || (current.description || '') !== description
+                ) {
+                  await github.rest.issues.updateLabel({
+                    owner: context.repo.owner, repo: context.repo.repo,
+                    name, new_name: name, color, description,
+                  });
+                }
+              }
+            }
+
+            async function currentLabels(number) {
+              const labels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: number, per_page: 100,
+              });
+              return new Set(labels.map((label) => label.name));
+            }
+
+            async function replaceGroup(number, group, next) {
+              const current = await currentLabels(number);
+              for (const label of group) {
+                if (label !== next && current.has(label)) {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner, repo: context.repo.repo,
+                    issue_number: number, name: label,
+                  });
+                }
+              }
+              if (next && !current.has(next)) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  issue_number: number, labels: [next],
+                });
+              }
+            }
+
+            async function markFactory(number) {
+              const current = await currentLabels(number);
+              if (!current.has('factory')) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  issue_number: number, labels: ['factory'],
+                });
+              }
+            }
+
+            async function ownerFromLinkedIssue(pr) {
+              const branch = pr.head.ref.match(/^factory\/(\d+)(?:-|$)/);
+              const closing = (pr.body || '').match(
                 /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/i,
               );
-              const issueNumber = Number(branchMatch?.[1] || bodyMatch?.[1] || 0);
-              if (!issueNumber) {
-                return 'factory:unowned';
-              }
+              const issueNumber = Number(branch?.[1] || closing?.[1] || 0);
+              if (!issueNumber) return 'factory:unowned';
 
               const comments = await github.paginate(github.rest.issues.listComments, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                per_page: 100,
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: issueNumber, per_page: 100,
               });
               comments.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
-
               for (const comment of comments) {
+                if (!trusted(comment.user?.login, comment.author_association)) continue;
                 const body = comment.body || '';
                 if (/comic-pile-factory-claim-released-v\d+:/.test(body)) {
                   return 'factory:unowned';
                 }
-                const worker = extractWorker(body);
-                if (worker) {
-                  return ownerLabelForWorker(worker);
-                }
+                const worker = workerFrom(body);
+                if (worker) return ownerFor(worker);
               }
               return 'factory:unowned';
             }
@@ -231,85 +181,60 @@ jobs:
             if (context.eventName === 'issue_comment') {
               const comment = context.payload.comment;
               const body = comment?.body || '';
-              if (
-                !body.includes('comic-pile-factory-')
-                || !isTrustedActor(comment?.user?.login, comment?.author_association)
-              ) {
-                return;
-              }
+              if (!body.includes('comic-pile-factory-')) return;
+              if (!trusted(comment?.user?.login, comment?.author_association)) return;
 
               const number = context.payload.issue.number;
               await markFactory(number);
-
-              if (/comic-pile-factory-claim-released-v\d+:/.test(body)) {
-                await replaceLabelGroup(number, ownerLabels, 'factory:unowned');
-              } else {
-                const worker = extractWorker(body);
-                if (worker) {
-                  await replaceLabelGroup(number, ownerLabels, ownerLabelForWorker(worker));
-                }
+              const released = /comic-pile-factory-claim-released-v\d+:/.test(body);
+              const worker = workerFrom(body);
+              if (released || worker) {
+                await replaceGroup(number, ownerLabels, released ? 'factory:unowned' : ownerFor(worker));
               }
-
-              const stage = stageFromMarker(body);
-              if (stage) {
-                await replaceLabelGroup(number, stageLabels, stage);
-              }
+              const stage = stageFrom(body);
+              if (stage) await replaceGroup(number, stageLabels, stage);
               return;
             }
 
             if (context.eventName === 'pull_request_target') {
               const pr = context.payload.pull_request;
-              const number = pr.number;
-              const sameRepository = pr.head.repo?.full_name === context.payload.repository.full_name;
-              const isFactory = (
-                sameRepository
-                && (
-                  pr.head.ref.startsWith('factory/')
-                  || (pr.body || '').includes('comic-pile-factory-')
-                )
-              ) || (pr.labels || []).some((label) => label.name === 'factory');
-              if (!isFactory) {
-                return;
-              }
+              const sameRepo = pr.head.repo?.full_name === context.payload.repository.full_name;
+              const alreadyFactory = (pr.labels || []).some((label) => label.name === 'factory');
+              const isFactory = alreadyFactory || (
+                sameRepo
+                && (pr.head.ref.startsWith('factory/') || (pr.body || '').includes('comic-pile-factory-'))
+              );
+              if (!isFactory) return;
 
-              await markFactory(number);
+              await markFactory(pr.number);
               if (['opened', 'reopened', 'ready_for_review'].includes(context.payload.action)) {
-                await replaceLabelGroup(number, ownerLabels, await findOwnerFromLinkedIssue(pr));
+                await replaceGroup(pr.number, ownerLabels, await ownerFromLinkedIssue(pr));
               }
-              await replaceLabelGroup(number, stageLabels, 'factory:review');
+              await replaceGroup(pr.number, stageLabels, 'factory:review');
               return;
             }
 
             if (context.eventName === 'pull_request_review') {
               const pr = context.payload.pull_request;
-              const number = pr.number;
-              const current = await getCurrentLabelNames(number);
-              const sameRepository = pr.head.repo?.full_name === context.payload.repository.full_name;
-              const isFactory = (sameRepository && pr.head.ref.startsWith('factory/'))
-                || current.has('factory');
-              if (!isFactory) {
-                return;
-              }
+              const current = await currentLabels(pr.number);
+              const sameRepo = pr.head.repo?.full_name === context.payload.repository.full_name;
+              if (!(current.has('factory') || (sameRepo && pr.head.ref.startsWith('factory/')))) return;
 
-              await markFactory(number);
+              await markFactory(pr.number);
               if (context.payload.action === 'dismissed') {
-                await replaceLabelGroup(number, stageLabels, 'factory:review');
+                await replaceGroup(pr.number, stageLabels, 'factory:review');
                 return;
               }
 
               const review = context.payload.review;
-              if (!isTrustedActor(review.user?.login, review.author_association)) {
-                return;
-              }
+              if (!trusted(review.user?.login, review.author_association)) return;
               const state = (review.state || '').toUpperCase();
               const body = review.body || '';
-              if (state === 'CHANGES_REQUESTED') {
-                await replaceLabelGroup(number, stageLabels, 'factory:changes-requested');
-              } else if (state === 'APPROVED') {
-                await replaceLabelGroup(number, stageLabels, 'factory:ci');
-              } else if (/Actionable comments posted:\s*[1-9]\d*/i.test(body)) {
-                await replaceLabelGroup(number, stageLabels, 'factory:changes-requested');
-              } else {
-                await replaceLabelGroup(number, stageLabels, 'factory:review');
+              let stage = 'factory:review';
+              if (state === 'CHANGES_REQUESTED') stage = 'factory:changes-requested';
+              else if (state === 'APPROVED') stage = 'factory:ci';
+              else if (/Actionable comments posted:\s*[1-9]\d*/i.test(body)) {
+                stage = 'factory:changes-requested';
               }
+              await replaceGroup(pr.number, stageLabels, stage);
             }

--- a/.github/workflows/factory-visibility.yml
+++ b/.github/workflows/factory-visibility.yml
@@ -284,7 +284,9 @@ jobs:
               const pr = context.payload.pull_request;
               const number = pr.number;
               const current = await getCurrentLabelNames(number);
-              const isFactory = pr.head.ref.startsWith('factory/') || current.has('factory');
+              const sameRepository = pr.head.repo?.full_name === context.payload.repository.full_name;
+              const isFactory = (sameRepository && pr.head.ref.startsWith('factory/'))
+                || current.has('factory');
               if (!isFactory) {
                 return;
               }

--- a/.github/workflows/factory-visibility.yml
+++ b/.github/workflows/factory-visibility.yml
@@ -56,6 +56,13 @@ jobs:
               'factory:ready',
               'factory:blocked',
             ];
+            const trustedAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+
+            function isTrustedActor(login, association) {
+              return trustedAssociations.has(association)
+                || login === 'coderabbitai[bot]'
+                || login === 'coderabbitai';
+            }
 
             async function ensureLabels() {
               const existing = await github.paginate(github.rest.issues.listLabelsForRepo, {
@@ -222,8 +229,12 @@ jobs:
             await ensureLabels();
 
             if (context.eventName === 'issue_comment') {
-              const body = context.payload.comment?.body || '';
-              if (!body.includes('comic-pile-factory-')) {
+              const comment = context.payload.comment;
+              const body = comment?.body || '';
+              if (
+                !body.includes('comic-pile-factory-')
+                || !isTrustedActor(comment?.user?.login, comment?.author_association)
+              ) {
                 return;
               }
 
@@ -249,9 +260,14 @@ jobs:
             if (context.eventName === 'pull_request_target') {
               const pr = context.payload.pull_request;
               const number = pr.number;
-              const isFactory = pr.head.ref.startsWith('factory/')
-                || (pr.body || '').includes('comic-pile-factory-')
-                || (pr.labels || []).some((label) => label.name === 'factory');
+              const sameRepository = pr.head.repo?.full_name === context.payload.repository.full_name;
+              const isFactory = (
+                sameRepository
+                && (
+                  pr.head.ref.startsWith('factory/')
+                  || (pr.body || '').includes('comic-pile-factory-')
+                )
+              ) || (pr.labels || []).some((label) => label.name === 'factory');
               if (!isFactory) {
                 return;
               }
@@ -280,6 +296,9 @@ jobs:
               }
 
               const review = context.payload.review;
+              if (!isTrustedActor(review.user?.login, review.author_association)) {
+                return;
+              }
               const state = (review.state || '').toUpperCase();
               const body = review.body || '';
               if (state === 'CHANGES_REQUESTED') {

--- a/docs/FACTORY_GITHUB_VISIBILITY.md
+++ b/docs/FACTORY_GITHUB_VISIBILITY.md
@@ -23,6 +23,8 @@ Exactly one stage label describes the current state:
 
 The labels are synchronized automatically from existing factory claim, progress, review, ready, release, and needs-human markers. Pull requests on `factory/*` branches are also recognized automatically. A linked issue claim supplies the initial pull-request owner when the branch name starts with `factory/<issue-number>-...`.
 
+Only marker comments from the repository owner, members, or collaborators are trusted. Formal review transitions are accepted from trusted collaborators and CodeRabbit. Public commenters and untrusted fork branches cannot spoof factory ownership or stage labels.
+
 Labels are visibility metadata, not merge evidence. A label-only change never counts as substantive factory progress and never overrides exact-head CI, review threads, mergeability, issue scope, or the canonical autonomous factory policy.
 
 ## GitHub review filters

--- a/docs/FACTORY_GITHUB_VISIBILITY.md
+++ b/docs/FACTORY_GITHUB_VISIBILITY.md
@@ -1,0 +1,42 @@
+# Factory GitHub visibility
+
+ComicPile factory work uses GitHub labels as a live dashboard around the canonical factory lease and review markers.
+
+## Labels
+
+Every active factory-owned issue or pull request carries the `factory` label.
+
+Exactly one owner label identifies the worker responsible for the next action:
+
+- `factory:1` through `factory:5` for the scheduled ChatGPT factories;
+- `factory:local` for the local OpenCode factory;
+- `factory:unowned` when no worker currently owns the next action.
+
+Exactly one stage label describes the current state:
+
+- `factory:building`: implementation or repair is actively underway;
+- `factory:review`: the exact current pull-request head needs review or re-review;
+- `factory:changes-requested`: actionable review findings block progress;
+- `factory:ci`: review passed and required exact-head checks are being verified;
+- `factory:ready`: every exact-head merge gate is satisfied;
+- `factory:blocked`: a genuine human, credential, or external blocker remains.
+
+The labels are synchronized automatically from existing factory claim, progress, review, ready, release, and needs-human markers. Pull requests on `factory/*` branches are also recognized automatically. A linked issue claim supplies the initial pull-request owner when the branch name starts with `factory/<issue-number>-...`.
+
+Labels are visibility metadata, not merge evidence. A label-only change never counts as substantive factory progress and never overrides exact-head CI, review threads, mergeability, issue scope, or the canonical autonomous factory policy.
+
+## GitHub review filters
+
+GitHub's built-in review filters remain useful, but they report formal GitHub review state rather than the complete factory gate:
+
+- **No reviews** finds pull requests with no submitted formal review.
+- **Approved review** requires an `APPROVED` review.
+- **Changes requested** requires a `CHANGES_REQUESTED` review.
+- **Review required** depends on branch or ruleset requirements that have not yet been satisfied.
+- **Reviewed by you**, **Not reviewed by you**, and **Awaiting review from you** are relative to the signed-in GitHub account.
+
+The current factories authenticate as `JoshCLWren`, and their pull requests are also authored as `JoshCLWren`. GitHub does not permit an author to approve their own pull request, so the approval-oriented filters cannot be the sole factory dashboard with the current identity model.
+
+CodeRabbit currently submits `COMMENTED` reviews even when it reports actionable comments. The visibility workflow therefore maps a CodeRabbit review body reporting one or more actionable comments to `factory:changes-requested`, while preserving GitHub's real formal review state.
+
+If factory pull requests later use a separate GitHub App or machine-user identity, independent reviewers should submit formal `APPROVE` or `REQUEST_CHANGES` reviews. At that point the built-in review filters can become a stronger first-class view. Do not add a required-approval branch rule until a reliable independent reviewer identity exists, because the present single-account setup would deadlock factory-authored pull requests.


### PR DESCRIPTION
## Summary

- add a GitHub-native visibility workflow that maps existing factory claim, review, ready, release, and blocker markers to owner and lifecycle labels
- label claimed issues before a PR exists, so active Factory 2-style work is visible immediately
- recognize `factory/*` pull requests and infer the owner from the linked issue claim
- mirror formal GitHub review states into labels and map CodeRabbit `COMMENTED` reviews with actionable findings to `factory:changes-requested`
- document which built-in GitHub review filters are reliable with the current single-account factory identity

## Label model

Owner: `factory:1` through `factory:5`, `factory:local`, or `factory:unowned`

Stage: `factory:building`, `factory:review`, `factory:changes-requested`, `factory:ci`, `factory:ready`, or `factory:blocked`

Exactly one owner and one stage label remain active at a time.

## Validation

- parsed the workflow YAML locally
- extracted and syntax-checked the complete `actions/github-script` JavaScript with `node --check`
- branch is based on current `main` and does not touch Factory 2's issue #817 branch
