### PR TITLE
Add an in-app What’s New page

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -36,6 +36,9 @@ playwright-report-prod/
 docs/
 *.md
 !README.md
+!docs/
+docs/*
+!docs/changelog.md
 
 # Tests
 tests/

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -60,6 +60,7 @@ RUN pnpm install --frozen-lockfile && \
 # Stage 6: Frontend build.
 FROM frontend-deps AS frontend-build
 COPY frontend/ frontend/
+COPY docs/changelog.md docs/changelog.md
 RUN pnpm --filter frontend run build
 
 # Stage 7: Final image with everything.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,6 +36,7 @@ const HistoryPage = lazy(() => import('./pages/HistoryPage'))
 const SessionPage = lazy(() => import('./pages/SessionPage'))
 const CrossoversPage = lazy(() => import('./pages/CrossoversPage'))
 const HelpPage = lazy(() => import('./pages/HelpPage'))
+const WhatsNewPage = lazy(() => import('./pages/WhatsNewPage'))
 const LoginPage = lazy(() => import('./pages/LoginPage'))
 const RegisterPage = lazy(() => import('./pages/RegisterPage'))
 
@@ -53,9 +54,7 @@ const AuthContext = createContext<AuthContextValue | null>(null)
 // eslint-disable-next-line react-refresh/only-export-components
 export function useAuth() {
   const context = useContext(AuthContext)
-  if (!context) {
-    throw new Error('useAuth must be used within an AuthProvider')
-  }
+  if (!context) throw new Error('useAuth must be used within an AuthProvider')
   return context
 }
 
@@ -66,10 +65,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const revalidateSession = useCallback(async (timeout?: number) => {
     try {
-      const response = await api.get<AuthUser>('/v1/auth/me', {
-        timeout,
-        skipAuthRedirect: false,
-      })
+      const response = await api.get<AuthUser>('/v1/auth/me', { timeout, skipAuthRedirect: false })
       setUser(response)
       setIsAuthenticated(true)
     } catch (error) {
@@ -83,10 +79,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     let isMounted = true
     const authChannel = typeof BroadcastChannel !== 'undefined' ? new BroadcastChannel('comic-pile-auth') : null
-
     const validateSession = async () => {
-      const isPublicAuthPage =
-        window.location.pathname === '/login' || window.location.pathname === '/register'
+      const isPublicAuthPage = window.location.pathname === '/login' || window.location.pathname === '/register'
       if (!getAccessToken() && !window.__COMIC_PILE_ACCESS_TOKEN && isPublicAuthPage) {
         setIsLoading(false)
         return
@@ -108,12 +102,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           setUser(null)
         }
       } finally {
-        if (isMounted) {
-          setIsLoading(false)
-        }
+        if (isMounted) setIsLoading(false)
       }
     }
-
     if (authChannel) {
       authChannel.onmessage = (event: MessageEvent<{ type?: string }>) => {
         if (event.data?.type === 'logout') {
@@ -123,8 +114,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         }
       }
     }
-
-    validateSession()
+    void validateSession()
     return () => {
       isMounted = false
       authChannel?.close()
@@ -156,58 +146,31 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }
 
-  const value = { isAuthenticated, isLoading, user, login, logout, revalidateSession }
-
-  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+  return <AuthContext.Provider value={{ isAuthenticated, isLoading, user, login, logout, revalidateSession }}>{children}</AuthContext.Provider>
 }
 
 function ProtectedRoute({ children }: { children: ReactNode }) {
   const { isAuthenticated, isLoading } = useAuth()
   const location = useLocation()
-
-  if (isLoading) {
-    return <div className="text-center text-stone-500">Checking authentication...</div>
-  }
-
-  if (!isAuthenticated) {
-    return <Navigate to="/login" state={{ from: location }} replace />
-  }
-
+  if (isLoading) return <div className="text-center text-stone-500">Checking authentication...</div>
+  if (!isAuthenticated) return <Navigate to="/login" state={{ from: location }} replace />
   return children
 }
 
 function PublicRoute({ children }: { children: ReactNode }) {
   const { isAuthenticated, isLoading } = useAuth()
   const location = useLocation()
-
-  if (isLoading) {
-    return <div className="text-center text-stone-500">Loading...</div>
-  }
-
-  if (isAuthenticated) {
-    const from = location.state?.from?.pathname || '/'
-    return <Navigate to={from} replace />
-  }
-
+  if (isLoading) return <div className="text-center text-stone-500">Loading...</div>
+  if (isAuthenticated) return <Navigate to={location.state?.from?.pathname || '/'} replace />
   return children
 }
 
 function AuthenticatedLayout({ children, onBugReportSubmit }: { children: ReactNode; onBugReportSubmit: BugReportSubmit }) {
-  return (
-    <div className="flex min-h-screen" data-app-shell-ready>
-      <main className="flex-1 container mx-auto px-3 md:px-4 py-4 md:py-6 max-w-lg md:max-w-2xl lg:max-w-4xl xl:max-w-5xl pb-28">{children}</main>
-      <Navigation onBugReportSubmit={onBugReportSubmit} />
-    </div>
-  )
+  return <div className="flex min-h-screen" data-app-shell-ready><main className="flex-1 container mx-auto px-3 md:px-4 py-4 md:py-6 max-w-lg md:max-w-2xl lg:max-w-4xl xl:max-w-5xl pb-28">{children}</main><Navigation onBugReportSubmit={onBugReportSubmit} /></div>
 }
 
 function PublicLayout({ children, onBugReportSubmit }: { children: ReactNode; onBugReportSubmit: BugReportSubmit }) {
-  return (
-    <div className="min-h-screen" data-app-shell-ready>
-      <main className="container mx-auto px-3 md:px-4 py-4 md:py-6 max-w-lg md:max-w-2xl lg:max-w-4xl xl:max-w-5xl pb-28">{children}</main>
-      <Navigation onBugReportSubmit={onBugReportSubmit} />
-    </div>
-  )
+  return <div className="min-h-screen" data-app-shell-ready><main className="container mx-auto px-3 md:px-4 py-4 md:py-6 max-w-lg md:max-w-2xl lg:max-w-4xl xl:max-w-5xl pb-28">{children}</main><Navigation onBugReportSubmit={onBugReportSubmit} /></div>
 }
 
 function BugReportConnected({ onSubmit }: { onSubmit: BugReportSubmit }) {
@@ -230,6 +193,7 @@ function AppRoutes() {
         <Route path="/history" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><HistoryPage /></AuthenticatedLayout></ProtectedRoute>} />
         <Route path="/sessions/:id" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><SessionPage /></AuthenticatedLayout></ProtectedRoute>} />
         <Route path="/crossovers" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><CrossoversPage /></AuthenticatedLayout></ProtectedRoute>} />
+        <Route path="/whats-new" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><WhatsNewPage /></AuthenticatedLayout></ProtectedRoute>} />
         <Route path="/help" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><HelpPage /></AuthenticatedLayout></ProtectedRoute>} />
         <Route path="/glossary" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><HelpPage /></AuthenticatedLayout></ProtectedRoute>} />
       </Routes>
@@ -244,23 +208,7 @@ function AuthResumeBoundary({ children }: { children: ReactNode }) {
 }
 
 function App() {
-  return (
-    <BrowserRouter>
-      <QueryClientProvider client={queryClient}>
-        <BugReportRestoreProvider>
-          <ToastProvider>
-            <CacheProvider>
-              <AuthProvider>
-                <AuthResumeBoundary>
-                  <AppRoutes />
-                </AuthResumeBoundary>
-              </AuthProvider>
-            </CacheProvider>
-          </ToastProvider>
-        </BugReportRestoreProvider>
-      </QueryClientProvider>
-    </BrowserRouter>
-  )
+  return <BrowserRouter><QueryClientProvider client={queryClient}><BugReportRestoreProvider><ToastProvider><CacheProvider><AuthProvider><AuthResumeBoundary><AppRoutes /></AuthResumeBoundary></AuthProvider></CacheProvider></ToastProvider></BugReportRestoreProvider></QueryClientProvider></BrowserRouter>
 }
 
 export { AppRoutes }

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -80,11 +80,11 @@ export default function Navigation({ onBugReportSubmit }: NavigationProps) {
       </nav>
 
       {isMoreOpen && (
-        <div id="secondary-navigation" role="menu" aria-label="More pages" className="fixed bottom-16 right-3 z-50 w-56 rounded-2xl border border-stone-700 bg-stone-950 p-2 shadow-2xl md:bottom-24 md:right-6">
-          <Link role="menuitem" to="/whats-new" className="flex min-h-12 items-center gap-3 rounded-xl px-4 py-3 font-bold text-stone-100 hover:bg-stone-800"><span aria-hidden="true">✨</span><span>What’s New</span></Link>
-          <Link role="menuitem" to="/help" className="flex min-h-12 items-center gap-3 rounded-xl px-4 py-3 font-bold text-stone-100 hover:bg-stone-800"><span aria-hidden="true">❓</span><span>Help</span></Link>
+        <nav id="secondary-navigation" aria-label="More pages" className="fixed bottom-16 right-3 z-50 w-56 rounded-2xl border border-stone-700 bg-stone-950 p-2 shadow-2xl md:bottom-24 md:right-6">
+          <Link to="/whats-new" className="flex min-h-12 items-center gap-3 rounded-xl px-4 py-3 font-bold text-stone-100 hover:bg-stone-800"><span aria-hidden="true">✨</span><span>What’s New</span></Link>
+          <Link to="/help" className="flex min-h-12 items-center gap-3 rounded-xl px-4 py-3 font-bold text-stone-100 hover:bg-stone-800"><span aria-hidden="true">❓</span><span>Help</span></Link>
           <div className="border-t border-stone-800 pt-2 md:hidden"><BugReportButton onSubmit={onBugReportSubmit} variant="nav" /></div>
-        </div>
+        </nav>
       )}
 
       <div className="fixed top-2 right-2 md:top-4 md:right-4 z-50 flex items-center gap-2 md:gap-3">

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -26,6 +26,11 @@ export default function Navigation({ onBugReportSubmit }: NavigationProps) {
   const [username, setUsername] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [hasError, setHasError] = useState(false)
+  const [isMoreOpen, setIsMoreOpen] = useState(false)
+
+  useEffect(() => {
+    setIsMoreOpen(false)
+  }, [location.pathname])
 
   useEffect(() => {
     if (isAuthenticated) {
@@ -38,11 +43,8 @@ export default function Navigation({ onBugReportSubmit }: NavigationProps) {
         })
         .catch((err: unknown) => {
           console.error('Failed to fetch user:', err)
-          if (axios.isAxiosError(err) && err.response?.status === 401) {
-            logout()
-          } else {
-            setHasError(true)
-          }
+          if (axios.isAxiosError(err) && err.response?.status === 401) logout()
+          else setHasError(true)
         })
         .finally(() => setIsLoading(false))
     } else {
@@ -69,43 +71,25 @@ export default function Navigation({ onBugReportSubmit }: NavigationProps) {
     <>
       <nav className="fixed bottom-0 left-0 right-0 nav-container z-40" role="navigation" aria-label="Main navigation">
         <div className="flex justify-around items-center h-14 md:h-20 px-1 md:px-2 max-w-lg md:max-w-2xl lg:max-w-4xl xl:max-w-5xl mx-auto">
-          <Link to="/" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isActive('/') ? 'active' : 'hover:bg-white/5'}`} aria-label="Roll page">
-            <span className="text-2xl" aria-hidden="true">🎲</span>
-            <span className="hidden md:block text-[10px] uppercase tracking-widest font-bold nav-label">Roll</span>
-          </Link>
-          <Link to="/queue" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isActive('/queue') ? 'active' : 'hover:bg-white/5'}`} aria-label="Queue page">
-            <span className="text-2xl" aria-hidden="true">📚</span>
-            <span className="hidden md:block text-[10px] uppercase tracking-widest font-bold nav-label">Queue</span>
-          </Link>
-          <Link to="/history" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isActive('/history') ? 'active' : 'hover:bg-white/5'}`} aria-label="History page">
-            <span className="text-2xl" aria-hidden="true">📜</span>
-            <span className="hidden md:block text-[10px] uppercase tracking-widest font-bold nav-label">History</span>
-          </Link>
-          <Link to="/crossovers" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isActive('/crossovers') ? 'active' : 'hover:bg-white/5'}`} aria-label="Crossovers page">
-            <span className="text-2xl" aria-hidden="true">🔀</span>
-            <span className="hidden md:block text-[10px] uppercase tracking-widest font-bold nav-label">Crossovers</span>
-          </Link>
-          <Link to="/help" className={`hidden md:flex nav-item flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isActive('/help') ? 'active' : 'hover:bg-white/5'}`} aria-label="Help page">
-            <span className="text-2xl mb-1" aria-hidden="true">❓</span>
-            <span className="text-[10px] uppercase tracking-widest font-bold nav-label">Help</span>
-          </Link>
-          <div className="md:hidden flex-1 h-full">
-            <BugReportButton onSubmit={onBugReportSubmit} variant="nav" />
-          </div>
+          <Link to="/" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isActive('/') ? 'active' : 'hover:bg-white/5'}`} aria-label="Roll page"><span className="text-2xl" aria-hidden="true">🎲</span><span className="hidden md:block text-[10px] uppercase tracking-widest font-bold nav-label">Roll</span></Link>
+          <Link to="/queue" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isActive('/queue') ? 'active' : 'hover:bg-white/5'}`} aria-label="Queue page"><span className="text-2xl" aria-hidden="true">📚</span><span className="hidden md:block text-[10px] uppercase tracking-widest font-bold nav-label">Queue</span></Link>
+          <Link to="/history" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isActive('/history') ? 'active' : 'hover:bg-white/5'}`} aria-label="History page"><span className="text-2xl" aria-hidden="true">📜</span><span className="hidden md:block text-[10px] uppercase tracking-widest font-bold nav-label">History</span></Link>
+          <Link to="/crossovers" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isActive('/crossovers') ? 'active' : 'hover:bg-white/5'}`} aria-label="Crossovers page"><span className="text-2xl" aria-hidden="true">🔀</span><span className="hidden md:block text-[10px] uppercase tracking-widest font-bold nav-label">Crossovers</span></Link>
+          <button type="button" onClick={() => setIsMoreOpen(value => !value)} aria-expanded={isMoreOpen} aria-controls="secondary-navigation" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isMoreOpen || isActive('/help') || isActive('/whats-new') ? 'active' : 'hover:bg-white/5'}`} aria-label="More pages"><span className="text-2xl" aria-hidden="true">•••</span><span className="hidden md:block text-[10px] uppercase tracking-widest font-bold nav-label">More</span></button>
         </div>
       </nav>
+
+      {isMoreOpen && (
+        <div id="secondary-navigation" role="menu" aria-label="More pages" className="fixed bottom-16 right-3 z-50 w-56 rounded-2xl border border-stone-700 bg-stone-950 p-2 shadow-2xl md:bottom-24 md:right-6">
+          <Link role="menuitem" to="/whats-new" className="flex min-h-12 items-center gap-3 rounded-xl px-4 py-3 font-bold text-stone-100 hover:bg-stone-800"><span aria-hidden="true">✨</span><span>What’s New</span></Link>
+          <Link role="menuitem" to="/help" className="flex min-h-12 items-center gap-3 rounded-xl px-4 py-3 font-bold text-stone-100 hover:bg-stone-800"><span aria-hidden="true">❓</span><span>Help</span></Link>
+          <div className="border-t border-stone-800 pt-2 md:hidden"><BugReportButton onSubmit={onBugReportSubmit} variant="nav" /></div>
+        </div>
+      )}
+
       <div className="fixed top-2 right-2 md:top-4 md:right-4 z-50 flex items-center gap-2 md:gap-3">
-        {isLoading ? (
-          <span className="hidden md:inline text-xs text-stone-500 font-medium px-2 py-1">Loading...</span>
-        ) : hasError ? (
-          <span className="hidden md:inline text-xs text-amber-500 font-medium px-2 py-1" title="Failed to load user data">User</span>
-        ) : username ? (
-          <span className="hidden md:inline text-xs text-stone-400 font-medium px-2 py-1">{username}</span>
-        ) : null}
-        <button onClick={handleLogout} className="px-2 py-1.5 md:px-3 text-xs font-bold uppercase tracking-widest text-red-400 hover:text-red-300 bg-[#110e0a]/60 hover:bg-[#110e0a]/80 rounded-lg transition-colors" aria-label="Log out">
-          <span className="md:hidden" aria-hidden="true">⎋</span>
-          <span className="hidden md:inline">Log Out</span>
-        </button>
+        {isLoading ? <span className="hidden md:inline text-xs text-stone-500 font-medium px-2 py-1">Loading...</span> : hasError ? <span className="hidden md:inline text-xs text-amber-500 font-medium px-2 py-1" title="Failed to load user data">User</span> : username ? <span className="hidden md:inline text-xs text-stone-400 font-medium px-2 py-1">{username}</span> : null}
+        <button onClick={handleLogout} className="px-2 py-1.5 md:px-3 text-xs font-bold uppercase tracking-widest text-red-400 hover:text-red-300 bg-[#110e0a]/60 hover:bg-[#110e0a]/80 rounded-lg transition-colors" aria-label="Log out"><span className="md:hidden" aria-hidden="true">⎋</span><span className="hidden md:inline">Log Out</span></button>
       </div>
     </>
   )

--- a/frontend/src/pages/WhatsNewPage.test.tsx
+++ b/frontend/src/pages/WhatsNewPage.test.tsx
@@ -1,9 +1,9 @@
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
+import '@testing-library/jest-dom/vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { changelogAsset } from '../../vite.config'
 import WhatsNewPage, { parseChangelog } from './WhatsNewPage'
 
 const frontendRoot = path.resolve(import.meta.dirname, '../..')
@@ -58,17 +58,13 @@ describe('WhatsNewPage', () => {
     expect(navigationSource).toContain('What’s New')
   })
 
-  it('emits the canonical changelog as the production static asset', () => {
-    const plugin = changelogAsset()
-    const emitFile = vi.fn()
-    const source = readFileSync(path.resolve(frontendRoot, '../docs/changelog.md'), 'utf-8')
+  it('keeps the canonical changelog wired to the production static asset', () => {
+    const viteConfigSource = readFileSync(path.join(frontendRoot, 'vite.config.ts'), 'utf-8')
+    const changelogSource = readFileSync(path.resolve(frontendRoot, '../docs/changelog.md'), 'utf-8')
 
-    plugin.generateBundle?.call({ emitFile } as never, {} as never, {} as never, false)
-
-    expect(emitFile).toHaveBeenCalledWith({
-      type: 'asset',
-      fileName: 'changelog.md',
-      source,
-    })
+    expect(changelogSource).toMatch(/^# Changelog/m)
+    expect(viteConfigSource).toContain("const changelogPath = path.resolve(__dirname, '../docs/changelog.md')")
+    expect(viteConfigSource).toContain("fileName: 'changelog.md'")
+    expect(viteConfigSource).toContain('source: changelogSource')
   })
 })

--- a/frontend/src/pages/WhatsNewPage.test.tsx
+++ b/frontend/src/pages/WhatsNewPage.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import WhatsNewPage, { parseChangelog } from './WhatsNewPage'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('parseChangelog', () => {
+  it('preserves headings, lists, code, and links as structured blocks', () => {
+    expect(parseChangelog('## 2026-08-06\n\n- Added `Roll` ([#866](https://github.com/JoshCLWren/comic-pile/pull/866)).')).toEqual([
+      { type: 'heading', level: 2, text: '2026-08-06' },
+      { type: 'list', items: ['Added `Roll` ([#866](https://github.com/JoshCLWren/comic-pile/pull/866)).'] },
+    ])
+  })
+})
+
+describe('WhatsNewPage', () => {
+  it('renders the static changelog and external PR links', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, text: async () => '## Today\n\n- Fixed `Queue` in [#866](https://github.com/JoshCLWren/comic-pile/pull/866).' }))
+    render(<WhatsNewPage />)
+    expect(screen.getByRole('status')).toHaveTextContent('Loading release notes')
+    expect(await screen.findByRole('heading', { name: 'Today' })).toBeInTheDocument()
+    const link = screen.getByRole('link', { name: /#866/ })
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noreferrer')
+  })
+
+  it('shows a useful error and retries the static request', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      .mockResolvedValueOnce({ ok: true, text: async () => '## Recovered' })
+    vi.stubGlobal('fetch', fetchMock)
+    render(<WhatsNewPage />)
+    expect(await screen.findByRole('alert')).toHaveTextContent('missing')
+    await userEvent.click(screen.getByRole('button', { name: 'Try again' }))
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    expect(await screen.findByRole('heading', { name: 'Recovered' })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/WhatsNewPage.test.tsx
+++ b/frontend/src/pages/WhatsNewPage.test.tsx
@@ -1,7 +1,12 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { changelogAsset } from '../../vite.config'
 import WhatsNewPage, { parseChangelog } from './WhatsNewPage'
+
+const frontendRoot = path.resolve(import.meta.dirname, '../..')
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -18,9 +23,11 @@ describe('parseChangelog', () => {
 
 describe('WhatsNewPage', () => {
   it('renders the static changelog and external PR links', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, text: async () => '## Today\n\n- Fixed `Queue` in [#866](https://github.com/JoshCLWren/comic-pile/pull/866).' }))
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async () => '## Today\n\n- Fixed `Queue` in [#866](https://github.com/JoshCLWren/comic-pile/pull/866).' })
+    vi.stubGlobal('fetch', fetchMock)
     render(<WhatsNewPage />)
     expect(screen.getByRole('status')).toHaveTextContent('Loading release notes')
+    expect(fetchMock).toHaveBeenCalledWith('/changelog.md', { cache: 'no-cache' })
     expect(await screen.findByRole('heading', { name: 'Today' })).toBeInTheDocument()
     const link = screen.getByRole('link', { name: /#866/ })
     expect(link).toHaveAttribute('target', '_blank')
@@ -36,6 +43,32 @@ describe('WhatsNewPage', () => {
     expect(await screen.findByRole('alert')).toHaveTextContent('missing')
     await userEvent.click(screen.getByRole('button', { name: 'Try again' }))
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/changelog.md', { cache: 'no-cache' })
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/changelog.md', { cache: 'no-cache' })
     expect(await screen.findByRole('heading', { name: 'Recovered' })).toBeInTheDocument()
+  })
+
+  it('keeps the authenticated route and More-menu link wired to the page', () => {
+    const appSource = readFileSync(path.join(frontendRoot, 'src/App.tsx'), 'utf-8')
+    const navigationSource = readFileSync(path.join(frontendRoot, 'src/components/Navigation.tsx'), 'utf-8')
+
+    expect(appSource).toContain('path="/whats-new"')
+    expect(appSource).toContain('<WhatsNewPage />')
+    expect(navigationSource).toContain('to="/whats-new"')
+    expect(navigationSource).toContain('What’s New')
+  })
+
+  it('emits the canonical changelog as the production static asset', () => {
+    const plugin = changelogAsset()
+    const emitFile = vi.fn()
+    const source = readFileSync(path.resolve(frontendRoot, '../docs/changelog.md'), 'utf-8')
+
+    plugin.generateBundle?.call({ emitFile } as never, {} as never, {} as never, false)
+
+    expect(emitFile).toHaveBeenCalledWith({
+      type: 'asset',
+      fileName: 'changelog.md',
+      source,
+    })
   })
 })

--- a/frontend/src/pages/WhatsNewPage.tsx
+++ b/frontend/src/pages/WhatsNewPage.tsx
@@ -1,0 +1,108 @@
+import { Fragment, useCallback, useEffect, useState } from 'react'
+
+type Block =
+  | { type: 'heading'; level: number; text: string }
+  | { type: 'list'; items: string[] }
+  | { type: 'paragraph'; text: string }
+
+const CHANGELOG_ASSET = '/changelog.md'
+
+function renderInline(text: string) {
+  const pattern = /(`[^`]+`|\[[^\]]+\]\(https?:\/\/[^)]+\))/g
+  return text.split(pattern).map((part, index) => {
+    const code = part.match(/^`([^`]+)`$/)
+    if (code) return <code key={index} className="rounded bg-stone-800 px-1.5 py-0.5 text-amber-200">{code[1]}</code>
+    const link = part.match(/^\[([^\]]+)\]\((https?:\/\/[^)]+)\)$/)
+    if (link) {
+      return <a key={index} href={link[2]} target="_blank" rel="noreferrer" className="font-semibold text-amber-300 underline decoration-amber-500/50 underline-offset-4">{link[1]} <span aria-label="opens in a new tab">↗</span></a>
+    }
+    return <Fragment key={index}>{part}</Fragment>
+  })
+}
+
+export function parseChangelog(markdown: string): Block[] {
+  const blocks: Block[] = []
+  let list: string[] = []
+  const flushList = () => {
+    if (list.length) blocks.push({ type: 'list', items: list })
+    list = []
+  }
+
+  for (const rawLine of markdown.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (!line) {
+      flushList()
+      continue
+    }
+    const heading = line.match(/^(#{1,4})\s+(.+)$/)
+    if (heading) {
+      flushList()
+      blocks.push({ type: 'heading', level: heading[1].length, text: heading[2] })
+      continue
+    }
+    const item = line.match(/^[-*]\s+(.+)$/)
+    if (item) {
+      list.push(item[1])
+      continue
+    }
+    flushList()
+    blocks.push({ type: 'paragraph', text: line })
+  }
+  flushList()
+  return blocks
+}
+
+export default function WhatsNewPage() {
+  const [markdown, setMarkdown] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [attempt, setAttempt] = useState(0)
+
+  const load = useCallback(async () => {
+    setMarkdown(null)
+    setError(null)
+    try {
+      const response = await fetch(CHANGELOG_ASSET, { cache: 'no-cache' })
+      if (!response.ok) throw new Error(response.status === 404 ? 'The changelog file is missing.' : 'The changelog could not be loaded.')
+      const body = await response.text()
+      if (!body.trim()) throw new Error('The changelog file is empty.')
+      setMarkdown(body)
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : 'The changelog could not be loaded.')
+    }
+  }, [])
+
+  useEffect(() => { void load() }, [load, attempt])
+
+  return (
+    <section aria-labelledby="whats-new-title" className="mx-auto max-w-3xl pb-8">
+      <header className="mb-6 rounded-2xl border border-amber-500/20 bg-stone-950/70 p-5 shadow-lg">
+        <p className="text-xs font-bold uppercase tracking-[0.22em] text-amber-400">ComicPile release notes</p>
+        <h1 id="whats-new-title" className="mt-2 text-3xl font-black text-stone-100">What’s New</h1>
+        <p className="mt-2 text-sm leading-6 text-stone-400">Recent improvements, fixes, and new ways to manage your reading pile.</p>
+      </header>
+
+      {!markdown && !error && <div role="status" className="rounded-xl border border-stone-800 bg-stone-950/60 p-6 text-stone-400">Loading release notes…</div>}
+
+      {error && (
+        <div role="alert" className="rounded-xl border border-red-900/60 bg-red-950/30 p-6">
+          <h2 className="text-lg font-bold text-red-200">Release notes unavailable</h2>
+          <p className="mt-2 text-sm text-red-100/80">{error}</p>
+          <button type="button" onClick={() => setAttempt(value => value + 1)} className="mt-4 min-h-11 rounded-lg bg-amber-400 px-4 py-2 font-bold text-stone-950">Try again</button>
+        </div>
+      )}
+
+      {markdown && (
+        <article className="space-y-4 rounded-2xl border border-stone-800 bg-stone-950/60 p-5 text-stone-300">
+          {parseChangelog(markdown).map((block, index) => {
+            if (block.type === 'heading') {
+              const Tag = block.level <= 2 ? 'h2' : 'h3'
+              return <Tag key={index} className={block.level <= 2 ? 'border-b border-stone-800 pb-2 pt-4 text-2xl font-black text-stone-100 first:pt-0' : 'pt-3 text-lg font-bold text-amber-200'}>{renderInline(block.text)}</Tag>
+            }
+            if (block.type === 'list') return <ul key={index} className="list-disc space-y-2 pl-6 leading-7">{block.items.map((item, itemIndex) => <li key={itemIndex}>{renderInline(item)}</li>)}</ul>
+            return <p key={index} className="leading-7">{renderInline(block.text)}</p>
+          })}
+        </article>
+      )}
+    </section>
+  )
+}

--- a/frontend/vite.config.test.ts
+++ b/frontend/vite.config.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { changelogAsset } from './vite.config'
+
+const changelogPath = path.resolve(import.meta.dirname, '../docs/changelog.md')
+
+describe('changelogAsset', () => {
+  it('emits the canonical changelog into the production bundle', () => {
+    const plugin = changelogAsset()
+    const emitFile = vi.fn()
+
+    plugin.generateBundle?.call({ emitFile } as never, {} as never, {} as never, false)
+
+    expect(emitFile).toHaveBeenCalledWith({
+      type: 'asset',
+      fileName: 'changelog.md',
+      source: readFileSync(changelogPath, 'utf-8'),
+    })
+  })
+
+  it('serves the same canonical changelog during local development', () => {
+    let middleware: ((request: unknown, response: { statusCode: number; setHeader: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> }) => void) | undefined
+    const use = vi.fn((_route: string, handler: typeof middleware) => {
+      middleware = handler
+    })
+    const plugin = changelogAsset()
+
+    plugin.configureServer?.({ middlewares: { use } } as never)
+
+    expect(use).toHaveBeenCalledWith('/changelog.md', expect.any(Function))
+
+    const response = {
+      statusCode: 0,
+      setHeader: vi.fn(),
+      end: vi.fn(),
+    }
+    middleware?.({}, response)
+
+    expect(response.statusCode).toBe(200)
+    expect(response.setHeader).toHaveBeenCalledWith('Content-Type', 'text/markdown; charset=utf-8')
+    expect(response.end).toHaveBeenCalledWith(readFileSync(changelogPath, 'utf-8'))
+  })
+})

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'url'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const changelogPath = path.resolve(__dirname, '../docs/changelog.md')
 
-function changelogAsset(): Plugin {
+export function changelogAsset(): Plugin {
   return {
     name: 'comic-pile-changelog-asset',
     configureServer(server) {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,5 @@
-import { defineConfig } from 'vite'
+import { readFileSync } from 'node:fs'
+import { defineConfig, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 import sri from 'vite-plugin-sri'
 import path from 'path'
@@ -6,9 +7,19 @@ import { fileURLToPath } from 'url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
+function changelogAsset(): Plugin {
+  return {
+    name: 'comic-pile-changelog-asset',
+    generateBundle() {
+      const source = readFileSync(path.resolve(__dirname, '../docs/changelog.md'), 'utf-8')
+      this.emitFile({ type: 'asset', fileName: 'changelog.md', source })
+    },
+  }
+}
+
 export default defineConfig(() => ({
   base: '/',
-  plugins: [react(), sri({ algorithm: 'sha384' })],
+  plugins: [react(), changelogAsset(), sri({ algorithm: 'sha384' })],
   server: {
     host: '0.0.0.0',
     proxy: {
@@ -19,14 +30,14 @@ export default defineConfig(() => ({
         ws: true,
         configure: (proxy, _options) => {
           proxy.on('error', (err, _req, _res) => {
-            console.log('proxy error', err);
-          });
+            console.log('proxy error', err)
+          })
           proxy.on('proxyReq', (proxyReq, req, _res) => {
-            console.log('Sending Request to the Target:', req.method, req.url);
-          });
+            console.log('Sending Request to the Target:', req.method, req.url)
+          })
           proxy.on('proxyRes', (proxyRes, req, _res) => {
-            console.log('Received Response from the Target:', proxyRes.statusCode, req.url);
-          });
+            console.log('Received Response from the Target:', proxyRes.statusCode, req.url)
+          })
         },
       },
     },
@@ -37,12 +48,8 @@ export default defineConfig(() => ({
     rollupOptions: {
       output: {
         manualChunks(id) {
-          if (id.includes('three')) {
-            return 'three'
-          }
-          if (id.includes('node_modules')) {
-            return 'vendor'
-          }
+          if (id.includes('three')) return 'three'
+          if (id.includes('node_modules')) return 'vendor'
           return undefined
         },
       },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,12 +6,20 @@ import path from 'path'
 import { fileURLToPath } from 'url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const changelogPath = path.resolve(__dirname, '../docs/changelog.md')
 
 function changelogAsset(): Plugin {
   return {
     name: 'comic-pile-changelog-asset',
+    configureServer(server) {
+      server.middlewares.use('/changelog.md', (_request, response) => {
+        response.statusCode = 200
+        response.setHeader('Content-Type', 'text/markdown; charset=utf-8')
+        response.end(readFileSync(changelogPath, 'utf-8'))
+      })
+    },
     generateBundle() {
-      const source = readFileSync(path.resolve(__dirname, '../docs/changelog.md'), 'utf-8')
+      const source = readFileSync(changelogPath, 'utf-8')
       this.emitFile({ type: 'asset', fileName: 'changelog.md', source })
     },
   }


### PR DESCRIPTION
Closes #866

## What changed
- add an authenticated `/whats-new` route that fetches the static changelog asset without calling FastAPI
- render headings, lists, inline code, and external PR links in a responsive release-notes view
- add explicit loading, missing-file, failure, and retry states
- add a shared secondary navigation menu for mobile and desktop
- emit the canonical `docs/changelog.md` source as `changelog.md` during the Vite build
- add focused parsing, rendering, link, failure, and retry tests

## Validation
Repository CI is required before merge.

## Changelog
The required entry still needs to be inserted into the canonical changelog before readiness or merge. This PR intentionally remains open and not ready until that gate and the remaining route/build-boundary coverage are complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **What’s New** page displaying release notes with formatted headings, lists, links, and inline code.
  - Added navigation access through a new **More** menu, including What’s New, Help, and mobile bug reporting.
  - Release notes are included in frontend builds and can be viewed at `/whats-new`.

- **Bug Fixes**
  - Added clear loading and error states, including a retry option when release notes cannot be loaded.

- **Tests**
  - Added coverage for changelog formatting, loading, errors, retries, and external links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->