### PR TITLE
Fix Vercel gate for slash-containing branches

### DIFF
--- a/docs/changelog.d/2026-08-07-891.md
+++ b/docs/changelog.d/2026-08-07-891.md
@@ -2,4 +2,4 @@
 
 ### Deployment
 
-- [PR #891](https://github.com/JoshCLWren/comic-pile/pull/891) closes a production-only deployment loophole where slash-containing branches such as `factory/...` could still trigger Vercel Preview deployments. ComicPile now keeps automatic Git deployments limited to `main`, avoiding unnecessary preview builds and quota use.
+- [#891](https://github.com/JoshCLWren/comic-pile/pull/891) closes a production-only deployment loophole where slash-containing branches such as `factory/...` could still trigger Vercel Preview deployments. ComicPile now keeps automatic Git deployments limited to `main`, avoiding unnecessary preview builds and quota use.

--- a/docs/changelog.d/2026-08-07-891.md
+++ b/docs/changelog.d/2026-08-07-891.md
@@ -1,0 +1,5 @@
+## 2026-08-07
+
+### Deployment
+
+- [PR #891](https://github.com/JoshCLWren/comic-pile/pull/891) closes a production-only deployment loophole where slash-containing branches such as `factory/...` could still trigger Vercel Preview deployments. ComicPile now keeps automatic Git deployments limited to `main`, avoiding unnecessary preview builds and quota use.

--- a/tests/test_vercel_production_only.py
+++ b/tests/test_vercel_production_only.py
@@ -14,7 +14,18 @@ def test_vercel_deploys_main_and_disables_non_production_branches() -> None:
     assert config["git"]["deploymentEnabled"] == {
         "main": True,
         "*": False,
+        "**/*": False,
     }
+
+
+def test_vercel_gate_covers_slash_containing_factory_branches() -> None:
+    """Factory branches must not escape the non-production deployment rule."""
+    config = json.loads((REPOSITORY_ROOT / "vercel.json").read_text(encoding="utf-8"))
+    deployment_rules = config["git"]["deploymentEnabled"]
+
+    assert deployment_rules["*"] is False
+    assert deployment_rules["**/*"] is False
+    assert deployment_rules["main"] is True
 
 
 def test_vercel_keeps_production_static_and_api_routes_intact() -> None:

--- a/tests/test_vercel_production_only.py
+++ b/tests/test_vercel_production_only.py
@@ -19,7 +19,14 @@ def test_vercel_deploys_main_and_disables_non_production_branches() -> None:
 
 
 def test_vercel_gate_covers_slash_containing_factory_branches() -> None:
-    """Factory branches must not escape the non-production deployment rule."""
+    """Factory branches must not escape the non-production deployment rule.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+    """
     config = json.loads((REPOSITORY_ROOT / "vercel.json").read_text(encoding="utf-8"))
     deployment_rules = config["git"]["deploymentEnabled"]
 

--- a/tests/test_vercel_production_only.py
+++ b/tests/test_vercel_production_only.py
@@ -1,7 +1,7 @@
 """Regression coverage for ComicPile's production-only Vercel deployment policy."""
 
 import json
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
@@ -33,6 +33,18 @@ def test_vercel_gate_covers_slash_containing_factory_branches() -> None:
     assert deployment_rules["*"] is False
     assert deployment_rules["**/*"] is False
     assert deployment_rules["main"] is True
+
+    def deployment_enabled(branch: str) -> bool:
+        matching_rules = (
+            enabled
+            for pattern, enabled in deployment_rules.items()
+            if PurePosixPath(branch).full_match(pattern)
+        )
+        return any(matching_rules)
+
+    assert deployment_enabled("main") is True
+    assert deployment_enabled("feature") is False
+    assert deployment_enabled("factory/example") is False
 
 
 def test_vercel_keeps_production_static_and_api_routes_intact() -> None:

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,8 @@
   "git": {
     "deploymentEnabled": {
       "main": true,
-      "*": false
+      "*": false,
+      "**/*": false
     }
   },
   "builds": [


### PR DESCRIPTION
Fixes #877

## What changed
- extend the Vercel Git deployment deny rules to cover branch names containing `/`, including `factory/...`
- add regression coverage for the slash-containing branch boundary
- add the required user-facing changelog fragment

## Why it matters
Live Vercel deployment history after PR #880 showed Preview deployments still being created for `factory/878-remove-obsolete-deployments`. Vercel documents `deploymentEnabled` patterns as minimatch rules, and `*` does not cover slash-separated branch paths. Adding `**/*` closes that gap while the explicit `main: true` rule keeps production Git deployments enabled.

## Verification
- live Vercel deployment history provided the failing branch evidence
- Vercel documentation confirms deploymentEnabled uses minimatch branch patterns and overlapping rules deploy when any matching rule is true
- after commits on this `factory/877-fix-slash-branch-vercel-gate` branch, the live deployment list shows no deployment for this branch, while recent `main` commits continue to appear as Production deployments
- repository regression coverage now requires both top-level and slash-containing non-production branch deny patterns

Changelog: `docs/changelog.d/2026-08-07-891.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Automatic Vercel deployments are now limited to the `main` branch.
  - Preview deployments from branches containing slashes are blocked.
  - Reduced unnecessary preview builds and unintended deployment activity.

- **Tests**
  - Added coverage verifying wildcard branch patterns remain disabled and slash-containing branches are blocked.

- **Documentation**
  - Documented the updated deployment behavior in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->