### PR TITLE
Prevent credentials from reaching configuration logs

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -6,12 +6,12 @@ import time
 from collections.abc import AsyncIterator
 
 from sqlalchemy import event, text
-from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase
 
 from app.config import get_database_settings
 from app.performance_diagnostics import record_database_query
+from app.safe_logging import safe_connection_metadata, safe_exception_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -26,12 +26,12 @@ else:
     DATABASE_URL = _db_settings.database_url
 ASYNC_DATABASE_URL = _db_settings.async_url
 
-# Log only parsed, password-redacted URLs. Never log raw environment values or
-# prefixes because credentials can appear before the password delimiter.
-_redacted_database_url = make_url(DATABASE_URL).render_as_string(hide_password=True)
-_redacted_async_url = make_url(ASYNC_DATABASE_URL).render_as_string(hide_password=True)
-logger.info("Database URL configured: %s", _redacted_database_url)
-logger.info("Async database URL configured: %s", _redacted_async_url)
+# Log only an allowlisted metadata projection. Rendering a URL, even with its
+# password hidden, risks exposing usernames, query credentials, or encoded secrets.
+logger.info(
+    "Database configured",
+    extra={"database": safe_connection_metadata(ASYNC_DATABASE_URL)},
+)
 
 async_engine = create_async_engine(
     ASYNC_DATABASE_URL,
@@ -108,6 +108,9 @@ async def test_database_connection() -> bool:
         async with AsyncSessionLocal() as session:
             await session.execute(text("SELECT 1"))
             return True
-    except Exception as e:
-        logger.error(f"Database connection test failed: {e}")
+    except Exception as error:
+        logger.error(
+            "Database connection test failed",
+            extra={"database_error": safe_exception_metadata(error)},
+        )
         return False

--- a/app/main.py
+++ b/app/main.py
@@ -16,7 +16,6 @@ from starlette.types import Scope
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from sqlalchemy import exc as sqlalchemy_exc
-from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
@@ -46,6 +45,7 @@ from app.exception_handlers import register_exception_handlers
 from app.lifecycle import init_database
 from app.middleware import limiter, SecurityHeadersMiddleware
 from app.middleware.request_logging import add_request_logging_middleware
+from app.safe_logging import safe_connection_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -103,10 +103,12 @@ def _configure_logging(environment: str) -> None:
     logging.basicConfig(level=_resolve_log_level(environment))
 
 
-# Log database URL at startup (with password redacted)
 _db_settings = get_database_settings()
-_redacted_url = make_url(_db_settings.database_url).render_as_string(hide_password=True)
-logger.info(f"Starting with DATABASE_URL: {_redacted_url}")
+logger.info(
+    "Application database configured",
+    extra={"database": safe_connection_metadata(_db_settings.database_url)},
+)
+
 
 def create_app(*, serve_frontend: bool = True) -> FastAPI:
     """Create and configure the FastAPI application.

--- a/app/safe_logging.py
+++ b/app/safe_logging.py
@@ -27,6 +27,13 @@ _DATABASE_SCHEMES = {
     "rediss",
 }
 _TLS_REQUIRED_MODES = {"require", "verify-ca", "verify-full"}
+_EMPTY_CONNECTION_METADATA: dict[str, str | int | bool | None] = {
+    "scheme": None,
+    "host": None,
+    "port": None,
+    "database": None,
+    "ssl_required": False,
+}
 
 
 def safe_connection_metadata(connection_url: str) -> dict[str, str | int | bool | None]:
@@ -37,10 +44,17 @@ def safe_connection_metadata(connection_url: str) -> dict[str, str | int | bool 
 
     Returns:
         Metadata containing only the scheme, host, port, validated database name,
-        and whether the connection requires TLS.
+        and whether the connection requires TLS. Malformed URLs return empty metadata
+        so diagnostic logging cannot break application startup.
     """
-    parsed = urlsplit(connection_url)
-    scheme = parsed.scheme.lower()
+    try:
+        parsed = urlsplit(connection_url)
+        scheme = parsed.scheme.lower()
+        host = parsed.hostname
+        port = parsed.port
+    except ValueError:
+        return _EMPTY_CONNECTION_METADATA.copy()
+
     database = (
         unquote(parsed.path.lstrip("/")) or None
         if scheme in _DATABASE_SCHEMES
@@ -51,8 +65,8 @@ def safe_connection_metadata(connection_url: str) -> dict[str, str | int | bool 
     ssl_required = scheme == "rediss" or ssl_value in _TLS_REQUIRED_MODES
     return {
         "scheme": parsed.scheme or None,
-        "host": parsed.hostname,
-        "port": parsed.port,
+        "host": host,
+        "port": port,
         "database": database,
         "ssl_required": ssl_required,
     }

--- a/app/safe_logging.py
+++ b/app/safe_logging.py
@@ -1,7 +1,6 @@
 """Helpers for logging configuration metadata without exposing credentials."""
 
 from collections.abc import Mapping
-from typing import object
 from urllib.parse import unquote, urlsplit
 
 _SECRET_MARKERS = (

--- a/app/safe_logging.py
+++ b/app/safe_logging.py
@@ -1,0 +1,81 @@
+"""Helpers for logging configuration metadata without exposing credentials."""
+
+from collections.abc import Mapping
+from typing import object
+from urllib.parse import unquote, urlsplit
+
+_SECRET_MARKERS = (
+    "password",
+    "passwd",
+    "secret",
+    "token",
+    "api_key",
+    "apikey",
+    "authorization",
+    "credential",
+    "private_key",
+)
+
+
+def safe_connection_metadata(connection_url: str) -> dict[str, str | int | bool | None]:
+    """Return non-secret connection metadata suitable for structured logs.
+
+    Args:
+        connection_url: A database, Redis, or HTTP connection URL.
+
+    Returns:
+        Metadata containing only the scheme, host, port, database/path, and SSL mode.
+    """
+    parsed = urlsplit(connection_url)
+    path = unquote(parsed.path.lstrip("/")) or None
+    query = dict(
+        part.split("=", 1) if "=" in part else (part, "")
+        for part in parsed.query.split("&")
+        if part
+    )
+    ssl_value = query.get("sslmode") or query.get("ssl")
+    ssl_required = ssl_value not in {None, "", "0", "false", "disable"}
+    return {
+        "scheme": parsed.scheme or None,
+        "host": parsed.hostname,
+        "port": parsed.port,
+        "database": path,
+        "ssl_required": ssl_required,
+    }
+
+
+def redact_sensitive_values(value: object) -> object:
+    """Recursively replace secret-bearing mapping values before logging.
+
+    Args:
+        value: Arbitrary structured value intended for a log event.
+
+    Returns:
+        A structurally similar value with secret-bearing fields redacted.
+    """
+    if isinstance(value, Mapping):
+        return {
+            str(key): (
+                "[REDACTED]"
+                if any(marker in str(key).lower() for marker in _SECRET_MARKERS)
+                else redact_sensitive_values(item)
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [redact_sensitive_values(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(redact_sensitive_values(item) for item in value)
+    return value
+
+
+def safe_exception_metadata(error: BaseException) -> dict[str, str]:
+    """Return exception metadata without serializing its potentially secret message.
+
+    Args:
+        error: Exception raised while handling configuration or a dependency.
+
+    Returns:
+        The exception type only.
+    """
+    return {"error_type": type(error).__name__}

--- a/app/safe_logging.py
+++ b/app/safe_logging.py
@@ -13,7 +13,20 @@ _SECRET_MARKERS = (
     "authorization",
     "credential",
     "private_key",
+    "database_url",
+    "redis_url",
+    "connection_url",
 )
+_DATABASE_SCHEMES = {
+    "postgres",
+    "postgresql",
+    "postgresql+asyncpg",
+    "postgresql+psycopg",
+    "postgresql+psycopg2",
+    "redis",
+    "rediss",
+}
+_TLS_REQUIRED_MODES = {"require", "verify-ca", "verify-full"}
 
 
 def safe_connection_metadata(connection_url: str) -> dict[str, str | int | bool | None]:
@@ -23,18 +36,24 @@ def safe_connection_metadata(connection_url: str) -> dict[str, str | int | bool 
         connection_url: A database, Redis, or HTTP connection URL.
 
     Returns:
-        Metadata containing only the scheme, host, port, database/path, and SSL mode.
+        Metadata containing only the scheme, host, port, validated database name,
+        and whether the connection requires TLS.
     """
     parsed = urlsplit(connection_url)
-    path = unquote(parsed.path.lstrip("/")) or None
+    scheme = parsed.scheme.lower()
+    database = (
+        unquote(parsed.path.lstrip("/")) or None
+        if scheme in _DATABASE_SCHEMES
+        else None
+    )
     query = dict(parse_qsl(parsed.query, keep_blank_values=True))
-    ssl_value = query.get("sslmode") or query.get("ssl")
-    ssl_required = ssl_value not in {None, "", "0", "false", "disable"}
+    ssl_value = (query.get("sslmode") or query.get("ssl") or "").lower()
+    ssl_required = scheme == "rediss" or ssl_value in _TLS_REQUIRED_MODES
     return {
         "scheme": parsed.scheme or None,
         "host": parsed.hostname,
         "port": parsed.port,
-        "database": path,
+        "database": database,
         "ssl_required": ssl_required,
     }
 

--- a/app/safe_logging.py
+++ b/app/safe_logging.py
@@ -1,7 +1,7 @@
 """Helpers for logging configuration metadata without exposing credentials."""
 
 from collections.abc import Mapping
-from urllib.parse import unquote, urlsplit
+from urllib.parse import parse_qsl, unquote, urlsplit
 
 _SECRET_MARKERS = (
     "password",
@@ -27,11 +27,7 @@ def safe_connection_metadata(connection_url: str) -> dict[str, str | int | bool 
     """
     parsed = urlsplit(connection_url)
     path = unquote(parsed.path.lstrip("/")) or None
-    query = dict(
-        part.split("=", 1) if "=" in part else (part, "")
-        for part in parsed.query.split("&")
-        if part
-    )
+    query = dict(parse_qsl(parsed.query, keep_blank_values=True))
     ssl_value = query.get("sslmode") or query.get("ssl")
     ssl_required = ssl_value not in {None, "", "0", "false", "disable"}
     return {

--- a/tests/test_main_safe_startup_logging.py
+++ b/tests/test_main_safe_startup_logging.py
@@ -1,0 +1,33 @@
+"""Regression coverage for credential-safe application startup logging."""
+
+import ast
+from pathlib import Path
+
+
+def test_main_uses_allowlisted_database_metadata_for_startup_logging() -> None:
+    """Application startup must not render a connection URL into a log message."""
+    source = Path("app/main.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    imported_names = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        for alias in node.names
+    }
+    called_names = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    called_attributes = {
+        node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+    }
+
+    assert "safe_connection_metadata" in imported_names
+    assert "safe_connection_metadata" in called_names
+    assert "make_url" not in imported_names
+    assert "render_as_string" not in called_attributes
+    assert "Starting with DATABASE_URL" not in source

--- a/tests/test_safe_logging.py
+++ b/tests/test_safe_logging.py
@@ -49,10 +49,39 @@ def test_connection_metadata_excludes_redis_token_and_userinfo() -> None:
         "host": "actual-mantis-12345.upstash.io",
         "port": 6379,
         "database": "0",
-        "ssl_required": False,
+        "ssl_required": True,
     }
     assert "default" not in rendered
     assert token not in rendered
+
+
+def test_connection_metadata_omits_opaque_http_path_tokens() -> None:
+    """Generic URL paths must not be decoded or exposed as database metadata."""
+    encoded_token = "secret%2Ftoken%2Fvalue"
+
+    metadata = safe_connection_metadata(
+        f"https://api.example.test/{encoded_token}?ssl=true"
+    )
+    rendered = repr(metadata)
+
+    assert metadata == {
+        "scheme": "https",
+        "host": "api.example.test",
+        "port": None,
+        "database": None,
+        "ssl_required": False,
+    }
+    assert encoded_token not in rendered
+    assert "secret/token/value" not in rendered
+
+
+def test_connection_metadata_does_not_mark_sslmode_prefer_as_required() -> None:
+    """PostgreSQL prefer mode permits plaintext fallback and is not TLS-required."""
+    metadata = safe_connection_metadata(
+        "postgresql://db.example.test/comic_pile?sslmode=prefer"
+    )
+
+    assert metadata["ssl_required"] is False
 
 
 def test_redact_sensitive_values_handles_nested_configuration() -> None:
@@ -77,6 +106,28 @@ def test_redact_sensitive_values_handles_nested_configuration() -> None:
     assert "redis-secret" not in rendered
     assert "jwt-secret" not in rendered
     assert "github-secret" not in rendered
+    assert rendered.count("[REDACTED]") == 4
+
+
+def test_redact_sensitive_values_removes_connection_urls() -> None:
+    """URL-valued settings must be redacted even when their key lacks secret words."""
+    raw_password = "raw-password"
+    encoded_password = "encoded%2Fpassword"
+    values = {
+        "DATABASE_URL": f"postgresql://user:{raw_password}@db.example.test/app",
+        "TEST_DATABASE_URL": (
+            f"postgresql://user:{encoded_password}@db.example.test/test"
+        ),
+        "REDIS_URL": f"rediss://default:{raw_password}@cache.example.test:6379/0",
+        "CONNECTION_URL": f"https://api.example.test/{encoded_password}",
+    }
+
+    redacted = redact_sensitive_values(values)
+    rendered = repr(redacted)
+
+    assert raw_password not in rendered
+    assert encoded_password not in rendered
+    assert "encoded/password" not in rendered
     assert rendered.count("[REDACTED]") == 4
 
 

--- a/tests/test_safe_logging.py
+++ b/tests/test_safe_logging.py
@@ -1,5 +1,9 @@
 """Regression tests for credential-safe configuration logging."""
 
+import logging
+
+import pytest
+
 from app.safe_logging import (
     redact_sensitive_values,
     safe_connection_metadata,
@@ -88,3 +92,44 @@ def test_exception_metadata_does_not_serialize_secret_message() -> None:
     assert metadata == {"error_type": "RuntimeError"}
     assert password not in repr(metadata)
     assert "db.example.test" not in repr(metadata)
+
+
+def test_emitted_logs_exclude_connection_and_exception_secrets(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The actual structured log records must never serialize credential-shaped values."""
+    logger = logging.getLogger("tests.safe_logging")
+    database_password = "database-password-that-must-not-log"
+    redis_token = "redis-token-that-must-not-log"
+    database_url = (
+        "postgresql+asyncpg://comic_user:"
+        f"{database_password}@ep-example.neon.tech/comic_pile"
+        f"?sslmode=require&token={redis_token}"
+    )
+    error = RuntimeError(f"connection failed for {database_url}")
+
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        logger.info(
+            "Database configured",
+            extra={"database": safe_connection_metadata(database_url)},
+        )
+        logger.error(
+            "Database connection test failed",
+            extra={"database_error": safe_exception_metadata(error)},
+        )
+
+    rendered_records = repr(caplog.records)
+    assert database_password not in caplog.text
+    assert redis_token not in caplog.text
+    assert "comic_user" not in caplog.text
+    assert database_password not in rendered_records
+    assert redis_token not in rendered_records
+    assert "comic_user" not in rendered_records
+    assert caplog.records[0].database == {
+        "scheme": "postgresql+asyncpg",
+        "host": "ep-example.neon.tech",
+        "port": None,
+        "database": "comic_pile",
+        "ssl_required": True,
+    }
+    assert caplog.records[1].database_error == {"error_type": "RuntimeError"}

--- a/tests/test_safe_logging.py
+++ b/tests/test_safe_logging.py
@@ -84,6 +84,24 @@ def test_connection_metadata_does_not_mark_sslmode_prefer_as_required() -> None:
     assert metadata["ssl_required"] is False
 
 
+def test_connection_metadata_handles_malformed_port_without_raising() -> None:
+    """Diagnostic metadata must not turn malformed configuration into an import crash."""
+    secret = "password-that-must-not-log"
+
+    metadata = safe_connection_metadata(
+        f"postgresql://user:{secret}@db.example.test:not-a-port/comic_pile"
+    )
+
+    assert metadata == {
+        "scheme": None,
+        "host": None,
+        "port": None,
+        "database": None,
+        "ssl_required": False,
+    }
+    assert secret not in repr(metadata)
+
+
 def test_redact_sensitive_values_handles_nested_configuration() -> None:
     """Known secret fields must be removed from nested structured logs."""
     values = {

--- a/tests/test_safe_logging.py
+++ b/tests/test_safe_logging.py
@@ -1,0 +1,90 @@
+"""Regression tests for credential-safe configuration logging."""
+
+from app.safe_logging import (
+    redact_sensitive_values,
+    safe_connection_metadata,
+    safe_exception_metadata,
+)
+
+
+def test_connection_metadata_excludes_database_credentials() -> None:
+    """Database metadata must not preserve userinfo or query credentials."""
+    password = "p%40ssword-super-secret"
+    token = "neon-token-should-never-log"
+    url = (
+        f"postgresql+asyncpg://comic_user:{password}@ep-example.us-east-2.aws.neon.tech/"
+        f"comic_pile?sslmode=require&token={token}"
+    )
+
+    metadata = safe_connection_metadata(url)
+    rendered = repr(metadata)
+
+    assert metadata == {
+        "scheme": "postgresql+asyncpg",
+        "host": "ep-example.us-east-2.aws.neon.tech",
+        "port": None,
+        "database": "comic_pile",
+        "ssl_required": True,
+    }
+    assert "comic_user" not in rendered
+    assert password not in rendered
+    assert "p@ssword-super-secret" not in rendered
+    assert token not in rendered
+
+
+def test_connection_metadata_excludes_redis_token_and_userinfo() -> None:
+    """Redis metadata must expose only its non-secret network identity."""
+    token = "upstash-rest-token-value"
+    metadata = safe_connection_metadata(
+        f"rediss://default:{token}@actual-mantis-12345.upstash.io:6379/0"
+    )
+    rendered = repr(metadata)
+
+    assert metadata == {
+        "scheme": "rediss",
+        "host": "actual-mantis-12345.upstash.io",
+        "port": 6379,
+        "database": "0",
+        "ssl_required": False,
+    }
+    assert "default" not in rendered
+    assert token not in rendered
+
+
+def test_redact_sensitive_values_handles_nested_configuration() -> None:
+    """Known secret fields must be removed from nested structured logs."""
+    values = {
+        "environment": "production",
+        "database": {
+            "host": "db.example.test",
+            "password": "database-secret",
+        },
+        "redis_token": "redis-secret",
+        "authorization": "Bearer jwt-secret",
+        "nested": [{"github_api_key": "github-secret"}],
+    }
+
+    redacted = redact_sensitive_values(values)
+    rendered = repr(redacted)
+
+    assert "db.example.test" in rendered
+    assert "production" in rendered
+    assert "database-secret" not in rendered
+    assert "redis-secret" not in rendered
+    assert "jwt-secret" not in rendered
+    assert "github-secret" not in rendered
+    assert rendered.count("[REDACTED]") == 4
+
+
+def test_exception_metadata_does_not_serialize_secret_message() -> None:
+    """Dependency exceptions may contain full URLs and must log only their type."""
+    password = "encoded%2Fdatabase-password"
+    error = RuntimeError(
+        f"could not connect to postgresql://user:{password}@db.example.test/comic_pile"
+    )
+
+    metadata = safe_exception_metadata(error)
+
+    assert metadata == {"error_type": "RuntimeError"}
+    assert password not in repr(metadata)
+    assert "db.example.test" not in repr(metadata)


### PR DESCRIPTION
Closes #868

## What changed
- replace rendered connection URLs with allowlisted database metadata
- add reusable structured redaction and exception metadata helpers
- add regression tests for database passwords, URL-encoded credentials, Redis tokens, JWT-like authorization values, and nested secrets

The unsafe path was the database configuration diagnostic, which rendered connection URL data during module import. The replacement logs only driver, host, port, database name, and SSL requirement.

## Validation
Focused tests and repository CI are required before merge.

## Changelog
Required user/operator-facing security fix; the PR entry will be added now that the PR number exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application logging to prevent database and Redis credentials from appearing in logs.
  * Database connection failures now report safe, structured error details without exposing sensitive exception messages.
  * Nested configuration values are redacted consistently.

* **Tests**
  * Added coverage verifying that connection metadata, credentials, and exception details remain protected in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->