### PR TITLE
Fix overlay stacking layers for menus and dialogs

### DIFF
--- a/docs/changelog.d/2026-08-07-895.md
+++ b/docs/changelog.d/2026-08-07-895.md
@@ -1,0 +1,5 @@
+## 2026-08-07
+
+### Queue and dialogs
+
+- [#895](https://github.com/JoshCLWren/comic-pile/pull/895) separates menu and dialog overlay layers so modals can reliably appear above queue menus and other portaled controls instead of being trapped in the menu stacking layer.

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -151,7 +151,7 @@ export default function Modal({
   if (!isOpen) return null
 
   return (
-    <OverlayPortal>
+    <OverlayPortal layer="dialog">
       <div
         ref={setOverlayElement}
         className={`fixed inset-0 flex items-end md:items-center justify-center md:px-4 ${overlayClassName || ''}`}

--- a/frontend/src/components/OverlayPortal.tsx
+++ b/frontend/src/components/OverlayPortal.tsx
@@ -39,7 +39,7 @@ export default function OverlayPortal({ children, layer = 'menu' }: OverlayPorta
     setOverlayRoot(root)
 
     return () => {
-      const remaining = (mountedPortalCounts.get(layer) ?? 1) - 1
+      const remaining = mountedPortalCounts.get(layer)! - 1
       if (remaining <= 0) {
         mountedPortalCounts.delete(layer)
         root.remove()

--- a/frontend/src/components/OverlayPortal.tsx
+++ b/frontend/src/components/OverlayPortal.tsx
@@ -2,40 +2,52 @@ import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import './overlay.css'
 
+export type OverlayLayer = 'menu' | 'dialog' | 'global-effect'
+
 interface OverlayPortalProps {
   children: React.ReactNode
+  layer?: OverlayLayer
 }
 
 const OVERLAY_ROOT_ID = 'comic-pile-overlay-root'
-const OVERLAY_ROOT_CLASS = 'comic-pile-overlay-root'
-let mountedPortalCount = 0
+const mountedPortalCounts = new Map<OverlayLayer, number>()
 
-function getOrCreateOverlayRoot(): HTMLElement {
-  const existingRoot = document.getElementById(OVERLAY_ROOT_ID)
+function getOverlayRootId(layer: OverlayLayer): string {
+  return layer === 'menu' ? OVERLAY_ROOT_ID : `${OVERLAY_ROOT_ID}-${layer}`
+}
+
+function getOrCreateOverlayRoot(layer: OverlayLayer): HTMLElement {
+  const rootId = getOverlayRootId(layer)
+  const existingRoot = document.getElementById(rootId)
   if (existingRoot) return existingRoot
 
   const overlayRoot = document.createElement('div')
-  overlayRoot.id = OVERLAY_ROOT_ID
-  overlayRoot.className = OVERLAY_ROOT_CLASS
+  overlayRoot.id = rootId
+  overlayRoot.className = `comic-pile-overlay-root comic-pile-overlay-root--${layer}`
   overlayRoot.dataset.overlayRoot = 'true'
-  overlayRoot.dataset.overlayLayer = 'menu'
+  overlayRoot.dataset.overlayLayer = layer
   document.body.appendChild(overlayRoot)
   return overlayRoot
 }
 
-export default function OverlayPortal({ children }: OverlayPortalProps) {
+export default function OverlayPortal({ children, layer = 'menu' }: OverlayPortalProps) {
   const [overlayRoot, setOverlayRoot] = useState<HTMLElement | null>(null)
 
   useEffect(() => {
-    const root = getOrCreateOverlayRoot()
-    mountedPortalCount += 1
+    const root = getOrCreateOverlayRoot(layer)
+    mountedPortalCounts.set(layer, (mountedPortalCounts.get(layer) ?? 0) + 1)
     setOverlayRoot(root)
 
     return () => {
-      mountedPortalCount -= 1
-      if (mountedPortalCount === 0) root.remove()
+      const remaining = (mountedPortalCounts.get(layer) ?? 1) - 1
+      if (remaining <= 0) {
+        mountedPortalCounts.delete(layer)
+        root.remove()
+      } else {
+        mountedPortalCounts.set(layer, remaining)
+      }
     }
-  }, [])
+  }, [layer])
 
   if (!overlayRoot) return null
   return createPortal(children, overlayRoot)

--- a/frontend/src/components/overlay.css
+++ b/frontend/src/components/overlay.css
@@ -7,9 +7,20 @@
 
 .comic-pile-overlay-root {
   position: relative;
-  z-index: var(--overlay-layer-menu);
   isolation: isolate;
   pointer-events: none;
+}
+
+.comic-pile-overlay-root--menu {
+  z-index: var(--overlay-layer-menu);
+}
+
+.comic-pile-overlay-root--dialog {
+  z-index: var(--overlay-layer-dialog);
+}
+
+.comic-pile-overlay-root--global-effect {
+  z-index: var(--overlay-layer-global-effect);
 }
 
 .comic-pile-overlay-root > * {

--- a/frontend/src/unit/OverlayPortal.test.tsx
+++ b/frontend/src/unit/OverlayPortal.test.tsx
@@ -4,6 +4,8 @@ import OverlayPortal from '../components/OverlayPortal'
 
 afterEach(() => {
   document.getElementById('comic-pile-overlay-root')?.remove()
+  document.getElementById('comic-pile-overlay-root-dialog')?.remove()
+  document.getElementById('comic-pile-overlay-root-global-effect')?.remove()
 })
 
 it('renders overlay content outside the application root', async () => {
@@ -19,6 +21,7 @@ it('renders overlay content outside the application root', async () => {
   expect(overlayRoot).toHaveAttribute('data-overlay-root', 'true')
   expect(overlayRoot).toHaveAttribute('data-overlay-layer', 'menu')
   expect(overlayRoot).toHaveClass('comic-pile-overlay-root')
+  expect(overlayRoot).toHaveClass('comic-pile-overlay-root--menu')
   expect(overlayRoot).toContainElement(menu)
   expect(overlayRoot?.parentElement).toBe(document.body)
 })
@@ -33,9 +36,35 @@ it('applies the canonical shared layer contract to interactive overlays', async 
   const action = await screen.findByRole('button', { name: 'Overlay action' })
   const overlayRoot = document.getElementById('comic-pile-overlay-root')
 
-  expect(overlayRoot).toHaveClass('comic-pile-overlay-root')
+  expect(overlayRoot).toHaveClass('comic-pile-overlay-root--menu')
   expect(overlayRoot).toHaveAttribute('data-overlay-layer', 'menu')
   expect(overlayRoot).toContainElement(action)
+})
+
+it('keeps dialogs in a higher independent stacking root than menus', async () => {
+  render(
+    <>
+      <OverlayPortal>
+        <div role="menu">Actions</div>
+      </OverlayPortal>
+      <OverlayPortal layer="dialog">
+        <div role="dialog">Edit thread</div>
+      </OverlayPortal>
+    </>,
+  )
+
+  const menu = await screen.findByRole('menu')
+  const dialog = await screen.findByRole('dialog')
+  const menuRoot = document.getElementById('comic-pile-overlay-root')
+  const dialogRoot = document.getElementById('comic-pile-overlay-root-dialog')
+
+  expect(menuRoot).toHaveAttribute('data-overlay-layer', 'menu')
+  expect(menuRoot).toHaveClass('comic-pile-overlay-root--menu')
+  expect(menuRoot).toContainElement(menu)
+  expect(dialogRoot).toHaveAttribute('data-overlay-layer', 'dialog')
+  expect(dialogRoot).toHaveClass('comic-pile-overlay-root--dialog')
+  expect(dialogRoot).toContainElement(dialog)
+  expect(menuRoot).not.toBe(dialogRoot)
 })
 
 it('shares one overlay root across concurrent overlays', async () => {


### PR DESCRIPTION
## Summary
- give menus, dialogs, and global effects independent shared portal roots
- keep the existing menu root ID for compatibility while assigning each root its canonical z-index token
- render `Modal` through the dialog root so dialog z-index is no longer trapped inside the menu stacking context
- add focused regression coverage proving menu and dialog roots remain independent

This advances #625 but does not close it; the remaining headed Chromium containment verification and any still-open mobile interaction cleanup stay on the parent issue.

Validation: focused CI requested by this PR; this runtime does not provide a local repository checkout.
