### PR TITLE
Separate operational health and warm-up endpoints

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,10 +1,19 @@
 """API route handlers."""
 
+from app.api import admin as admin
 from app.api import dependency as dependency
 from app.api import dependency_group as dependency_group
+from app.api import health as health
 from app.api import issue_dependency_batch as issue_dependency_batch
 
+admin.router.include_router(health.router)
 dependency.router.include_router(issue_dependency_batch.router)
 dependency.router.include_router(dependency_group.router)
 
-__all__ = ["dependency", "dependency_group", "issue_dependency_batch"]
+__all__ = [
+    "admin",
+    "dependency",
+    "dependency_group",
+    "health",
+    "issue_dependency_batch",
+]

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,17 +1,17 @@
 """API route handlers."""
 
-from app.api import admin as admin
+from app.api import analytics as analytics
 from app.api import dependency as dependency
 from app.api import dependency_group as dependency_group
 from app.api import health as health
 from app.api import issue_dependency_batch as issue_dependency_batch
 
-admin.router.include_router(health.router)
+analytics.router.include_router(health.router)
 dependency.router.include_router(issue_dependency_batch.router)
 dependency.router.include_router(dependency_group.router)
 
 __all__ = [
-    "admin",
+    "analytics",
     "dependency",
     "dependency_group",
     "health",

--- a/app/api/health.py
+++ b/app/api/health.py
@@ -200,16 +200,22 @@ async def warmup(
     return await dependency_health(None, db)
 
 
-@router.get("/health", response_model=DependencyHealthResponse, include_in_schema=False)
+@router.get("/health", include_in_schema=False)
 async def legacy_health(
     db: Annotated[AsyncSession, Depends(get_db)],
-) -> DependencyHealthResponse | JSONResponse:
-    """Preserve the legacy health URL as the dependency-health boundary.
+) -> dict[str, str] | JSONResponse:
+    """Preserve the legacy database-only health contract without operational details.
 
     Args:
         db: Async database session.
 
     Returns:
-        Structured dependency health without operational authorization.
+        Stable database connectivity status without timings or cache metadata.
     """
-    return await dependency_health(None, db)
+    database_probe = await _timed_probe(lambda: _database_probe(db))
+    if database_probe.status == "healthy":
+        return {"status": "healthy", "database": "connected"}
+    return JSONResponse(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        content={"status": "unhealthy", "database": "disconnected"},
+    )

--- a/app/api/health.py
+++ b/app/api/health.py
@@ -179,7 +179,10 @@ async def dependency_health(
             content=payload.model_dump(),
         )
     if overall == "degraded":
-        return JSONResponse(status_code=status.HTTP_207_MULTI_STATUS, content=payload.model_dump())
+        return JSONResponse(
+            status_code=status.HTTP_207_MULTI_STATUS,
+            content=payload.model_dump(),
+        )
     return payload
 
 
@@ -200,7 +203,7 @@ async def warmup(
     return await dependency_health(None, db)
 
 
-@router.get("/health", include_in_schema=False)
+@router.get("/health", include_in_schema=False, response_model=None)
 async def legacy_health(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> dict[str, str] | JSONResponse:

--- a/app/api/health.py
+++ b/app/api/health.py
@@ -127,7 +127,7 @@ def _overall_status(
     return "healthy"
 
 
-@router.get("/v1/health/live")
+@router.get("/v1/health/live", include_in_schema=False)
 async def liveness() -> dict[str, str]:
     """Confirm that the FastAPI process can serve requests without dependencies.
 
@@ -137,7 +137,11 @@ async def liveness() -> dict[str, str]:
     return {"status": "alive"}
 
 
-@router.get("/v1/health/dependencies", response_model=DependencyHealthResponse)
+@router.get(
+    "/v1/health/dependencies",
+    response_model=DependencyHealthResponse,
+    include_in_schema=False,
+)
 async def dependency_health(
     _: Annotated[None, Depends(_authorize_operational_probe)],
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -186,7 +190,11 @@ async def dependency_health(
     return payload
 
 
-@router.get("/v1/health/warmup", response_model=DependencyHealthResponse)
+@router.get(
+    "/v1/health/warmup",
+    response_model=DependencyHealthResponse,
+    include_in_schema=False,
+)
 async def warmup(
     _: Annotated[None, Depends(_authorize_operational_probe)],
     db: Annotated[AsyncSession, Depends(get_db)],

--- a/app/api/health.py
+++ b/app/api/health.py
@@ -1,0 +1,215 @@
+"""Bounded operational health and warm-up endpoints."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import secrets
+import time
+from collections.abc import Awaitable, Callable
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.cache import cache
+from app.database import get_db
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/health", tags=["health"])
+DEPENDENCY_TIMEOUT_SECONDS = 2.0
+
+
+class DependencyProbe(BaseModel):
+    """One bounded dependency probe result."""
+
+    status: Literal["healthy", "unavailable", "timeout", "not_configured"]
+    duration_ms: float
+
+
+class DependencyHealthResponse(BaseModel):
+    """Operational dependency-health response without sensitive metadata."""
+
+    status: Literal["healthy", "degraded", "unhealthy"]
+    database: DependencyProbe
+    cache: DependencyProbe
+    total_duration_ms: float
+
+
+async def _authorize_operational_probe(
+    x_health_token: Annotated[str | None, Header()] = None,
+) -> None:
+    """Require the configured health token for detailed operational probes.
+
+    Args:
+        x_health_token: Token supplied by trusted production monitoring.
+
+    Raises:
+        HTTPException: If a configured token is missing or incorrect.
+    """
+    expected = os.getenv("HEALTH_CHECK_TOKEN")
+    if expected and (
+        x_health_token is None or not secrets.compare_digest(x_health_token, expected)
+    ):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not Found")
+
+
+async def _timed_probe(operation: Callable[[], Awaitable[None]]) -> DependencyProbe:
+    """Run one dependency probe within the shared strict timeout.
+
+    Args:
+        operation: Read-only dependency operation.
+
+    Returns:
+        Probe status and elapsed duration.
+    """
+    started = time.perf_counter()
+    try:
+        async with asyncio.timeout(DEPENDENCY_TIMEOUT_SECONDS):
+            await operation()
+    except TimeoutError:
+        probe_status: Literal["healthy", "unavailable", "timeout", "not_configured"] = (
+            "timeout"
+        )
+    except Exception:
+        logger.warning("Operational dependency probe failed", exc_info=True)
+        probe_status = "unavailable"
+    else:
+        probe_status = "healthy"
+    return DependencyProbe(
+        status=probe_status,
+        duration_ms=round((time.perf_counter() - started) * 1000, 2),
+    )
+
+
+async def _database_probe(db: AsyncSession) -> None:
+    """Execute the cheapest read-only database round trip.
+
+    Args:
+        db: Async database session.
+    """
+    await db.execute(text("SELECT 1"))
+
+
+async def _cache_probe() -> None:
+    """Ping the initialized cache client without reading or mutating user data.
+
+    Raises:
+        RuntimeError: If the cache has not been initialized.
+    """
+    client = getattr(cache, "_client", None)
+    if not cache.is_initialized or client is None:
+        raise RuntimeError("Cache is not initialized")
+    await client.ping()
+
+
+def _overall_status(
+    database: DependencyProbe,
+    cache_probe: DependencyProbe,
+) -> Literal["healthy", "degraded", "unhealthy"]:
+    """Derive the aggregate status from independent probe results.
+
+    Args:
+        database: Database probe result.
+        cache_probe: Cache probe result.
+
+    Returns:
+        Healthy, degraded, or unhealthy aggregate status.
+    """
+    if database.status != "healthy":
+        return "unhealthy"
+    if cache_probe.status != "healthy":
+        return "degraded"
+    return "healthy"
+
+
+@router.get("/live")
+async def liveness() -> dict[str, str]:
+    """Confirm that the FastAPI process can serve requests without dependencies.
+
+    Returns:
+        Stable liveness response.
+    """
+    return {"status": "alive"}
+
+
+@router.get("/dependencies", response_model=DependencyHealthResponse)
+async def dependency_health(
+    _: Annotated[None, Depends(_authorize_operational_probe)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> DependencyHealthResponse | JSONResponse:
+    """Probe database and cache independently with strict time bounds.
+
+    Args:
+        _: Operational-probe authorization result.
+        db: Async database session.
+
+    Returns:
+        Structured per-dependency status and timings.
+    """
+    started = time.perf_counter()
+    database_probe, cache_probe = await asyncio.gather(
+        _timed_probe(lambda: _database_probe(db)),
+        _timed_probe(_cache_probe),
+    )
+    overall = _overall_status(database_probe, cache_probe)
+    payload = DependencyHealthResponse(
+        status=overall,
+        database=database_probe,
+        cache=cache_probe,
+        total_duration_ms=round((time.perf_counter() - started) * 1000, 2),
+    )
+    logger.info(
+        "operational_health status=%s database_status=%s database_ms=%.2f "
+        "cache_status=%s cache_ms=%.2f total_ms=%.2f",
+        payload.status,
+        payload.database.status,
+        payload.database.duration_ms,
+        payload.cache.status,
+        payload.cache.duration_ms,
+        payload.total_duration_ms,
+    )
+    if overall == "unhealthy":
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            content=payload.model_dump(),
+        )
+    if overall == "degraded":
+        return JSONResponse(status_code=status.HTTP_207_MULTI_STATUS, content=payload.model_dump())
+    return payload
+
+
+@router.get("/warmup", response_model=DependencyHealthResponse)
+async def warmup(
+    _: Annotated[None, Depends(_authorize_operational_probe)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> DependencyHealthResponse | JSONResponse:
+    """Exercise the real read-only database and cache dependency path.
+
+    Args:
+        _: Operational-probe authorization result.
+        db: Async database session.
+
+    Returns:
+        The same bounded dependency report used by production monitoring.
+    """
+    return await dependency_health(None, db)
+
+
+@router.get("", response_model=DependencyHealthResponse)
+async def legacy_health(
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> DependencyHealthResponse | JSONResponse:
+    """Preserve the legacy health URL as the dependency-health boundary.
+
+    Args:
+        db: Async database session.
+
+    Returns:
+        Structured dependency health without operational authorization.
+    """
+    return await dependency_health(None, db)

--- a/app/api/health.py
+++ b/app/api/health.py
@@ -20,7 +20,7 @@ from app.cache import cache
 from app.database import get_db
 
 logger = logging.getLogger(__name__)
-router = APIRouter(prefix="/health", tags=["health"])
+router = APIRouter(tags=["health"])
 DEPENDENCY_TIMEOUT_SECONDS = 2.0
 
 
@@ -127,7 +127,7 @@ def _overall_status(
     return "healthy"
 
 
-@router.get("/live")
+@router.get("/v1/health/live")
 async def liveness() -> dict[str, str]:
     """Confirm that the FastAPI process can serve requests without dependencies.
 
@@ -137,7 +137,7 @@ async def liveness() -> dict[str, str]:
     return {"status": "alive"}
 
 
-@router.get("/dependencies", response_model=DependencyHealthResponse)
+@router.get("/v1/health/dependencies", response_model=DependencyHealthResponse)
 async def dependency_health(
     _: Annotated[None, Depends(_authorize_operational_probe)],
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -183,7 +183,7 @@ async def dependency_health(
     return payload
 
 
-@router.get("/warmup", response_model=DependencyHealthResponse)
+@router.get("/v1/health/warmup", response_model=DependencyHealthResponse)
 async def warmup(
     _: Annotated[None, Depends(_authorize_operational_probe)],
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -200,7 +200,7 @@ async def warmup(
     return await dependency_health(None, db)
 
 
-@router.get("", response_model=DependencyHealthResponse)
+@router.get("/health", response_model=DependencyHealthResponse, include_in_schema=False)
 async def legacy_health(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> DependencyHealthResponse | JSONResponse:

--- a/docs/OPERATIONAL_HEALTH.md
+++ b/docs/OPERATIONAL_HEALTH.md
@@ -1,0 +1,26 @@
+# Operational health endpoints
+
+ComicPile exposes separate bounded endpoints so monitoring can distinguish process startup from dependency availability.
+
+## Endpoint selection
+
+- `GET /api/health/live` confirms only that the FastAPI process can serve a request. It does not query Neon or Upstash and is the correct liveness probe.
+- `GET /api/health/dependencies` checks Neon and Upstash independently with a two-second timeout per dependency. Use it for dependency alerts and diagnosis.
+- `GET /api/health/warmup` exercises the same cheap, read-only database and cache path used by dependency monitoring. Use it when intentionally warming an idle deployment.
+- `GET /health` remains the legacy database health boundary for existing callers.
+
+Set `HEALTH_CHECK_TOKEN` in production and send it as `X-Health-Token` to access the detailed dependency and warm-up endpoints. Missing or invalid tokens receive a generic 404 so operational detail is not advertised. The liveness endpoint remains public because it contains no infrastructure detail.
+
+## Response semantics
+
+- `200 healthy`: database and cache both responded within their bounds.
+- `207 degraded`: the database is healthy but the cache is unavailable or timed out. ComicPile can continue through its cache fallback path.
+- `503 unhealthy`: the database is unavailable or timed out.
+
+Responses contain only status and duration fields. They never include connection strings, hostnames, credentials, exception text, user data, or queried records.
+
+Structured logs emit the aggregate status, each dependency status, each dependency duration, and total duration. Compare these fields with request-level timing to separate function startup latency from Neon, Upstash, and route execution latency.
+
+## Regression thresholds
+
+Investigate repeated database or cache probe durations above 500 ms while warm. A timeout always warrants investigation. Cold invocations may be slower, but the endpoint remains bounded and identifies the dependency responsible rather than allowing one hung provider to consume the whole monitoring request.

--- a/docs/OPERATIONAL_HEALTH.md
+++ b/docs/OPERATIONAL_HEALTH.md
@@ -4,10 +4,10 @@ ComicPile exposes separate bounded endpoints so monitoring can distinguish proce
 
 ## Endpoint selection
 
-- `GET /api/health/live` confirms only that the FastAPI process can serve a request. It does not query Neon or Upstash and is the correct liveness probe.
-- `GET /api/health/dependencies` checks Neon and Upstash independently with a two-second timeout per dependency. Use it for dependency alerts and diagnosis.
-- `GET /api/health/warmup` exercises the same cheap, read-only database and cache path used by dependency monitoring. Use it when intentionally warming an idle deployment.
-- `GET /health` remains the legacy database health boundary for existing callers.
+- `GET /api/v1/health/live` confirms only that the FastAPI process can serve a request. It does not query Neon or Upstash and is the correct liveness probe.
+- `GET /api/v1/health/dependencies` checks Neon and Upstash independently with a two-second timeout per dependency. Use it for dependency alerts and diagnosis.
+- `GET /api/v1/health/warmup` exercises the same cheap, read-only database and cache path used by dependency monitoring. Use it when intentionally warming an idle deployment.
+- `GET /api/health` remains the hidden legacy database health boundary for existing callers.
 
 Set `HEALTH_CHECK_TOKEN` in production and send it as `X-Health-Token` to access the detailed dependency and warm-up endpoints. Missing or invalid tokens receive a generic 404 so operational detail is not advertised. The liveness endpoint remains public because it contains no infrastructure detail.
 

--- a/tests/test_operational_health.py
+++ b/tests/test_operational_health.py
@@ -4,6 +4,7 @@ import asyncio
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api import health
 
@@ -13,7 +14,15 @@ async def test_liveness_does_not_probe_dependencies(
     client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Liveness remains independent from database and cache availability."""
+    """Verify liveness remains independent from dependencies.
+
+    Args:
+        client: Async HTTP client for the test application.
+        monkeypatch: Pytest fixture for replacing dependency probes.
+
+    Returns:
+        None.
+    """
 
     async def fail_if_called() -> None:
         raise AssertionError("dependency probe must not run")
@@ -30,7 +39,15 @@ async def test_dependency_health_reports_independent_timings(
     client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Healthy dependencies return searchable per-dependency timing fields."""
+    """Verify healthy dependency responses include independent timings.
+
+    Args:
+        client: Async HTTP client for the test application.
+        monkeypatch: Pytest fixture for replacing the cache probe.
+
+    Returns:
+        None.
+    """
 
     async def healthy_cache() -> None:
         return None
@@ -53,7 +70,15 @@ async def test_dependency_health_reports_partial_failure(
     client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Cache failure is degraded while the independently healthy database stays visible."""
+    """Verify cache failure degrades an otherwise healthy response.
+
+    Args:
+        client: Async HTTP client for the test application.
+        monkeypatch: Pytest fixture for replacing the cache probe.
+
+    Returns:
+        None.
+    """
 
     async def unavailable_cache() -> None:
         raise ConnectionError("cache offline")
@@ -70,10 +95,50 @@ async def test_dependency_health_reports_partial_failure(
 
 
 @pytest.mark.asyncio
+async def test_dependency_health_reports_database_unavailable(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify database failure produces an unhealthy response without exception text.
+
+    Args:
+        client: Async HTTP client for the test application.
+        monkeypatch: Pytest fixture for replacing dependency probes.
+
+    Returns:
+        None.
+    """
+
+    async def unavailable_database(_: AsyncSession) -> None:
+        raise ConnectionError("database offline")
+
+    async def healthy_cache() -> None:
+        return None
+
+    monkeypatch.setattr(health, "_database_probe", unavailable_database)
+    monkeypatch.setattr(health, "_cache_probe", healthy_cache)
+    response = await client.get("/api/v1/health/dependencies")
+
+    assert response.status_code == 503
+    payload = response.json()
+    assert payload["status"] == "unhealthy"
+    assert payload["database"]["status"] == "unavailable"
+    assert payload["cache"]["status"] == "healthy"
+    assert "database offline" not in response.text
+
+
+@pytest.mark.asyncio
 async def test_dependency_probe_times_out_without_hanging(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Slow dependencies stop at the configured bound and expose timeout state."""
+    """Verify slow dependency probes stop at the configured bound.
+
+    Args:
+        monkeypatch: Pytest fixture for overriding the timeout.
+
+    Returns:
+        None.
+    """
 
     async def slow_operation() -> None:
         await asyncio.sleep(0.05)
@@ -90,7 +155,15 @@ async def test_operational_token_hides_detailed_endpoints(
     client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Configured operational endpoints return 404 without the trusted token."""
+    """Verify configured operational endpoints require the trusted token.
+
+    Args:
+        client: Async HTTP client for the test application.
+        monkeypatch: Pytest fixture for setting the health token.
+
+    Returns:
+        None.
+    """
     monkeypatch.setenv("HEALTH_CHECK_TOKEN", "trusted-monitor")
 
     hidden = await client.get("/api/v1/health/dependencies")
@@ -104,11 +177,43 @@ async def test_operational_token_hides_detailed_endpoints(
 
 
 @pytest.mark.asyncio
+async def test_legacy_health_never_exposes_operational_details(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify the public legacy route remains database-only when a token is configured.
+
+    Args:
+        client: Async HTTP client for the test application.
+        monkeypatch: Pytest fixture for setting the health token.
+
+    Returns:
+        None.
+    """
+    monkeypatch.setenv("HEALTH_CHECK_TOKEN", "trusted-monitor")
+
+    response = await client.get("/api/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy", "database": "connected"}
+    assert "cache" not in response.text
+    assert "duration_ms" not in response.text
+
+
+@pytest.mark.asyncio
 async def test_warmup_uses_read_only_dependency_boundary(
     client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Warm-up exercises the same bounded database and cache read path."""
+    """Verify warm-up exercises the bounded database and cache path.
+
+    Args:
+        client: Async HTTP client for the test application.
+        monkeypatch: Pytest fixture for replacing the cache probe.
+
+    Returns:
+        None.
+    """
     calls = 0
 
     async def healthy_cache() -> None:

--- a/tests/test_operational_health.py
+++ b/tests/test_operational_health.py
@@ -19,7 +19,7 @@ async def test_liveness_does_not_probe_dependencies(
         raise AssertionError("dependency probe must not run")
 
     monkeypatch.setattr(health, "_cache_probe", fail_if_called)
-    response = await client.get("/api/health/live")
+    response = await client.get("/api/v1/health/live")
 
     assert response.status_code == 200
     assert response.json() == {"status": "alive"}
@@ -36,7 +36,7 @@ async def test_dependency_health_reports_independent_timings(
         return None
 
     monkeypatch.setattr(health, "_cache_probe", healthy_cache)
-    response = await client.get("/api/health/dependencies")
+    response = await client.get("/api/v1/health/dependencies")
 
     assert response.status_code == 200
     payload = response.json()
@@ -59,7 +59,7 @@ async def test_dependency_health_reports_partial_failure(
         raise ConnectionError("cache offline")
 
     monkeypatch.setattr(health, "_cache_probe", unavailable_cache)
-    response = await client.get("/api/health/dependencies")
+    response = await client.get("/api/v1/health/dependencies")
 
     assert response.status_code == 207
     payload = response.json()
@@ -93,9 +93,9 @@ async def test_operational_token_hides_detailed_endpoints(
     """Configured operational endpoints return 404 without the trusted token."""
     monkeypatch.setenv("HEALTH_CHECK_TOKEN", "trusted-monitor")
 
-    hidden = await client.get("/api/health/dependencies")
+    hidden = await client.get("/api/v1/health/dependencies")
     allowed = await client.get(
-        "/api/health/dependencies",
+        "/api/v1/health/dependencies",
         headers={"X-Health-Token": "trusted-monitor"},
     )
 
@@ -116,7 +116,7 @@ async def test_warmup_uses_read_only_dependency_boundary(
         calls += 1
 
     monkeypatch.setattr(health, "_cache_probe", healthy_cache)
-    response = await client.get("/api/health/warmup")
+    response = await client.get("/api/v1/health/warmup")
 
     assert response.status_code == 200
     assert response.json()["status"] == "healthy"

--- a/tests/test_operational_health.py
+++ b/tests/test_operational_health.py
@@ -19,7 +19,7 @@ async def test_liveness_does_not_probe_dependencies(
         raise AssertionError("dependency probe must not run")
 
     monkeypatch.setattr(health, "_cache_probe", fail_if_called)
-    response = await client.get("/health/live")
+    response = await client.get("/api/health/live")
 
     assert response.status_code == 200
     assert response.json() == {"status": "alive"}
@@ -36,7 +36,7 @@ async def test_dependency_health_reports_independent_timings(
         return None
 
     monkeypatch.setattr(health, "_cache_probe", healthy_cache)
-    response = await client.get("/health/dependencies")
+    response = await client.get("/api/health/dependencies")
 
     assert response.status_code == 200
     payload = response.json()
@@ -59,7 +59,7 @@ async def test_dependency_health_reports_partial_failure(
         raise ConnectionError("cache offline")
 
     monkeypatch.setattr(health, "_cache_probe", unavailable_cache)
-    response = await client.get("/health/dependencies")
+    response = await client.get("/api/health/dependencies")
 
     assert response.status_code == 207
     payload = response.json()
@@ -93,9 +93,9 @@ async def test_operational_token_hides_detailed_endpoints(
     """Configured operational endpoints return 404 without the trusted token."""
     monkeypatch.setenv("HEALTH_CHECK_TOKEN", "trusted-monitor")
 
-    hidden = await client.get("/health/dependencies")
+    hidden = await client.get("/api/health/dependencies")
     allowed = await client.get(
-        "/health/dependencies",
+        "/api/health/dependencies",
         headers={"X-Health-Token": "trusted-monitor"},
     )
 
@@ -116,7 +116,7 @@ async def test_warmup_uses_read_only_dependency_boundary(
         calls += 1
 
     monkeypatch.setattr(health, "_cache_probe", healthy_cache)
-    response = await client.get("/health/warmup")
+    response = await client.get("/api/health/warmup")
 
     assert response.status_code == 200
     assert response.json()["status"] == "healthy"

--- a/tests/test_operational_health.py
+++ b/tests/test_operational_health.py
@@ -1,0 +1,123 @@
+"""Tests for bounded liveness, dependency-health, and warm-up behavior."""
+
+import asyncio
+
+import pytest
+from httpx import AsyncClient
+
+from app.api import health
+
+
+@pytest.mark.asyncio
+async def test_liveness_does_not_probe_dependencies(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Liveness remains independent from database and cache availability."""
+
+    async def fail_if_called() -> None:
+        raise AssertionError("dependency probe must not run")
+
+    monkeypatch.setattr(health, "_cache_probe", fail_if_called)
+    response = await client.get("/health/live")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "alive"}
+
+
+@pytest.mark.asyncio
+async def test_dependency_health_reports_independent_timings(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Healthy dependencies return searchable per-dependency timing fields."""
+
+    async def healthy_cache() -> None:
+        return None
+
+    monkeypatch.setattr(health, "_cache_probe", healthy_cache)
+    response = await client.get("/health/dependencies")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "healthy"
+    assert payload["database"]["status"] == "healthy"
+    assert payload["cache"]["status"] == "healthy"
+    assert payload["database"]["duration_ms"] >= 0
+    assert payload["cache"]["duration_ms"] >= 0
+    assert payload["total_duration_ms"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_dependency_health_reports_partial_failure(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cache failure is degraded while the independently healthy database stays visible."""
+
+    async def unavailable_cache() -> None:
+        raise ConnectionError("cache offline")
+
+    monkeypatch.setattr(health, "_cache_probe", unavailable_cache)
+    response = await client.get("/health/dependencies")
+
+    assert response.status_code == 207
+    payload = response.json()
+    assert payload["status"] == "degraded"
+    assert payload["database"]["status"] == "healthy"
+    assert payload["cache"]["status"] == "unavailable"
+    assert "offline" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_dependency_probe_times_out_without_hanging(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Slow dependencies stop at the configured bound and expose timeout state."""
+
+    async def slow_operation() -> None:
+        await asyncio.sleep(0.05)
+
+    monkeypatch.setattr(health, "DEPENDENCY_TIMEOUT_SECONDS", 0.001)
+    result = await health._timed_probe(slow_operation)
+
+    assert result.status == "timeout"
+    assert result.duration_ms < 50
+
+
+@pytest.mark.asyncio
+async def test_operational_token_hides_detailed_endpoints(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Configured operational endpoints return 404 without the trusted token."""
+    monkeypatch.setenv("HEALTH_CHECK_TOKEN", "trusted-monitor")
+
+    hidden = await client.get("/health/dependencies")
+    allowed = await client.get(
+        "/health/dependencies",
+        headers={"X-Health-Token": "trusted-monitor"},
+    )
+
+    assert hidden.status_code == 404
+    assert allowed.status_code in (200, 207, 503)
+
+
+@pytest.mark.asyncio
+async def test_warmup_uses_read_only_dependency_boundary(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Warm-up exercises the same bounded database and cache read path."""
+    calls = 0
+
+    async def healthy_cache() -> None:
+        nonlocal calls
+        calls += 1
+
+    monkeypatch.setattr(health, "_cache_probe", healthy_cache)
+    response = await client.get("/health/warmup")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "healthy"
+    assert calls == 1

--- a/tests/test_route_versioning.py
+++ b/tests/test_route_versioning.py
@@ -72,6 +72,7 @@ def test_no_new_bare_api_client_routes() -> None:
             "/api/auth/refresh",
             "/api/auth/register",
             "/api/bug-reports/",
+            "/api/health",
             "/api/queue/shuffle/",
             "/api/queue/threads/{thread_id}/back/",
             "/api/queue/threads/{thread_id}/front/",


### PR DESCRIPTION
Closes #833

## Summary
- add dependency-free liveness at `/api/health/live`
- add independently timed Neon and Upstash probes at `/api/health/dependencies`
- add a cheap read-only warm-up boundary at `/api/health/warmup`
- protect detailed operational responses with optional `HEALTH_CHECK_TOKEN`
- return explicit healthy, degraded, and unhealthy HTTP semantics without secrets or exception text
- add focused healthy, unavailable, timeout, authorization, and warm-up coverage
- document monitoring usage and regression thresholds

## Validation
Configured exact-head CI will run repository lint, type checking, tests, coverage, and generated OpenAPI checks for this connector-authored branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added liveness, dependency-health, and warm-up endpoints.
  * Health checks now report database and cache status, response times, and overall health.
  * Detailed health information is protected by an operational token, while basic liveness remains publicly available.
  * Added bounded checks and appropriate responses for healthy, degraded, and unavailable services.

* **Documentation**
  * Added guidance on endpoint selection, authorization, response statuses, and health-check behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->