### PR TITLE
fix(queue): show full reposition offset

### DIFF
--- a/frontend/src/components/PositionSlider.tsx
+++ b/frontend/src/components/PositionSlider.tsx
@@ -38,7 +38,7 @@ export default function PositionSlider({
   const [sliderValue, setSliderValue] = useState(Math.max(0, currentIndex))
 
   const maxPosition = sortedThreads.length - 1
-  const selectedOffset = sliderValue - currentIndex
+  const selectedOffset = currentIndex - sliderValue
   const formattedOffset = selectedOffset > 0 ? `+${selectedOffset}` : `${selectedOffset}`
 
   // Get context threads (2-3 above and below current slider position)

--- a/frontend/src/components/PositionSlider.tsx
+++ b/frontend/src/components/PositionSlider.tsx
@@ -38,6 +38,8 @@ export default function PositionSlider({
   const [sliderValue, setSliderValue] = useState(Math.max(0, currentIndex))
 
   const maxPosition = sortedThreads.length - 1
+  const selectedOffset = sliderValue - currentIndex
+  const formattedOffset = selectedOffset > 0 ? `+${selectedOffset}` : `${selectedOffset}`
 
   // Get context threads (2-3 above and below current slider position)
   const contextThreads = useMemo(() => {
@@ -185,8 +187,11 @@ export default function PositionSlider({
                   <span className="text-[9px] font-bold uppercase tracking-wider text-amber-500">Moving</span>
                 )}
                 {willBeDisplaced && (
-                  <span className="text-[9px] font-bold uppercase tracking-wider text-amber-400">
-                    {sliderValue < currentIndex ? '+1' : '-1'}
+                  <span
+                    data-testid="position-slider-offset"
+                    className="text-[9px] font-bold uppercase tracking-wider text-amber-400"
+                  >
+                    {formattedOffset}
                   </span>
                 )}
               </div>

--- a/frontend/src/unit/PositionSlider.offset.test.tsx
+++ b/frontend/src/unit/PositionSlider.offset.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { expect, it, vi } from 'vitest'
+import PositionSlider from '../components/PositionSlider'
+
+it('shows the full signed offset for multi-position moves', () => {
+  const current = { id: 4, title: 'Fourth', queue_position: 4 }
+  const threads = [
+    { id: 1, title: 'First', queue_position: 1 },
+    { id: 2, title: 'Second', queue_position: 2 },
+    { id: 3, title: 'Third', queue_position: 3 },
+    current,
+    { id: 5, title: 'Fifth', queue_position: 5 },
+  ]
+
+  render(
+    <PositionSlider
+      threads={threads}
+      currentThread={current}
+      onPositionSelect={vi.fn()}
+      onCancel={vi.fn()}
+    />,
+  )
+
+  const slider = screen.getByRole('slider')
+  fireEvent.change(slider, { target: { value: '0' } })
+  expect(screen.getByTestId('position-slider-offset')).toHaveTextContent('-3')
+
+  fireEvent.change(slider, { target: { value: '4' } })
+  expect(screen.getByTestId('position-slider-offset')).toHaveTextContent('+1')
+})

--- a/frontend/src/unit/PositionSlider.offset.test.tsx
+++ b/frontend/src/unit/PositionSlider.offset.test.tsx
@@ -23,8 +23,8 @@ it('shows the full signed offset for multi-position moves', () => {
 
   const slider = screen.getByRole('slider')
   fireEvent.change(slider, { target: { value: '0' } })
-  expect(screen.getByTestId('position-slider-offset')).toHaveTextContent('-3')
+  expect(screen.getByTestId('position-slider-offset')).toHaveTextContent('+3')
 
   fireEvent.change(slider, { target: { value: '4' } })
-  expect(screen.getByTestId('position-slider-offset')).toHaveTextContent('+1')
+  expect(screen.getByTestId('position-slider-offset')).toHaveTextContent('-1')
 })


### PR DESCRIPTION
## Summary

- calculate the selected queue move distance from the current and target indexes
- display the complete signed offset instead of a hard-coded one-position value
- add focused regression coverage for a three-position move and a one-position move

Closes #817

Model: GPT-5.6 Thinking