### PR TITLE
fix(factory): restore Google free-tier model credentials

### DIFF
--- a/docs/changelog.d/2026-08-06-886.md
+++ b/docs/changelog.d/2026-08-06-886.md
@@ -2,4 +2,4 @@
 
 ### Factory reliability
 
-- [PR #886](https://github.com/JoshCLWren/comic-pile/pull/886) lets the local factory and model scout use the existing Google API key with OpenCode's Google provider, so the curated free-tier Gemini models can actually join model rotation instead of failing authentication.
+- [#886](https://github.com/JoshCLWren/comic-pile/pull/886) lets the local factory and model scout use the existing Google API key with OpenCode's Google provider, so the curated free-tier Gemini models can actually join model rotation instead of failing authentication.

--- a/docs/changelog.d/2026-08-06-886.md
+++ b/docs/changelog.d/2026-08-06-886.md
@@ -1,0 +1,5 @@
+## 2026-08-06
+
+### Factory reliability
+
+- [PR #886](https://github.com/JoshCLWren/comic-pile/pull/886) lets the local factory and model scout use the existing Google API key with OpenCode's Google provider, so the curated free-tier Gemini models can actually join model rotation instead of failing authentication.

--- a/scripts/comic-pile-opencode-factory.sh
+++ b/scripts/comic-pile-opencode-factory.sh
@@ -31,6 +31,12 @@ ALLOWED_PROVIDERS="${COMIC_PILE_FACTORY_ALLOWED_PROVIDERS:-opencode nvidia fcm-n
 # Only these Google models are verified free on the free tier; probing the whole
 # google/ prefix would otherwise probe paid pro models.
 GOOGLE_FREE_MODELS="${COMIC_PILE_GOOGLE_FREE_MODELS:-google/gemini-3.1-flash-lite google/gemini-2.5-flash-lite}"
+# OpenCode's Google provider reads GOOGLE_GENERATIVE_AI_API_KEY, but the
+# credentials file exports GOOGLE_API_KEY. Alias it so free-tier Gemini models
+# can be probed and confirmed.
+if [[ -z "${GOOGLE_GENERATIVE_AI_API_KEY:-}" && -n "${GOOGLE_API_KEY:-}" ]]; then
+  export GOOGLE_GENERATIVE_AI_API_KEY="$GOOGLE_API_KEY"
+fi
 FAILURE_THRESHOLD="${FACTORY_FAILURE_THRESHOLD:-2}"
 
 usage() {

--- a/scripts/opencode-model-scout.sh
+++ b/scripts/opencode-model-scout.sh
@@ -18,6 +18,12 @@ ALLOWED_PROVIDERS="${COMIC_PILE_FACTORY_ALLOWED_PROVIDERS:-opencode nvidia fcm-n
 # Only these Google models are verified free on the free tier; probing the whole
 # google/ prefix would otherwise probe paid pro models.
 GOOGLE_FREE_MODELS="${COMIC_PILE_GOOGLE_FREE_MODELS:-google/gemini-3.1-flash-lite google/gemini-2.5-flash-lite}"
+# OpenCode's Google provider reads GOOGLE_GENERATIVE_AI_API_KEY, but the
+# credentials file exports GOOGLE_API_KEY. Alias it so free-tier Gemini models
+# can be probed and confirmed.
+if [[ -z "${GOOGLE_GENERATIVE_AI_API_KEY:-}" && -n "${GOOGLE_API_KEY:-}" ]]; then
+  export GOOGLE_GENERATIVE_AI_API_KEY="$GOOGLE_API_KEY"
+fi
 WATCH=0
 RECHECK_SECONDS=600
 FORCE=0


### PR DESCRIPTION
Replaces conflicted PR #884 with the same focused credential fix replayed on current `main`.

OpenCode's Google provider reads `GOOGLE_GENERATIVE_AI_API_KEY`, while the generated free-model credentials export `GOOGLE_API_KEY`. The factory runner and model scout now alias the existing key only when the provider-specific variable is unset, allowing the curated free-tier Gemini models added in #818 to authenticate without changing user credentials.

The stale #884 branch was 45 commits behind `main`; this PR intentionally carries only the credential alias and none of that branch's unrelated historical diff.

Validation: exact-head CI will verify the current branch. The original implementation also directly confirmed both curated Gemini models could pass the scout tool-call probe after this alias was present.
