### PR TITLE
Add dedicated crossover management

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,7 @@ const QueuePage = lazy(() => import('./pages/QueuePage'))
 const ThreadDetailView = lazy(() => import('./pages/ThreadDetailView'))
 const HistoryPage = lazy(() => import('./pages/HistoryPage'))
 const SessionPage = lazy(() => import('./pages/SessionPage'))
+const CrossoversPage = lazy(() => import('./pages/CrossoversPage'))
 const HelpPage = lazy(() => import('./pages/HelpPage'))
 const LoginPage = lazy(() => import('./pages/LoginPage'))
 const RegisterPage = lazy(() => import('./pages/RegisterPage'))
@@ -228,6 +229,7 @@ function AppRoutes() {
         <Route path="/thread/:id" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><ThreadDetailView /></AuthenticatedLayout></ProtectedRoute>} />
         <Route path="/history" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><HistoryPage /></AuthenticatedLayout></ProtectedRoute>} />
         <Route path="/sessions/:id" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><SessionPage /></AuthenticatedLayout></ProtectedRoute>} />
+        <Route path="/crossovers" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><CrossoversPage /></AuthenticatedLayout></ProtectedRoute>} />
         <Route path="/help" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><HelpPage /></AuthenticatedLayout></ProtectedRoute>} />
         <Route path="/glossary" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><HelpPage /></AuthenticatedLayout></ProtectedRoute>} />
       </Routes>

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -81,6 +81,10 @@ export default function Navigation({ onBugReportSubmit }: NavigationProps) {
             <span className="text-2xl" aria-hidden="true">📜</span>
             <span className="hidden md:block text-[10px] uppercase tracking-widest font-bold nav-label">History</span>
           </Link>
+          <Link to="/crossovers" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isActive('/crossovers') ? 'active' : 'hover:bg-white/5'}`} aria-label="Crossovers page">
+            <span className="text-2xl" aria-hidden="true">🔀</span>
+            <span className="hidden md:block text-[10px] uppercase tracking-widest font-bold nav-label">Crossovers</span>
+          </Link>
           <Link to="/help" className={`hidden md:flex nav-item flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isActive('/help') ? 'active' : 'hover:bg-white/5'}`} aria-label="Help page">
             <span className="text-2xl mb-1" aria-hidden="true">❓</span>
             <span className="text-[10px] uppercase tracking-widest font-bold nav-label">Help</span>

--- a/frontend/src/pages/CrossoversPage.tsx
+++ b/frontend/src/pages/CrossoversPage.tsx
@@ -44,6 +44,8 @@ export default function CrossoversPage() {
 
   const createGroup = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
+    if (isLoading) return
+
     const trimmedName = name.trim()
     if (!trimmedName) {
       setCreateError('Enter a crossover name.')
@@ -64,6 +66,7 @@ export default function CrossoversPage() {
   }
 
   const beginRename = (group: DependencyGroup) => {
+    if (busyId !== null) return
     setMutationError(null)
     setEditingId(group.id)
     setEditingName(group.name)
@@ -95,6 +98,7 @@ export default function CrossoversPage() {
   }
 
   const deleteGroup = async (group: DependencyGroup) => {
+    if (busyId !== null) return
     if (!window.confirm(`Delete “${group.name}”? Its comic memberships will be removed.`)) return
 
     setMutationError(null)
@@ -131,9 +135,9 @@ export default function CrossoversPage() {
             maxLength={200}
             className="min-w-0 flex-1 rounded-xl border border-stone-600 bg-stone-950 px-3 py-2.5 text-stone-100 outline-none focus:border-amber-500 focus:ring-2 focus:ring-amber-500/30"
             placeholder="Age of Apocalypse"
-            disabled={isCreating}
+            disabled={isCreating || isLoading}
           />
-          <button type="submit" disabled={isCreating} className="rounded-xl bg-amber-500 px-4 py-2.5 font-bold text-stone-950 disabled:cursor-not-allowed disabled:opacity-50">
+          <button type="submit" disabled={isCreating || isLoading} className="rounded-xl bg-amber-500 px-4 py-2.5 font-bold text-stone-950 disabled:cursor-not-allowed disabled:opacity-50">
             {isCreating ? 'Creating…' : 'Create crossover'}
           </button>
         </div>
@@ -159,6 +163,7 @@ export default function CrossoversPage() {
           {groups.map((group) => {
             const isEditing = editingId === group.id
             const isBusy = busyId === group.id
+            const hasPendingMutation = busyId !== null
             const isExpanded = expandedId === group.id
             return (
               <li key={group.id} className="rounded-2xl border border-stone-700 bg-stone-900/60 p-4">
@@ -184,8 +189,8 @@ export default function CrossoversPage() {
                       <span className="text-sm text-stone-500">{group.memberships.length} {group.memberships.length === 1 ? 'member' : 'members'}</span>
                     </button>
                     <div className="flex gap-2">
-                      <button type="button" onClick={() => beginRename(group)} disabled={isBusy} className="flex-1 rounded-lg border border-stone-600 px-3 py-2 text-sm font-bold text-stone-300 hover:border-amber-500">Rename</button>
-                      <button type="button" onClick={() => void deleteGroup(group)} disabled={isBusy} className="flex-1 rounded-lg border border-red-800 px-3 py-2 text-sm font-bold text-red-400 hover:bg-red-950/40 disabled:opacity-50">Delete</button>
+                      <button type="button" onClick={() => beginRename(group)} disabled={hasPendingMutation} className="flex-1 rounded-lg border border-stone-600 px-3 py-2 text-sm font-bold text-stone-300 hover:border-amber-500 disabled:opacity-50">Rename</button>
+                      <button type="button" onClick={() => void deleteGroup(group)} disabled={hasPendingMutation} className="flex-1 rounded-lg border border-red-800 px-3 py-2 text-sm font-bold text-red-400 hover:bg-red-950/40 disabled:opacity-50">Delete</button>
                     </div>
                   </div>
                 )}

--- a/frontend/src/pages/CrossoversPage.tsx
+++ b/frontend/src/pages/CrossoversPage.tsx
@@ -1,0 +1,208 @@
+import { FormEvent, useCallback, useEffect, useState } from 'react'
+import axios from 'axios'
+import {
+  dependencyGroupsApi,
+  type DependencyGroup,
+} from '../services/api-dependency-groups'
+
+function errorMessage(error: unknown, fallback: string): string {
+  if (axios.isAxiosError(error)) {
+    const detail = error.response?.data?.detail
+    if (typeof detail === 'string' && detail.trim()) return detail
+  }
+  return error instanceof Error && error.message ? error.message : fallback
+}
+
+export default function CrossoversPage() {
+  const [groups, setGroups] = useState<DependencyGroup[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [name, setName] = useState('')
+  const [createError, setCreateError] = useState<string | null>(null)
+  const [isCreating, setIsCreating] = useState(false)
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [editingName, setEditingName] = useState('')
+  const [mutationError, setMutationError] = useState<string | null>(null)
+  const [busyId, setBusyId] = useState<number | null>(null)
+  const [expandedId, setExpandedId] = useState<number | null>(null)
+
+  const loadGroups = useCallback(async () => {
+    setIsLoading(true)
+    setLoadError(null)
+    try {
+      setGroups(await dependencyGroupsApi.list())
+    } catch (error) {
+      setLoadError(errorMessage(error, 'Unable to load crossovers.'))
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadGroups()
+  }, [loadGroups])
+
+  const createGroup = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const trimmedName = name.trim()
+    if (!trimmedName) {
+      setCreateError('Enter a crossover name.')
+      return
+    }
+
+    setCreateError(null)
+    setIsCreating(true)
+    try {
+      const created = await dependencyGroupsApi.create(trimmedName)
+      setGroups((current) => [...current, created].sort((a, b) => a.name.localeCompare(b.name)))
+      setName('')
+    } catch (error) {
+      setCreateError(errorMessage(error, 'Unable to create crossover.'))
+    } finally {
+      setIsCreating(false)
+    }
+  }
+
+  const beginRename = (group: DependencyGroup) => {
+    setMutationError(null)
+    setEditingId(group.id)
+    setEditingName(group.name)
+  }
+
+  const saveRename = async (groupId: number) => {
+    const trimmedName = editingName.trim()
+    if (!trimmedName) {
+      setMutationError('Enter a crossover name.')
+      return
+    }
+
+    setMutationError(null)
+    setBusyId(groupId)
+    try {
+      const renamed = await dependencyGroupsApi.rename(groupId, trimmedName)
+      setGroups((current) =>
+        current
+          .map((group) => (group.id === groupId ? renamed : group))
+          .sort((a, b) => a.name.localeCompare(b.name)),
+      )
+      setEditingId(null)
+      setEditingName('')
+    } catch (error) {
+      setMutationError(errorMessage(error, 'Unable to rename crossover.'))
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  const deleteGroup = async (group: DependencyGroup) => {
+    if (!window.confirm(`Delete “${group.name}”? Its comic memberships will be removed.`)) return
+
+    setMutationError(null)
+    setBusyId(group.id)
+    try {
+      await dependencyGroupsApi.delete(group.id)
+      setGroups((current) => current.filter((item) => item.id !== group.id))
+      if (expandedId === group.id) setExpandedId(null)
+      if (editingId === group.id) setEditingId(null)
+    } catch (error) {
+      setMutationError(errorMessage(error, 'Unable to delete crossover.'))
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  return (
+    <section className="space-y-6" aria-labelledby="crossovers-heading">
+      <header>
+        <p className="text-xs font-bold uppercase tracking-[0.25em] text-amber-500">Continuity</p>
+        <h1 id="crossovers-heading" className="mt-1 text-3xl font-black text-stone-100">Crossovers</h1>
+        <p className="mt-2 max-w-2xl text-sm text-stone-400">
+          Name connected comics so their continuity is easy to recognize across ComicPile. Membership does not create a reading block by itself.
+        </p>
+      </header>
+
+      <form onSubmit={createGroup} className="rounded-2xl border border-stone-700 bg-stone-900/70 p-4" aria-label="Create crossover">
+        <label htmlFor="crossover-name" className="block text-sm font-bold text-stone-200">New crossover</label>
+        <div className="mt-2 flex flex-col gap-2 sm:flex-row">
+          <input
+            id="crossover-name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            maxLength={200}
+            className="min-w-0 flex-1 rounded-xl border border-stone-600 bg-stone-950 px-3 py-2.5 text-stone-100 outline-none focus:border-amber-500 focus:ring-2 focus:ring-amber-500/30"
+            placeholder="Age of Apocalypse"
+            disabled={isCreating}
+          />
+          <button type="submit" disabled={isCreating} className="rounded-xl bg-amber-500 px-4 py-2.5 font-bold text-stone-950 disabled:cursor-not-allowed disabled:opacity-50">
+            {isCreating ? 'Creating…' : 'Create crossover'}
+          </button>
+        </div>
+        {createError && <p role="alert" className="mt-2 text-sm text-red-400">{createError}</p>}
+      </form>
+
+      {mutationError && <p role="alert" className="rounded-xl border border-red-800 bg-red-950/40 p-3 text-sm text-red-300">{mutationError}</p>}
+
+      {isLoading ? (
+        <p role="status" className="rounded-2xl border border-stone-800 p-6 text-center text-stone-400">Loading crossovers…</p>
+      ) : loadError ? (
+        <div role="alert" className="rounded-2xl border border-red-800 bg-red-950/40 p-4 text-red-300">
+          <p>{loadError}</p>
+          <button type="button" onClick={() => void loadGroups()} className="mt-3 rounded-lg border border-red-500 px-3 py-2 text-sm font-bold">Try again</button>
+        </div>
+      ) : groups.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-stone-700 p-8 text-center">
+          <p className="text-lg font-bold text-stone-200">No crossovers yet</p>
+          <p className="mt-1 text-sm text-stone-500">Create one above, then add comics from dependency management.</p>
+        </div>
+      ) : (
+        <ul className="grid gap-3" aria-label="Your crossovers">
+          {groups.map((group) => {
+            const isEditing = editingId === group.id
+            const isBusy = busyId === group.id
+            const isExpanded = expandedId === group.id
+            return (
+              <li key={group.id} className="rounded-2xl border border-stone-700 bg-stone-900/60 p-4">
+                {isEditing ? (
+                  <div className="flex flex-col gap-2 sm:flex-row">
+                    <label className="sr-only" htmlFor={`rename-${group.id}`}>Rename {group.name}</label>
+                    <input
+                      id={`rename-${group.id}`}
+                      value={editingName}
+                      onChange={(event) => setEditingName(event.target.value)}
+                      className="min-w-0 flex-1 rounded-xl border border-stone-600 bg-stone-950 px-3 py-2 text-stone-100"
+                      disabled={isBusy}
+                    />
+                    <div className="flex gap-2">
+                      <button type="button" onClick={() => void saveRename(group.id)} disabled={isBusy} className="flex-1 rounded-lg bg-amber-500 px-3 py-2 text-sm font-bold text-stone-950 disabled:opacity-50">Save</button>
+                      <button type="button" onClick={() => setEditingId(null)} disabled={isBusy} className="flex-1 rounded-lg border border-stone-600 px-3 py-2 text-sm font-bold text-stone-300">Cancel</button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <button type="button" onClick={() => setExpandedId(isExpanded ? null : group.id)} aria-expanded={isExpanded} className="min-w-0 text-left">
+                      <span className="block truncate text-lg font-black text-stone-100">{group.name}</span>
+                      <span className="text-sm text-stone-500">{group.memberships.length} {group.memberships.length === 1 ? 'member' : 'members'}</span>
+                    </button>
+                    <div className="flex gap-2">
+                      <button type="button" onClick={() => beginRename(group)} disabled={isBusy} className="flex-1 rounded-lg border border-stone-600 px-3 py-2 text-sm font-bold text-stone-300 hover:border-amber-500">Rename</button>
+                      <button type="button" onClick={() => void deleteGroup(group)} disabled={isBusy} className="flex-1 rounded-lg border border-red-800 px-3 py-2 text-sm font-bold text-red-400 hover:bg-red-950/40 disabled:opacity-50">Delete</button>
+                    </div>
+                  </div>
+                )}
+                {isExpanded && !isEditing && (
+                  <div className="mt-4 border-t border-stone-800 pt-4 text-sm text-stone-400">
+                    {group.memberships.length === 0 ? (
+                      <p>This crossover has no comics yet.</p>
+                    ) : (
+                      <p>{group.memberships.filter((member) => member.issue_id !== null).length} issue memberships and {group.memberships.filter((member) => member.thread_id !== null).length} thread memberships.</p>
+                    )}
+                  </div>
+                )}
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/unit/CrossoversPage.test.tsx
+++ b/frontend/src/unit/CrossoversPage.test.tsx
@@ -152,6 +152,22 @@ describe('CrossoversPage', () => {
     expect(await screen.findByRole('alert')).toHaveTextContent('Duplicate crossover name')
   })
 
+  it('uses API detail messages and safe fallbacks for non-Error failures', async () => {
+    api.list
+      .mockRejectedValueOnce({ isAxiosError: true, response: { data: { detail: 'Crossover service unavailable' } } })
+      .mockRejectedValueOnce({ isAxiosError: true, response: { data: { detail: '   ' } } })
+      .mockRejectedValueOnce('offline')
+
+    render(<CrossoversPage />)
+    expect(await screen.findByRole('alert')).toHaveTextContent('Crossover service unavailable')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent('Unable to load crossovers.')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent('Unable to load crossovers.')
+  })
+
   it('allows a failed initial load to be retried', async () => {
     api.list.mockRejectedValueOnce(new Error('Network unavailable')).mockResolvedValueOnce([annihilation])
     render(<CrossoversPage />)

--- a/frontend/src/unit/CrossoversPage.test.tsx
+++ b/frontend/src/unit/CrossoversPage.test.tsx
@@ -86,6 +86,59 @@ describe('CrossoversPage', () => {
     expect(groupButton).toHaveAttribute('aria-expanded', 'true')
   })
 
+  it('shows singular and empty membership states and collapses details', async () => {
+    api.list.mockResolvedValue([
+      { ...annihilation, id: 8, name: 'Secret Wars', memberships: [{ id: 3, issue_id: 12, thread_id: null }] },
+      { ...annihilation, id: 9, name: 'House of M', memberships: [] },
+    ])
+    render(<CrossoversPage />)
+
+    const secretWars = await screen.findByRole('button', { name: /Secret Wars.*1 member/ })
+    fireEvent.click(secretWars)
+    expect(screen.getByText('1 issue memberships and 0 thread memberships.')).toBeInTheDocument()
+    fireEvent.click(secretWars)
+    expect(screen.queryByText('1 issue memberships and 0 thread memberships.')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /House of M.*0 members/ }))
+    expect(screen.getByText('This crossover has no comics yet.')).toBeInTheDocument()
+  })
+
+  it('validates rename, cancels editing, and reports rename failures', async () => {
+    api.list.mockResolvedValue([annihilation])
+    api.rename.mockRejectedValue(new Error('Rename unavailable'))
+    render(<CrossoversPage />)
+
+    await screen.findByText('Annihilation')
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
+    fireEvent.change(screen.getByLabelText('Rename Annihilation'), { target: { value: '   ' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    expect(screen.getByRole('alert')).toHaveTextContent('Enter a crossover name.')
+    expect(api.rename).not.toHaveBeenCalled()
+
+    fireEvent.change(screen.getByLabelText('Rename Annihilation'), { target: { value: 'Annihilation Wave' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent('Rename unavailable')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.queryByLabelText('Rename Annihilation')).not.toBeInTheDocument()
+  })
+
+  it('keeps a crossover when deletion is cancelled and reports delete failures', async () => {
+    api.list.mockResolvedValue([annihilation])
+    vi.mocked(window.confirm).mockReturnValueOnce(false).mockReturnValueOnce(true)
+    api.delete.mockRejectedValue(new Error('Delete unavailable'))
+    render(<CrossoversPage />)
+
+    await screen.findByText('Annihilation')
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    expect(api.delete).not.toHaveBeenCalled()
+    expect(screen.getByText('Annihilation')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent('Delete unavailable')
+    expect(screen.getByText('Annihilation')).toBeInTheDocument()
+  })
+
   it('presents validation and server failures clearly', async () => {
     api.create.mockRejectedValue(new Error('Duplicate crossover name'))
     render(<CrossoversPage />)

--- a/frontend/src/unit/CrossoversPage.test.tsx
+++ b/frontend/src/unit/CrossoversPage.test.tsx
@@ -42,6 +42,28 @@ describe('CrossoversPage', () => {
     expect(await screen.findByText('No crossovers yet')).toBeInTheDocument()
   })
 
+  it('blocks creation until the current list request settles', async () => {
+    let resolveList: ((groups: []) => void) | undefined
+    api.list.mockImplementation(() => new Promise((resolve) => { resolveList = resolve }))
+    api.create.mockResolvedValue(annihilation)
+
+    render(<CrossoversPage />)
+    const nameInput = screen.getByLabelText('New crossover')
+    const createButton = screen.getByRole('button', { name: 'Create crossover' })
+    expect(nameInput).toBeDisabled()
+    expect(createButton).toBeDisabled()
+
+    resolveList?.([])
+    await screen.findByText('No crossovers yet')
+    expect(nameInput).toBeEnabled()
+    expect(createButton).toBeEnabled()
+
+    fireEvent.change(nameInput, { target: { value: 'Annihilation' } })
+    fireEvent.click(createButton)
+    expect(await screen.findByText('Annihilation')).toBeInTheDocument()
+    expect(api.create).toHaveBeenCalledWith('Annihilation')
+  })
+
   it('creates a trimmed crossover and displays it', async () => {
     api.create.mockResolvedValue(annihilation)
     render(<CrossoversPage />)
@@ -73,6 +95,29 @@ describe('CrossoversPage', () => {
     await waitFor(() => expect(screen.queryByText('Annihilation Conquest')).not.toBeInTheDocument())
     expect(window.confirm).toHaveBeenCalled()
     expect(api.delete).toHaveBeenCalledWith(7)
+  })
+
+  it('blocks competing mutations while a rename is pending', async () => {
+    const secretWars = { ...annihilation, id: 8, name: 'Secret Wars' }
+    let resolveRename: ((group: typeof annihilation) => void) | undefined
+    api.list.mockResolvedValue([annihilation, secretWars])
+    api.rename.mockImplementation(() => new Promise((resolve) => { resolveRename = resolve }))
+    render(<CrossoversPage />)
+
+    await screen.findByText('Annihilation')
+    const renameButtons = screen.getAllByRole('button', { name: 'Rename' })
+    fireEvent.click(renameButtons[0])
+    fireEvent.change(screen.getByLabelText('Rename Annihilation'), { target: { value: 'Annihilation Conquest' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(screen.getByRole('button', { name: 'Rename' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled()
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
+    expect(screen.queryByLabelText('Rename Secret Wars')).not.toBeInTheDocument()
+
+    resolveRename?.({ ...annihilation, name: 'Annihilation Conquest' })
+    expect(await screen.findByText('Annihilation Conquest')).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: 'Rename' })[1]).toBeEnabled()
   })
 
   it('opens crossover detail with issue and thread counts', async () => {

--- a/frontend/src/unit/CrossoversPage.test.tsx
+++ b/frontend/src/unit/CrossoversPage.test.tsx
@@ -1,0 +1,112 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import CrossoversPage from '../pages/CrossoversPage'
+import { dependencyGroupsApi } from '../services/api-dependency-groups'
+
+vi.mock('../services/api-dependency-groups', () => ({
+  dependencyGroupsApi: {
+    list: vi.fn(),
+    create: vi.fn(),
+    rename: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+const api = vi.mocked(dependencyGroupsApi)
+
+const annihilation = {
+  id: 7,
+  name: 'Annihilation',
+  created_at: '2026-08-06T00:00:00Z',
+  memberships: [
+    { id: 1, issue_id: 11, thread_id: null },
+    { id: 2, issue_id: null, thread_id: 22 },
+  ],
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  api.list.mockResolvedValue([])
+  vi.spyOn(window, 'confirm').mockReturnValue(true)
+})
+
+describe('CrossoversPage', () => {
+  it('shows loading and then the empty state', async () => {
+    let resolveList: ((groups: []) => void) | undefined
+    api.list.mockImplementation(() => new Promise((resolve) => { resolveList = resolve }))
+
+    render(<CrossoversPage />)
+    expect(screen.getByRole('status')).toHaveTextContent('Loading crossovers')
+
+    resolveList?.([])
+    expect(await screen.findByText('No crossovers yet')).toBeInTheDocument()
+  })
+
+  it('creates a trimmed crossover and displays it', async () => {
+    api.create.mockResolvedValue(annihilation)
+    render(<CrossoversPage />)
+    await screen.findByText('No crossovers yet')
+
+    fireEvent.change(screen.getByLabelText('New crossover'), { target: { value: '  Annihilation  ' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create crossover' }))
+
+    expect(await screen.findByText('Annihilation')).toBeInTheDocument()
+    expect(api.create).toHaveBeenCalledWith('Annihilation')
+    expect(screen.getByText('2 members')).toBeInTheDocument()
+  })
+
+  it('renames and deletes an existing crossover', async () => {
+    api.list.mockResolvedValue([annihilation])
+    api.rename.mockResolvedValue({ ...annihilation, name: 'Annihilation Conquest' })
+    api.delete.mockResolvedValue()
+    render(<CrossoversPage />)
+
+    await screen.findByText('Annihilation')
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
+    fireEvent.change(screen.getByLabelText('Rename Annihilation'), { target: { value: 'Annihilation Conquest' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(await screen.findByText('Annihilation Conquest')).toBeInTheDocument()
+    expect(api.rename).toHaveBeenCalledWith(7, 'Annihilation Conquest')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await waitFor(() => expect(screen.queryByText('Annihilation Conquest')).not.toBeInTheDocument())
+    expect(window.confirm).toHaveBeenCalled()
+    expect(api.delete).toHaveBeenCalledWith(7)
+  })
+
+  it('opens crossover detail with issue and thread counts', async () => {
+    api.list.mockResolvedValue([annihilation])
+    render(<CrossoversPage />)
+
+    const groupButton = await screen.findByRole('button', { name: /Annihilation.*2 members/ })
+    fireEvent.click(groupButton)
+
+    expect(screen.getByText('1 issue memberships and 1 thread memberships.')).toBeInTheDocument()
+    expect(groupButton).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('presents validation and server failures clearly', async () => {
+    api.create.mockRejectedValue(new Error('Duplicate crossover name'))
+    render(<CrossoversPage />)
+    await screen.findByText('No crossovers yet')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create crossover' }))
+    expect(screen.getByRole('alert')).toHaveTextContent('Enter a crossover name.')
+
+    fireEvent.change(screen.getByLabelText('New crossover'), { target: { value: 'Annihilation' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create crossover' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent('Duplicate crossover name')
+  })
+
+  it('allows a failed initial load to be retried', async () => {
+    api.list.mockRejectedValueOnce(new Error('Network unavailable')).mockResolvedValueOnce([annihilation])
+    render(<CrossoversPage />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Network unavailable')
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+
+    expect(await screen.findByText('Annihilation')).toBeInTheDocument()
+    expect(api.list).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
Closes #838

## Summary
- add a dedicated authenticated `/crossovers` management page
- support create, inspect, rename, and delete through the existing typed dependency-group client
- expose member counts, empty/loading/retry states, and clear validation/API errors
- add a responsive navigation entry and focused lifecycle component coverage

## Validation
- CI requested for the exact branch head
- focused Vitest coverage added in `frontend/src/unit/CrossoversPage.test.tsx`

Local execution is unavailable in this connector runtime, so no local command result is claimed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Crossovers page for viewing and managing dependency groups.
  * Users can create, rename, delete, expand, and review group membership counts.
  * Added Crossovers navigation with active-state styling and responsive labeling.
  * Added loading, retry, validation, confirmation, and user-friendly error states.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->