### PR TITLE
Schedule production Playwright monitoring

### DIFF
--- a/.github/workflows/production-e2e-monitoring.yml
+++ b/.github/workflows/production-e2e-monitoring.yml
@@ -28,8 +28,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24'
-          cache: pnpm
-          cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: Enable pnpm
         run: corepack enable
@@ -43,7 +41,6 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Capture production timings
-        id: timings
         shell: bash
         run: |
           set -euo pipefail
@@ -71,7 +68,7 @@ jobs:
             echo '| --- | ---: | ---: |'
             tail -n +2 "$output" | awk -F '\t' '{printf "| `%s` | %.3fs | %.3fs |\n", $1, $2, $3}'
             echo
-            echo "First root request is treated as the cold-candidate sample only. A following warm request does not prove cold startup is fixed."
+            echo 'The first root request is a cold-candidate sample only. The following warm request does not prove cold startup is fixed.'
           } >> "$GITHUB_STEP_SUMMARY"
 
           if awk -v actual="$cold_root_ttfb" -v threshold="$ROOT_TTFB_WARNING_SECONDS" 'BEGIN { exit !(actual > threshold) }'; then

--- a/.github/workflows/production-e2e-monitoring.yml
+++ b/.github/workflows/production-e2e-monitoring.yml
@@ -1,0 +1,103 @@
+name: Production E2E monitoring
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '*/30 * * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-e2e-monitoring
+  cancel-in-progress: true
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      PROD_BASE_URL: https://comic-pile.vercel.app
+      WORKERS: '1'
+      ROOT_TTFB_WARNING_SECONDS: '5'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Enable pnpm
+        run: corepack enable
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Chromium
+        working-directory: frontend
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Capture production timings
+        id: timings
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p production-monitoring
+          output=production-monitoring/timings.tsv
+          printf 'path\tttfb_seconds\ttotal_seconds\n' > "$output"
+
+          probe() {
+            local path="$1"
+            curl --fail --silent --show-error --location \
+              --output /dev/null \
+              --write-out "${path}\t%{time_starttransfer}\t%{time_total}\n" \
+              "${PROD_BASE_URL}${path}" | tee -a "$output"
+          }
+
+          probe '/'
+          probe '/'
+          probe '/openapi.json'
+
+          cold_root_ttfb=$(awk -F '\t' '$1=="/" {print $2; exit}' "$output")
+          {
+            echo '## Production timing sample'
+            echo
+            echo '| Request | TTFB | Total |'
+            echo '| --- | ---: | ---: |'
+            tail -n +2 "$output" | awk -F '\t' '{printf "| `%s` | %.3fs | %.3fs |\n", $1, $2, $3}'
+            echo
+            echo "First root request is treated as the cold-candidate sample only. A following warm request does not prove cold startup is fixed."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if awk -v actual="$cold_root_ttfb" -v threshold="$ROOT_TTFB_WARNING_SECONDS" 'BEGIN { exit !(actual > threshold) }'; then
+            echo "::warning::First root TTFB was ${cold_root_ttfb}s, above the ${ROOT_TTFB_WARNING_SECONDS}s monitoring threshold."
+          fi
+
+      - name: Run production Playwright suite
+        working-directory: frontend
+        run: pnpm run test:e2e:prod-all
+
+      - name: Upload timing evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-timings-${{ github.run_id }}-${{ github.run_attempt }}
+          path: production-monitoring/timings.tsv
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Upload Playwright failure evidence
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-playwright-failure-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            playwright-report-prod-all/
+            frontend/test-results/
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/changelog.d/2026-08-06-888.md
+++ b/docs/changelog.d/2026-08-06-888.md
@@ -1,0 +1,5 @@
+## 2026-08-06
+
+### Reliability
+
+- [PR #888](https://github.com/JoshCLWren/comic-pile/pull/888) adds recurring production Chromium monitoring with cold-candidate timing evidence, bounded runs, and failure artifacts so production regressions and slow starts are visible without relying on manual checks.

--- a/docs/changelog.d/2026-08-06-888.md
+++ b/docs/changelog.d/2026-08-06-888.md
@@ -2,4 +2,4 @@
 
 ### Reliability
 
-- [PR #888](https://github.com/JoshCLWren/comic-pile/pull/888) adds recurring production Chromium monitoring with cold-candidate timing evidence, bounded runs, and failure artifacts so production regressions and slow starts are visible without relying on manual checks.
+- [#888](https://github.com/JoshCLWren/comic-pile/pull/888) adds recurring production Chromium monitoring with cold-candidate timing evidence, bounded runs, and failure artifacts so production regressions and slow starts are visible without relying on manual checks.


### PR DESCRIPTION
Closes #831

Adds scheduled and manual production browser monitoring against `https://comic-pile.vercel.app` using the existing `playwright.prod-all.config.ts` suite with one Chromium worker.

The workflow records root and OpenAPI TTFB/total timings, warns when the first root TTFB exceeds 5 seconds, prevents overlapping runs, bounds total runtime, and uploads timing plus Playwright failure evidence.

Validation: exact-head GitHub Actions will validate workflow syntax and repository checks. The production run itself intentionally exercises the deployed application rather than a seeded local database.