### PR TITLE
feat(types): pilot generated auth token response

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,12 @@
+import type { components } from './generated/openapi'
+
+export * from './types/index'
+
+/**
+ * Authentication token payload generated from the FastAPI OpenAPI contract.
+ *
+ * Keep the public types barrel on the generated response so backend changes to
+ * TokenResponse produce a deterministic frontend type diff instead of silently
+ * drifting from a handwritten copy.
+ */
+export type AuthTokens = components['schemas']['TokenResponse']

--- a/frontend/src/unit/generated-auth-token-contract.test.ts
+++ b/frontend/src/unit/generated-auth-token-contract.test.ts
@@ -1,0 +1,10 @@
+import { describe, expectTypeOf, it } from 'vitest'
+
+import type { components } from '../generated/openapi'
+import type { AuthTokens } from '../types'
+
+describe('generated authentication token contract', () => {
+  it('exports the OpenAPI TokenResponse through the public types barrel', () => {
+    expectTypeOf<AuthTokens>().toEqualTypeOf<components['schemas']['TokenResponse']>()
+  })
+})


### PR DESCRIPTION
## Summary

- add a public frontend types barrel that preserves existing exports while overriding `AuthTokens` with the generated OpenAPI `TokenResponse` schema
- make backend token-response changes flow into frontend typechecking instead of drifting from the handwritten response shape
- add focused compile-time regression coverage proving the public type is exactly the generated schema

## Scope

This completes the low-risk generated-type pilot portion of #639. The broader remaining migration of other handwritten resource types stays on #639 and this PR does not claim to close the full issue.

## Validation

Exact-head frontend typecheck, unit tests, lint, build, generated-artifact verification, and repository CI are required before merge.

Model: GPT-5.6 Thinking