### PR TITLE
Persist browser sessions across access-token expiry

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -38,6 +38,7 @@ from app.security import (
 router = APIRouter(tags=["auth"])
 
 REFRESH_COOKIE_NAME = "refresh_token"
+REFRESH_COOKIE_PATH = "/api"
 
 
 def _set_refresh_cookie(response: Response, request: Request, refresh_token: str) -> None:
@@ -48,7 +49,7 @@ def _set_refresh_cookie(response: Response, request: Request, refresh_token: str
         httponly=True,
         secure=is_secure_request(request),
         samesite="lax",
-        path="/api/auth",
+        path=REFRESH_COOKIE_PATH,
         max_age=60 * 60 * 24 * 30,
     )
 
@@ -315,7 +316,7 @@ async def logout_user(
 
     response.delete_cookie(
         key=REFRESH_COOKIE_NAME,
-        path="/api/auth",
+        path=REFRESH_COOKIE_PATH,
         httponly=True,
         secure=is_secure_request(request),
         samesite="lax",

--- a/docs/changelog.d/2026-08-06-887.md
+++ b/docs/changelog.d/2026-08-06-887.md
@@ -1,0 +1,5 @@
+## 2026-08-06
+
+**Authentication**
+
+- ComicPile now keeps signed-in browser sessions alive when the short-lived access token expires, using the existing 30-day refresh session instead of unexpectedly sending readers back to login ([#887](https://github.com/JoshCLWren/comic-pile/pull/887)).

--- a/tests/test_auth_persistence.py
+++ b/tests/test_auth_persistence.py
@@ -1,0 +1,58 @@
+"""Regression coverage for browser authentication persistence."""
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_v1_auth_refresh_cookie_survives_access_token_expiry(client: AsyncClient) -> None:
+    """The browser refresh cookie must be sent to the versioned auth endpoints."""
+    register_response = await client.post(
+        "/api/v1/auth/register",
+        json={
+            "username": "persistent-session-user",
+            "email": "persistent-session@example.com",
+            "password": "password123",
+        },
+    )
+    assert register_response.status_code == 200
+
+    login_response = await client.post(
+        "/api/v1/auth/login",
+        json={"username": "persistent-session-user", "password": "password123"},
+    )
+    assert login_response.status_code == 200
+    set_cookie = login_response.headers.get("set-cookie", "")
+    assert "refresh_token=" in set_cookie
+    assert "Path=/api" in set_cookie
+    assert "HttpOnly" in set_cookie
+    assert "Max-Age=2592000" in set_cookie
+
+    refresh_response = await client.post("/api/v1/auth/refresh")
+    assert refresh_response.status_code == 200
+    assert refresh_response.json()["access_token"]
+
+
+@pytest.mark.asyncio
+async def test_v1_logout_clears_persistent_refresh_cookie(client: AsyncClient) -> None:
+    """Logging out must clear the same cookie scope used for persistent sessions."""
+    register_response = await client.post(
+        "/api/v1/auth/register",
+        json={
+            "username": "persistent-logout-user",
+            "email": "persistent-logout@example.com",
+            "password": "password123",
+        },
+    )
+    assert register_response.status_code == 200
+    access_token = register_response.json()["access_token"]
+
+    logout_response = await client.post(
+        "/api/v1/auth/logout",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert logout_response.status_code == 200
+    set_cookie = logout_response.headers.get("set-cookie", "")
+    assert "refresh_token=" in set_cookie
+    assert "Path=/api" in set_cookie
+    assert "Max-Age=0" in set_cookie


### PR DESCRIPTION
Fixes #885

## What changed
- broadened the HttpOnly refresh-token cookie path to the shared `/api` auth surface so both legacy and versioned auth aliases receive it
- kept the refresh cookie persistent for 30 days
- made logout clear the cookie using the same path
- added regression coverage proving `/api/v1/auth/refresh` can renew a session using only the browser cookie

## Why it matters
The frontend logs in and refreshes through `/api/v1/auth/*`, but the refresh cookie was scoped to `/api/auth`. Browsers therefore withheld the cookie from the versioned refresh endpoint, so an expired in-memory access token turned into an unnecessary login prompt instead of a transparent refresh.

## Validation
Focused regression coverage is included. Repository CI will validate the branch; this connector runtime does not provide a local checkout for executing pytest.
