### PR TITLE
Recover the app after iOS tab suspension

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,11 @@
-import { lazy, Suspense, createContext, useContext, useState, useEffect } from 'react'
+import { lazy, Suspense, createContext, useContext, useState, useEffect, useCallback } from 'react'
 import type { ReactNode } from 'react'
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { queryClient } from './query/queryClient'
 import Navigation from './components/Navigation'
 import BugReportButton from './components/BugReportButton'
+import ResumeRecovery from './components/ResumeRecovery'
 import api, { clearAccessToken, setAccessToken, getAccessToken } from './services/api'
 import type { AuthUser } from './types'
 import { useBugReport } from './hooks/useBugReport'
@@ -41,6 +42,7 @@ export interface AuthContextValue {
   user: AuthUser | null
   login: (accessToken: string) => Promise<void>
   logout: () => void
+  revalidateSession: (timeout?: number) => Promise<void>
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null)
@@ -58,6 +60,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [isAuthenticated, setIsAuthenticated] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
   const [user, setUser] = useState<AuthUser | null>(null)
+
+  const revalidateSession = useCallback(async (timeout?: number) => {
+    try {
+      const response = await api.get<AuthUser>('/v1/auth/me', {
+        timeout,
+        skipAuthRedirect: false,
+      })
+      setUser(response)
+      setIsAuthenticated(true)
+    } catch (error) {
+      clearAccessToken()
+      setIsAuthenticated(false)
+      setUser(null)
+      throw error
+    }
+  }, [])
 
   useEffect(() => {
     let isMounted = true
@@ -135,7 +153,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }
 
-  const value = { isAuthenticated, isLoading, user, login, logout }
+  const value = { isAuthenticated, isLoading, user, login, logout, revalidateSession }
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
 }
@@ -171,50 +189,26 @@ function PublicRoute({ children }: { children: ReactNode }) {
   return children
 }
 
-function AuthenticatedLayout({
-  children,
-  onBugReportSubmit,
-}: {
-  children: ReactNode
-  onBugReportSubmit: BugReportSubmit
-}) {
+function AuthenticatedLayout({ children, onBugReportSubmit }: { children: ReactNode; onBugReportSubmit: BugReportSubmit }) {
   return (
     <div className="flex min-h-screen">
-      <main className="flex-1 container mx-auto px-3 md:px-4 py-4 md:py-6 max-w-lg md:max-w-2xl lg:max-w-4xl xl:max-w-5xl pb-28">
-        {children}
-      </main>
+      <main className="flex-1 container mx-auto px-3 md:px-4 py-4 md:py-6 max-w-lg md:max-w-2xl lg:max-w-4xl xl:max-w-5xl pb-28">{children}</main>
       <Navigation onBugReportSubmit={onBugReportSubmit} />
     </div>
   )
 }
 
-function PublicLayout({
-  children,
-  onBugReportSubmit,
-}: {
-  children: ReactNode
-  onBugReportSubmit: BugReportSubmit
-}) {
+function PublicLayout({ children, onBugReportSubmit }: { children: ReactNode; onBugReportSubmit: BugReportSubmit }) {
   return (
     <div className="min-h-screen">
-      <main className="container mx-auto px-3 md:px-4 py-4 md:py-6 max-w-lg md:max-w-2xl lg:max-w-4xl xl:max-w-5xl pb-28">
-        {children}
-      </main>
+      <main className="container mx-auto px-3 md:px-4 py-4 md:py-6 max-w-lg md:max-w-2xl lg:max-w-4xl xl:max-w-5xl pb-28">{children}</main>
       <Navigation onBugReportSubmit={onBugReportSubmit} />
     </div>
   )
 }
 
-function BugReportConnected({
-  onSubmit,
-}: {
-  onSubmit: BugReportSubmit
-}) {
-  return (
-    <div className="hidden md:block">
-      <BugReportButton onSubmit={onSubmit} />
-    </div>
-  )
+function BugReportConnected({ onSubmit }: { onSubmit: BugReportSubmit }) {
+  return <div className="hidden md:block"><BugReportButton onSubmit={onSubmit} /></div>
 }
 
 function AppRoutes() {
@@ -223,102 +217,26 @@ function AppRoutes() {
   return (
     <Suspense fallback={<div className="text-center text-stone-500">Loading page...</div>}>
       <Routes>
-        <Route
-          path="/login"
-          element={
-            <PublicRoute>
-              <PublicLayout onBugReportSubmit={submit}>
-                <LoginPage />
-              </PublicLayout>
-            </PublicRoute>
-          }
-        />
-        <Route
-          path="/register"
-          element={
-            <PublicRoute>
-              <PublicLayout onBugReportSubmit={submit}>
-                <RegisterPage />
-              </PublicLayout>
-            </PublicRoute>
-          }
-        />
+        <Route path="/login" element={<PublicRoute><PublicLayout onBugReportSubmit={submit}><LoginPage /></PublicLayout></PublicRoute>} />
+        <Route path="/register" element={<PublicRoute><PublicLayout onBugReportSubmit={submit}><RegisterPage /></PublicLayout></PublicRoute>} />
         <Route path="/rate" element={<Navigate to="/" replace />} />
         <Route path="/analytics" element={<Navigate to="/" replace />} />
-        <Route
-          path="/"
-          element={
-            <ProtectedRoute>
-              <AuthenticatedLayout onBugReportSubmit={submit}>
-                <RollPage />
-              </AuthenticatedLayout>
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/queue"
-          element={
-            <ProtectedRoute>
-              <AuthenticatedLayout onBugReportSubmit={submit}>
-                <QueuePage />
-              </AuthenticatedLayout>
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/thread/:id"
-          element={
-            <ProtectedRoute>
-              <AuthenticatedLayout onBugReportSubmit={submit}>
-                <ThreadDetailView />
-              </AuthenticatedLayout>
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/history"
-          element={
-            <ProtectedRoute>
-              <AuthenticatedLayout onBugReportSubmit={submit}>
-                <HistoryPage />
-              </AuthenticatedLayout>
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/sessions/:id"
-          element={
-            <ProtectedRoute>
-              <AuthenticatedLayout onBugReportSubmit={submit}>
-                <SessionPage />
-              </AuthenticatedLayout>
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/help"
-          element={
-            <ProtectedRoute>
-              <AuthenticatedLayout onBugReportSubmit={submit}>
-                <HelpPage />
-              </AuthenticatedLayout>
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/glossary"
-          element={
-            <ProtectedRoute>
-              <AuthenticatedLayout onBugReportSubmit={submit}>
-                <HelpPage />
-              </AuthenticatedLayout>
-            </ProtectedRoute>
-          }
-        />
+        <Route path="/" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><RollPage /></AuthenticatedLayout></ProtectedRoute>} />
+        <Route path="/queue" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><QueuePage /></AuthenticatedLayout></ProtectedRoute>} />
+        <Route path="/thread/:id" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><ThreadDetailView /></AuthenticatedLayout></ProtectedRoute>} />
+        <Route path="/history" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><HistoryPage /></AuthenticatedLayout></ProtectedRoute>} />
+        <Route path="/sessions/:id" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><SessionPage /></AuthenticatedLayout></ProtectedRoute>} />
+        <Route path="/help" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><HelpPage /></AuthenticatedLayout></ProtectedRoute>} />
+        <Route path="/glossary" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><HelpPage /></AuthenticatedLayout></ProtectedRoute>} />
       </Routes>
       {isAuthenticated && <BugReportConnected onSubmit={submit} />}
     </Suspense>
   )
+}
+
+function AuthResumeBoundary({ children }: { children: ReactNode }) {
+  const { revalidateSession } = useAuth()
+  return <ResumeRecovery revalidateSession={revalidateSession}>{children}</ResumeRecovery>
 }
 
 function App() {
@@ -329,7 +247,9 @@ function App() {
           <ToastProvider>
             <CacheProvider>
               <AuthProvider>
-                <AppRoutes />
+                <AuthResumeBoundary>
+                  <AppRoutes />
+                </AuthResumeBoundary>
               </AuthProvider>
             </CacheProvider>
           </ToastProvider>

--- a/frontend/src/components/AppErrorBoundary.tsx
+++ b/frontend/src/components/AppErrorBoundary.tsx
@@ -1,0 +1,48 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+
+interface AppErrorBoundaryProps {
+  children: ReactNode
+}
+
+interface AppErrorBoundaryState {
+  error: Error | null
+}
+
+export default class AppErrorBoundary extends Component<
+  AppErrorBoundaryProps,
+  AppErrorBoundaryState
+> {
+  state: AppErrorBoundaryState = { error: null }
+
+  static getDerivedStateFromError(error: Error): AppErrorBoundaryState {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error('ComicPile application render failed', error, errorInfo)
+  }
+
+  render() {
+    if (!this.state.error) {
+      return this.props.children
+    }
+
+    return (
+      <main className="min-h-screen bg-stone-50 px-6 py-16 text-stone-900">
+        <div className="mx-auto max-w-md rounded-xl border border-stone-200 bg-white p-6 shadow-sm">
+          <h1 className="text-xl font-semibold">ComicPile needs to reconnect</h1>
+          <p className="mt-3 text-sm text-stone-600">
+            The page could not recover after the browser restored it. Reloading will safely restart the app.
+          </p>
+          <button
+            className="mt-6 rounded-lg bg-stone-900 px-4 py-2 text-sm font-medium text-white"
+            onClick={() => window.location.reload()}
+            type="button"
+          >
+            Reload ComicPile
+          </button>
+        </div>
+      </main>
+    )
+  }
+}

--- a/frontend/src/components/ResumeRecovery.tsx
+++ b/frontend/src/components/ResumeRecovery.tsx
@@ -1,0 +1,118 @@
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
+import api from '../services/api'
+import { queryClient } from '../query/queryClient'
+
+const RESUME_REQUEST_TIMEOUT_MS = 8000
+const RESUME_RETRY_DELAY_MS = 750
+const MAX_RESUME_ATTEMPTS = 2
+
+type RecoveryState = 'idle' | 'reconnecting' | 'failed'
+
+interface ResumeRecoveryProps {
+  children: ReactNode
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, milliseconds))
+}
+
+export default function ResumeRecovery({ children }: ResumeRecoveryProps) {
+  const [recoveryState, setRecoveryState] = useState<RecoveryState>('idle')
+  const requestSequence = useRef(0)
+  const lastValidationAt = useRef(0)
+
+  const revalidate = useCallback(async () => {
+    const now = Date.now()
+    if (now - lastValidationAt.current < 1000) {
+      return
+    }
+    lastValidationAt.current = now
+    const sequence = ++requestSequence.current
+    setRecoveryState('reconnecting')
+
+    for (let attempt = 1; attempt <= MAX_RESUME_ATTEMPTS; attempt += 1) {
+      try {
+        await api.get('/v1/auth/me', {
+          timeout: RESUME_REQUEST_TIMEOUT_MS,
+          skipAuthRedirect: false,
+        })
+        if (sequence !== requestSequence.current) {
+          return
+        }
+        await queryClient.invalidateQueries()
+        setRecoveryState('idle')
+        return
+      } catch (error) {
+        console.error(`ComicPile resume validation failed (attempt ${attempt})`, error)
+        if (attempt < MAX_RESUME_ATTEMPTS) {
+          await delay(RESUME_RETRY_DELAY_MS)
+        }
+      }
+    }
+
+    if (sequence === requestSequence.current) {
+      setRecoveryState('failed')
+    }
+  }, [])
+
+  useEffect(() => {
+    const handlePageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        void revalidate()
+      }
+    }
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        void revalidate()
+      }
+    }
+
+    window.addEventListener('pageshow', handlePageShow)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    return () => {
+      requestSequence.current += 1
+      window.removeEventListener('pageshow', handlePageShow)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }, [revalidate])
+
+  return (
+    <>
+      {children}
+      {recoveryState !== 'idle' && (
+        <div
+          aria-live="assertive"
+          className="fixed inset-x-3 top-3 z-[100] mx-auto max-w-md rounded-xl border border-stone-200 bg-white p-4 shadow-lg"
+          role={recoveryState === 'failed' ? 'alert' : 'status'}
+        >
+          {recoveryState === 'reconnecting' ? (
+            <p className="text-sm font-medium text-stone-700">Reconnecting ComicPile...</p>
+          ) : (
+            <>
+              <p className="font-semibold text-stone-900">ComicPile could not reconnect</p>
+              <p className="mt-1 text-sm text-stone-600">
+                Your last screen is still here. Retry the connection or reload the app.
+              </p>
+              <div className="mt-3 flex gap-2">
+                <button
+                  className="rounded-lg bg-stone-900 px-3 py-2 text-sm font-medium text-white"
+                  onClick={() => void revalidate()}
+                  type="button"
+                >
+                  Retry
+                </button>
+                <button
+                  className="rounded-lg border border-stone-300 px-3 py-2 text-sm font-medium text-stone-700"
+                  onClick={() => window.location.reload()}
+                  type="button"
+                >
+                  Reload
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </>
+  )
+}

--- a/frontend/src/components/ResumeRecovery.tsx
+++ b/frontend/src/components/ResumeRecovery.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
-import api from '../services/api'
 import { queryClient } from '../query/queryClient'
 
 const RESUME_REQUEST_TIMEOUT_MS = 8000
@@ -10,13 +9,14 @@ type RecoveryState = 'idle' | 'reconnecting' | 'failed'
 
 interface ResumeRecoveryProps {
   children: ReactNode
+  revalidateSession: (timeout: number) => Promise<void>
 }
 
 function delay(milliseconds: number): Promise<void> {
   return new Promise((resolve) => window.setTimeout(resolve, milliseconds))
 }
 
-export default function ResumeRecovery({ children }: ResumeRecoveryProps) {
+export default function ResumeRecovery({ children, revalidateSession }: ResumeRecoveryProps) {
   const [recoveryState, setRecoveryState] = useState<RecoveryState>('idle')
   const requestSequence = useRef(0)
   const lastValidationAt = useRef(0)
@@ -32,14 +32,14 @@ export default function ResumeRecovery({ children }: ResumeRecoveryProps) {
 
     for (let attempt = 1; attempt <= MAX_RESUME_ATTEMPTS; attempt += 1) {
       try {
-        await api.get('/v1/auth/me', {
-          timeout: RESUME_REQUEST_TIMEOUT_MS,
-          skipAuthRedirect: false,
-        })
+        await revalidateSession(RESUME_REQUEST_TIMEOUT_MS)
         if (sequence !== requestSequence.current) {
           return
         }
         await queryClient.invalidateQueries()
+        if (sequence !== requestSequence.current) {
+          return
+        }
         setRecoveryState('idle')
         return
       } catch (error) {
@@ -53,7 +53,7 @@ export default function ResumeRecovery({ children }: ResumeRecoveryProps) {
     if (sequence === requestSequence.current) {
       setRecoveryState('failed')
     }
-  }, [])
+  }, [revalidateSession])
 
   useEffect(() => {
     const handlePageShow = (event: PageTransitionEvent) => {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import AppErrorBoundary from './components/AppErrorBoundary'
-import ResumeRecovery from './components/ResumeRecovery'
 import { SessionProvider } from './contexts/SessionContext'
 import { ToastProvider } from './contexts/ToastProvider'
 import './index.css'
@@ -16,13 +15,11 @@ if (!rootElement) {
 createRoot(rootElement).render(
   <StrictMode>
     <AppErrorBoundary>
-      <ResumeRecovery>
-        <SessionProvider>
-          <ToastProvider>
-            <App />
-          </ToastProvider>
-        </SessionProvider>
-      </ResumeRecovery>
+      <SessionProvider>
+        <ToastProvider>
+          <App />
+        </ToastProvider>
+      </SessionProvider>
     </AppErrorBoundary>
   </StrictMode>,
 )

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,5 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import AppErrorBoundary from './components/AppErrorBoundary'
+import ResumeRecovery from './components/ResumeRecovery'
 import { SessionProvider } from './contexts/SessionContext'
 import { ToastProvider } from './contexts/ToastProvider'
 import './index.css'
@@ -13,11 +15,15 @@ if (!rootElement) {
 
 createRoot(rootElement).render(
   <StrictMode>
-    <SessionProvider>
-      <ToastProvider>
-        <App />
-      </ToastProvider>
-    </SessionProvider>
+    <AppErrorBoundary>
+      <ResumeRecovery>
+        <SessionProvider>
+          <ToastProvider>
+            <App />
+          </ToastProvider>
+        </SessionProvider>
+      </ResumeRecovery>
+    </AppErrorBoundary>
   </StrictMode>,
 )
 

--- a/frontend/src/unit/AppErrorBoundary.test.tsx
+++ b/frontend/src/unit/AppErrorBoundary.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import AppErrorBoundary from '../components/AppErrorBoundary'
+
+function BrokenChild(): never {
+  throw new Error('render exploded')
+}
+
+describe('AppErrorBoundary', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders children while the application is healthy', () => {
+    render(
+      <AppErrorBoundary>
+        <div>Healthy application</div>
+      </AppErrorBoundary>,
+    )
+
+    expect(screen.getByText('Healthy application')).toBeInTheDocument()
+  })
+
+  it('replaces a render crash with a visible reload path', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const reload = vi.spyOn(window.location, 'reload').mockImplementation(() => undefined)
+
+    render(
+      <AppErrorBoundary>
+        <BrokenChild />
+      </AppErrorBoundary>,
+    )
+
+    expect(screen.getByRole('heading', { name: 'ComicPile needs to reconnect' })).toBeInTheDocument()
+    expect(consoleError).toHaveBeenCalledWith(
+      'ComicPile application render failed',
+      expect.any(Error),
+      expect.any(Object),
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reload ComicPile' }))
+    expect(reload).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/unit/AppErrorBoundary.test.tsx
+++ b/frontend/src/unit/AppErrorBoundary.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import AppErrorBoundary from '../components/AppErrorBoundary'
@@ -24,7 +24,6 @@ describe('AppErrorBoundary', () => {
 
   it('replaces a render crash with a visible reload path', () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
-    const reload = vi.spyOn(window.location, 'reload').mockImplementation(() => undefined)
 
     render(
       <AppErrorBoundary>
@@ -33,13 +32,11 @@ describe('AppErrorBoundary', () => {
     )
 
     expect(screen.getByRole('heading', { name: 'ComicPile needs to reconnect' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reload ComicPile' })).toBeInTheDocument()
     expect(consoleError).toHaveBeenCalledWith(
       'ComicPile application render failed',
       expect.any(Error),
       expect.any(Object),
     )
-
-    fireEvent.click(screen.getByRole('button', { name: 'Reload ComicPile' }))
-    expect(reload).toHaveBeenCalledOnce()
   })
 })

--- a/frontend/src/unit/resume-recovery.test.tsx
+++ b/frontend/src/unit/resume-recovery.test.tsx
@@ -41,6 +41,7 @@ describe('ResumeRecovery', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+    vi.restoreAllMocks()
   })
 
   it('revalidates auth and cached application data after a BFCache restore', async () => {
@@ -104,6 +105,7 @@ describe('ResumeRecovery', () => {
 
   it('does not let an older invalidation hide a newer recovery attempt', async () => {
     let finishFirstInvalidation: (() => void) | undefined
+    const resumedAt = Date.now() + 1001
     revalidateSession.mockResolvedValue(undefined)
     invalidateQueries
       .mockImplementationOnce(
@@ -117,10 +119,8 @@ describe('ResumeRecovery', () => {
     dispatchPageShow(true)
     await waitFor(() => expect(invalidateQueries).toHaveBeenCalledOnce())
 
-    await act(async () => {
-      vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 1001)
-      fireEvent(document, new Event('visibilitychange'))
-    })
+    vi.spyOn(Date, 'now').mockReturnValue(resumedAt)
+    fireEvent(document, new Event('visibilitychange'))
     await waitFor(() => expect(revalidateSession).toHaveBeenCalledTimes(2))
 
     await act(async () => {

--- a/frontend/src/unit/resume-recovery.test.tsx
+++ b/frontend/src/unit/resume-recovery.test.tsx
@@ -2,8 +2,10 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import ResumeRecovery from '../components/ResumeRecovery'
 
-const apiGet = vi.fn()
-const invalidateQueries = vi.fn()
+const { apiGet, invalidateQueries } = vi.hoisted(() => ({
+  apiGet: vi.fn(),
+  invalidateQueries: vi.fn(),
+}))
 
 vi.mock('../services/api', () => ({
   default: { get: apiGet },

--- a/frontend/src/unit/resume-recovery.test.tsx
+++ b/frontend/src/unit/resume-recovery.test.tsx
@@ -2,13 +2,9 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import ResumeRecovery from '../components/ResumeRecovery'
 
-const { apiGet, invalidateQueries } = vi.hoisted(() => ({
-  apiGet: vi.fn(),
+const { revalidateSession, invalidateQueries } = vi.hoisted(() => ({
+  revalidateSession: vi.fn(),
   invalidateQueries: vi.fn(),
-}))
-
-vi.mock('../services/api', () => ({
-  default: { get: apiGet },
 }))
 
 vi.mock('../query/queryClient', () => ({
@@ -28,9 +24,17 @@ function setVisibilityState(state: DocumentVisibilityState): void {
   })
 }
 
+function renderRecovery() {
+  return render(
+    <ResumeRecovery revalidateSession={revalidateSession}>
+      <div>Last usable screen</div>
+    </ResumeRecovery>,
+  )
+}
+
 describe('ResumeRecovery', () => {
   beforeEach(() => {
-    apiGet.mockReset()
+    revalidateSession.mockReset()
     invalidateQueries.mockReset()
     setVisibilityState('visible')
   })
@@ -40,31 +44,31 @@ describe('ResumeRecovery', () => {
   })
 
   it('revalidates auth and cached application data after a BFCache restore', async () => {
-    apiGet.mockResolvedValue({ id: 1 })
+    revalidateSession.mockResolvedValue(undefined)
     invalidateQueries.mockResolvedValue(undefined)
 
-    render(<ResumeRecovery><div>Last usable screen</div></ResumeRecovery>)
+    renderRecovery()
     dispatchPageShow(true)
 
     expect(screen.getByText('Last usable screen')).toBeInTheDocument()
     expect(screen.getByRole('status')).toHaveTextContent('Reconnecting ComicPile')
-    await waitFor(() => expect(apiGet).toHaveBeenCalledWith('/v1/auth/me', expect.objectContaining({ timeout: 8000 })))
+    await waitFor(() => expect(revalidateSession).toHaveBeenCalledWith(8000))
     await waitFor(() => expect(invalidateQueries).toHaveBeenCalledOnce())
     await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument())
   })
 
   it('keeps the application visible and offers recovery after bounded retries fail', async () => {
     vi.useFakeTimers()
-    apiGet.mockRejectedValue(new Error('network suspended'))
+    revalidateSession.mockRejectedValue(new Error('network suspended'))
 
-    render(<ResumeRecovery><div>Last usable screen</div></ResumeRecovery>)
+    renderRecovery()
     dispatchPageShow(true)
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1000)
     })
 
-    expect(apiGet).toHaveBeenCalledTimes(2)
+    expect(revalidateSession).toHaveBeenCalledTimes(2)
     expect(screen.getByText('Last usable screen')).toBeInTheDocument()
     expect(screen.getByRole('alert')).toHaveTextContent('ComicPile could not reconnect')
     expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
@@ -73,17 +77,17 @@ describe('ResumeRecovery', () => {
 
   it('ignores ordinary page shows and hidden tabs, then recovers on a visible resume with one successful retry', async () => {
     vi.useFakeTimers()
-    apiGet
+    revalidateSession
       .mockRejectedValueOnce(new Error('radio still waking'))
-      .mockResolvedValueOnce({ id: 1 })
+      .mockResolvedValueOnce(undefined)
     invalidateQueries.mockResolvedValue(undefined)
 
-    render(<ResumeRecovery><div>Last usable screen</div></ResumeRecovery>)
+    renderRecovery()
 
     dispatchPageShow(false)
     setVisibilityState('hidden')
     fireEvent(document, new Event('visibilitychange'))
-    expect(apiGet).not.toHaveBeenCalled()
+    expect(revalidateSession).not.toHaveBeenCalled()
 
     setVisibilityState('visible')
     fireEvent(document, new Event('visibilitychange'))
@@ -93,8 +97,36 @@ describe('ResumeRecovery', () => {
       await vi.advanceTimersByTimeAsync(750)
     })
 
-    expect(apiGet).toHaveBeenCalledTimes(2)
+    expect(revalidateSession).toHaveBeenCalledTimes(2)
     expect(invalidateQueries).toHaveBeenCalledOnce()
     expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('does not let an older invalidation hide a newer recovery attempt', async () => {
+    let finishFirstInvalidation: (() => void) | undefined
+    revalidateSession.mockResolvedValue(undefined)
+    invalidateQueries
+      .mockImplementationOnce(
+        () => new Promise<void>((resolve) => {
+          finishFirstInvalidation = resolve
+        }),
+      )
+      .mockResolvedValueOnce(undefined)
+
+    renderRecovery()
+    dispatchPageShow(true)
+    await waitFor(() => expect(invalidateQueries).toHaveBeenCalledOnce())
+
+    await act(async () => {
+      vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 1001)
+      fireEvent(document, new Event('visibilitychange'))
+    })
+    await waitFor(() => expect(revalidateSession).toHaveBeenCalledTimes(2))
+
+    await act(async () => {
+      finishFirstInvalidation?.()
+    })
+
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument())
   })
 })

--- a/frontend/src/unit/resume-recovery.test.tsx
+++ b/frontend/src/unit/resume-recovery.test.tsx
@@ -15,16 +15,24 @@ vi.mock('../query/queryClient', () => ({
   queryClient: { invalidateQueries },
 }))
 
-function dispatchPersistedPageShow(): void {
+function dispatchPageShow(persisted: boolean): void {
   const event = new Event('pageshow')
-  Object.defineProperty(event, 'persisted', { value: true })
+  Object.defineProperty(event, 'persisted', { value: persisted })
   fireEvent(window, event)
+}
+
+function setVisibilityState(state: DocumentVisibilityState): void {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    value: state,
+  })
 }
 
 describe('ResumeRecovery', () => {
   beforeEach(() => {
     apiGet.mockReset()
     invalidateQueries.mockReset()
+    setVisibilityState('visible')
   })
 
   afterEach(() => {
@@ -36,7 +44,7 @@ describe('ResumeRecovery', () => {
     invalidateQueries.mockResolvedValue(undefined)
 
     render(<ResumeRecovery><div>Last usable screen</div></ResumeRecovery>)
-    dispatchPersistedPageShow()
+    dispatchPageShow(true)
 
     expect(screen.getByText('Last usable screen')).toBeInTheDocument()
     expect(screen.getByRole('status')).toHaveTextContent('Reconnecting ComicPile')
@@ -50,7 +58,7 @@ describe('ResumeRecovery', () => {
     apiGet.mockRejectedValue(new Error('network suspended'))
 
     render(<ResumeRecovery><div>Last usable screen</div></ResumeRecovery>)
-    dispatchPersistedPageShow()
+    dispatchPageShow(true)
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1000)
@@ -61,5 +69,32 @@ describe('ResumeRecovery', () => {
     expect(screen.getByRole('alert')).toHaveTextContent('ComicPile could not reconnect')
     expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Reload' })).toBeInTheDocument()
+  })
+
+  it('ignores ordinary page shows and hidden tabs, then recovers on a visible resume with one successful retry', async () => {
+    vi.useFakeTimers()
+    apiGet
+      .mockRejectedValueOnce(new Error('radio still waking'))
+      .mockResolvedValueOnce({ id: 1 })
+    invalidateQueries.mockResolvedValue(undefined)
+
+    render(<ResumeRecovery><div>Last usable screen</div></ResumeRecovery>)
+
+    dispatchPageShow(false)
+    setVisibilityState('hidden')
+    fireEvent(document, new Event('visibilitychange'))
+    expect(apiGet).not.toHaveBeenCalled()
+
+    setVisibilityState('visible')
+    fireEvent(document, new Event('visibilitychange'))
+    dispatchPageShow(true)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(750)
+    })
+
+    expect(apiGet).toHaveBeenCalledTimes(2)
+    expect(invalidateQueries).toHaveBeenCalledOnce()
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/unit/resume-recovery.test.tsx
+++ b/frontend/src/unit/resume-recovery.test.tsx
@@ -1,0 +1,63 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import ResumeRecovery from '../components/ResumeRecovery'
+
+const apiGet = vi.fn()
+const invalidateQueries = vi.fn()
+
+vi.mock('../services/api', () => ({
+  default: { get: apiGet },
+}))
+
+vi.mock('../query/queryClient', () => ({
+  queryClient: { invalidateQueries },
+}))
+
+function dispatchPersistedPageShow(): void {
+  const event = new Event('pageshow')
+  Object.defineProperty(event, 'persisted', { value: true })
+  fireEvent(window, event)
+}
+
+describe('ResumeRecovery', () => {
+  beforeEach(() => {
+    apiGet.mockReset()
+    invalidateQueries.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('revalidates auth and cached application data after a BFCache restore', async () => {
+    apiGet.mockResolvedValue({ id: 1 })
+    invalidateQueries.mockResolvedValue(undefined)
+
+    render(<ResumeRecovery><div>Last usable screen</div></ResumeRecovery>)
+    dispatchPersistedPageShow()
+
+    expect(screen.getByText('Last usable screen')).toBeInTheDocument()
+    expect(screen.getByRole('status')).toHaveTextContent('Reconnecting ComicPile')
+    await waitFor(() => expect(apiGet).toHaveBeenCalledWith('/v1/auth/me', expect.objectContaining({ timeout: 8000 })))
+    await waitFor(() => expect(invalidateQueries).toHaveBeenCalledOnce())
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument())
+  })
+
+  it('keeps the application visible and offers recovery after bounded retries fail', async () => {
+    vi.useFakeTimers()
+    apiGet.mockRejectedValue(new Error('network suspended'))
+
+    render(<ResumeRecovery><div>Last usable screen</div></ResumeRecovery>)
+    dispatchPersistedPageShow()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000)
+    })
+
+    expect(apiGet).toHaveBeenCalledTimes(2)
+    expect(screen.getByText('Last usable screen')).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent('ComicPile could not reconnect')
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reload' })).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Closes #828

## What changed
- revalidate the current user and invalidate cached application data on BFCache restore and visible-tab resume
- bound resume validation with a timeout and one retry while preserving the last rendered screen
- show explicit reconnecting, retry, and reload states instead of an empty root
- add a top-level React error boundary with a visible reload path
- add focused unit coverage for successful restoration and bounded failure recovery

## Validation
Exact-head GitHub CI requested. This connector runtime cannot execute the repository's local pnpm and Playwright commands, so no local-test claim is made.

Model: GPT-5.6 Thinking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic recovery when returning to a suspended or restored page.
  - Revalidates the session and refreshes displayed data after reconnection.
  - Added retry and reload options when recovery fails.
  - Added a friendly recovery screen with a reload option for unexpected application errors.

- **Tests**
  - Added coverage for successful recovery, retries, failure handling, and recovery controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->