### PR TITLE
Defer Redis connectivity until cache use

### DIFF
--- a/app/cache.py
+++ b/app/cache.py
@@ -14,7 +14,8 @@ Usage:
         # Expensive DB query
         ...
 
-    # Initialize at startup
+    # Configure at startup without opening a network connection. The first
+    # real cache command performs the connection lazily.
     from app.config import get_redis_settings
     settings = get_redis_settings()
     if settings.is_configured:
@@ -25,7 +26,6 @@ Usage:
 
 from __future__ import annotations
 
-import asyncio
 import enum
 import functools
 import hashlib
@@ -189,7 +189,11 @@ class UpstashCache:
         token: str | None = None,
         local_url: str | None = None,
     ) -> None:
-        """Initialize Redis connection.
+        """Configure a Redis client without opening a network connection.
+
+        Startup must remain independent from optional cache availability. Client
+        construction is local; the first real cache command performs the network
+        connection and is protected by the command-level failure handling.
 
         Supports two modes:
         - Upstash cloud: provide url (REST URL) and token
@@ -200,47 +204,25 @@ class UpstashCache:
             return
 
         if local_url:
-            client = aioredis.Redis.from_url(
+            self._client = aioredis.Redis.from_url(
                 local_url,
                 decode_responses=True,
                 socket_connect_timeout=_CONNECT_TIMEOUT_SECONDS,
                 socket_timeout=_CONNECT_TIMEOUT_SECONDS,
             )
-            try:
-                async with asyncio.timeout(_CONNECT_TIMEOUT_SECONDS):
-                    await client.ping()
-                self._client = client
-                self._circuit_breaker.reset()
-                self._initialized = True
-                self._is_upstash = False
-                logger.info("Local Redis cache initialized: %s", local_url)
-                return
-            except Exception as e:
-                logger.error("Failed to initialize local Redis: %s", e)
-                try:
-                    await client.aclose()
-                except Exception:
-                    logger.debug("Failed to close unsuccessful Redis client", exc_info=True)
-                self._client = None
-                self._initialized = False
-                return
+            self._circuit_breaker.reset()
+            self._initialized = True
+            self._is_upstash = False
+            logger.info("Local Redis cache configured for lazy connection")
+            return
 
         if url and token:
-            client = UpstashRedis(url=url, token=token)
-            try:
-                async with asyncio.timeout(_CONNECT_TIMEOUT_SECONDS):
-                    await client.ping()
-                self._client = client
-                self._circuit_breaker.reset()
-                self._initialized = True
-                self._is_upstash = True
-                logger.info("Upstash Redis cache initialized")
-                return
-            except Exception as e:
-                logger.error("Failed to initialize Upstash Redis: %s", e)
-                self._client = None
-                self._initialized = False
-                return
+            self._client = UpstashRedis(url=url, token=token)
+            self._circuit_breaker.reset()
+            self._initialized = True
+            self._is_upstash = True
+            logger.info("Upstash Redis cache configured for lazy connection")
+            return
 
         logger.warning("No Redis configuration provided - caching disabled")
 
@@ -299,7 +281,7 @@ class UpstashCache:
             return value
 
         if isinstance(value, set):
-            return {"__type__": "set", "values": [UpstashCache._prepare_value(v) for v in value]}
+            return {"__type__": "set", "values": [UpstashCache._prepare_value(v) for v in value["values"]]} if "values" in value else {"__type__": "set", "values": [UpstashCache._prepare_value(v) for v in value]}
 
         if isinstance(value, dict):
             return {k: UpstashCache._prepare_value(v) for k, v in value.items()}

--- a/app/cache.py
+++ b/app/cache.py
@@ -281,7 +281,7 @@ class UpstashCache:
             return value
 
         if isinstance(value, set):
-            return {"__type__": "set", "values": [UpstashCache._prepare_value(v) for v in value["values"]]} if "values" in value else {"__type__": "set", "values": [UpstashCache._prepare_value(v) for v in value]}
+            return {"__type__": "set", "values": [UpstashCache._prepare_value(v) for v in value]}
 
         if isinstance(value, dict):
             return {k: UpstashCache._prepare_value(v) for k, v in value.items()}

--- a/docs/changelog.d/2026-08-06-889.md
+++ b/docs/changelog.d/2026-08-06-889.md
@@ -1,0 +1,5 @@
+## 2026-08-06
+
+### Reliability
+
+- [#889](https://github.com/JoshCLWren/comic-pile/pull/889) keeps Redis off ComicPile's startup critical path by configuring cache clients without contacting the service, so an enabled but slow or unavailable cache cannot delay FastAPI from becoming ready.

--- a/tests/test_cache_feature_flag.py
+++ b/tests/test_cache_feature_flag.py
@@ -97,6 +97,44 @@ async def test_uninitialized_cache_invalidation_makes_no_remote_calls() -> None:
 
 
 @pytest.mark.asyncio
+async def test_upstash_initialization_does_not_ping_remote_service(monkeypatch) -> None:
+    """Configuring Upstash at startup must perform no network command."""
+    from app import cache as cache_module
+
+    remote_client = AsyncMock()
+    monkeypatch.setattr(cache_module.cache, "_initialized", False)
+    monkeypatch.setattr(cache_module.cache, "_client", None)
+    monkeypatch.setattr(cache_module, "UpstashRedis", lambda **_: remote_client)
+
+    await cache_module.cache.initialize(
+        url="https://example.upstash.io",
+        token="test-token",
+    )
+
+    assert cache_module.cache.is_initialized is True
+    remote_client.ping.assert_not_awaited()
+    remote_client.get.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_local_redis_initialization_does_not_ping_service(monkeypatch) -> None:
+    """Configuring local Redis must defer connectivity until a cache command."""
+    from app import cache as cache_module
+
+    local_client = AsyncMock()
+    from_url = AsyncMock(return_value=local_client)
+    monkeypatch.setattr(cache_module.cache, "_initialized", False)
+    monkeypatch.setattr(cache_module.cache, "_client", None)
+    monkeypatch.setattr(cache_module.aioredis.Redis, "from_url", from_url)
+
+    await cache_module.cache.initialize(local_url="redis://localhost:6379/0")
+
+    assert cache_module.cache.is_initialized is True
+    from_url.assert_called_once()
+    local_client.ping.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_startup_skips_redis_with_credentials_when_gate_is_disabled(monkeypatch) -> None:
     """Cold startup never initializes or pings Redis when the gate is off."""
     from app import main

--- a/tests/test_cache_feature_flag.py
+++ b/tests/test_cache_feature_flag.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable
 from typing import cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -122,7 +122,7 @@ async def test_local_redis_initialization_does_not_ping_service(monkeypatch) -> 
     from app import cache as cache_module
 
     local_client = AsyncMock()
-    from_url = AsyncMock(return_value=local_client)
+    from_url = Mock(return_value=local_client)
     monkeypatch.setattr(cache_module.cache, "_initialized", False)
     monkeypatch.setattr(cache_module.cache, "_client", None)
     monkeypatch.setattr(cache_module.aioredis.Redis, "from_url", from_url)
@@ -130,7 +130,12 @@ async def test_local_redis_initialization_does_not_ping_service(monkeypatch) -> 
     await cache_module.cache.initialize(local_url="redis://localhost:6379/0")
 
     assert cache_module.cache.is_initialized is True
-    from_url.assert_called_once()
+    from_url.assert_called_once_with(
+        "redis://localhost:6379/0",
+        decode_responses=True,
+        socket_connect_timeout=5.0,
+        socket_timeout=5.0,
+    )
     local_client.ping.assert_not_awaited()
 
 


### PR DESCRIPTION
Closes #871

## What changed
- configure Upstash and local Redis clients at startup without sending a `PING`
- defer the first Redis network operation until a route actually performs a cache command
- preserve connection/socket timeouts and circuit-breaker fallback once cache traffic begins
- add regression coverage proving both Redis client modes perform no network command during initialization

This completes the remaining startup boundary after the earlier #871 work removed production Neon startup probes, added dependency-free liveness, bounded first database acquisition, and verified those behaviors in production.

## Validation
Focused regression coverage is included; repository CI will validate the branch. Production evidence already recorded on #871 confirms dependency-free liveness and bounded database acquisition. A changelog fragment will be added using this PR number before readiness.