### PR TITLE
Add ownership-safe production E2E data janitor

### DIFF
--- a/.github/workflows/production-performance.yml
+++ b/.github/workflows/production-performance.yml
@@ -72,6 +72,7 @@ jobs:
           DATABASE_URL: ${{ secrets.PROD_E2E_DATABASE_URL }}
           PROD_E2E_ACCOUNT_EMAIL: ${{ secrets.PROD_E2E_ACCOUNT_EMAIL }}
         run: |
+          set -o pipefail
           if [ -z "$DATABASE_URL" ] || [ -z "$PROD_E2E_ACCOUNT_EMAIL" ]; then
             echo 'Missing dedicated production E2E cleanup secrets.' >&2
             exit 1

--- a/.github/workflows/production-performance.yml
+++ b/.github/workflows/production-performance.yml
@@ -39,6 +39,10 @@ jobs:
         with:
           python-version: '3.14'
 
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
       - name: Restore bounded performance history
         uses: actions/cache/restore@v4
         with:
@@ -59,6 +63,25 @@ jobs:
           printf '%s' "$STORAGE_STATE_JSON" > "$storage_state_path"
           chmod 600 "$storage_state_path"
           echo "PROD_PROFILE_STORAGE_STATE=$storage_state_path" >> "$GITHUB_ENV"
+
+      - name: Install backend dependencies
+        run: uv sync --frozen
+
+      - name: Remove stale production E2E records
+        env:
+          DATABASE_URL: ${{ secrets.PROD_E2E_DATABASE_URL }}
+          PROD_E2E_ACCOUNT_EMAIL: ${{ secrets.PROD_E2E_ACCOUNT_EMAIL }}
+        run: |
+          if [ -z "$DATABASE_URL" ] || [ -z "$PROD_E2E_ACCOUNT_EMAIL" ]; then
+            echo 'Missing dedicated production E2E cleanup secrets.' >&2
+            exit 1
+          fi
+          uv run python scripts/cleanup_production_e2e_data.py --max-age-hours 24 \
+            | tee production-e2e-cleanup.json
+          echo '### Production E2E cleanup' >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          cat production-e2e-cleanup.json >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Install frontend dependencies
         working-directory: frontend
@@ -93,6 +116,7 @@ jobs:
         with:
           name: production-performance-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
+            production-e2e-cleanup.json
             test-results/production-performance.json
             test-results/production-performance-history.jsonl
             test-results/production-performance-summary.md

--- a/app/database.py
+++ b/app/database.py
@@ -26,19 +26,12 @@ else:
     DATABASE_URL = _db_settings.database_url
 ASYNC_DATABASE_URL = _db_settings.async_url
 
-# Log database URLs with password redacted
+# Log only parsed, password-redacted URLs. Never log raw environment values or
+# prefixes because credentials can appear before the password delimiter.
 _redacted_database_url = make_url(DATABASE_URL).render_as_string(hide_password=True)
 _redacted_async_url = make_url(ASYNC_DATABASE_URL).render_as_string(hide_password=True)
-logger.info(f"Database URL configured: {_redacted_database_url}")
-logger.info(f"Async database URL: {_redacted_async_url}")
-
-# Additional debugging: log environment variables
-logger.info(
-    f"DATABASE_URL env var: {os.getenv('DATABASE_URL', 'NOT SET')[:50] if os.getenv('DATABASE_URL') else 'NOT SET'}..."
-)
-logger.info(
-    f"TEST_DATABASE_URL env var: {os.getenv('TEST_DATABASE_URL', 'NOT SET')[:50] if os.getenv('TEST_DATABASE_URL') else 'NOT SET'}..."
-)
+logger.info("Database URL configured: %s", _redacted_database_url)
+logger.info("Async database URL configured: %s", _redacted_async_url)
 
 async_engine = create_async_engine(
     ASYNC_DATABASE_URL,

--- a/docs/PRODUCTION_E2E_DATA.md
+++ b/docs/PRODUCTION_E2E_DATA.md
@@ -1,0 +1,34 @@
+# Production E2E data safety
+
+Production browser monitoring uses a dedicated account and must never create records under a personal account.
+
+## Naming contract
+
+Every production-created thread must set `is_test=true` and use this title format:
+
+```text
+[E2E] <run-id> <description>
+```
+
+The run ID may contain letters, numbers, dots, underscores, and hyphens. Tests should derive it from the GitHub run ID and attempt so records remain attributable without including comic or account data.
+
+Each test that mutates production must delete its own records in a `finally` block or fixture teardown. The janitor is a recovery boundary for interrupted processes, not the normal cleanup path.
+
+## Scheduled janitor
+
+`scripts/cleanup_production_e2e_data.py` runs before scheduled production performance monitoring. It deletes a thread only when all of these are true:
+
+- the thread belongs to the exact user identified by `PROD_E2E_ACCOUNT_EMAIL`;
+- `Thread.is_test` is true;
+- the title strictly matches the production E2E naming contract;
+- the thread is older than 24 hours.
+
+The command is idempotent and supports `--dry-run`. Its output contains only the cutoff, candidate count, account-found state, and dry-run state. It never logs titles, record IDs, email addresses, tokens, or database connection details.
+
+Required repository secrets:
+
+- `PROD_E2E_ACCOUNT_EMAIL`
+- `PROD_E2E_DATABASE_URL`
+- `PROD_E2E_STORAGE_STATE_JSON`
+
+Credential rotation must update all three boundaries together and verify a manual workflow run before scheduled monitoring resumes.

--- a/scripts/cleanup_production_e2e_data.py
+++ b/scripts/cleanup_production_e2e_data.py
@@ -7,12 +7,14 @@ import asyncio
 import json
 import os
 import re
+import sys
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import delete, select
 
 from app.database import AsyncSessionLocal, async_engine
+from app.models.reading_order import ReadingOrderItem
 from app.models.thread import Thread
 from app.models.user import User
 
@@ -51,6 +53,9 @@ async def cleanup_stale_threads(
 ) -> CleanupResult:
     """Delete stale, unmistakably test-owned threads for one account.
 
+    Candidate rows are locked until deletion commits so no concurrent update can
+    remove a safety predicate between validation and deletion.
+
     Args:
         account_email: Exact email of the dedicated production E2E account.
         max_age_hours: Minimum thread age before deletion.
@@ -83,26 +88,32 @@ async def cleanup_stale_threads(
                 dry_run=dry_run,
             )
 
-        candidate_rows = (
-            await session.execute(
-                select(Thread.id, Thread.title)
-                .where(Thread.user_id == user_id)
-                .where(Thread.is_test.is_(True))
-                .where(Thread.created_at < cutoff)
-            )
-        ).all()
-        candidate_ids = [
-            thread_id
-            for thread_id, title in candidate_rows
-            if is_managed_e2e_title(title)
+        candidate_threads = list(
+            (
+                await session.scalars(
+                    select(Thread)
+                    .where(Thread.user_id == user_id)
+                    .where(Thread.is_test.is_(True))
+                    .where(Thread.created_at < cutoff)
+                    .with_for_update()
+                )
+            ).all()
+        )
+        managed_threads = [
+            thread
+            for thread in candidate_threads
+            if is_managed_e2e_title(thread.title)
         ]
+        candidate_ids = [thread.id for thread in managed_threads]
 
         if candidate_ids and not dry_run:
             await session.execute(
-                delete(Thread)
-                .where(Thread.user_id == user_id)
-                .where(Thread.id.in_(candidate_ids))
+                delete(ReadingOrderItem).where(
+                    ReadingOrderItem.thread_id.in_(candidate_ids)
+                )
             )
+            for thread in managed_threads:
+                await session.delete(thread)
             await session.commit()
 
         return CleanupResult(
@@ -144,7 +155,7 @@ async def _main() -> int:
         )
         print(json.dumps(asdict(result), sort_keys=True))
         if not result.account_found:
-            print("Dedicated production E2E account was not found.")
+            print("Dedicated production E2E account was not found.", file=sys.stderr)
             return 2
         return 0
     finally:

--- a/scripts/cleanup_production_e2e_data.py
+++ b/scripts/cleanup_production_e2e_data.py
@@ -1,0 +1,164 @@
+"""Delete stale production E2E threads for the dedicated automation account."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import delete, select
+
+from app.database import AsyncSessionLocal, async_engine
+from app.models.thread import Thread
+from app.models.user import User
+
+E2E_TITLE_PATTERN = re.compile(r"^\[E2E\] [A-Za-z0-9._-]+ .+")
+DEFAULT_MAX_AGE_HOURS = 24
+
+
+@dataclass(frozen=True)
+class CleanupResult:
+    """Sanitized cleanup result suitable for logs and workflow summaries."""
+
+    account_found: bool
+    cutoff: str
+    deleted_count: int
+    dry_run: bool
+
+
+def is_managed_e2e_title(title: str) -> bool:
+    """Return whether a title follows the production E2E ownership convention.
+
+    Args:
+        title: Thread title to validate.
+
+    Returns:
+        True only for the strict ``[E2E] <run-id> <description>`` format.
+    """
+    return E2E_TITLE_PATTERN.fullmatch(title) is not None
+
+
+async def cleanup_stale_threads(
+    *,
+    account_email: str,
+    max_age_hours: int = DEFAULT_MAX_AGE_HOURS,
+    dry_run: bool = False,
+    now: datetime | None = None,
+) -> CleanupResult:
+    """Delete stale, unmistakably test-owned threads for one account.
+
+    Args:
+        account_email: Exact email of the dedicated production E2E account.
+        max_age_hours: Minimum thread age before deletion.
+        dry_run: Report candidates without deleting them.
+        now: Optional deterministic clock for tests.
+
+    Returns:
+        Sanitized cleanup result without titles, IDs, or account data.
+
+    Raises:
+        ValueError: If the account email or age boundary is invalid.
+    """
+    normalized_email = account_email.strip().lower()
+    if not normalized_email:
+        raise ValueError("account_email must not be empty")
+    if max_age_hours < 1:
+        raise ValueError("max_age_hours must be at least 1")
+
+    cutoff = (now or datetime.now(UTC)) - timedelta(hours=max_age_hours)
+
+    async with AsyncSessionLocal() as session:
+        user_id = await session.scalar(
+            select(User.id).where(User.email == normalized_email)
+        )
+        if user_id is None:
+            return CleanupResult(
+                account_found=False,
+                cutoff=cutoff.isoformat(),
+                deleted_count=0,
+                dry_run=dry_run,
+            )
+
+        candidate_rows = (
+            await session.execute(
+                select(Thread.id, Thread.title)
+                .where(Thread.user_id == user_id)
+                .where(Thread.is_test.is_(True))
+                .where(Thread.created_at < cutoff)
+            )
+        ).all()
+        candidate_ids = [
+            thread_id
+            for thread_id, title in candidate_rows
+            if is_managed_e2e_title(title)
+        ]
+
+        if candidate_ids and not dry_run:
+            await session.execute(
+                delete(Thread)
+                .where(Thread.user_id == user_id)
+                .where(Thread.id.in_(candidate_ids))
+            )
+            await session.commit()
+
+        return CleanupResult(
+            account_found=True,
+            cutoff=cutoff.isoformat(),
+            deleted_count=len(candidate_ids),
+            dry_run=dry_run,
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Returns:
+        Parsed janitor arguments.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--account-email",
+        default=os.getenv("PROD_E2E_ACCOUNT_EMAIL", ""),
+        help="Dedicated production E2E account email",
+    )
+    parser.add_argument(
+        "--max-age-hours",
+        type=int,
+        default=DEFAULT_MAX_AGE_HOURS,
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+async def _main() -> int:
+    args = parse_args()
+    try:
+        result = await cleanup_stale_threads(
+            account_email=args.account_email,
+            max_age_hours=args.max_age_hours,
+            dry_run=args.dry_run,
+        )
+        print(json.dumps(asdict(result), sort_keys=True))
+        if not result.account_found:
+            print("Dedicated production E2E account was not found.")
+            return 2
+        return 0
+    finally:
+        await async_engine.dispose()
+
+
+def main() -> int:
+    """Run the production E2E janitor.
+
+    Returns:
+        Process exit code.
+    """
+    return asyncio.run(_main())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cleanup_production_e2e_data.py
+++ b/tests/test_cleanup_production_e2e_data.py
@@ -1,0 +1,47 @@
+"""Tests for the production E2E data janitor."""
+
+import pytest
+
+from scripts.cleanup_production_e2e_data import (
+    cleanup_stale_threads,
+    is_managed_e2e_title,
+)
+
+
+@pytest.mark.parametrize(
+    ("title", "expected"),
+    [
+        ("[E2E] 12345-1 queue smoke", True),
+        ("[E2E] run_20260806 thread edit", True),
+        ("[E2E] run.with-dots dependency test", True),
+        ("[E2E] missing-description", False),
+        ("[E2E]  queue smoke", False),
+        ("[e2e] 123 queue smoke", False),
+        ("Josh's real thread", False),
+        ("prefix [E2E] 123 queue smoke", False),
+        ("[E2E] 123", False),
+    ],
+)
+def test_is_managed_e2e_title_requires_strict_prefix_and_run_id(
+    title: str,
+    expected: bool,
+) -> None:
+    """Only unmistakably automation-owned titles are cleanup candidates."""
+    assert is_managed_e2e_title(title) is expected
+
+
+@pytest.mark.asyncio
+async def test_cleanup_rejects_empty_account_before_database_access() -> None:
+    """Cleanup cannot run without an exact dedicated-account boundary."""
+    with pytest.raises(ValueError, match="account_email must not be empty"):
+        await cleanup_stale_threads(account_email="   ")
+
+
+@pytest.mark.asyncio
+async def test_cleanup_rejects_nonpositive_age_before_database_access() -> None:
+    """Cleanup cannot erase active or newly-created test records."""
+    with pytest.raises(ValueError, match="max_age_hours must be at least 1"):
+        await cleanup_stale_threads(
+            account_email="automation@example.com",
+            max_age_hours=0,
+        )

--- a/tests/test_cleanup_production_e2e_data.py
+++ b/tests/test_cleanup_production_e2e_data.py
@@ -1,7 +1,14 @@
 """Tests for the production E2E data janitor."""
 
-import pytest
+from datetime import UTC, datetime, timedelta
 
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+import scripts.cleanup_production_e2e_data as cleanup_module
+from app.models.thread import Thread
+from app.models.user import User
 from scripts.cleanup_production_e2e_data import (
     cleanup_stale_threads,
     is_managed_e2e_title,
@@ -38,10 +45,147 @@ async def test_cleanup_rejects_empty_account_before_database_access() -> None:
 
 
 @pytest.mark.asyncio
-async def test_cleanup_rejects_nonpositive_age_before_database_access() -> None:
+@pytest.mark.parametrize("max_age_hours", [0, -1])
+async def test_cleanup_rejects_nonpositive_age_before_database_access(
+    max_age_hours: int,
+) -> None:
     """Cleanup cannot erase active or newly-created test records."""
     with pytest.raises(ValueError, match="max_age_hours must be at least 1"):
         await cleanup_stale_threads(
             account_email="automation@example.com",
-            max_age_hours=0,
+            max_age_hours=max_age_hours,
         )
+
+
+def _thread(
+    *,
+    title: str,
+    user_id: int,
+    created_at: datetime,
+    queue_position: int,
+    is_test: bool = True,
+) -> Thread:
+    """Build a minimal persisted thread for janitor boundary tests."""
+    return Thread(
+        title=title,
+        format="series",
+        issues_remaining=0,
+        queue_position=queue_position,
+        is_test=is_test,
+        created_at=created_at,
+        user_id=user_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_cleanup_deletes_only_owned_stale_managed_test_threads(
+    db_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ownership, age, test flag, and title format all gate destructive cleanup."""
+    session_factory = async_sessionmaker(db_engine, expire_on_commit=False)
+    monkeypatch.setattr(cleanup_module, "AsyncSessionLocal", session_factory)
+    now = datetime(2026, 8, 6, 14, 0, tzinfo=UTC)
+
+    async with session_factory() as session:
+        owner = User(username="janitor-owner", email="automation@example.com")
+        other = User(username="janitor-other", email="other@example.com")
+        session.add_all([owner, other])
+        await session.flush()
+        candidates = [
+            _thread(
+                title="[E2E] run-1 delete me",
+                user_id=owner.id,
+                created_at=now - timedelta(hours=25),
+                queue_position=1,
+            ),
+            _thread(
+                title="[E2E] run-2 other account",
+                user_id=other.id,
+                created_at=now - timedelta(hours=25),
+                queue_position=2,
+            ),
+            _thread(
+                title="[E2E] run-3 ordinary flag",
+                user_id=owner.id,
+                created_at=now - timedelta(hours=25),
+                queue_position=3,
+                is_test=False,
+            ),
+            _thread(
+                title="ordinary title",
+                user_id=owner.id,
+                created_at=now - timedelta(hours=25),
+                queue_position=4,
+            ),
+            _thread(
+                title="[E2E] run-5 exact boundary",
+                user_id=owner.id,
+                created_at=now - timedelta(hours=24),
+                queue_position=5,
+            ),
+            _thread(
+                title="[E2E] run-6 recent",
+                user_id=owner.id,
+                created_at=now - timedelta(hours=23),
+                queue_position=6,
+            ),
+        ]
+        session.add_all(candidates)
+        await session.commit()
+
+    result = await cleanup_stale_threads(
+        account_email="AUTOMATION@example.com",
+        max_age_hours=24,
+        now=now,
+    )
+
+    assert result.account_found is True
+    assert result.deleted_count == 1
+    assert result.dry_run is False
+    async with session_factory() as session:
+        remaining_titles = set((await session.scalars(select(Thread.title))).all())
+    assert remaining_titles == {
+        "[E2E] run-2 other account",
+        "[E2E] run-3 ordinary flag",
+        "ordinary title",
+        "[E2E] run-5 exact boundary",
+        "[E2E] run-6 recent",
+    }
+
+
+@pytest.mark.asyncio
+async def test_cleanup_dry_run_reports_without_deleting(
+    db_engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dry-run mode counts eligible records but leaves them persisted."""
+    session_factory = async_sessionmaker(db_engine, expire_on_commit=False)
+    monkeypatch.setattr(cleanup_module, "AsyncSessionLocal", session_factory)
+    now = datetime(2026, 8, 6, 14, 0, tzinfo=UTC)
+
+    async with session_factory() as session:
+        owner = User(username="janitor-dry-run", email="dry-run@example.com")
+        session.add(owner)
+        await session.flush()
+        thread = _thread(
+            title="[E2E] dry-run-1 retain me",
+            user_id=owner.id,
+            created_at=now - timedelta(hours=25),
+            queue_position=1,
+        )
+        session.add(thread)
+        await session.commit()
+        thread_id = thread.id
+
+    result = await cleanup_stale_threads(
+        account_email="dry-run@example.com",
+        max_age_hours=24,
+        dry_run=True,
+        now=now,
+    )
+
+    assert result.deleted_count == 1
+    assert result.dry_run is True
+    async with session_factory() as session:
+        assert await session.get(Thread, thread_id) is not None

--- a/tests/test_cleanup_production_e2e_data.py
+++ b/tests/test_cleanup_production_e2e_data.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
 
 import scripts.cleanup_production_e2e_data as cleanup_module
 from app.models.thread import Thread
@@ -89,7 +89,7 @@ async def test_cleanup_deletes_only_owned_stale_managed_test_threads(
 
     async with session_factory() as session:
         owner = User(username="janitor-owner", email="automation@example.com")
-        other = User(username="janitor-other", email="other@example.com")
+        other = User(username="janitor-other", email="janitor-other@example.com")
         session.add_all([owner, other])
         await session.flush()
         candidates = [


### PR DESCRIPTION
Closes #835

## Summary
- add a strict, user-scoped async janitor for stale production E2E threads
- require `is_test`, the `[E2E] <run-id> <description>` convention, exact account ownership, and a 24-hour age boundary
- run cleanup before scheduled production monitoring and surface sanitized evidence
- add safety-boundary tests and operational documentation

## Safety
The janitor never scans or deletes across users, never deletes ordinary records, and logs no titles, IDs, account details, credentials, or connection strings.

## Validation
Exact-head CI requested. Production execution remains credential-gated by #832.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated cleanup for stale production test data.
  * Supports safe dry runs, strict test-record matching, sanitized results, and configurable retention periods.
  * Production performance checks now remove stale test records before frontend testing and report cleanup evidence.

* **Documentation**
  * Documented production E2E data-safety requirements, naming conventions, cleanup practices, and recovery procedures.

* **Tests**
  * Added coverage for valid and invalid test-record formats and cleanup input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->