### PR TITLE
refactor(frontend): generate public auth user type

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3,6 +3,15 @@ import type { components } from './generated/openapi'
 export * from './types/index'
 
 /**
+ * Authenticated user payload generated from the FastAPI OpenAPI contract.
+ *
+ * Keep the public types barrel on the generated response so backend changes to
+ * UserResponse produce a deterministic frontend type diff instead of silently
+ * drifting from a handwritten copy.
+ */
+export type AuthUser = components['schemas']['UserResponse']
+
+/**
  * Authentication token payload generated from the FastAPI OpenAPI contract.
  *
  * Keep the public types barrel on the generated response so backend changes to

--- a/frontend/src/unit/generated-auth-user-contract.test.ts
+++ b/frontend/src/unit/generated-auth-user-contract.test.ts
@@ -1,0 +1,10 @@
+import { describe, expectTypeOf, it } from 'vitest'
+
+import type { components } from '../generated/openapi'
+import type { AuthUser } from '../types'
+
+describe('generated authentication user contract', () => {
+  it('exports the OpenAPI UserResponse through the public types barrel', () => {
+    expectTypeOf<AuthUser>().toEqualTypeOf<components['schemas']['UserResponse']>()
+  })
+})


### PR DESCRIPTION
## Summary

- export `AuthUser` from the generated OpenAPI `UserResponse` schema through the public frontend types barrel
- preserve the existing public type name while removing another handwritten backend contract boundary
- add a compile-time Vitest contract proving the public alias exactly matches generated OpenAPI

## Scope

This is a focused continuation of #639. It does not close the full issue because remaining resource types still need migration.

## Validation

Exact-head CI will run the frontend typecheck and unit suite.

Model: GPT-5.6 Thinking