### PR TITLE
Contain nested queue keyboard actions

### DIFF
--- a/docs/changelog.d/2026-08-07-898.md
+++ b/docs/changelog.d/2026-08-07-898.md
@@ -1,0 +1,5 @@
+## 2026-08-07
+
+### Queue
+
+- [#898](https://github.com/JoshCLWren/comic-pile/pull/898) keeps keyboard activation of queue controls from also opening the comic thread, so mobile and keyboard users can manage dependencies without accidental navigation.

--- a/frontend/src/pages/QueuePage/QueueThreadCard.tsx
+++ b/frontend/src/pages/QueuePage/QueueThreadCard.tsx
@@ -74,6 +74,7 @@ export default function QueueThreadCard({
         role="button"
         tabIndex={0}
         onKeyDown={(e) => {
+          if (e.target !== e.currentTarget) return
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault()
             onCardClick()

--- a/frontend/src/unit/QueueThreadCard.test.tsx
+++ b/frontend/src/unit/QueueThreadCard.test.tsx
@@ -112,6 +112,18 @@ describe('QueueThreadCard', () => {
     expect(onCardClick).not.toHaveBeenCalled()
   })
 
+  it('does not treat nested control keyboard activation as card activation', () => {
+    const onCardClick = vi.fn()
+    const onDependencies = vi.fn()
+    renderCard(createMockThread(), { onCardClick, onDependencies })
+
+    const mobileButton = screen.getByTestId('mobile-dependency-action')
+    fireEvent.keyDown(mobileButton, { key: 'Enter' })
+    fireEvent.keyDown(mobileButton, { key: ' ' })
+
+    expect(onCardClick).not.toHaveBeenCalled()
+  })
+
   it('renders blocked thread explanation button when thread is blocked', () => {
     const thread = createMockThread()
     renderCard(thread, {


### PR DESCRIPTION
Contributes to #625.

## Summary
- keep queue-card Enter/Space navigation scoped to the card itself
- prevent keyboard events from nested controls from also opening thread details
- add focused regression coverage for the mobile dependency control

## Validation
This connector runtime does not provide a local checkout, so focused validation is delegated to the configured exact-head CI boundary. The change is intentionally small and covered by the existing QueueThreadCard unit suite plus the new regression.

The parent #625 remains open for its final Chromium containment verification and any still-reproducible interaction defects.