### PR TITLE
Restore recent changelog entries and enforce factory release notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,7 +336,7 @@ make migrate  # Run migrations (or: alembic upgrade head)
 - Commit messages: imperative, component-scoped (e.g., "Add thread creation API endpoint")
 - Run `make lint` and `make pytest` before committing
 - Open PRs as **ready for review by default**. Do **not** open draft PRs unless the user explicitly asks for a draft. This repo relies on CodeRabbit signals that do not arrive on draft PRs for the current plan/tier.
-- **Update `docs/changelog.md`** when deploying changes to production (add new dated entry, group by feature area, describe what changed not how)
+- **Update `docs/changelog.md` in every product, behavior, deployment, operational, or factory-tooling PR before readiness or merge.** Add a current dated entry, group it by user-recognizable feature area, link the PR, and describe what changed and why it matters rather than how it was implemented. Documentation-only, test-only, generated-artifact-only, or strictly internal refactors may omit an entry only when the PR body explicitly says `Changelog: not user-facing`.
 
 ## GitHub Issue Workflow
 

--- a/docs/AUTONOMOUS_FACTORY_POLICY.md
+++ b/docs/AUTONOMOUS_FACTORY_POLICY.md
@@ -1,6 +1,6 @@
 # ComicPile Autonomous Factory Policy
 
-Version: 16
+Version: 17
 
 This is the canonical policy for every scheduled ChatGPT worker, the local OpenCode factory, and interactive factory repair sessions.
 
@@ -73,6 +73,23 @@ Repeat until the selected issue reaches closure or a valid blocker:
 `inspect contract -> implement closure-critical behavior -> focused validation -> commit -> push -> inspect exact SHA -> account for all review feedback -> repair blockers -> verify merge gates -> merge when eligible -> verify issue closure`
 
 After work becomes blocked, merge-gated, or dependent on a human-only decision, preserve durable context and return to selection rather than polishing indefinitely.
+
+## User-facing changelog gate
+
+Every product, behavior, deployment, operational, or factory-tooling PR must update
+`docs/changelog.md` before it can receive a pass verdict, ready marker, merge-gated marker, or
+merge. Add the entry under the current date, group it by user-recognizable feature area, link the
+PR number, and describe what changed and why it matters rather than narrating implementation
+steps.
+
+A documentation-only, test-only, generated-artifact-only, or strictly internal refactor PR may
+omit a changelog entry only when its PR body explicitly states `Changelog: not user-facing` and
+the worker verifies that the change has no user, operator, deployment, or factory behavior impact.
+A missing required changelog entry is an actionable review defect and blocks readiness and merge.
+
+Before merging, compare all merged PRs newer than the newest dated changelog section. If older
+factory work is missing, repair the backlog in the current PR rather than recording only the
+worker's own change.
 
 ## Review-feedback gate
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,60 @@
 # Changelog
 
+## 2026-08-06
+
+**Faster and more resilient startup**
+
+- The production frontend is now served as static Vercel output, keeping the home page and React routes out of the FastAPI cold-start path ([#863](https://github.com/JoshCLWren/comic-pile/pull/863)).
+- A branded bootstrap shell keeps useful loading and reconnecting feedback visible until the application is actually ready ([#859](https://github.com/JoshCLWren/comic-pile/pull/859)).
+- Returning to an iOS tab after suspension now revalidates the session, refreshes cached data, and offers retry or reload recovery instead of leaving an empty app ([#854](https://github.com/JoshCLWren/comic-pile/pull/854)).
+- Production probes now track document, application shell, first API response, and Queue readiness over time, with bounded history and regression reporting ([#861](https://github.com/JoshCLWren/comic-pile/pull/861)).
+- Separate liveness, dependency-health, and warm-up endpoints make operational checks cheaper and more precise ([#860](https://github.com/JoshCLWren/comic-pile/pull/860)).
+
+**Crossovers and reading order**
+
+- Reading-order groups are now presented as Crossovers throughout the Roll experience ([#856](https://github.com/JoshCLWren/comic-pile/pull/856)).
+- A dedicated Crossovers page supports creating, inspecting, renaming, and deleting crossover groups from the app ([#857](https://github.com/JoshCLWren/comic-pile/pull/857)).
+- Crossover management can add an inclusive range of issues from a thread in one operation, with duplicate-safe results and validation ([#858](https://github.com/JoshCLWren/comic-pile/pull/858)).
+- Fixed Roll crossover loading to use the real versioned API routes ([#822](https://github.com/JoshCLWren/comic-pile/pull/822)).
+
+**Authentication, feedback, and Queue**
+
+- Authentication routes and maintained frontend callers now use canonical `/api/v1/auth/*` paths while retaining compatibility aliases ([#825](https://github.com/JoshCLWren/comic-pile/pull/825), [#826](https://github.com/JoshCLWren/comic-pile/pull/826), [#827](https://github.com/JoshCLWren/comic-pile/pull/827)).
+- Feedback can now be submitted explicitly as either a bug report or a feature request, with matching GitHub labels ([#855](https://github.com/JoshCLWren/comic-pile/pull/855)).
+- Queue reposition previews now display the full selected move distance instead of always showing one position ([#821](https://github.com/JoshCLWren/comic-pile/pull/821)).
+- Frontend API contracts now derive additional auth types from generated OpenAPI output, and shared query keys establish targeted cache-update behavior ([#820](https://github.com/JoshCLWren/comic-pile/pull/820), [#823](https://github.com/JoshCLWren/comic-pile/pull/823), [#824](https://github.com/JoshCLWren/comic-pile/pull/824)).
+
+**Factory visibility and reliability**
+
+- GitHub labels now expose factory ownership and lifecycle state on issues and pull requests ([#819](https://github.com/JoshCLWren/comic-pile/pull/819)).
+- Factory worktrees refresh from current main before each heartbeat, the free-model pool includes curated Google and OpenRouter options, and transient failures rotate models without prematurely retiring them ([#814](https://github.com/JoshCLWren/comic-pile/pull/814), [#818](https://github.com/JoshCLWren/comic-pile/pull/818)).
+
+## 2026-08-05
+
+**Roll mutation recovery**
+
+- Rating and snooze operations now reconcile server-committed changes after browser timeouts or failed refreshes, and stale bootstrap responses can no longer overwrite newer reconciled state ([#784](https://github.com/JoshCLWren/comic-pile/pull/784), [#798](https://github.com/JoshCLWren/comic-pile/pull/798), [#799](https://github.com/JoshCLWren/comic-pile/pull/799), [#800](https://github.com/JoshCLWren/comic-pile/pull/800)).
+- Deterministic latest-session lookups gained an index and phase-level observability for current-session and History reads ([#778](https://github.com/JoshCLWren/comic-pile/pull/778), [#801](https://github.com/JoshCLWren/comic-pile/pull/801)).
+
+**Reading-order foundations**
+
+- Added the ownership-scoped named dependency-group API, typed frontend client, and Roll presentation used by the later Crossovers interface ([#790](https://github.com/JoshCLWren/comic-pile/pull/790), [#805](https://github.com/JoshCLWren/comic-pile/pull/805), [#807](https://github.com/JoshCLWren/comic-pile/pull/807), [#808](https://github.com/JoshCLWren/comic-pile/pull/808), [#809](https://github.com/JoshCLWren/comic-pile/pull/809)).
+
+**Maintenance and safeguards**
+
+- Completed removal of retired Reviews persistence and kept completed Queue threads collapsed by default ([#810](https://github.com/JoshCLWren/comic-pile/pull/810), [#811](https://github.com/JoshCLWren/comic-pile/pull/811)).
+- CI now rejects stale or untracked generated OpenAPI artifacts ([#812](https://github.com/JoshCLWren/comic-pile/pull/812), [#813](https://github.com/JoshCLWren/comic-pile/pull/813)).
+- The factory now prioritizes backlog delivery, respects review gates, and may merge only after the complete exact-head gate set is satisfied ([#797](https://github.com/JoshCLWren/comic-pile/pull/797)).
+
+## 2026-08-04
+
+**Mobile overlays and data restore**
+
+- Modals and the Queue position menu now share a document-level overlay lifecycle and stable stacking contract, preventing nested overlays from being clipped or layered incorrectly ([#786](https://github.com/JoshCLWren/comic-pile/pull/786), [#787](https://github.com/JoshCLWren/comic-pile/pull/787), [#789](https://github.com/JoshCLWren/comic-pile/pull/789)).
+- Local restore now remaps retained export relationships safely instead of reusing production graph identifiers ([#785](https://github.com/JoshCLWren/comic-pile/pull/785)).
+- OpenCode provider rotation now exhausts available providers correctly instead of getting stuck on one failing provider ([#792](https://github.com/JoshCLWren/comic-pile/pull/792)).
+
+
 ## 2026-08-03
 
 **OpenCode model discovery, rotation, and attribution (factory tooling)**

--- a/scripts/check-autonomous-factory-policy.py
+++ b/scripts/check-autonomous-factory-policy.py
@@ -52,7 +52,10 @@ def validate_texts(policy: str, protocol: str, entrypoint: str) -> None:
         None.
     """
     for needle in (
-        "Version: 16",
+        "Version: 17",
+        "Every product, behavior, deployment, operational, or factory-tooling PR must update",
+        "Changelog: not user-facing",
+        "A missing required changelog entry is an actionable review defect",
         "Drive the open issue backlog to zero",
         "The newest unclaimed open issue labeled both `user-reported` and `bug`.",
         "The highest-priority unclaimed reproducible E2E-discovered `bug` issue.",
@@ -129,6 +132,8 @@ def validate_texts(policy: str, protocol: str, entrypoint: str) -> None:
     for needle in (
         "docs/AUTONOMOUS_FACTORY_POLICY.md",
         "Drive the open issue backlog to zero",
+        "Treat docs/changelog.md as part of the completion contract",
+        "Changelog: not user-facing",
         "newest unclaimed open issue labeled both `user-reported` and `bug`",
         "reproducible E2E-discovered",
         "fewer than four substantive implementation PRs",

--- a/scripts/comic-pile-opencode-factory-heartbeat.sh
+++ b/scripts/comic-pile-opencode-factory-heartbeat.sh
@@ -187,6 +187,11 @@ ANTI-ORBIT RULES
 - Waiting for CI, review, merge, Josh, or external availability does not reserve the worker.
   Preserve context and select another free issue.
 - Do not create replacement PRs merely because main advanced.
+- Treat docs/changelog.md as part of the completion contract for every product, behavior,
+  deployment, operational, or factory-tooling PR. Before pass, readiness, merge-gating, or merge,
+  add a current-date user-facing entry with the PR link and repair any newer merged PRs missing
+  from the changelog. Only documentation-only, test-only, generated-artifact-only, or strictly
+  internal refactors may omit it, and the PR body must say `Changelog: not user-facing`.
 - Do not split one issue into avoidable foundation or stage PRs. Implement the full contract
   in one coherent non-draft PR whenever reasonably reviewable.
 
@@ -291,7 +296,7 @@ PROMPT
 FACTORY_PROMPT="${FACTORY_PROMPT//__WORKER_ID__/$WORKER_ID}"
 FACTORY_PROMPT="${FACTORY_PROMPT//__MODEL_ID__/$MODEL}"
 
-printf 'ComicPile local factory v16 (backlog-drain and gated-merge)\n'
+printf 'ComicPile local factory v17 (backlog-drain, release-notes, and gated-merge)\n'
 printf '  Source repo: %s\n' "$SOURCE_REPO"
 printf '  Worktree:    %s\n' "$WORKTREE"
 printf '  Model:       %s\n' "$MODEL"

--- a/scripts/tests/test_autonomous_factory_policy.py
+++ b/scripts/tests/test_autonomous_factory_policy.py
@@ -14,7 +14,7 @@ SPEC.loader.exec_module(CHECKER)
 
 
 class AutonomousFactoryPolicyTests(unittest.TestCase):
-    """Verify backlog, review, merge, and Chromium policy invariants."""
+    """Verify backlog, changelog, review, merge, and Chromium policy invariants."""
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -95,7 +95,7 @@ class AutonomousFactoryPolicyTests(unittest.TestCase):
             self.validate(entrypoint=f"{self.entrypoint}\n{rule}\n")
 
     def test_current_sources_are_aligned(self) -> None:
-        """Accept the current V16 policy, protocol, and runtime prompt.
+        """Accept the current V17 policy, protocol, and runtime prompt.
 
         Returns:
             None.
@@ -108,7 +108,7 @@ class AutonomousFactoryPolicyTests(unittest.TestCase):
         Returns:
             None.
         """
-        self.assert_policy_change_fails("Version: 16", "Version: 15")
+        self.assert_policy_change_fails("Version: 17", "Version: 16")
         self.assert_policy_change_fails(
             "Drive the open issue backlog to zero",
             "Keep existing pull requests busy",
@@ -138,6 +138,21 @@ class AutonomousFactoryPolicyTests(unittest.TestCase):
         self.assert_policy_change_fails(
             "At most one implementation worker may own an issue",
             "Any number of workers may own an issue",
+        )
+
+    def test_user_facing_changelog_gate_is_required(self) -> None:
+        """Require release notes before factory readiness or merge.
+
+        Returns:
+            None.
+        """
+        self.assert_policy_change_fails(
+            "Every product, behavior, deployment, operational, or factory-tooling PR must update",
+            "Factory pull requests may skip release notes",
+        )
+        self.assert_policy_change_fails(
+            "A missing required changelog entry is an actionable review defect",
+            "Changelog omissions do not block merge",
         )
 
     def test_review_feedback_gate_is_required(self) -> None:


### PR DESCRIPTION
## Summary

- backfill the user-facing changelog for merged work from August 4 through August 6
- group the missing changes into readable release themes with links to the merged pull requests
- promote the autonomous factory policy to V17 and make changelog maintenance a readiness and merge gate
- put the same rule in the live OpenCode heartbeat prompt and contributor guidance
- extend the policy drift checker and mutation tests so future prompt changes cannot silently remove the requirement

## Root cause

The repository guidance only asked for changelog updates when deploying to production. Factory workers treated that as optional or outside individual PR completion, so a dense series of merged factory PRs landed while `docs/changelog.md` remained at August 3.

## Changelog contract

Product, behavior, deployment, operational, and factory-tooling PRs must now add a current-date, user-facing entry before pass, readiness, merge-gating, or merge. Only documentation-only, test-only, generated-artifact-only, or strictly internal refactors may omit one, and the PR body must explicitly say `Changelog: not user-facing`.

## Validation

- audited the branch comparison against current `main`: six intended files, 104 changed lines, no unrelated files
- verified all six remote updates are present on the branch and it is six commits ahead, zero behind
- the Factory Policy workflow will run shell syntax checks, compile the checker and tests, validate canonical invariants, and run the mutation suite on this exact head

## Phone follow-up

The recommended next step is an authenticated `/changelog` or `/whats-new` page sourced from this same file, linked from the mobile overflow menu. That avoids GitHub's code viewer while preserving one source of truth.