### PR TITLE
Render a resilient application bootstrap shell

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,8 +5,119 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Comic Pile</title>
+    <style>
+      #bootstrap-shell {
+        position: fixed;
+        inset: 0;
+        z-index: 9999;
+        display: flex;
+        min-height: 100vh;
+        flex-direction: column;
+        justify-content: space-between;
+        background: radial-gradient(circle at top, #2b2118 0%, #110e0a 48%, #090806 100%);
+        color: #f5f0e8;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      .bootstrap-shell__main {
+        width: min(100% - 2rem, 38rem);
+        margin: auto;
+        padding: 2rem 0 7rem;
+        text-align: center;
+      }
+
+      .bootstrap-shell__mark {
+        display: inline-grid;
+        width: 4rem;
+        height: 4rem;
+        place-items: center;
+        border: 1px solid rgba(245, 240, 232, 0.18);
+        border-radius: 1rem;
+        background: rgba(17, 14, 10, 0.72);
+        box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.35);
+        font-size: 2rem;
+      }
+
+      .bootstrap-shell__title {
+        margin: 1rem 0 0.35rem;
+        font-size: clamp(1.75rem, 7vw, 2.75rem);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .bootstrap-shell__status {
+        min-height: 3rem;
+        margin: 0 auto;
+        color: #b8aea1;
+        line-height: 1.5;
+      }
+
+      .bootstrap-shell__pulse {
+        width: 2.5rem;
+        height: 0.25rem;
+        margin: 1.5rem auto 0;
+        overflow: hidden;
+        border-radius: 999px;
+        background: rgba(245, 240, 232, 0.12);
+      }
+
+      .bootstrap-shell__pulse::after {
+        display: block;
+        width: 50%;
+        height: 100%;
+        border-radius: inherit;
+        background: #d4a35f;
+        content: "";
+        animation: bootstrap-pulse 1.15s ease-in-out infinite alternate;
+      }
+
+      .bootstrap-shell__nav {
+        position: fixed;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        min-height: 4rem;
+        border-top: 1px solid rgba(245, 240, 232, 0.1);
+        background: rgba(17, 14, 10, 0.94);
+        backdrop-filter: blur(12px);
+      }
+
+      .bootstrap-shell__nav span {
+        display: grid;
+        place-items: center;
+        color: #8f8579;
+        font-size: 1.35rem;
+      }
+
+      @keyframes bootstrap-pulse {
+        from { transform: translateX(-75%); }
+        to { transform: translateX(175%); }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .bootstrap-shell__pulse::after { animation: none; }
+      }
+    </style>
   </head>
   <body>
+    <div id="bootstrap-shell" role="status" aria-live="polite" aria-label="ComicPile is starting">
+      <main class="bootstrap-shell__main">
+        <div class="bootstrap-shell__mark" aria-hidden="true">📚</div>
+        <h1 class="bootstrap-shell__title">ComicPile</h1>
+        <p class="bootstrap-shell__status" data-bootstrap-status data-state="loading">
+          Opening your reading desk and checking your session…
+        </p>
+        <div class="bootstrap-shell__pulse" aria-hidden="true"></div>
+      </main>
+      <nav class="bootstrap-shell__nav" aria-label="ComicPile navigation loading">
+        <span aria-hidden="true">🎲</span>
+        <span aria-hidden="true">📚</span>
+        <span aria-hidden="true">📜</span>
+        <span aria-hidden="true">🔀</span>
+      </nav>
+    </div>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -194,7 +194,7 @@ function PublicRoute({ children }: { children: ReactNode }) {
 
 function AuthenticatedLayout({ children, onBugReportSubmit }: { children: ReactNode; onBugReportSubmit: BugReportSubmit }) {
   return (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-screen" data-app-shell-ready>
       <main className="flex-1 container mx-auto px-3 md:px-4 py-4 md:py-6 max-w-lg md:max-w-2xl lg:max-w-4xl xl:max-w-5xl pb-28">{children}</main>
       <Navigation onBugReportSubmit={onBugReportSubmit} />
     </div>
@@ -203,7 +203,7 @@ function AuthenticatedLayout({ children, onBugReportSubmit }: { children: ReactN
 
 function PublicLayout({ children, onBugReportSubmit }: { children: ReactNode; onBugReportSubmit: BugReportSubmit }) {
   return (
-    <div className="min-h-screen">
+    <div className="min-h-screen" data-app-shell-ready>
       <main className="container mx-auto px-3 md:px-4 py-4 md:py-6 max-w-lg md:max-w-2xl lg:max-w-4xl xl:max-w-5xl pb-28">{children}</main>
       <Navigation onBugReportSubmit={onBugReportSubmit} />
     </div>

--- a/frontend/src/bootstrapShell.ts
+++ b/frontend/src/bootstrapShell.ts
@@ -1,4 +1,4 @@
-const READY_SELECTOR = '[data-app-shell-ready], .min-h-screen'
+const READY_SELECTOR = '[data-app-shell-ready]'
 const RECONNECTING_DELAY_MS = 8_000
 
 export interface BootstrapShellLifecycle {

--- a/frontend/src/bootstrapShell.ts
+++ b/frontend/src/bootstrapShell.ts
@@ -1,0 +1,53 @@
+const READY_SELECTOR = '[data-app-shell-ready], .min-h-screen'
+const RECONNECTING_DELAY_MS = 8_000
+
+export interface BootstrapShellLifecycle {
+  disconnect: () => void
+}
+
+export function startBootstrapShellLifecycle(
+  rootElement: HTMLElement,
+  shellElement: HTMLElement | null,
+  reconnectingDelayMs = RECONNECTING_DELAY_MS,
+): BootstrapShellLifecycle {
+  if (!shellElement) {
+    return { disconnect: () => undefined }
+  }
+
+  const statusElement = shellElement.querySelector<HTMLElement>('[data-bootstrap-status]')
+  const removeShellWhenReady = () => {
+    if (!rootElement.querySelector(READY_SELECTOR)) {
+      return false
+    }
+
+    shellElement.remove()
+    return true
+  }
+
+  if (removeShellWhenReady()) {
+    return { disconnect: () => undefined }
+  }
+
+  const observer = new MutationObserver(() => {
+    if (removeShellWhenReady()) {
+      observer.disconnect()
+      window.clearTimeout(reconnectingTimer)
+    }
+  })
+
+  const reconnectingTimer = window.setTimeout(() => {
+    if (statusElement && shellElement.isConnected) {
+      statusElement.textContent = 'Still waking ComicPile. Your library is safe while services reconnect.'
+      statusElement.dataset.state = 'reconnecting'
+    }
+  }, reconnectingDelayMs)
+
+  observer.observe(rootElement, { childList: true, subtree: true })
+
+  return {
+    disconnect: () => {
+      observer.disconnect()
+      window.clearTimeout(reconnectingTimer)
+    },
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import AppErrorBoundary from './components/AppErrorBoundary'
 import { SessionProvider } from './contexts/SessionContext'
 import { ToastProvider } from './contexts/ToastProvider'
+import { startBootstrapShellLifecycle } from './bootstrapShell'
 import './index.css'
 import App from './App'
 
@@ -11,6 +12,9 @@ const rootElement = document.getElementById('root')
 if (!rootElement) {
   throw new Error('Root element not found')
 }
+
+const bootstrapShell = document.getElementById('bootstrap-shell')
+const bootstrapShellLifecycle = startBootstrapShellLifecycle(rootElement, bootstrapShell)
 
 createRoot(rootElement).render(
   <StrictMode>
@@ -25,3 +29,7 @@ createRoot(rootElement).render(
 )
 
 rootElement.classList.add('loaded')
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => bootstrapShellLifecycle.disconnect())
+}

--- a/frontend/src/unit/bootstrapShell.test.ts
+++ b/frontend/src/unit/bootstrapShell.test.ts
@@ -63,6 +63,31 @@ describe('startBootstrapShellLifecycle', () => {
     expect(document.getElementById('bootstrap-shell')).toBeNull()
   })
 
+  it('removes the shell immediately when the application is already ready', () => {
+    const root = document.getElementById('root') as HTMLElement
+    const shell = document.getElementById('bootstrap-shell') as HTMLElement
+    root.innerHTML = '<main data-app-shell-ready>Ready</main>'
+
+    const lifecycle = startBootstrapShellLifecycle(root, shell)
+
+    expect(document.getElementById('bootstrap-shell')).toBeNull()
+    expect(() => lifecycle.disconnect()).not.toThrow()
+  })
+
+  it('disconnects observation and cancels the reconnecting timer', async () => {
+    const root = document.getElementById('root') as HTMLElement
+    const shell = document.getElementById('bootstrap-shell') as HTMLElement
+    const lifecycle = startBootstrapShellLifecycle(root, shell, 100)
+
+    lifecycle.disconnect()
+    root.innerHTML = '<main data-app-shell-ready>Ready</main>'
+    await Promise.resolve()
+    vi.advanceTimersByTime(100)
+
+    expect(document.getElementById('bootstrap-shell')).toBe(shell)
+    expect(shell.querySelector<HTMLElement>('[data-bootstrap-status]')?.dataset.state).toBe('loading')
+  })
+
   it('is safe when the static shell is absent', () => {
     const root = document.getElementById('root') as HTMLElement
 

--- a/frontend/src/unit/bootstrapShell.test.ts
+++ b/frontend/src/unit/bootstrapShell.test.ts
@@ -28,7 +28,7 @@ describe('startBootstrapShellLifecycle', () => {
     expect(document.getElementById('bootstrap-shell')).toBe(shell)
   })
 
-  it('changes to a reconnecting message when bootstrap is slow', () => {
+  it('changes to a reconnecting message when bootstrap times out', () => {
     const root = document.getElementById('root') as HTMLElement
     const shell = document.getElementById('bootstrap-shell') as HTMLElement
 
@@ -38,14 +38,26 @@ describe('startBootstrapShellLifecycle', () => {
     const status = shell.querySelector<HTMLElement>('[data-bootstrap-status]')
     expect(status?.dataset.state).toBe('reconnecting')
     expect(status?.textContent).toContain('Still waking ComicPile')
+    expect(document.getElementById('bootstrap-shell')).toBe(shell)
   })
 
-  it('removes the static shell only after a real application layout renders', async () => {
+  it('does not treat a presentation class as application readiness', async () => {
     const root = document.getElementById('root') as HTMLElement
     const shell = document.getElementById('bootstrap-shell') as HTMLElement
 
     startBootstrapShellLifecycle(root, shell)
-    root.innerHTML = '<main class="min-h-screen">Ready</main>'
+    root.innerHTML = '<main class="min-h-screen">Still resolving</main>'
+    await Promise.resolve()
+
+    expect(document.getElementById('bootstrap-shell')).toBe(shell)
+  })
+
+  it('removes the static shell only after a resolved application layout renders', async () => {
+    const root = document.getElementById('root') as HTMLElement
+    const shell = document.getElementById('bootstrap-shell') as HTMLElement
+
+    startBootstrapShellLifecycle(root, shell)
+    root.innerHTML = '<main class="min-h-screen" data-app-shell-ready>Ready</main>'
     await Promise.resolve()
 
     expect(document.getElementById('bootstrap-shell')).toBeNull()

--- a/frontend/src/unit/bootstrapShell.test.ts
+++ b/frontend/src/unit/bootstrapShell.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { startBootstrapShellLifecycle } from '../bootstrapShell'
+
+describe('startBootstrapShellLifecycle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    document.body.innerHTML = `
+      <div id="bootstrap-shell">
+        <p data-bootstrap-status data-state="loading">Starting…</p>
+      </div>
+      <div id="root"></div>
+    `
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    document.body.innerHTML = ''
+  })
+
+  it('keeps the static shell while authentication is unresolved', async () => {
+    const root = document.getElementById('root') as HTMLElement
+    const shell = document.getElementById('bootstrap-shell') as HTMLElement
+
+    startBootstrapShellLifecycle(root, shell)
+    root.innerHTML = '<div>Checking authentication...</div>'
+    await Promise.resolve()
+
+    expect(document.getElementById('bootstrap-shell')).toBe(shell)
+  })
+
+  it('changes to a reconnecting message when bootstrap is slow', () => {
+    const root = document.getElementById('root') as HTMLElement
+    const shell = document.getElementById('bootstrap-shell') as HTMLElement
+
+    startBootstrapShellLifecycle(root, shell, 100)
+    vi.advanceTimersByTime(100)
+
+    const status = shell.querySelector<HTMLElement>('[data-bootstrap-status]')
+    expect(status?.dataset.state).toBe('reconnecting')
+    expect(status?.textContent).toContain('Still waking ComicPile')
+  })
+
+  it('removes the static shell only after a real application layout renders', async () => {
+    const root = document.getElementById('root') as HTMLElement
+    const shell = document.getElementById('bootstrap-shell') as HTMLElement
+
+    startBootstrapShellLifecycle(root, shell)
+    root.innerHTML = '<main class="min-h-screen">Ready</main>'
+    await Promise.resolve()
+
+    expect(document.getElementById('bootstrap-shell')).toBeNull()
+  })
+
+  it('is safe when the static shell is absent', () => {
+    const root = document.getElementById('root') as HTMLElement
+
+    expect(() => startBootstrapShellLifecycle(root, null).disconnect()).not.toThrow()
+  })
+})


### PR DESCRIPTION
Closes #830

## What changed
- render a branded ComicPile shell directly from static HTML before React or backend bootstrap completes
- keep the shell visible while authentication is unresolved
- change the status to a reconnecting message when startup is slow
- remove the shell only after a real public or authenticated application layout renders
- cover delayed, reconnecting, ready, and missing-shell behavior

## Validation
- Focused Vitest coverage added in `frontend/src/unit/bootstrapShell.test.ts`
- Full exact-head CI is required before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a branded ComicPile loading screen while the app starts.
  * Displays loading status text, an animated progress indicator, and navigation placeholders.
  * Supports reduced-motion preferences for a more accessible experience.
  * Automatically transitions to the application once it is ready.
  * Shows a reconnecting status when startup takes longer than expected.
* **Bug Fixes**
  * Improved handling when the application shell is unavailable, allowing startup to continue safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->