### PR TITLE
Rename Roll reading-order groups to crossovers

### DIFF
--- a/frontend/src/pages/RollPage/components/ReadingOrderGroups.tsx
+++ b/frontend/src/pages/RollPage/components/ReadingOrderGroups.tsx
@@ -13,7 +13,7 @@ export function ReadingOrderGroups({ threadId }: ReadingOrderGroupsProps) {
     return (
       <div className="text-center" role="status" aria-live="polite">
         <span className="text-[10px] font-bold uppercase tracking-wider text-stone-500">
-          Loading reading-order groups…
+          Loading crossovers…
         </span>
       </div>
     )
@@ -22,7 +22,7 @@ export function ReadingOrderGroups({ threadId }: ReadingOrderGroupsProps) {
   if (error) {
     return (
       <p className="text-center text-[10px] font-bold text-rose-500" role="alert">
-        Unable to load reading-order groups.
+        Unable to load crossovers.
       </p>
     )
   }
@@ -30,12 +30,12 @@ export function ReadingOrderGroups({ threadId }: ReadingOrderGroupsProps) {
   if (groups.length === 0) return null
 
   return (
-    <section aria-labelledby="reading-order-groups-heading" className="space-y-2 text-center">
+    <section aria-labelledby="crossovers-heading" className="space-y-2 text-center">
       <h3
-        id="reading-order-groups-heading"
+        id="crossovers-heading"
         className="text-[10px] font-black uppercase tracking-[0.2em] text-stone-500"
       >
-        Reading-order groups
+        Crossovers
       </h3>
       <ul className="flex flex-wrap justify-center gap-2">
         {groups.map((group) => (

--- a/frontend/src/unit/RatingViewReadingOrderGroups.test.tsx
+++ b/frontend/src/unit/RatingViewReadingOrderGroups.test.tsx
@@ -23,8 +23,8 @@ const callbacks = {
   onRefreshThread: vi.fn(),
 }
 
-describe('RatingView reading-order groups', () => {
-  it('shows names owned by the active rating thread', () => {
+describe('RatingView crossovers', () => {
+  it('shows crossover names owned by the active rating thread', () => {
     render(
       <RatingView
         activeRatingThread={{
@@ -52,11 +52,11 @@ describe('RatingView reading-order groups', () => {
       />,
     )
 
-    expect(screen.getByRole('heading', { name: 'Reading-order groups' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Crossovers' })).toBeInTheDocument()
     expect(screen.getByText('Cosmic bridge')).toBeInTheDocument()
   })
 
-  it('does not show group chrome without an active thread', () => {
+  it('does not show crossover chrome without an active thread', () => {
     render(
       <RatingView
         activeRatingThread={null}
@@ -76,6 +76,6 @@ describe('RatingView reading-order groups', () => {
       />,
     )
 
-    expect(screen.queryByRole('heading', { name: 'Reading-order groups' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Crossovers' })).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/unit/ReadingOrderGroups.test.tsx
+++ b/frontend/src/unit/ReadingOrderGroups.test.tsx
@@ -23,16 +23,16 @@ describe('ReadingOrderGroups', () => {
     expect(mockedUseDependencyGroups).toHaveBeenCalledWith(null)
   })
 
-  it('announces loading without showing stale group names', () => {
+  it('announces crossover loading without showing stale names', () => {
     mockedUseDependencyGroups.mockReturnValue({ groups: [], isLoading: true, error: null })
 
     render(<ReadingOrderGroups threadId={17} />)
 
-    expect(screen.getByRole('status')).toHaveTextContent('Loading reading-order groups')
+    expect(screen.getByRole('status')).toHaveTextContent('Loading crossovers')
     expect(screen.queryByRole('list')).not.toBeInTheDocument()
   })
 
-  it('renders an accessible error state', () => {
+  it('renders an accessible crossover error state', () => {
     mockedUseDependencyGroups.mockReturnValue({
       groups: [],
       isLoading: false,
@@ -41,10 +41,10 @@ describe('ReadingOrderGroups', () => {
 
     render(<ReadingOrderGroups threadId={17} />)
 
-    expect(screen.getByRole('alert')).toHaveTextContent('Unable to load reading-order groups.')
+    expect(screen.getByRole('alert')).toHaveTextContent('Unable to load crossovers.')
   })
 
-  it('does not add an empty section for threads without groups', () => {
+  it('does not add an empty section for threads without crossovers', () => {
     mockedUseDependencyGroups.mockReturnValue({ groups: [], isLoading: false, error: null })
 
     const { container } = render(<ReadingOrderGroups threadId={17} />)
@@ -52,11 +52,11 @@ describe('ReadingOrderGroups', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  it('renders every owned group name and preserves long-name wrapping', () => {
+  it('renders every owned crossover name and preserves long-name wrapping', () => {
     mockedUseDependencyGroups.mockReturnValue({
       groups: [
         { id: 1, name: 'Bwa Haha-era Justice League' },
-        { id: 2, name: 'A deliberately long reading-order group name for narrow mobile screens' },
+        { id: 2, name: 'A deliberately long crossover name for narrow mobile screens' },
       ],
       isLoading: false,
       error: null,
@@ -64,11 +64,11 @@ describe('ReadingOrderGroups', () => {
 
     render(<ReadingOrderGroups threadId={17} />)
 
-    expect(screen.getByRole('heading', { name: 'Reading-order groups' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Crossovers' })).toBeInTheDocument()
     expect(screen.getByRole('list')).toBeInTheDocument()
     expect(screen.getByText('Bwa Haha-era Justice League')).toBeInTheDocument()
     expect(
-      screen.getByText('A deliberately long reading-order group name for narrow mobile screens'),
+      screen.getByText('A deliberately long crossover name for narrow mobile screens'),
     ).toHaveClass('break-words')
   })
 })


### PR DESCRIPTION
Closes #837

## Summary
- present existing dependency-group memberships as **Crossovers** on the Roll rating surface
- update loading, failure, heading, and accessible labeling consistently
- preserve internal dependency-group storage, routes, hook names, and API compatibility
- add focused component coverage for the new user-facing terminology and long mobile names

## Validation
- Exact-head CI requested through the normal pull-request workflows
- Local execution is unavailable in the connector runtime, so no local command evidence is claimed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Updated terminology from “reading-order groups” to “crossovers” across headings, section labels, loading states, and error messages.
  * Improved accessibility wording for crossover loading and error states.
  * Empty crossover results now omit the section instead of displaying an empty area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->