### PR TITLE
Enforce production-only Vercel deployments

### DIFF
--- a/docs/PRODUCTION_PROFILE.md
+++ b/docs/PRODUCTION_PROFILE.md
@@ -100,7 +100,7 @@ Consequences for the production profile report:
 
 - `serverTiming` is currently expected to be `null` for records captured against this deployment. Treat that as an observed limitation of the current deployment path, not a permanent or documented Vercel platform guarantee.
 - Timing and diagnostics evidence remains available from the per-request `X-Request-ID`, `X-App-DB-Queries`, and `X-App-Cache` headers, from the structured `Slow HTTP request` warning logs, and from Vercel runtime logs such as request `x-vercel-id` and invocation timing information.
-- A preview-deployment comparison or origin-versus-proxy capture is still required before attributing the missing header to a specific Vercel proxy layer.
+- Investigate the missing header with local origin-versus-proxy captures or production runtime evidence. ComicPile intentionally does not provision Vercel Preview deployments for comparison testing.
 
 ## Production slow-request warnings are enabled
 

--- a/docs/VERCEL_DEPLOYMENT.md
+++ b/docs/VERCEL_DEPLOYMENT.md
@@ -1,0 +1,25 @@
+# Vercel deployment
+
+ComicPile uses Vercel for production only. The production branch is `main`.
+
+## Deployment contract
+
+- A push or merge to `main` may create the production deployment.
+- Pull requests and non-production branches must not create Vercel deployments.
+- Pull requests are validated locally and through GitHub Actions.
+- The React/Vite frontend is built as static output, while `/api/*` and the API documentation routes are served by FastAPI.
+- Neon is the production PostgreSQL provider.
+
+`vercel.json` enforces the repository side of this contract with `git.deploymentEnabled`: `main` is enabled and every other branch is disabled.
+
+## Live-project verification
+
+The Vercel project must track `main` as its Production Branch. Verify this in **Project Settings → Environments → Production → Branch Tracking**.
+
+After this change is merged:
+
+1. Push or update a non-production branch and confirm that no Vercel deployment is created.
+2. Merge a validated change to `main` and confirm that one Production deployment is created.
+3. Confirm the production alias still points to the successful `main` deployment.
+
+Do not add Preview credentials, Preview databases, Preview Redis instances, or Preview-specific runtime branches. Disposable service instances used by local development or GitHub Actions are separate from Vercel Preview and remain supported.

--- a/docs/changelog.d/2026-08-06-880.md
+++ b/docs/changelog.d/2026-08-06-880.md
@@ -1,0 +1,5 @@
+## 2026-08-06
+
+**Deployments**
+
+- ComicPile now treats Vercel as production-only, allowing automatic deployment from `main` while preventing pull-request and other non-production branches from consuming deployment resources ([#880](https://github.com/JoshCLWren/comic-pile/pull/880)).

--- a/tests/test_vercel_production_only.py
+++ b/tests/test_vercel_production_only.py
@@ -1,0 +1,33 @@
+"""Regression coverage for ComicPile's production-only Vercel deployment policy."""
+
+import json
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_vercel_deploys_main_and_disables_non_production_branches() -> None:
+    """Only main may receive an automatic Git deployment from Vercel."""
+    config = json.loads((REPOSITORY_ROOT / "vercel.json").read_text(encoding="utf-8"))
+
+    assert config["git"]["deploymentEnabled"] == {
+        "main": True,
+        "*": False,
+    }
+
+
+def test_vercel_keeps_production_static_and_api_routes_intact() -> None:
+    """The branch gate must not disturb the production frontend/API split."""
+    config = json.loads((REPOSITORY_ROOT / "vercel.json").read_text(encoding="utf-8"))
+    routes = config["routes"]
+
+    assert any(route.get("src") == "/api(?:/.*)?" for route in routes)
+    assert any(
+        route.get("src") == "/" and route.get("dest") == "/index.html"
+        for route in routes
+    )
+    assert any(
+        route.get("src") == "/(.*)" and route.get("dest") == "/index.html"
+        for route in routes
+    )

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,10 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "regions": ["cle1"],
   "git": {
-    "deploymentEnabled": false
+    "deploymentEnabled": {
+      "main": true,
+      "*": false
+    }
   },
   "builds": [
     {


### PR DESCRIPTION
Advances #877

## What changed
- replaced the all-branches Vercel deployment shutdown with an explicit branch policy that enables `main` and disables every non-production branch
- documented the production-only deployment contract and exact live-project verification steps
- kept local development and GitHub Actions as the pull-request validation paths
- added the required per-PR changelog fragment

## Why it matters
ComicPile no longer needs Preview deployments, but production still must deploy from `main`. The prior `deploymentEnabled: false` configuration disabled automatic Git deployments indiscriminately; this change makes the intended boundary explicit.

## External verification still required
The connected Vercel project confirms the latest deployment targets production, but the available project connector cannot change or expose the Production Branch setting. In Project Settings → Environments → Production → Branch Tracking, verify that the Production Branch is `main`. After merge, confirm a non-production branch creates no deployment and a `main` merge creates one Production deployment.

## Validation
- configuration follows Vercel's supported minimatch-based `git.deploymentEnabled` branch-map contract
- regression tests verify `main` remains enabled, all other branches are disabled, and static/API routing is preserved
- repository CI validates the exact branch

Changelog: `docs/changelog.d/2026-08-06-880.md`