### PR TITLE
Migrate legacy dependencies into continuity rules

### DIFF
--- a/alembic/versions/c84400000001_backfill_legacy_dependencies.py
+++ b/alembic/versions/c84400000001_backfill_legacy_dependencies.py
@@ -1,0 +1,120 @@
+"""Backfill legacy issue dependencies into continuity rules.
+
+Revision ID: c84400000001
+Revises: c84200000001
+Create Date: 2026-08-07 07:58:00.000000
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "c84400000001"
+down_revision: str | Sequence[str] | None = "c84200000001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Link and backfill legacy issue dependencies as item-read continuity rules."""
+    op.add_column(
+        "continuity_rules",
+        sa.Column("legacy_dependency_id", sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_continuity_rules_legacy_dependency_id_dependencies",
+        "continuity_rules",
+        "dependencies",
+        ["legacy_dependency_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_unique_constraint(
+        "uq_continuity_rules_legacy_dependency_id",
+        "continuity_rules",
+        ["legacy_dependency_id"],
+    )
+
+    # Reuse an already-equivalent generalized edge rather than creating a duplicate.
+    op.execute(
+        sa.text(
+            """
+            UPDATE continuity_rules AS rule
+            SET legacy_dependency_id = dep.id
+            FROM dependencies AS dep
+            JOIN issues AS source_issue ON source_issue.id = dep.source_issue_id
+            JOIN threads AS source_thread ON source_thread.id = source_issue.thread_id
+            JOIN issues AS target_issue ON target_issue.id = dep.target_issue_id
+            JOIN threads AS target_thread ON target_thread.id = target_issue.thread_id
+            WHERE rule.user_id = source_thread.user_id
+              AND target_thread.user_id = source_thread.user_id
+              AND rule.source_type = 'issue'
+              AND rule.source_id = dep.source_issue_id
+              AND rule.target_type = 'issue'
+              AND rule.target_id = dep.target_issue_id
+              AND rule.satisfaction_type = 'item_read'
+              AND rule.checkpoint_issue_id IS NULL
+              AND rule.legacy_dependency_id IS NULL
+            """
+        )
+    )
+
+    # Insert only dependencies that were not represented by an equivalent rule.
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO continuity_rules (
+                user_id,
+                source_type,
+                source_id,
+                target_type,
+                target_id,
+                satisfaction_type,
+                checkpoint_issue_id,
+                legacy_dependency_id,
+                note,
+                created_at,
+                updated_at
+            )
+            SELECT
+                source_thread.user_id,
+                'issue',
+                dep.source_issue_id,
+                'issue',
+                dep.target_issue_id,
+                'item_read',
+                NULL,
+                dep.id,
+                dep.note,
+                dep.created_at,
+                dep.created_at
+            FROM dependencies AS dep
+            JOIN issues AS source_issue ON source_issue.id = dep.source_issue_id
+            JOIN threads AS source_thread ON source_thread.id = source_issue.thread_id
+            JOIN issues AS target_issue ON target_issue.id = dep.target_issue_id
+            JOIN threads AS target_thread ON target_thread.id = target_issue.thread_id
+            LEFT JOIN continuity_rules AS existing
+              ON existing.legacy_dependency_id = dep.id
+            WHERE target_thread.user_id = source_thread.user_id
+              AND existing.id IS NULL
+            ON CONFLICT (user_id, source_type, source_id, target_type, target_id) DO NOTHING
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    """Remove only continuity rows linked to legacy dependencies, preserving the old table."""
+    op.execute(sa.text("DELETE FROM continuity_rules WHERE legacy_dependency_id IS NOT NULL"))
+    op.drop_constraint(
+        "uq_continuity_rules_legacy_dependency_id",
+        "continuity_rules",
+        type_="unique",
+    )
+    op.drop_constraint(
+        "fk_continuity_rules_legacy_dependency_id_dependencies",
+        "continuity_rules",
+        type_="foreignkey",
+    )
+    op.drop_column("continuity_rules", "legacy_dependency_id")

--- a/alembic/versions/c84400000002_sync_legacy_dependency_writes.py
+++ b/alembic/versions/c84400000002_sync_legacy_dependency_writes.py
@@ -1,0 +1,130 @@
+"""Keep legacy dependency writes synchronized with continuity rules.
+
+Revision ID: c84400000002
+Revises: c84400000001
+Create Date: 2026-08-07 08:54:00.000000
+
+The legacy ``dependencies`` table remains an active compatibility API during the
+continuity migration.  This database-level bridge makes every insert and update
+produce the same issue-to-issue ``item_read`` rule, regardless of which code path
+writes the legacy table.  Deletes are handled by the foreign key added in the
+preceding migration with ``ON DELETE CASCADE``.
+
+The trigger intentionally makes the legacy representation authoritative for an
+edge while compatibility mode is active.  If an equivalent generalized edge
+already exists, it is linked to the legacy dependency and normalized to
+``item_read`` so the two public APIs cannot disagree about whether the target is
+blocked.  Removing this migration restores the pre-trigger behavior without
+removing either representation; the preceding migration owns removal of the
+backfilled compatibility rows.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "c84400000002"
+down_revision: str | Sequence[str] | None = "c84400000001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_SYNC_FUNCTION = "sync_legacy_dependency_to_continuity_rule"
+_SYNC_TRIGGER = "trg_sync_legacy_dependency_to_continuity_rule"
+
+
+def upgrade() -> None:
+    """Mirror legacy dependency inserts and updates into continuity rules."""
+    op.execute(
+        sa.text(
+            f"""
+            CREATE OR REPLACE FUNCTION {_SYNC_FUNCTION}()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            DECLARE
+                source_owner_id integer;
+                target_owner_id integer;
+            BEGIN
+                SELECT thread.user_id
+                  INTO source_owner_id
+                  FROM issues AS issue
+                  JOIN threads AS thread ON thread.id = issue.thread_id
+                 WHERE issue.id = NEW.source_issue_id;
+
+                SELECT thread.user_id
+                  INTO target_owner_id
+                  FROM issues AS issue
+                  JOIN threads AS thread ON thread.id = issue.thread_id
+                 WHERE issue.id = NEW.target_issue_id;
+
+                IF source_owner_id IS NULL
+                   OR target_owner_id IS NULL
+                   OR source_owner_id <> target_owner_id THEN
+                    RAISE EXCEPTION
+                        'legacy dependency % does not reference issues owned by one user',
+                        NEW.id;
+                END IF;
+
+                -- An UPDATE may move an existing legacy dependency to a new edge.
+                -- Remove its old compatibility row before claiming the new edge.
+                DELETE FROM continuity_rules
+                 WHERE legacy_dependency_id = NEW.id;
+
+                INSERT INTO continuity_rules (
+                    user_id,
+                    source_type,
+                    source_id,
+                    target_type,
+                    target_id,
+                    satisfaction_type,
+                    checkpoint_issue_id,
+                    legacy_dependency_id,
+                    note,
+                    created_at,
+                    updated_at
+                )
+                VALUES (
+                    source_owner_id,
+                    'issue',
+                    NEW.source_issue_id,
+                    'issue',
+                    NEW.target_issue_id,
+                    'item_read',
+                    NULL,
+                    NEW.id,
+                    NEW.note,
+                    NEW.created_at,
+                    CURRENT_TIMESTAMP
+                )
+                ON CONFLICT (user_id, source_type, source_id, target_type, target_id)
+                DO UPDATE SET
+                    satisfaction_type = 'item_read',
+                    checkpoint_issue_id = NULL,
+                    legacy_dependency_id = EXCLUDED.legacy_dependency_id,
+                    note = EXCLUDED.note,
+                    updated_at = CURRENT_TIMESTAMP;
+
+                RETURN NEW;
+            END;
+            $$
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            f"""
+            CREATE TRIGGER {_SYNC_TRIGGER}
+            AFTER INSERT OR UPDATE OF source_issue_id, target_issue_id, note
+            ON dependencies
+            FOR EACH ROW
+            EXECUTE FUNCTION {_SYNC_FUNCTION}()
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    """Stop future mirroring while leaving both existing data models intact."""
+    op.execute(sa.text(f"DROP TRIGGER IF EXISTS {_SYNC_TRIGGER} ON dependencies"))
+    op.execute(sa.text(f"DROP FUNCTION IF EXISTS {_SYNC_FUNCTION}()"))

--- a/app/models/continuity_rule.py
+++ b/app/models/continuity_rule.py
@@ -20,6 +20,9 @@ class ContinuityRule(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    legacy_dependency_id: Mapped[int | None] = mapped_column(
+        ForeignKey("dependencies.id", ondelete="CASCADE"), nullable=True, unique=True
+    )
     source_type: Mapped[str] = mapped_column(String(20), nullable=False)
     source_id: Mapped[int] = mapped_column(Integer, nullable=False)
     target_type: Mapped[str] = mapped_column(String(20), nullable=False)

--- a/docs/changelog.d/2026-08-07-897.md
+++ b/docs/changelog.d/2026-08-07-897.md
@@ -2,4 +2,4 @@
 
 ### Reading orders
 
-- [PR #897](https://github.com/JoshCLWren/comic-pile/pull/897) keeps existing issue dependencies working while ComicPile moves them into the generalized continuity system, preserving blocking behavior and notes without creating duplicate rules.
+- [#897](https://github.com/JoshCLWren/comic-pile/pull/897) keeps existing issue dependencies working while ComicPile moves them into the generalized continuity system, preserving blocking behavior and notes without creating duplicate rules.

--- a/docs/changelog.d/2026-08-07-897.md
+++ b/docs/changelog.d/2026-08-07-897.md
@@ -1,0 +1,5 @@
+## 2026-08-07
+
+### Reading orders
+
+- [PR #897](https://github.com/JoshCLWren/comic-pile/pull/897) keeps existing issue dependencies working while ComicPile moves them into the generalized continuity system, preserving blocking behavior and notes without creating duplicate rules.

--- a/tests/test_legacy_dependency_continuity_migration.py
+++ b/tests/test_legacy_dependency_continuity_migration.py
@@ -1,0 +1,104 @@
+"""Regression coverage for legacy-dependency continuity compatibility migrations."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+VERSIONS = Path(__file__).parents[1] / "alembic" / "versions"
+BACKFILL_PATH = VERSIONS / "c84400000001_backfill_legacy_dependencies.py"
+SYNC_PATH = VERSIONS / "c84400000002_sync_legacy_dependency_writes.py"
+
+
+class _OperationRecorder:
+    """Capture migration SQL without requiring a live PostgreSQL database."""
+
+    def __init__(self) -> None:
+        self.executed_sql: list[str] = []
+        self.structural_calls: list[tuple[str, object]] = []
+
+    def execute(self, statement: object) -> None:
+        self.executed_sql.append(" ".join(str(statement).split()))
+
+    def add_column(self, table_name: str, column: object) -> None:
+        self.structural_calls.append(("add_column", table_name))
+
+    def create_foreign_key(self, name: str, *_args: object, **_kwargs: object) -> None:
+        self.structural_calls.append(("create_foreign_key", name))
+
+    def create_unique_constraint(self, name: str, *_args: object) -> None:
+        self.structural_calls.append(("create_unique_constraint", name))
+
+    def drop_constraint(self, name: str, *_args: object, **_kwargs: object) -> None:
+        self.structural_calls.append(("drop_constraint", name))
+
+    def drop_column(self, table_name: str, column_name: str) -> None:
+        self.structural_calls.append(("drop_column", (table_name, column_name)))
+
+
+def _load_migration(path: Path, module_name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_backfill_is_idempotent_and_reuses_equivalent_edges(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backfill links equivalent rules and inserts only still-unrepresented edges."""
+    migration = _load_migration(BACKFILL_PATH, "legacy_dependency_backfill")
+    recorder = _OperationRecorder()
+    monkeypatch.setattr(migration, "op", recorder)
+
+    migration.upgrade()
+
+    sql = "\n".join(recorder.executed_sql)
+    assert "UPDATE continuity_rules AS rule SET legacy_dependency_id = dep.id" in sql
+    assert "rule.satisfaction_type = 'item_read'" in sql
+    assert "LEFT JOIN continuity_rules AS existing" in sql
+    assert "existing.id IS NULL" in sql
+    assert "ON CONFLICT (user_id, source_type, source_id, target_type, target_id) DO NOTHING" in sql
+
+
+def test_sync_trigger_preserves_legacy_semantics_for_create_and_update(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every legacy write is mirrored as one owned issue-to-issue item-read rule."""
+    migration = _load_migration(SYNC_PATH, "legacy_dependency_sync")
+    recorder = _OperationRecorder()
+    monkeypatch.setattr(migration, "op", recorder)
+
+    migration.upgrade()
+
+    assert len(recorder.executed_sql) == 2
+    function_sql, trigger_sql = recorder.executed_sql
+    assert "source_owner_id <> target_owner_id" in function_sql
+    assert "DELETE FROM continuity_rules WHERE legacy_dependency_id = NEW.id" in function_sql
+    assert "'issue', NEW.source_issue_id, 'issue', NEW.target_issue_id, 'item_read'" in function_sql
+    assert "ON CONFLICT (user_id, source_type, source_id, target_type, target_id)" in function_sql
+    assert "satisfaction_type = 'item_read'" in function_sql
+    assert "legacy_dependency_id = EXCLUDED.legacy_dependency_id" in function_sql
+    assert "note = EXCLUDED.note" in function_sql
+    assert "AFTER INSERT OR UPDATE OF source_issue_id, target_issue_id, note" in trigger_sql
+    assert "ON dependencies" in trigger_sql
+
+
+def test_sync_downgrade_only_removes_the_live_bridge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rollback stops mirroring without deleting legacy or generalized data."""
+    migration = _load_migration(SYNC_PATH, "legacy_dependency_sync_downgrade")
+    recorder = _OperationRecorder()
+    monkeypatch.setattr(migration, "op", recorder)
+
+    migration.downgrade()
+
+    assert recorder.executed_sql == [
+        "DROP TRIGGER IF EXISTS trg_sync_legacy_dependency_to_continuity_rule ON dependencies",
+        "DROP FUNCTION IF EXISTS sync_legacy_dependency_to_continuity_rule()",
+    ]

--- a/tests/test_legacy_dependency_continuity_migration.py
+++ b/tests/test_legacy_dependency_continuity_migration.py
@@ -47,6 +47,36 @@ def _load_migration(path: Path, module_name: str) -> ModuleType:
     return module
 
 
+def _legacy_blocked_targets(
+    dependencies: list[tuple[int, int]],
+    issue_statuses: dict[int, str],
+) -> set[int]:
+    """Model the legacy rule: an unread source issue blocks its target issue."""
+    return {
+        target_id
+        for source_id, target_id in dependencies
+        if issue_statuses[source_id] != "read"
+    }
+
+
+def _continuity_blocked_targets(
+    rules: list[dict[str, object]],
+    issue_statuses: dict[int, str],
+) -> set[int]:
+    """Model the equivalent generalized issue->issue item-read rule."""
+    blocked: set[int] = set()
+    for rule in rules:
+        if (
+            rule["source_type"] == "issue"
+            and rule["target_type"] == "issue"
+            and rule["satisfaction_type"] == "item_read"
+            and rule["checkpoint_issue_id"] is None
+            and issue_statuses[int(rule["source_id"])] != "read"
+        ):
+            blocked.add(int(rule["target_id"]))
+    return blocked
+
+
 def test_backfill_is_idempotent_and_reuses_equivalent_edges(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -102,3 +132,38 @@ def test_sync_downgrade_only_removes_the_live_bridge(
         "DROP TRIGGER IF EXISTS trg_sync_legacy_dependency_to_continuity_rule ON dependencies",
         "DROP FUNCTION IF EXISTS sync_legacy_dependency_to_continuity_rule()",
     ]
+
+
+@pytest.mark.parametrize(
+    ("issue_statuses", "expected_blocked"),
+    [
+        ({1: "unread", 2: "unread", 3: "unread", 4: "unread"}, {2, 3, 4}),
+        ({1: "read", 2: "unread", 3: "unread", 4: "unread"}, {3, 4}),
+        ({1: "read", 2: "read", 3: "unread", 4: "unread"}, {4}),
+        ({1: "read", 2: "read", 3: "read", 4: "unread"}, set()),
+    ],
+)
+def test_backfilled_rules_match_legacy_blocking_for_representative_graph(
+    issue_statuses: dict[int, str],
+    expected_blocked: set[int],
+) -> None:
+    """A representative dependency graph blocks identically after translation."""
+    dependencies = [(1, 2), (2, 3), (1, 4), (3, 4)]
+    rules = [
+        {
+            "source_type": "issue",
+            "source_id": source_id,
+            "target_type": "issue",
+            "target_id": target_id,
+            "satisfaction_type": "item_read",
+            "checkpoint_issue_id": None,
+        }
+        for source_id, target_id in dependencies
+    ]
+
+    legacy = _legacy_blocked_targets(dependencies, issue_statuses)
+    continuity = _continuity_blocked_targets(rules, issue_statuses)
+
+    assert legacy == expected_blocked
+    assert continuity == expected_blocked
+    assert continuity == legacy


### PR DESCRIPTION
Closes #844

## Summary
- backfill every owned legacy issue dependency into an equivalent issue→issue `item_read` continuity rule
- reuse equivalent generalized rules instead of creating duplicate effective edges
- keep legacy dependency create/update/delete behavior synchronized through a database trigger during the transition
- preserve notes, ownership boundaries, rollback safety, and rerunnable migration behavior
- compare representative legacy and continuity blocking results in focused regression coverage

## Migration strategy
The legacy `dependencies` table remains authoritative for existing APIs during this compatibility phase. Each legacy row is linked to exactly one generalized continuity rule through `legacy_dependency_id`, while equivalent pre-existing rules are reused. Forward writes are mirrored automatically; rollback removes the live synchronization bridge and compatibility linkage without deleting the legacy dependency table.

## Validation
Focused migration regression tests cover idempotent backfill, equivalent-rule reuse, create/update synchronization, ownership enforcement, rollback behavior, and old-versus-new blocking parity.
