### PR TITLE
Add generalized continuity-rule persistence

### DIFF
--- a/alembic/versions/c84200000001_add_continuity_rules.py
+++ b/alembic/versions/c84200000001_add_continuity_rules.py
@@ -1,7 +1,7 @@
 """Add generalized continuity rules.
 
 Revision ID: c84200000001
-Revises: a613b7c9d201
+Revises: 7f41d0a9c2e1
 Create Date: 2026-08-06 04:58:00.000000
 """
 
@@ -11,7 +11,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision: str = "c84200000001"
-down_revision: str | Sequence[str] | None = "a613b7c9d201"
+down_revision: str | Sequence[str] | None = "7f41d0a9c2e1"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/alembic/versions/c84200000001_add_continuity_rules.py
+++ b/alembic/versions/c84200000001_add_continuity_rules.py
@@ -1,0 +1,69 @@
+"""Add generalized continuity rules.
+
+Revision ID: c84200000001
+Revises: a613b7c9d201
+Create Date: 2026-08-06 04:58:00.000000
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "c84200000001"
+down_revision: str | Sequence[str] | None = "a613b7c9d201"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create continuity rules and selected-member persistence."""
+    op.create_table(
+        "continuity_rules",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("source_type", sa.String(length=20), nullable=False),
+        sa.Column("source_id", sa.Integer(), nullable=False),
+        sa.Column("target_type", sa.String(length=20), nullable=False),
+        sa.Column("target_id", sa.Integer(), nullable=False),
+        sa.Column("satisfaction_type", sa.String(length=32), nullable=False),
+        sa.Column("checkpoint_issue_id", sa.Integer(), nullable=True),
+        sa.Column("note", sa.String(length=500), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint("source_type IN ('issue', 'crossover')", name="ck_continuity_rule_source_type"),
+        sa.CheckConstraint("target_type IN ('issue', 'crossover')", name="ck_continuity_rule_target_type"),
+        sa.CheckConstraint("satisfaction_type IN ('item_read', 'all_members_read', 'checkpoint', 'selected_members_read')", name="ck_continuity_rule_satisfaction_type"),
+        sa.CheckConstraint("NOT (source_type = target_type AND source_id = target_id)", name="ck_continuity_rule_not_self"),
+        sa.CheckConstraint("(satisfaction_type = 'checkpoint' AND checkpoint_issue_id IS NOT NULL) OR (satisfaction_type <> 'checkpoint' AND checkpoint_issue_id IS NULL)", name="ck_continuity_rule_checkpoint_shape"),
+        sa.ForeignKeyConstraint(["checkpoint_issue_id"], ["issues.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "source_type", "source_id", "target_type", "target_id", name="uq_continuity_rule_edge"),
+    )
+    op.create_index("ix_continuity_rules_user_id", "continuity_rules", ["user_id"])
+    op.create_index("ix_continuity_rules_source", "continuity_rules", ["user_id", "source_type", "source_id"])
+    op.create_index("ix_continuity_rules_target", "continuity_rules", ["user_id", "target_type", "target_id"])
+    op.create_table(
+        "continuity_rule_selected_members",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("rule_id", sa.Integer(), nullable=False),
+        sa.Column("issue_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["issue_id"], ["issues.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["rule_id"], ["continuity_rules.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("rule_id", "issue_id", name="uq_continuity_rule_selected_member"),
+    )
+    op.create_index("ix_continuity_rule_selected_members_rule_id", "continuity_rule_selected_members", ["rule_id"])
+    op.create_index("ix_continuity_rule_selected_members_issue_id", "continuity_rule_selected_members", ["issue_id"])
+
+
+def downgrade() -> None:
+    """Remove generalized continuity-rule persistence."""
+    op.drop_index("ix_continuity_rule_selected_members_issue_id", table_name="continuity_rule_selected_members")
+    op.drop_index("ix_continuity_rule_selected_members_rule_id", table_name="continuity_rule_selected_members")
+    op.drop_table("continuity_rule_selected_members")
+    op.drop_index("ix_continuity_rules_target", table_name="continuity_rules")
+    op.drop_index("ix_continuity_rules_source", table_name="continuity_rules")
+    op.drop_index("ix_continuity_rules_user_id", table_name="continuity_rules")
+    op.drop_table("continuity_rules")

--- a/app/continuity_rules.py
+++ b/app/continuity_rules.py
@@ -1,0 +1,90 @@
+"""Ownership validation helpers for generalized continuity rules."""
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dependency_group import DependencyGroup
+from app.models.issue import Issue
+from app.models.thread import Thread
+from app.schemas.continuity_rule import ContinuityNodeType, ContinuityRuleCreate
+
+
+async def ensure_owned_continuity_node(
+    db: AsyncSession,
+    *,
+    user_id: int,
+    node_type: ContinuityNodeType,
+    node_id: int,
+) -> None:
+    """Ensure a continuity node belongs to the authenticated user.
+
+    Args:
+        db: The asynchronous database session.
+        user_id: Authenticated user identifier.
+        node_type: Continuity node kind.
+        node_id: Node identifier.
+
+    Raises:
+        HTTPException: If the node does not exist for the authenticated user.
+    """
+    if node_type == "crossover":
+        statement = select(DependencyGroup.id).where(
+            DependencyGroup.id == node_id,
+            DependencyGroup.user_id == user_id,
+        )
+    else:
+        statement = (
+            select(Issue.id)
+            .join(Thread, Thread.id == Issue.thread_id)
+            .where(Issue.id == node_id, Thread.user_id == user_id)
+        )
+
+    if (await db.execute(statement)).scalar_one_or_none() is None:
+        raise HTTPException(status_code=404, detail=f"{node_type.title()} {node_id} not found")
+
+
+async def ensure_owned_continuity_rule_references(
+    db: AsyncSession,
+    *,
+    user_id: int,
+    payload: ContinuityRuleCreate,
+) -> None:
+    """Validate ownership of every entity referenced by a continuity rule request.
+
+    Args:
+        db: The asynchronous database session.
+        user_id: Authenticated user identifier.
+        payload: Validated continuity-rule request.
+
+    Raises:
+        HTTPException: If any referenced node or issue is not owned by the user.
+    """
+    await ensure_owned_continuity_node(
+        db,
+        user_id=user_id,
+        node_type=payload.source_type,
+        node_id=payload.source_id,
+    )
+    await ensure_owned_continuity_node(
+        db,
+        user_id=user_id,
+        node_type=payload.target_type,
+        node_id=payload.target_id,
+    )
+
+    referenced_issue_ids = set(payload.selected_member_issue_ids)
+    if payload.checkpoint_issue_id is not None:
+        referenced_issue_ids.add(payload.checkpoint_issue_id)
+    if not referenced_issue_ids:
+        return
+
+    result = await db.execute(
+        select(Issue.id)
+        .join(Thread, Thread.id == Issue.thread_id)
+        .where(Issue.id.in_(referenced_issue_ids), Thread.user_id == user_id)
+    )
+    owned_issue_ids = set(result.scalars())
+    missing_issue_ids = sorted(referenced_issue_ids - owned_issue_ids)
+    if missing_issue_ids:
+        raise HTTPException(status_code=404, detail=f"Issue {missing_issue_ids[0]} not found")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,5 +1,6 @@
 """SQLAlchemy database models."""
 
+from app.models.continuity_rule import ContinuityRule, ContinuityRuleSelectedMember
 from app.models.dependency import Dependency
 from app.models.dependency_group import DependencyGroup, DependencyGroupMembership
 from app.models.event import Event
@@ -13,6 +14,8 @@ from app.models.thread import Thread
 from app.models.user import User
 
 __all__ = [
+    "ContinuityRule",
+    "ContinuityRuleSelectedMember",
     "Dependency",
     "DependencyGroup",
     "DependencyGroupMembership",

--- a/app/models/continuity_rule.py
+++ b/app/models/continuity_rule.py
@@ -1,0 +1,92 @@
+"""Generalized continuity-rule persistence models."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, Integer, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import Base
+
+NODE_TYPES = ("issue", "crossover")
+SATISFACTION_TYPES = ("item_read", "all_members_read", "checkpoint", "selected_members_read")
+
+
+class ContinuityRule(Base):
+    """A user-owned directional blocking rule between issue or crossover nodes."""
+
+    __tablename__ = "continuity_rules"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    source_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    source_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    target_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    target_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    satisfaction_type: Mapped[str] = mapped_column(String(32), nullable=False)
+    checkpoint_issue_id: Mapped[int | None] = mapped_column(
+        ForeignKey("issues.id", ondelete="RESTRICT"), nullable=True
+    )
+    note: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+        nullable=False,
+    )
+
+    selected_members: Mapped[list[ContinuityRuleSelectedMember]] = relationship(
+        "ContinuityRuleSelectedMember",
+        back_populates="rule",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+
+    __table_args__ = (
+        CheckConstraint("source_type IN ('issue', 'crossover')", name="ck_continuity_rule_source_type"),
+        CheckConstraint("target_type IN ('issue', 'crossover')", name="ck_continuity_rule_target_type"),
+        CheckConstraint(
+            "satisfaction_type IN ('item_read', 'all_members_read', 'checkpoint', 'selected_members_read')",
+            name="ck_continuity_rule_satisfaction_type",
+        ),
+        CheckConstraint(
+            "NOT (source_type = target_type AND source_id = target_id)",
+            name="ck_continuity_rule_not_self",
+        ),
+        CheckConstraint(
+            "(satisfaction_type = 'checkpoint' AND checkpoint_issue_id IS NOT NULL) OR "
+            "(satisfaction_type <> 'checkpoint' AND checkpoint_issue_id IS NULL)",
+            name="ck_continuity_rule_checkpoint_shape",
+        ),
+        UniqueConstraint(
+            "user_id", "source_type", "source_id", "target_type", "target_id",
+            name="uq_continuity_rule_edge",
+        ),
+        Index("ix_continuity_rules_user_id", "user_id"),
+        Index("ix_continuity_rules_source", "user_id", "source_type", "source_id"),
+        Index("ix_continuity_rules_target", "user_id", "target_type", "target_id"),
+    )
+
+
+class ContinuityRuleSelectedMember(Base):
+    """An issue required by a selected-members continuity satisfaction policy."""
+
+    __tablename__ = "continuity_rule_selected_members"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    rule_id: Mapped[int] = mapped_column(
+        ForeignKey("continuity_rules.id", ondelete="CASCADE"), nullable=False
+    )
+    issue_id: Mapped[int] = mapped_column(ForeignKey("issues.id", ondelete="CASCADE"), nullable=False)
+
+    rule: Mapped[ContinuityRule] = relationship("ContinuityRule", back_populates="selected_members")
+
+    __table_args__ = (
+        UniqueConstraint("rule_id", "issue_id", name="uq_continuity_rule_selected_member"),
+        Index("ix_continuity_rule_selected_members_rule_id", "rule_id"),
+        Index("ix_continuity_rule_selected_members_issue_id", "issue_id"),
+    )

--- a/app/schemas/continuity_rule.py
+++ b/app/schemas/continuity_rule.py
@@ -27,7 +27,7 @@ class ContinuityRuleCreate(BaseModel):
     note: str | None = Field(default=None, max_length=500)
 
     @model_validator(mode="after")
-    def validate_shape(self) -> "ContinuityRuleCreate":
+    def validate_shape(self) -> ContinuityRuleCreate:
         """Reject ambiguous satisfaction-policy combinations.
 
         Returns:

--- a/app/schemas/continuity_rule.py
+++ b/app/schemas/continuity_rule.py
@@ -1,0 +1,69 @@
+"""Continuity-rule request and response schemas."""
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+ContinuityNodeType = Literal["issue", "crossover"]
+ContinuitySatisfactionType = Literal[
+    "item_read",
+    "all_members_read",
+    "checkpoint",
+    "selected_members_read",
+]
+
+
+class ContinuityRuleCreate(BaseModel):
+    """Schema for creating a generalized continuity rule."""
+
+    source_type: ContinuityNodeType
+    source_id: int = Field(gt=0)
+    target_type: ContinuityNodeType
+    target_id: int = Field(gt=0)
+    satisfaction_type: ContinuitySatisfactionType
+    checkpoint_issue_id: int | None = Field(default=None, gt=0)
+    selected_member_issue_ids: list[int] = Field(default_factory=list, max_length=250)
+    note: str | None = Field(default=None, max_length=500)
+
+    @model_validator(mode="after")
+    def validate_shape(self) -> "ContinuityRuleCreate":
+        """Reject ambiguous satisfaction-policy combinations.
+
+        Returns:
+            The validated request.
+
+        Raises:
+            ValueError: If node or satisfaction fields form an invalid rule.
+        """
+        if self.source_type == self.target_type and self.source_id == self.target_id:
+            raise ValueError("A continuity rule cannot target its own source node")
+        if self.satisfaction_type == "checkpoint":
+            if self.checkpoint_issue_id is None:
+                raise ValueError("checkpoint_issue_id is required for checkpoint rules")
+        elif self.checkpoint_issue_id is not None:
+            raise ValueError("checkpoint_issue_id is only valid for checkpoint rules")
+        if self.satisfaction_type == "selected_members_read":
+            if not self.selected_member_issue_ids:
+                raise ValueError("selected-member rules require at least one issue")
+        elif self.selected_member_issue_ids:
+            raise ValueError("selected_member_issue_ids are only valid for selected-member rules")
+        self.selected_member_issue_ids = list(dict.fromkeys(self.selected_member_issue_ids))
+        return self
+
+
+class ContinuityRuleResponse(BaseModel):
+    """Schema for a persisted generalized continuity rule."""
+
+    id: int
+    user_id: int
+    source_type: ContinuityNodeType
+    source_id: int
+    target_type: ContinuityNodeType
+    target_id: int
+    satisfaction_type: ContinuitySatisfactionType
+    checkpoint_issue_id: int | None
+    selected_member_issue_ids: list[int]
+    note: str | None
+    created_at: datetime
+    updated_at: datetime

--- a/docs/changelog.d/2026-08-07-894.md
+++ b/docs/changelog.d/2026-08-07-894.md
@@ -1,0 +1,4 @@
+## 2026-08-07
+
+### Reading order
+- [PR #894](https://github.com/JoshCLWren/comic-pile/pull/894) adds durable continuity rules between individual issues and crossovers, including checkpoint and selected-member requirements, so future reading-order features can express real blocking relationships without overloading the older issue-only dependency model.

--- a/docs/changelog.d/2026-08-07-894.md
+++ b/docs/changelog.d/2026-08-07-894.md
@@ -1,4 +1,4 @@
 ## 2026-08-07
 
 ### Reading order
-- [PR #894](https://github.com/JoshCLWren/comic-pile/pull/894) adds durable continuity rules between individual issues and crossovers, including checkpoint and selected-member requirements, so future reading-order features can express real blocking relationships without overloading the older issue-only dependency model.
+- [#894](https://github.com/JoshCLWren/comic-pile/pull/894) adds durable continuity rules between individual issues and crossovers, including checkpoint and selected-member requirements, so future reading-order features can express real blocking relationships without overloading the older issue-only dependency model.

--- a/tests/test_continuity_rule_schema.py
+++ b/tests/test_continuity_rule_schema.py
@@ -1,0 +1,87 @@
+"""Focused validation coverage for generalized continuity-rule schemas."""
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.continuity_rule import ContinuityRuleCreate
+
+
+@pytest.mark.parametrize(
+    ("source_type", "target_type"),
+    [
+        ("issue", "issue"),
+        ("issue", "crossover"),
+        ("crossover", "issue"),
+        ("crossover", "crossover"),
+    ],
+)
+def test_continuity_rule_accepts_all_node_pairings(
+    source_type: str,
+    target_type: str,
+) -> None:
+    rule = ContinuityRuleCreate(
+        source_type=source_type,
+        source_id=1,
+        target_type=target_type,
+        target_id=2,
+        satisfaction_type="item_read",
+    )
+
+    assert rule.source_type == source_type
+    assert rule.target_type == target_type
+
+
+def test_checkpoint_requires_checkpoint_issue() -> None:
+    with pytest.raises(ValidationError, match="checkpoint_issue_id is required"):
+        ContinuityRuleCreate(
+            source_type="issue",
+            source_id=1,
+            target_type="crossover",
+            target_id=2,
+            satisfaction_type="checkpoint",
+        )
+
+
+def test_checkpoint_issue_is_rejected_for_other_policies() -> None:
+    with pytest.raises(ValidationError, match="checkpoint_issue_id is only valid"):
+        ContinuityRuleCreate(
+            source_type="issue",
+            source_id=1,
+            target_type="issue",
+            target_id=2,
+            satisfaction_type="item_read",
+            checkpoint_issue_id=3,
+        )
+
+
+def test_selected_members_are_required_and_deduplicated() -> None:
+    rule = ContinuityRuleCreate(
+        source_type="crossover",
+        source_id=1,
+        target_type="issue",
+        target_id=2,
+        satisfaction_type="selected_members_read",
+        selected_member_issue_ids=[3, 4, 3],
+    )
+
+    assert rule.selected_member_issue_ids == [3, 4]
+
+    with pytest.raises(ValidationError, match="require at least one issue"):
+        ContinuityRuleCreate(
+            source_type="crossover",
+            source_id=1,
+            target_type="issue",
+            target_id=2,
+            satisfaction_type="selected_members_read",
+        )
+
+
+def test_self_rule_is_rejected() -> None:
+    with pytest.raises(ValidationError, match="cannot target its own source node"):
+        ContinuityRuleCreate(
+            source_type="crossover",
+            source_id=7,
+            target_type="crossover",
+            target_id=7,
+            satisfaction_type="all_members_read",
+        )

--- a/tests/test_continuity_rule_schema.py
+++ b/tests/test_continuity_rule_schema.py
@@ -19,6 +19,7 @@ def test_continuity_rule_accepts_all_node_pairings(
     source_type: str,
     target_type: str,
 ) -> None:
+    """Accept every supported source/target node-type pairing."""
     rule = ContinuityRuleCreate(
         source_type=source_type,
         source_id=1,
@@ -32,6 +33,7 @@ def test_continuity_rule_accepts_all_node_pairings(
 
 
 def test_checkpoint_requires_checkpoint_issue() -> None:
+    """Require a checkpoint issue for checkpoint satisfaction rules."""
     with pytest.raises(ValidationError, match="checkpoint_issue_id is required"):
         ContinuityRuleCreate(
             source_type="issue",
@@ -43,6 +45,7 @@ def test_checkpoint_requires_checkpoint_issue() -> None:
 
 
 def test_checkpoint_issue_is_rejected_for_other_policies() -> None:
+    """Reject checkpoint issue IDs on non-checkpoint policies."""
     with pytest.raises(ValidationError, match="checkpoint_issue_id is only valid"):
         ContinuityRuleCreate(
             source_type="issue",
@@ -55,6 +58,7 @@ def test_checkpoint_issue_is_rejected_for_other_policies() -> None:
 
 
 def test_selected_members_are_required_and_deduplicated() -> None:
+    """Require selected members and deduplicate repeated issue IDs."""
     rule = ContinuityRuleCreate(
         source_type="crossover",
         source_id=1,
@@ -77,6 +81,7 @@ def test_selected_members_are_required_and_deduplicated() -> None:
 
 
 def test_self_rule_is_rejected() -> None:
+    """Reject a continuity rule whose source and target are identical."""
     with pytest.raises(ValidationError, match="cannot target its own source node"):
         ContinuityRuleCreate(
             source_type="crossover",


### PR DESCRIPTION
Closes #842

## What changed
- add durable user-owned continuity rules between issue and crossover nodes
- add normalized selected-member persistence for partial crossover requirements
- add unambiguous satisfaction-policy schemas and ownership validation helpers
- cover all four supported node pairings, checkpoint policy shape, selected-member validation, deduplication, and self-rule rejection

## Why it matters
This establishes the durable dependency model needed for reading-order blocks between individual issues and crossovers without overloading the existing issue-only dependency table. Roll behavior is intentionally unchanged in this issue.

## Verification
Focused schema coverage is included on the branch. Persistence/migration coverage and exact-head CI remain to be completed before merge.
