### PR TITLE
Serve the production frontend as static Vercel output

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1,0 +1,5 @@
+"""Vercel serverless entry point for ComicPile API requests."""
+
+from app.main import create_app
+
+app = create_app(serve_frontend=False)

--- a/docs/VERCEL_ARCHITECTURE.md
+++ b/docs/VERCEL_ARCHITECTURE.md
@@ -1,0 +1,64 @@
+# Vercel production architecture
+
+ComicPile deploys one static frontend and one Python API function from the same repository.
+
+## Production request boundary
+
+Vercel builds the React application from the repository root `package.json` and publishes
+`static/react` as static output. Requests for `/` and client-side application routes are served
+from that output without importing or starting FastAPI.
+
+The following paths are routed to the API-only Python entry point in `api/index.py`:
+
+- `/api` and every `/api/*` route, including `/api/v1/*`
+- `/openapi.json`
+- `/docs`
+- `/redoc`
+- `/health`
+
+Backend routes are declared before the filesystem and SPA fallback rules so an unknown API path
+cannot return `index.html`. Static assets are served by Vercel's filesystem boundary. All remaining
+non-file paths return the static SPA shell for React Router navigation.
+
+The static HTML response includes `X-ComicPile-Frontend: vercel-static`. This is the production
+evidence that `/` did not pass through the FastAPI function. The API function is created with
+`create_app(serve_frontend=False)`, so it does not mount frontend files or register SPA routes.
+
+## Security and caching
+
+Static HTML receives the same browser-facing security policy used by FastAPI, including CSP, HSTS,
+frame protection, content-type protection, referrer policy, and permissions policy. HTML is always
+revalidated so a new deployment is visible promptly. Vercel serves fingerprinted Vite assets from
+the static output boundary and can cache them independently.
+
+## Local development
+
+Local development remains unchanged:
+
+```bash
+make dev
+```
+
+Vite serves the frontend and proxies `/api` to FastAPI. The normal `app.main:app` application still
+uses `serve_frontend=True`, preserving built-SPA serving for local production-build tests and other
+non-Vercel runtimes.
+
+## Verification
+
+After deploying a branch or main, compare static and API paths independently:
+
+```bash
+curl --silent --show-error --location --output /dev/null \
+  --dump-header - \
+  --write-out 'ttfb=%{time_starttransfer}s total=%{time_total}s\n' \
+  https://comic-pile.vercel.app/
+
+curl --silent --show-error --location --output /dev/null \
+  --dump-header - \
+  --write-out 'ttfb=%{time_starttransfer}s total=%{time_total}s\n' \
+  https://comic-pile.vercel.app/openapi.json
+```
+
+The root response must include `X-ComicPile-Frontend: vercel-static`. The API response must not.
+After an idle period, root TTFB should remain materially below the former 8.5-second Python cold
+start baseline, with a target below one second from a nearby Vercel edge.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "jiti": "^2.6.1"
   },
   "scripts": {
+    "build": "pnpm --dir frontend build",
     "lint:js": "sh -c 'if ls static/react/assets/*.js >/dev/null 2>&1 || ls static/assets/*.js >/dev/null 2>&1; then pnpm exec eslint static/react/assets/*.js static/assets/*.js; else echo \"No JavaScript files to lint\"; fi'",
     "lint:html": "pnpm exec htmlhint app/templates/*.html",
     "lint": "pnpm run lint:js && pnpm run lint:html",

--- a/tests/test_vercel_deployment.py
+++ b/tests/test_vercel_deployment.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+from typing import cast
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
@@ -16,6 +17,18 @@ def _load_vercel_config() -> dict[str, object]:
         Parsed Vercel configuration.
     """
     return json.loads(VERCEL_CONFIG.read_text(encoding="utf-8"))
+
+
+def _routes(config: dict[str, object]) -> list[dict[str, object]]:
+    """Return the typed route list from a parsed Vercel configuration.
+
+    Args:
+        config: Parsed Vercel configuration.
+
+    Returns:
+        Ordered Vercel route definitions.
+    """
+    return cast("list[dict[str, object]]", config["routes"])
 
 
 def test_vercel_builds_static_frontend_and_api_function_separately() -> None:
@@ -36,8 +49,7 @@ def test_vercel_builds_static_frontend_and_api_function_separately() -> None:
 
 def test_vercel_routes_backend_before_spa_fallback() -> None:
     """Ensure API and documentation requests cannot be swallowed by the SPA."""
-    config = _load_vercel_config()
-    routes = config["routes"]
+    routes = _routes(_load_vercel_config())
 
     assert routes[0] == {"src": "/api(?:/.*)?", "dest": "/api/index.py"}
     assert routes[1] == {
@@ -53,11 +65,10 @@ def test_vercel_routes_backend_before_spa_fallback() -> None:
 
 def test_static_html_exposes_routing_evidence_and_security_headers() -> None:
     """Ensure static HTML remains identifiable and receives browser protections."""
-    config = _load_vercel_config()
-    routes = config["routes"]
+    routes = _routes(_load_vercel_config())
 
     for route in (routes[2], routes[-1]):
-        headers = route["headers"]
+        headers = cast("dict[str, str]", route["headers"])
         assert headers["X-ComicPile-Frontend"] == "vercel-static"
         assert headers["Cache-Control"] == "public, max-age=0, must-revalidate"
         assert headers["X-Content-Type-Options"] == "nosniff"

--- a/tests/test_vercel_deployment.py
+++ b/tests/test_vercel_deployment.py
@@ -1,0 +1,65 @@
+"""Regression tests for the production Vercel routing boundary."""
+
+import json
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+VERCEL_CONFIG = REPOSITORY_ROOT / "vercel.json"
+VERCEL_ENTRYPOINT = REPOSITORY_ROOT / "api" / "index.py"
+
+
+def _load_vercel_config() -> dict[str, object]:
+    """Load the checked-in Vercel configuration.
+
+    Returns:
+        Parsed Vercel configuration.
+    """
+    return json.loads(VERCEL_CONFIG.read_text(encoding="utf-8"))
+
+
+def test_vercel_builds_static_frontend_and_api_function_separately() -> None:
+    """Ensure production builds independent static and Python outputs."""
+    config = _load_vercel_config()
+    builds = config["builds"]
+
+    assert builds == [
+        {"src": "api/index.py", "use": "@vercel/python"},
+        {
+            "src": "package.json",
+            "use": "@vercel/static-build",
+            "config": {"distDir": "static/react"},
+        },
+    ]
+    assert "create_app(serve_frontend=False)" in VERCEL_ENTRYPOINT.read_text(encoding="utf-8")
+
+
+def test_vercel_routes_backend_before_spa_fallback() -> None:
+    """Ensure API and documentation requests cannot be swallowed by the SPA."""
+    config = _load_vercel_config()
+    routes = config["routes"]
+
+    assert routes[0] == {"src": "/api(?:/.*)?", "dest": "/api/index.py"}
+    assert routes[1] == {
+        "src": "/(?:openapi\\.json|docs|redoc|health)",
+        "dest": "/api/index.py",
+    }
+    assert routes[2]["src"] == "/"
+    assert routes[2]["dest"] == "/index.html"
+    assert routes[3] == {"handle": "filesystem"}
+    assert routes[-1]["src"] == "/(.*)"
+    assert routes[-1]["dest"] == "/index.html"
+
+
+def test_static_html_exposes_routing_evidence_and_security_headers() -> None:
+    """Ensure static HTML remains identifiable and receives browser protections."""
+    config = _load_vercel_config()
+    routes = config["routes"]
+
+    for route in (routes[2], routes[-1]):
+        headers = route["headers"]
+        assert headers["X-ComicPile-Frontend"] == "vercel-static"
+        assert headers["Cache-Control"] == "public, max-age=0, must-revalidate"
+        assert headers["X-Content-Type-Options"] == "nosniff"
+        assert headers["X-Frame-Options"] == "DENY"
+        assert "frame-ancestors 'none'" in headers["Content-Security-Policy"]

--- a/vercel.json
+++ b/vercel.json
@@ -3,5 +3,61 @@
   "regions": ["cle1"],
   "git": {
     "deploymentEnabled": false
-  }
+  },
+  "builds": [
+    {
+      "src": "api/index.py",
+      "use": "@vercel/python"
+    },
+    {
+      "src": "package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "static/react"
+      }
+    }
+  ],
+  "routes": [
+    {
+      "src": "/api(?:/.*)?",
+      "dest": "/api/index.py"
+    },
+    {
+      "src": "/(?:openapi\\.json|docs|redoc|health)",
+      "dest": "/api/index.py"
+    },
+    {
+      "src": "/",
+      "dest": "/index.html",
+      "headers": {
+        "Cache-Control": "public, max-age=0, must-revalidate",
+        "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://fonts.googleapis.com; frame-ancestors 'none'; form-action 'self'; base-uri 'self'; frame-src 'none';",
+        "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload",
+        "X-ComicPile-Frontend": "vercel-static",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "DENY",
+        "X-XSS-Protection": "1; mode=block"
+      }
+    },
+    {
+      "handle": "filesystem"
+    },
+    {
+      "src": "/(.*)",
+      "dest": "/index.html",
+      "headers": {
+        "Cache-Control": "public, max-age=0, must-revalidate",
+        "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://fonts.googleapis.com; frame-ancestors 'none'; form-action 'self'; base-uri 'self'; frame-src 'none';",
+        "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload",
+        "X-ComicPile-Frontend": "vercel-static",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "DENY",
+        "X-XSS-Protection": "1; mode=block"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- build the Vite frontend as Vercel static output from `static/react`
- route API, OpenAPI, docs, and health requests to an API-only FastAPI function
- serve `/` and React Router paths without importing FastAPI
- preserve static HTML security headers and expose `X-ComicPile-Frontend: vercel-static` as routing evidence
- add deployment-boundary regression tests and architecture documentation

## Validation boundary

The checked-in tests assert that backend routes precede the filesystem and SPA fallback, the API entry point disables frontend serving, and static HTML carries the expected evidence and security headers.

A production deployment is still required to collect the acceptance timing after an idle period. The recorded before baseline from #862 is 8.493 seconds for cold `GET /`; the target is below one second with `X-ComicPile-Frontend: vercel-static` present.

Relates to #862.