### PR TITLE
Track production performance history and regressions

### DIFF
--- a/.github/workflows/production-performance.yml
+++ b/.github/workflows/production-performance.yml
@@ -18,7 +18,6 @@ jobs:
     timeout-minutes: 10
     env:
       PROD_BASE_URL: https://comic-pile.vercel.app
-      PROD_PROFILE_STORAGE_STATE: ${{ runner.temp }}/production-storage-state.json
       PROD_PERFORMANCE_OUTPUT: ../test-results/production-performance.json
       PROD_DEPLOYMENT_ID: ${{ github.sha }}
     steps:
@@ -54,8 +53,10 @@ jobs:
             echo 'Missing PROD_E2E_STORAGE_STATE_JSON repository secret.' >&2
             exit 1
           fi
-          printf '%s' "$STORAGE_STATE_JSON" > "$PROD_PROFILE_STORAGE_STATE"
-          chmod 600 "$PROD_PROFILE_STORAGE_STATE"
+          storage_state_path="$RUNNER_TEMP/production-storage-state.json"
+          printf '%s' "$STORAGE_STATE_JSON" > "$storage_state_path"
+          chmod 600 "$storage_state_path"
+          echo "PROD_PROFILE_STORAGE_STATE=$storage_state_path" >> "$GITHUB_ENV"
 
       - name: Install frontend dependencies
         working-directory: frontend

--- a/.github/workflows/production-performance.yml
+++ b/.github/workflows/production-performance.yml
@@ -1,0 +1,98 @@
+name: Production Performance
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 */6 * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-performance
+  cancel-in-progress: false
+
+jobs:
+  measure:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      PROD_BASE_URL: https://comic-pile.vercel.app
+      PROD_PROFILE_STORAGE_STATE: ${{ runner.temp }}/production-storage-state.json
+      PROD_PERFORMANCE_OUTPUT: ../test-results/production-performance.json
+      PROD_DEPLOYMENT_ID: ${{ github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+
+      - name: Restore bounded performance history
+        uses: actions/cache/restore@v4
+        with:
+          path: test-results/production-performance-history.jsonl
+          key: production-performance-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            production-performance-
+
+      - name: Prepare authenticated storage state
+        env:
+          STORAGE_STATE_JSON: ${{ secrets.PROD_E2E_STORAGE_STATE_JSON }}
+        run: |
+          if [ -z "$STORAGE_STATE_JSON" ]; then
+            echo 'Missing PROD_E2E_STORAGE_STATE_JSON repository secret.' >&2
+            exit 1
+          fi
+          printf '%s' "$STORAGE_STATE_JSON" > "$PROD_PROFILE_STORAGE_STATE"
+          chmod 600 "$PROD_PROFILE_STORAGE_STATE"
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Chromium
+        working-directory: frontend
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Measure production milestones
+        working-directory: frontend
+        run: pnpm exec playwright test --config=playwright.prod-performance.config.ts
+
+      - name: Append history and detect regressions
+        run: |
+          python scripts/update_production_performance_history.py \
+            --sample test-results/production-performance.json \
+            --history test-results/production-performance-history.jsonl \
+            --summary test-results/production-performance-summary.md
+          cat test-results/production-performance-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Save bounded performance history
+        if: success()
+        uses: actions/cache/save@v4
+        with:
+          path: test-results/production-performance-history.jsonl
+          key: production-performance-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Upload measurement evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-performance-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            test-results/production-performance.json
+            test-results/production-performance-history.jsonl
+            test-results/production-performance-summary.md
+            playwright-report-prod-performance
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/production-performance.yml
+++ b/.github/workflows/production-performance.yml
@@ -22,6 +22,8 @@ jobs:
       PROD_DEPLOYMENT_ID: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v4
         with:

--- a/frontend/playwright.prod-performance.config.ts
+++ b/frontend/playwright.prod-performance.config.ts
@@ -1,0 +1,44 @@
+import { existsSync } from 'node:fs'
+import { defineConfig, devices } from '@playwright/test'
+
+const baseURL = process.env.PROD_BASE_URL ?? process.env.BASE_URL
+const storageState = process.env.PROD_PROFILE_STORAGE_STATE
+
+if (!baseURL) {
+  throw new Error('Set PROD_BASE_URL (or BASE_URL) to run the production performance probe.')
+}
+
+if (!storageState || !existsSync(storageState)) {
+  throw new Error('Set PROD_PROFILE_STORAGE_STATE to an existing Playwright storage-state file.')
+}
+
+export default defineConfig({
+  testDir: './src/test',
+  testMatch: 'production-performance.spec.ts',
+  fullyParallel: false,
+  retries: 1,
+  workers: 1,
+  timeout: 2 * 60 * 1000,
+  reporter: [
+    ['list'],
+    ['html', { open: 'never', outputFolder: '../playwright-report-prod-performance' }],
+  ],
+  use: {
+    baseURL,
+    storageState,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'off',
+    actionTimeout: 30_000,
+    navigationTimeout: 60_000,
+  },
+  expect: {
+    timeout: 60_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})

--- a/frontend/src/test/production-performance.spec.ts
+++ b/frontend/src/test/production-performance.spec.ts
@@ -16,6 +16,11 @@ type PerformanceSample = {
   serverTiming: string | null
 }
 
+type TimedResponse = {
+  response: Response
+  arrivedAtMs: number
+}
+
 const outputPath = process.env.PROD_PERFORMANCE_OUTPUT ?? '../test-results/production-performance.json'
 
 function elapsedSince(startedAt: number): number {
@@ -30,16 +35,17 @@ function classifyInvocation(serverTiming: string | null): PerformanceSample['cla
   return 'unknown'
 }
 
-async function waitForFirstApiResponse(page: Page): Promise<Response> {
-  return page.waitForResponse((response) => {
-    const path = new URL(response.url()).pathname
-    return path.startsWith('/api/') && response.request().resourceType() !== 'document'
+async function waitForFirstApiResponse(page: Page, startedAt: number): Promise<TimedResponse> {
+  const response = await page.waitForResponse((candidate) => {
+    const path = new URL(candidate.url()).pathname
+    return path.startsWith('/api/') && candidate.request().resourceType() !== 'document'
   })
+  return { response, arrivedAtMs: elapsedSince(startedAt) }
 }
 
 test('records production startup and queue milestones', async ({ page }, testInfo) => {
   const startedAt = performance.now()
-  const firstApiResponsePromise = waitForFirstApiResponse(page)
+  const firstApiResponsePromise = waitForFirstApiResponse(page, startedAt)
 
   const documentResponse = await page.goto('/', { waitUntil: 'domcontentloaded' })
   expect(documentResponse, 'Initial document response').not.toBeNull()
@@ -55,9 +61,8 @@ test('records production startup and queue milestones', async ({ page }, testInf
   await expect(page.locator('[data-app-shell-ready="true"]')).toBeVisible({ timeout: 60_000 })
   const shellReadyMs = elapsedSince(startedAt)
 
-  const firstApiResponse = await firstApiResponsePromise
-  await firstApiResponse.finished()
-  const firstApiResponseMs = elapsedSince(startedAt)
+  const { response: firstApiResponse, arrivedAtMs: firstApiResponseMs } =
+    await firstApiResponsePromise
   const firstApiHeaders = await firstApiResponse.allHeaders()
   const serverTiming = firstApiHeaders['server-timing'] ?? null
 
@@ -87,5 +92,6 @@ test('records production startup and queue milestones', async ({ page }, testInf
   })
 
   expect(sample.documentResponseMs).toBeGreaterThanOrEqual(0)
+  expect(sample.firstApiResponseMs).toBeGreaterThanOrEqual(0)
   expect(sample.firstApiStatus).toBeLessThan(400)
 })

--- a/frontend/src/test/production-performance.spec.ts
+++ b/frontend/src/test/production-performance.spec.ts
@@ -1,0 +1,91 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { expect, test, type Page, type Response } from '@playwright/test'
+
+type PerformanceSample = {
+  capturedAt: string
+  deploymentId: string
+  runAttempt: string
+  classification: 'cold' | 'warm' | 'unknown'
+  documentResponseMs: number
+  shellReadyMs: number
+  firstApiResponseMs: number
+  queueReadyMs: number
+  firstApiPath: string | null
+  firstApiStatus: number | null
+  serverTiming: string | null
+}
+
+const outputPath = process.env.PROD_PERFORMANCE_OUTPUT ?? '../test-results/production-performance.json'
+
+function elapsedSince(startedAt: number): number {
+  return Math.round(performance.now() - startedAt)
+}
+
+function classifyInvocation(serverTiming: string | null): PerformanceSample['classification'] {
+  if (!serverTiming) return 'unknown'
+  const normalized = serverTiming.toLowerCase()
+  if (normalized.includes('cold')) return 'cold'
+  if (normalized.includes('warm')) return 'warm'
+  return 'unknown'
+}
+
+async function waitForFirstApiResponse(page: Page): Promise<Response> {
+  return page.waitForResponse((response) => {
+    const path = new URL(response.url()).pathname
+    return path.startsWith('/api/') && response.request().resourceType() !== 'document'
+  })
+}
+
+test('records production startup and queue milestones', async ({ page }, testInfo) => {
+  const startedAt = performance.now()
+  const firstApiResponsePromise = waitForFirstApiResponse(page)
+
+  const documentResponse = await page.goto('/', { waitUntil: 'domcontentloaded' })
+  expect(documentResponse, 'Initial document response').not.toBeNull()
+
+  const navigation = await page.evaluate(() => {
+    const [entry] = performance.getEntriesByType('navigation') as PerformanceNavigationTiming[]
+    return entry
+      ? { responseStart: entry.responseStart, startTime: entry.startTime }
+      : { responseStart: 0, startTime: 0 }
+  })
+  const documentResponseMs = Math.round(navigation.responseStart - navigation.startTime)
+
+  await expect(page.locator('[data-app-shell-ready="true"]')).toBeVisible({ timeout: 60_000 })
+  const shellReadyMs = elapsedSince(startedAt)
+
+  const firstApiResponse = await firstApiResponsePromise
+  await firstApiResponse.finished()
+  const firstApiResponseMs = elapsedSince(startedAt)
+  const firstApiHeaders = await firstApiResponse.allHeaders()
+  const serverTiming = firstApiHeaders['server-timing'] ?? null
+
+  await page.goto('/queue', { waitUntil: 'domcontentloaded' })
+  await expect(page.getByRole('heading', { name: 'Read Queue' })).toBeVisible({ timeout: 60_000 })
+  const queueReadyMs = elapsedSince(startedAt)
+
+  const sample: PerformanceSample = {
+    capturedAt: new Date().toISOString(),
+    deploymentId: process.env.PROD_DEPLOYMENT_ID ?? process.env.GITHUB_SHA ?? 'unknown',
+    runAttempt: process.env.GITHUB_RUN_ATTEMPT ?? 'local',
+    classification: classifyInvocation(serverTiming),
+    documentResponseMs,
+    shellReadyMs,
+    firstApiResponseMs,
+    queueReadyMs,
+    firstApiPath: new URL(firstApiResponse.url()).pathname,
+    firstApiStatus: firstApiResponse.status(),
+    serverTiming,
+  }
+
+  await mkdir(dirname(outputPath), { recursive: true })
+  await writeFile(outputPath, `${JSON.stringify(sample, null, 2)}\n`, 'utf8')
+  await testInfo.attach('production-performance.json', {
+    body: Buffer.from(JSON.stringify(sample, null, 2)),
+    contentType: 'application/json',
+  })
+
+  expect(sample.documentResponseMs).toBeGreaterThanOrEqual(0)
+  expect(sample.firstApiStatus).toBeLessThan(400)
+})

--- a/scripts/update_production_performance_history.py
+++ b/scripts/update_production_performance_history.py
@@ -191,7 +191,14 @@ def build_summary(history: list[Sample], sample: Sample) -> str:
 
 
 def main() -> None:
-    """Append the current sample and write comparison output."""
+    """Append the current sample and write comparison output.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+    """
     args = parse_args()
     sample = load_sample(args.sample)
     history = load_history(args.history)

--- a/scripts/update_production_performance_history.py
+++ b/scripts/update_production_performance_history.py
@@ -7,7 +7,7 @@ import argparse
 import json
 import statistics
 from pathlib import Path
-from typing import TypedDict
+from typing import TypedDict, cast
 
 
 class Sample(TypedDict):
@@ -32,6 +32,7 @@ METRICS = (
     "firstApiResponseMs",
     "queueReadyMs",
 )
+CLASSIFICATIONS = {"cold", "warm", "unknown"}
 MAX_HISTORY = 240
 REGRESSION_RATIO = 1.35
 MIN_REGRESSION_MS = 250
@@ -50,6 +51,54 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def validate_sample(payload: object) -> Sample:
+    """Validate and narrow one decoded performance record.
+
+    Args:
+        payload: Decoded JSON value.
+
+    Returns:
+        Fully validated sample.
+
+    Raises:
+        ValueError: If the value is not a complete valid sample.
+    """
+    if not isinstance(payload, dict):
+        raise ValueError("Performance sample must be a JSON object")
+
+    required_string_fields = ("capturedAt", "deploymentId", "runAttempt")
+    for key in required_string_fields:
+        if not isinstance(payload.get(key), str) or not payload[key]:
+            raise ValueError(f"Invalid required string field: {key}")
+
+    classification = payload.get("classification")
+    if classification not in CLASSIFICATIONS:
+        raise ValueError(f"Invalid classification: {classification!r}")
+
+    for metric in METRICS:
+        value = payload.get(metric)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError(f"Invalid non-negative integer metric: {metric}")
+
+    first_api_path = payload.get("firstApiPath")
+    if first_api_path is not None and not isinstance(first_api_path, str):
+        raise ValueError("firstApiPath must be a string or null")
+
+    first_api_status = payload.get("firstApiStatus")
+    if first_api_status is not None and (
+        isinstance(first_api_status, bool)
+        or not isinstance(first_api_status, int)
+        or not 100 <= first_api_status <= 599
+    ):
+        raise ValueError("firstApiStatus must be an HTTP status or null")
+
+    server_timing = payload.get("serverTiming")
+    if server_timing is not None and not isinstance(server_timing, str):
+        raise ValueError("serverTiming must be a string or null")
+
+    return cast(Sample, payload)
+
+
 def load_sample(path: Path) -> Sample:
     """Load and validate one probe sample.
 
@@ -59,25 +108,30 @@ def load_sample(path: Path) -> Sample:
     Returns:
         Validated sample.
     """
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    for key in ("capturedAt", "deploymentId", "classification", *METRICS):
-        if key not in payload:
-            raise ValueError(f"Missing required sample field: {key}")
-    return payload
+    return validate_sample(json.loads(path.read_text(encoding="utf-8")))
 
 
 def load_history(path: Path) -> list[Sample]:
-    """Load JSON-lines history if present.
+    """Load and validate JSON-lines history if present.
 
     Args:
         path: History path.
 
     Returns:
-        Parsed samples.
+        Validated samples.
     """
     if not path.exists():
         return []
-    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+    samples: list[Sample] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line:
+            continue
+        try:
+            samples.append(validate_sample(json.loads(line)))
+        except (json.JSONDecodeError, ValueError) as error:
+            raise ValueError(f"Invalid history record on line {line_number}: {error}") from error
+    return samples
 
 
 def baseline(history: list[Sample], sample: Sample, metric: str) -> float | None:
@@ -94,7 +148,7 @@ def baseline(history: list[Sample], sample: Sample, metric: str) -> float | None
     comparable = [
         int(item[metric])
         for item in history
-        if item.get("classification") == sample["classification"]
+        if item["classification"] == sample["classification"]
     ][-20:]
     return statistics.median(comparable) if comparable else None
 

--- a/scripts/update_production_performance_history.py
+++ b/scripts/update_production_performance_history.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Append one production performance sample and summarize regressions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from pathlib import Path
+from typing import TypedDict
+
+
+class Sample(TypedDict):
+    """Stored production performance sample."""
+
+    capturedAt: str
+    deploymentId: str
+    runAttempt: str
+    classification: str
+    documentResponseMs: int
+    shellReadyMs: int
+    firstApiResponseMs: int
+    queueReadyMs: int
+    firstApiPath: str | None
+    firstApiStatus: int | None
+    serverTiming: str | None
+
+
+METRICS = (
+    "documentResponseMs",
+    "shellReadyMs",
+    "firstApiResponseMs",
+    "queueReadyMs",
+)
+MAX_HISTORY = 240
+REGRESSION_RATIO = 1.35
+MIN_REGRESSION_MS = 250
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Returns:
+        Parsed arguments.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sample", type=Path, required=True)
+    parser.add_argument("--history", type=Path, required=True)
+    parser.add_argument("--summary", type=Path, required=True)
+    return parser.parse_args()
+
+
+def load_sample(path: Path) -> Sample:
+    """Load and validate one probe sample.
+
+    Args:
+        path: JSON sample path.
+
+    Returns:
+        Validated sample.
+    """
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    for key in ("capturedAt", "deploymentId", "classification", *METRICS):
+        if key not in payload:
+            raise ValueError(f"Missing required sample field: {key}")
+    return payload
+
+
+def load_history(path: Path) -> list[Sample]:
+    """Load JSON-lines history if present.
+
+    Args:
+        path: History path.
+
+    Returns:
+        Parsed samples.
+    """
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+def baseline(history: list[Sample], sample: Sample, metric: str) -> float | None:
+    """Return median baseline for the sample classification.
+
+    Args:
+        history: Previous samples.
+        sample: Current sample.
+        metric: Metric field.
+
+    Returns:
+        Median of up to 20 comparable samples, or None.
+    """
+    comparable = [
+        int(item[metric])
+        for item in history
+        if item.get("classification") == sample["classification"]
+    ][-20:]
+    return statistics.median(comparable) if comparable else None
+
+
+def build_summary(history: list[Sample], sample: Sample) -> str:
+    """Build a human-readable Markdown comparison.
+
+    Args:
+        history: Previous samples.
+        sample: Current sample.
+
+    Returns:
+        Markdown summary.
+    """
+    lines = [
+        "## Production performance",
+        "",
+        f"Deployment: `{sample['deploymentId']}`",
+        f"Classification: `{sample['classification']}`",
+        "",
+        "| Metric | Current | Baseline | Result |",
+        "|---|---:|---:|---|",
+    ]
+    regressions = 0
+    for metric in METRICS:
+        current = int(sample[metric])
+        prior = baseline(history, sample, metric)
+        if prior is None:
+            result = "baseline pending"
+            prior_text = "n/a"
+        else:
+            delta = current - prior
+            is_regression = current >= prior * REGRESSION_RATIO and delta >= MIN_REGRESSION_MS
+            result = "REGRESSION" if is_regression else "ok"
+            regressions += int(is_regression)
+            prior_text = f"{prior:.0f} ms"
+        lines.append(f"| `{metric}` | {current} ms | {prior_text} | {result} |")
+    lines.extend(["", f"Regression count: **{regressions}**"])
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    """Append the current sample and write comparison output."""
+    args = parse_args()
+    sample = load_sample(args.sample)
+    history = load_history(args.history)
+    summary = build_summary(history, sample)
+    retained = (history + [sample])[-MAX_HISTORY:]
+    args.history.parent.mkdir(parents=True, exist_ok=True)
+    args.history.write_text(
+        "".join(f"{json.dumps(item, separators=(',', ':'))}\n" for item in retained),
+        encoding="utf-8",
+    )
+    args.summary.parent.mkdir(parents=True, exist_ok=True)
+    args.summary.write_text(summary, encoding="utf-8")
+    print(summary)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add a bounded Chromium production probe for document, shell, first API, and Queue readiness milestones
- retain up to 240 samples through GitHub Actions cache and upload each run as an artifact
- compare cold, warm, and unknown classifications separately against the latest 20 comparable samples
- surface regressions in the Actions job summary when a metric is at least 35% and 250 ms slower than its baseline
- preserve deployment/run correlation without collecting comic titles, account records, credentials, or response bodies

## Validation

This connector runtime cannot execute the repository toolchain locally. Exact-head CI must validate TypeScript, linting, workflow guards, and tests before any readiness claim.

## Dependency

The scheduled workflow expects the dedicated production E2E storage-state secret from #832. This PR establishes the complete measurement and history path, but #834 must remain open until that credential boundary exists and a scheduled run produces evidence.

Refs #834

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated production performance measurements for key loading and readiness milestones.
  * Added performance tracking across deployments, including response timing, API details, and deployment metadata.
  * Added regression detection by comparing results with recent historical measurements.
  * Added Markdown summaries and downloadable measurement artifacts for each successful run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->