### PR TITLE
Complete crossover membership editing

### DIFF
--- a/docs/changelog.d/2026-08-07-900.md
+++ b/docs/changelog.d/2026-08-07-900.md
@@ -2,4 +2,4 @@
 
 ### Crossovers
 
-- [PR #900](https://github.com/JoshCLWren/comic-pile/pull/900) makes crossover membership fully editable from the Crossovers screen. You can now see individual issue and thread memberships, add a whole thread, and remove a comic without deleting the crossover or changing its blocking rules.
+- [#900](https://github.com/JoshCLWren/comic-pile/pull/900) makes crossover membership fully editable from the Crossovers screen. You can now see individual issue and thread memberships, add a whole thread, and remove a comic without deleting the crossover or changing its blocking rules.

--- a/docs/changelog.d/2026-08-07-900.md
+++ b/docs/changelog.d/2026-08-07-900.md
@@ -1,0 +1,5 @@
+## 2026-08-07
+
+### Crossovers
+
+- [PR #900](https://github.com/JoshCLWren/comic-pile/pull/900) makes crossover membership fully editable from the Crossovers screen. You can now see individual issue and thread memberships, add a whole thread, and remove a comic without deleting the crossover or changing its blocking rules.

--- a/frontend/src/pages/CrossoversPage.tsx
+++ b/frontend/src/pages/CrossoversPage.tsx
@@ -185,16 +185,20 @@ export default function CrossoversPage() {
     setBusyId(groupId)
     try {
       const result = await dependencyGroupsApi.addIssueRange(groupId, threadId, start, end)
-      const refreshed = await dependencyGroupsApi.get(groupId)
-      setGroups((current) =>
-        current.map((group) => (group.id === groupId ? refreshed : group)),
-      )
-      setMembershipMessage(
-        `${result.added_issue_ids.length} added, ${result.already_present_issue_ids.length} already present.`,
-      )
+      const successMessage = `${result.added_issue_ids.length} added, ${result.already_present_issue_ids.length} already present.`
+      setMembershipMessage(successMessage)
       setRangeThreadId('')
       setRangeStart('')
       setRangeEnd('')
+      try {
+        const refreshed = await dependencyGroupsApi.get(groupId)
+        setGroups((current) =>
+          current.map((group) => (group.id === groupId ? refreshed : group)),
+        )
+      } catch (error) {
+        const refreshError = errorMessage(error, 'Unable to refresh crossover memberships.')
+        setMembershipMessage(`${successMessage} Saved, but the latest memberships could not be refreshed: ${refreshError}`)
+      }
     } catch (error) {
       setMutationError(errorMessage(error, 'Unable to add issue range.'))
     } finally {

--- a/frontend/src/pages/CrossoversPage.tsx
+++ b/frontend/src/pages/CrossoversPage.tsx
@@ -25,10 +25,11 @@ export default function CrossoversPage() {
   const [mutationError, setMutationError] = useState<string | null>(null)
   const [busyId, setBusyId] = useState<number | null>(null)
   const [expandedId, setExpandedId] = useState<number | null>(null)
+  const [memberThreadId, setMemberThreadId] = useState('')
   const [rangeThreadId, setRangeThreadId] = useState('')
   const [rangeStart, setRangeStart] = useState('')
   const [rangeEnd, setRangeEnd] = useState('')
-  const [rangeMessage, setRangeMessage] = useState<string | null>(null)
+  const [membershipMessage, setMembershipMessage] = useState<string | null>(null)
 
   const loadGroups = useCallback(async () => {
     setIsLoading(true)
@@ -46,17 +47,18 @@ export default function CrossoversPage() {
     void loadGroups()
   }, [loadGroups])
 
-  const clearRangeState = () => {
+  const clearMembershipState = () => {
+    setMemberThreadId('')
     setRangeThreadId('')
     setRangeStart('')
     setRangeEnd('')
-    setRangeMessage(null)
+    setMembershipMessage(null)
   }
 
   const toggleExpanded = (groupId: number) => {
     if (busyId !== null) return
     setExpandedId((current) => (current === groupId ? null : groupId))
-    clearRangeState()
+    clearMembershipState()
     setMutationError(null)
   }
 
@@ -72,7 +74,9 @@ export default function CrossoversPage() {
     setIsCreating(true)
     try {
       const created = await dependencyGroupsApi.create(trimmedName)
-      setGroups((current) => [...current, created].sort((a, b) => a.name.localeCompare(b.name)))
+      setGroups((current) =>
+        [...current, created].sort((a, b) => a.name.localeCompare(b.name)),
+      )
       setName('')
     } catch (error) {
       setCreateError(errorMessage(error, 'Unable to create crossover.'))
@@ -98,7 +102,11 @@ export default function CrossoversPage() {
     setBusyId(groupId)
     try {
       const renamed = await dependencyGroupsApi.rename(groupId, trimmedName)
-      setGroups((current) => current.map((group) => (group.id === groupId ? renamed : group)).sort((a, b) => a.name.localeCompare(b.name)))
+      setGroups((current) =>
+        current
+          .map((group) => (group.id === groupId ? renamed : group))
+          .sort((a, b) => a.name.localeCompare(b.name)),
+      )
       setEditingId(null)
       setEditingName('')
     } catch (error) {
@@ -118,11 +126,39 @@ export default function CrossoversPage() {
       setGroups((current) => current.filter((item) => item.id !== group.id))
       if (expandedId === group.id) {
         setExpandedId(null)
-        clearRangeState()
+        clearMembershipState()
       }
       if (editingId === group.id) setEditingId(null)
     } catch (error) {
       setMutationError(errorMessage(error, 'Unable to delete crossover.'))
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  const addThreadMember = async (event: FormEvent<HTMLFormElement>, groupId: number) => {
+    event.preventDefault()
+    const threadId = Number(memberThreadId)
+    if (!Number.isInteger(threadId) || threadId < 1) {
+      setMutationError('Enter a valid thread ID.')
+      return
+    }
+    setMutationError(null)
+    setMembershipMessage(null)
+    setBusyId(groupId)
+    try {
+      const member = await dependencyGroupsApi.addMember(groupId, { thread_id: threadId })
+      setGroups((current) =>
+        current.map((group) =>
+          group.id === groupId
+            ? { ...group, memberships: [...group.memberships, member] }
+            : group,
+        ),
+      )
+      setMemberThreadId('')
+      setMembershipMessage('Thread added to crossover.')
+    } catch (error) {
+      setMutationError(errorMessage(error, 'Unable to add thread to crossover.'))
     } finally {
       setBusyId(null)
     }
@@ -133,18 +169,29 @@ export default function CrossoversPage() {
     const threadId = Number(rangeThreadId)
     const start = Number(rangeStart)
     const end = Number(rangeEnd)
-    if (!Number.isInteger(threadId) || threadId < 1 || !Number.isInteger(start) || start < 1 || !Number.isInteger(end) || end < start) {
+    if (
+      !Number.isInteger(threadId)
+      || threadId < 1
+      || !Number.isInteger(start)
+      || start < 1
+      || !Number.isInteger(end)
+      || end < start
+    ) {
       setMutationError('Enter a valid thread ID and an inclusive issue-position range.')
       return
     }
     setMutationError(null)
-    setRangeMessage(null)
+    setMembershipMessage(null)
     setBusyId(groupId)
     try {
       const result = await dependencyGroupsApi.addIssueRange(groupId, threadId, start, end)
       const refreshed = await dependencyGroupsApi.get(groupId)
-      setGroups((current) => current.map((group) => (group.id === groupId ? refreshed : group)))
-      setRangeMessage(`${result.added_issue_ids.length} added, ${result.already_present_issue_ids.length} already present.`)
+      setGroups((current) =>
+        current.map((group) => (group.id === groupId ? refreshed : group)),
+      )
+      setMembershipMessage(
+        `${result.added_issue_ids.length} added, ${result.already_present_issue_ids.length} already present.`,
+      )
       setRangeThreadId('')
       setRangeStart('')
       setRangeEnd('')
@@ -155,31 +202,86 @@ export default function CrossoversPage() {
     }
   }
 
+  const removeMember = async (groupId: number, memberId: number) => {
+    if (busyId !== null) return
+    setMutationError(null)
+    setMembershipMessage(null)
+    setBusyId(groupId)
+    try {
+      await dependencyGroupsApi.removeMember(groupId, memberId)
+      setGroups((current) =>
+        current.map((group) =>
+          group.id === groupId
+            ? {
+                ...group,
+                memberships: group.memberships.filter((member) => member.id !== memberId),
+              }
+            : group,
+        ),
+      )
+      setMembershipMessage('Comic removed from crossover.')
+    } catch (error) {
+      setMutationError(errorMessage(error, 'Unable to remove crossover member.'))
+    } finally {
+      setBusyId(null)
+    }
+  }
+
   return (
     <section className="space-y-6" aria-labelledby="crossovers-heading">
       <header>
         <p className="text-xs font-bold uppercase tracking-[0.25em] text-amber-500">Continuity</p>
         <h1 id="crossovers-heading" className="mt-1 text-3xl font-black text-stone-100">Crossovers</h1>
-        <p className="mt-2 max-w-2xl text-sm text-stone-400">Name connected comics so their continuity is easy to recognize across ComicPile. Membership does not create a reading block by itself.</p>
+        <p className="mt-2 max-w-2xl text-sm text-stone-400">
+          Name connected comics so their continuity is easy to recognize across ComicPile. Membership does not create a reading block by itself.
+        </p>
       </header>
 
-      <form onSubmit={createGroup} className="rounded-2xl border border-stone-700 bg-stone-900/70 p-4" aria-label="Create crossover">
+      <form
+        onSubmit={createGroup}
+        className="rounded-2xl border border-stone-700 bg-stone-900/70 p-4"
+        aria-label="Create crossover"
+      >
         <label htmlFor="crossover-name" className="block text-sm font-bold text-stone-200">New crossover</label>
         <div className="mt-2 flex flex-col gap-2 sm:flex-row">
-          <input id="crossover-name" value={name} onChange={(event) => setName(event.target.value)} maxLength={200} className="min-w-0 flex-1 rounded-xl border border-stone-600 bg-stone-950 px-3 py-2.5 text-stone-100 outline-none focus:border-amber-500 focus:ring-2 focus:ring-amber-500/30" placeholder="Age of Apocalypse" disabled={isCreating || isLoading} />
-          <button type="submit" disabled={isCreating || isLoading} className="rounded-xl bg-amber-500 px-4 py-2.5 font-bold text-stone-950 disabled:cursor-not-allowed disabled:opacity-50">{isCreating ? 'Creating…' : 'Create crossover'}</button>
+          <input
+            id="crossover-name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            maxLength={200}
+            className="min-w-0 flex-1 rounded-xl border border-stone-600 bg-stone-950 px-3 py-2.5 text-stone-100 outline-none focus:border-amber-500 focus:ring-2 focus:ring-amber-500/30"
+            placeholder="Age of Apocalypse"
+            disabled={isCreating || isLoading}
+          />
+          <button
+            type="submit"
+            disabled={isCreating || isLoading}
+            className="rounded-xl bg-amber-500 px-4 py-2.5 font-bold text-stone-950 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isCreating ? 'Creating…' : 'Create crossover'}
+          </button>
         </div>
         {createError && <p role="alert" className="mt-2 text-sm text-red-400">{createError}</p>}
       </form>
 
-      {mutationError && <p role="alert" className="rounded-xl border border-red-800 bg-red-950/40 p-3 text-sm text-red-300">{mutationError}</p>}
+      {mutationError && (
+        <p role="alert" className="rounded-xl border border-red-800 bg-red-950/40 p-3 text-sm text-red-300">
+          {mutationError}
+        </p>
+      )}
 
       {isLoading ? (
         <p role="status" className="rounded-2xl border border-stone-800 p-6 text-center text-stone-400">Loading crossovers…</p>
       ) : loadError ? (
-        <div role="alert" className="rounded-2xl border border-red-800 bg-red-950/40 p-4 text-red-300"><p>{loadError}</p><button type="button" onClick={() => void loadGroups()} className="mt-3 rounded-lg border border-red-500 px-3 py-2 text-sm font-bold">Try again</button></div>
+        <div role="alert" className="rounded-2xl border border-red-800 bg-red-950/40 p-4 text-red-300">
+          <p>{loadError}</p>
+          <button type="button" onClick={() => void loadGroups()} className="mt-3 rounded-lg border border-red-500 px-3 py-2 text-sm font-bold">Try again</button>
+        </div>
       ) : groups.length === 0 ? (
-        <div className="rounded-2xl border border-dashed border-stone-700 p-8 text-center"><p className="text-lg font-bold text-stone-200">No crossovers yet</p><p className="mt-1 text-sm text-stone-500">Create one above, then add comics from dependency management.</p></div>
+        <div className="rounded-2xl border border-dashed border-stone-700 p-8 text-center">
+          <p className="text-lg font-bold text-stone-200">No crossovers yet</p>
+          <p className="mt-1 text-sm text-stone-500">Create one above, then add comics here as your continuity plan grows.</p>
+        </div>
       ) : (
         <ul className="grid gap-3" aria-label="Your crossovers">
           {groups.map((group) => {
@@ -187,30 +289,116 @@ export default function CrossoversPage() {
             const isBusy = busyId === group.id
             const hasPendingMutation = busyId !== null
             const isExpanded = expandedId === group.id
+            const issueCount = group.memberships.filter((member) => member.issue_id !== null).length
+            const threadCount = group.memberships.filter((member) => member.thread_id !== null).length
+
             return (
               <li key={group.id} className="rounded-2xl border border-stone-700 bg-stone-900/60 p-4">
                 {isEditing ? (
                   <div className="flex flex-col gap-2 sm:flex-row">
                     <label className="sr-only" htmlFor={`rename-${group.id}`}>Rename {group.name}</label>
-                    <input id={`rename-${group.id}`} value={editingName} onChange={(event) => setEditingName(event.target.value)} className="min-w-0 flex-1 rounded-xl border border-stone-600 bg-stone-950 px-3 py-2 text-stone-100" disabled={isBusy} />
-                    <div className="flex gap-2"><button type="button" onClick={() => void saveRename(group.id)} disabled={isBusy} className="flex-1 rounded-lg bg-amber-500 px-3 py-2 text-sm font-bold text-stone-950 disabled:opacity-50">Save</button><button type="button" onClick={() => setEditingId(null)} disabled={isBusy} className="flex-1 rounded-lg border border-stone-600 px-3 py-2 text-sm font-bold text-stone-300">Cancel</button></div>
+                    <input
+                      id={`rename-${group.id}`}
+                      value={editingName}
+                      onChange={(event) => setEditingName(event.target.value)}
+                      className="min-w-0 flex-1 rounded-xl border border-stone-600 bg-stone-950 px-3 py-2 text-stone-100"
+                      disabled={isBusy}
+                    />
+                    <div className="flex gap-2">
+                      <button type="button" onClick={() => void saveRename(group.id)} disabled={isBusy} className="flex-1 rounded-lg bg-amber-500 px-3 py-2 text-sm font-bold text-stone-950 disabled:opacity-50">Save</button>
+                      <button type="button" onClick={() => setEditingId(null)} disabled={isBusy} className="flex-1 rounded-lg border border-stone-600 px-3 py-2 text-sm font-bold text-stone-300">Cancel</button>
+                    </div>
                   </div>
                 ) : (
                   <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                    <button type="button" onClick={() => toggleExpanded(group.id)} disabled={hasPendingMutation} aria-expanded={isExpanded} className="min-w-0 text-left disabled:cursor-not-allowed disabled:opacity-50"><span className="block truncate text-lg font-black text-stone-100">{group.name}</span><span className="text-sm text-stone-500">{group.memberships.length} {group.memberships.length === 1 ? 'member' : 'members'}</span></button>
-                    <div className="flex gap-2"><button type="button" onClick={() => beginRename(group)} disabled={hasPendingMutation} className="flex-1 rounded-lg border border-stone-600 px-3 py-2 text-sm font-bold text-stone-300 hover:border-amber-500 disabled:opacity-50">Rename</button><button type="button" onClick={() => void deleteGroup(group)} disabled={hasPendingMutation} className="flex-1 rounded-lg border border-red-800 px-3 py-2 text-sm font-bold text-red-400 hover:bg-red-950/40 disabled:opacity-50">Delete</button></div>
+                    <button
+                      type="button"
+                      onClick={() => toggleExpanded(group.id)}
+                      disabled={hasPendingMutation}
+                      aria-expanded={isExpanded}
+                      className="min-w-0 text-left disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      <span className="block truncate text-lg font-black text-stone-100">{group.name}</span>
+                      <span className="text-sm text-stone-500">{group.memberships.length} {group.memberships.length === 1 ? 'member' : 'members'}</span>
+                    </button>
+                    <div className="flex gap-2">
+                      <button type="button" onClick={() => beginRename(group)} disabled={hasPendingMutation} className="flex-1 rounded-lg border border-stone-600 px-3 py-2 text-sm font-bold text-stone-300 hover:border-amber-500 disabled:opacity-50">Rename</button>
+                      <button type="button" onClick={() => void deleteGroup(group)} disabled={hasPendingMutation} className="flex-1 rounded-lg border border-red-800 px-3 py-2 text-sm font-bold text-red-400 hover:bg-red-950/40 disabled:opacity-50">Delete</button>
+                    </div>
                   </div>
                 )}
+
                 {isExpanded && !isEditing && (
                   <div className="mt-4 space-y-4 border-t border-stone-800 pt-4 text-sm text-stone-400">
-                    {group.memberships.length === 0 ? <p>This crossover has no comics yet.</p> : <p>{group.memberships.filter((member) => member.issue_id !== null).length} issue memberships and {group.memberships.filter((member) => member.thread_id !== null).length} thread memberships.</p>}
-                    <form onSubmit={(event) => void addRange(event, group.id)} aria-label={`Add issue range to ${group.name}`} className="grid gap-2 rounded-xl border border-stone-800 bg-stone-950/50 p-3 sm:grid-cols-4">
-                      <label className="grid gap-1"><span className="font-bold text-stone-300">Thread ID</span><input inputMode="numeric" value={rangeThreadId} onChange={(event) => setRangeThreadId(event.target.value)} disabled={hasPendingMutation} className="rounded-lg border border-stone-700 bg-stone-950 px-3 py-2 text-stone-100" /></label>
-                      <label className="grid gap-1"><span className="font-bold text-stone-300">Start position</span><input inputMode="numeric" value={rangeStart} onChange={(event) => setRangeStart(event.target.value)} disabled={hasPendingMutation} className="rounded-lg border border-stone-700 bg-stone-950 px-3 py-2 text-stone-100" /></label>
-                      <label className="grid gap-1"><span className="font-bold text-stone-300">End position</span><input inputMode="numeric" value={rangeEnd} onChange={(event) => setRangeEnd(event.target.value)} disabled={hasPendingMutation} className="rounded-lg border border-stone-700 bg-stone-950 px-3 py-2 text-stone-100" /></label>
-                      <button type="submit" disabled={hasPendingMutation} className="self-end rounded-lg bg-amber-500 px-3 py-2 font-bold text-stone-950 disabled:opacity-50">{isBusy ? 'Adding…' : 'Add range'}</button>
+                    {group.memberships.length === 0 ? (
+                      <p>This crossover has no comics yet.</p>
+                    ) : (
+                      <>
+                        <p>{issueCount} issue memberships and {threadCount} thread memberships.</p>
+                        <ul className="grid gap-2" aria-label={`${group.name} members`}>
+                          {group.memberships.map((member) => (
+                            <li key={member.id} className="flex items-center justify-between gap-3 rounded-xl border border-stone-800 bg-stone-950/50 px-3 py-2">
+                              <span className="min-w-0 font-bold text-stone-300">
+                                {member.issue_id !== null ? `Issue ${member.issue_id}` : `Thread ${member.thread_id}`}
+                              </span>
+                              <button
+                                type="button"
+                                onClick={() => void removeMember(group.id, member.id)}
+                                disabled={hasPendingMutation}
+                                aria-label={`Remove ${member.issue_id !== null ? `issue ${member.issue_id}` : `thread ${member.thread_id}`} from ${group.name}`}
+                                className="shrink-0 rounded-lg border border-red-900 px-3 py-1.5 text-xs font-bold text-red-400 hover:bg-red-950/40 disabled:opacity-50"
+                              >
+                                Remove
+                              </button>
+                            </li>
+                          ))}
+                        </ul>
+                      </>
+                    )}
+
+                    <form
+                      onSubmit={(event) => void addThreadMember(event, group.id)}
+                      aria-label={`Add thread to ${group.name}`}
+                      className="grid gap-2 rounded-xl border border-stone-800 bg-stone-950/50 p-3 sm:grid-cols-[1fr_auto]"
+                    >
+                      <label className="grid gap-1">
+                        <span className="font-bold text-stone-300">Whole thread ID</span>
+                        <input
+                          inputMode="numeric"
+                          value={memberThreadId}
+                          onChange={(event) => setMemberThreadId(event.target.value)}
+                          disabled={hasPendingMutation}
+                          className="rounded-lg border border-stone-700 bg-stone-950 px-3 py-2 text-stone-100"
+                        />
+                      </label>
+                      <button type="submit" disabled={hasPendingMutation} className="self-end rounded-lg bg-violet-500 px-3 py-2 font-bold text-stone-950 disabled:opacity-50">
+                        {isBusy ? 'Saving…' : 'Add thread'}
+                      </button>
                     </form>
-                    {rangeMessage && <p role="status" className="text-emerald-400">{rangeMessage}</p>}
+
+                    <form
+                      onSubmit={(event) => void addRange(event, group.id)}
+                      aria-label={`Add issue range to ${group.name}`}
+                      className="grid gap-2 rounded-xl border border-stone-800 bg-stone-950/50 p-3 sm:grid-cols-4"
+                    >
+                      <label className="grid gap-1">
+                        <span className="font-bold text-stone-300">Thread ID</span>
+                        <input inputMode="numeric" value={rangeThreadId} onChange={(event) => setRangeThreadId(event.target.value)} disabled={hasPendingMutation} className="rounded-lg border border-stone-700 bg-stone-950 px-3 py-2 text-stone-100" />
+                      </label>
+                      <label className="grid gap-1">
+                        <span className="font-bold text-stone-300">Start position</span>
+                        <input inputMode="numeric" value={rangeStart} onChange={(event) => setRangeStart(event.target.value)} disabled={hasPendingMutation} className="rounded-lg border border-stone-700 bg-stone-950 px-3 py-2 text-stone-100" />
+                      </label>
+                      <label className="grid gap-1">
+                        <span className="font-bold text-stone-300">End position</span>
+                        <input inputMode="numeric" value={rangeEnd} onChange={(event) => setRangeEnd(event.target.value)} disabled={hasPendingMutation} className="rounded-lg border border-stone-700 bg-stone-950 px-3 py-2 text-stone-100" />
+                      </label>
+                      <button type="submit" disabled={hasPendingMutation} className="self-end rounded-lg bg-amber-500 px-3 py-2 font-bold text-stone-950 disabled:opacity-50">
+                        {isBusy ? 'Adding…' : 'Add range'}
+                      </button>
+                    </form>
+
+                    {membershipMessage && <p role="status" className="text-emerald-400">{membershipMessage}</p>}
                   </div>
                 )}
               </li>

--- a/frontend/src/unit/CrossoversPage.memberships.test.tsx
+++ b/frontend/src/unit/CrossoversPage.memberships.test.tsx
@@ -57,6 +57,19 @@ describe('CrossoversPage membership editing', () => {
     expect(screen.getByLabelText('Whole thread ID')).toHaveValue('')
   })
 
+  it('keeps the whole-thread form usable when adding a membership fails', async () => {
+    api.addMember.mockRejectedValue(new Error('Thread lookup unavailable'))
+    render(<CrossoversPage />)
+    fireEvent.click(await screen.findByRole('button', { name: /Annihilation.*2 members/ }))
+
+    fireEvent.change(screen.getByLabelText('Whole thread ID'), { target: { value: '44' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add thread' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Thread lookup unavailable')
+    expect(screen.getByLabelText('Whole thread ID')).toHaveValue('44')
+    expect(screen.getByRole('button', { name: 'Add thread' })).toBeEnabled()
+  })
+
   it('rejects an invalid whole-thread ID before calling the API', async () => {
     render(<CrossoversPage />)
     fireEvent.click(await screen.findByRole('button', { name: /Annihilation.*2 members/ }))

--- a/frontend/src/unit/CrossoversPage.memberships.test.tsx
+++ b/frontend/src/unit/CrossoversPage.memberships.test.tsx
@@ -81,7 +81,13 @@ describe('CrossoversPage membership editing', () => {
   })
 
   it('keeps a successful range add committed when the membership refresh fails', async () => {
-    api.addIssueRange.mockResolvedValue({ added_issue_ids: [31], already_present_issue_ids: [] })
+    api.addIssueRange.mockResolvedValue({
+      thread_id: 22,
+      start_position: 3,
+      end_position: 5,
+      added_issue_ids: [31],
+      already_present_issue_ids: [],
+    })
     api.get.mockRejectedValue(new Error('Refresh unavailable'))
     render(<CrossoversPage />)
     fireEvent.click(await screen.findByRole('button', { name: /Annihilation.*2 members/ }))

--- a/frontend/src/unit/CrossoversPage.memberships.test.tsx
+++ b/frontend/src/unit/CrossoversPage.memberships.test.tsx
@@ -70,13 +70,16 @@ describe('CrossoversPage membership editing', () => {
     expect(screen.getByRole('button', { name: 'Add thread' })).toBeEnabled()
   })
 
-  it('rejects an invalid whole-thread ID before calling the API', async () => {
+  it('rejects invalid whole-thread IDs before calling the API', async () => {
     render(<CrossoversPage />)
     fireEvent.click(await screen.findByRole('button', { name: /Annihilation.*2 members/ }))
 
     fireEvent.change(screen.getByLabelText('Whole thread ID'), { target: { value: '0' } })
     fireEvent.click(screen.getByRole('button', { name: 'Add thread' }))
+    expect(screen.getByRole('alert')).toHaveTextContent('Enter a valid thread ID.')
 
+    fireEvent.change(screen.getByLabelText('Whole thread ID'), { target: { value: '1.5' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add thread' }))
     expect(screen.getByRole('alert')).toHaveTextContent('Enter a valid thread ID.')
     expect(api.addMember).not.toHaveBeenCalled()
   })
@@ -92,6 +95,23 @@ describe('CrossoversPage membership editing', () => {
     expect(api.removeMember).toHaveBeenCalledWith(7, 1)
     expect(screen.getByText('Annihilation')).toBeInTheDocument()
     expect(screen.getByRole('status')).toHaveTextContent('Comic removed from crossover.')
+  })
+
+  it('ignores another membership removal while one is pending', async () => {
+    let resolveRemoval: (() => void) | undefined
+    api.removeMember.mockImplementation(() => new Promise<void>((resolve) => {
+      resolveRemoval = resolve
+    }))
+    render(<CrossoversPage />)
+    fireEvent.click(await screen.findByRole('button', { name: /Annihilation.*2 members/ }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove issue 31 from Annihilation' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Remove thread 22 from Annihilation' }))
+
+    expect(api.removeMember).toHaveBeenCalledTimes(1)
+    resolveRemoval?.()
+    await waitFor(() => expect(screen.queryByText('Issue 31')).not.toBeInTheDocument())
+    expect(screen.getByText('Thread 22')).toBeInTheDocument()
   })
 
   it('keeps membership visible when removal fails', async () => {

--- a/frontend/src/unit/CrossoversPage.memberships.test.tsx
+++ b/frontend/src/unit/CrossoversPage.memberships.test.tsx
@@ -80,6 +80,27 @@ describe('CrossoversPage membership editing', () => {
     expect(screen.getByRole('button', { name: /Secret Invasion.*1 member/ })).toBeInTheDocument()
   })
 
+  it('keeps a successful range add committed when the membership refresh fails', async () => {
+    api.addIssueRange.mockResolvedValue({ added_issue_ids: [31], already_present_issue_ids: [] })
+    api.get.mockRejectedValue(new Error('Refresh unavailable'))
+    render(<CrossoversPage />)
+    fireEvent.click(await screen.findByRole('button', { name: /Annihilation.*2 members/ }))
+
+    fireEvent.change(screen.getByLabelText('Thread ID'), { target: { value: '22' } })
+    fireEvent.change(screen.getByLabelText('Start position'), { target: { value: '3' } })
+    fireEvent.change(screen.getByLabelText('End position'), { target: { value: '5' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add range' }))
+
+    const status = await screen.findByRole('status')
+    expect(status).toHaveTextContent('1 added, 0 already present.')
+    expect(status).toHaveTextContent('latest memberships could not be refreshed: Refresh unavailable')
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('Thread ID')).toHaveValue('')
+    expect(screen.getByLabelText('Start position')).toHaveValue('')
+    expect(screen.getByLabelText('End position')).toHaveValue('')
+    expect(api.addIssueRange).toHaveBeenCalledTimes(1)
+  })
+
   it('keeps the whole-thread form usable when adding a membership fails', async () => {
     api.addMember.mockRejectedValue(new Error('Thread lookup unavailable'))
     render(<CrossoversPage />)

--- a/frontend/src/unit/CrossoversPage.memberships.test.tsx
+++ b/frontend/src/unit/CrossoversPage.memberships.test.tsx
@@ -57,6 +57,29 @@ describe('CrossoversPage membership editing', () => {
     expect(screen.getByLabelText('Whole thread ID')).toHaveValue('')
   })
 
+  it('preserves unrelated crossovers while adding and removing memberships', async () => {
+    const unrelated = {
+      id: 8,
+      name: 'Secret Invasion',
+      created_at: '2026-08-06T00:00:00Z',
+      memberships: [{ id: 8, issue_id: 80, thread_id: null }],
+    }
+    api.list.mockResolvedValue([crossover, unrelated])
+    api.addMember.mockResolvedValue({ id: 3, issue_id: null, thread_id: 44 })
+    api.removeMember.mockResolvedValue(undefined)
+    render(<CrossoversPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /Annihilation.*2 members/ }))
+    fireEvent.change(screen.getByLabelText('Whole thread ID'), { target: { value: '44' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add thread' }))
+    expect(await screen.findByText('Thread 44')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove issue 31 from Annihilation' }))
+    await waitFor(() => expect(screen.queryByText('Issue 31')).not.toBeInTheDocument())
+
+    expect(screen.getByRole('button', { name: /Secret Invasion.*1 member/ })).toBeInTheDocument()
+  })
+
   it('keeps the whole-thread form usable when adding a membership fails', async () => {
     api.addMember.mockRejectedValue(new Error('Thread lookup unavailable'))
     render(<CrossoversPage />)

--- a/frontend/src/unit/CrossoversPage.memberships.test.tsx
+++ b/frontend/src/unit/CrossoversPage.memberships.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import CrossoversPage from '../pages/CrossoversPage'
+import { dependencyGroupsApi } from '../services/api-dependency-groups'
+
+vi.mock('../services/api-dependency-groups', () => ({
+  dependencyGroupsApi: {
+    list: vi.fn(),
+    get: vi.fn(),
+    create: vi.fn(),
+    rename: vi.fn(),
+    delete: vi.fn(),
+    addMember: vi.fn(),
+    addIssueRange: vi.fn(),
+    removeMember: vi.fn(),
+  },
+}))
+
+const api = vi.mocked(dependencyGroupsApi)
+
+const crossover = {
+  id: 7,
+  name: 'Annihilation',
+  created_at: '2026-08-06T00:00:00Z',
+  memberships: [
+    { id: 1, issue_id: 31, thread_id: null },
+    { id: 2, issue_id: null, thread_id: 22 },
+  ],
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  api.list.mockResolvedValue([crossover])
+})
+
+describe('CrossoversPage membership editing', () => {
+  it('shows individual issue and thread memberships', async () => {
+    render(<CrossoversPage />)
+    fireEvent.click(await screen.findByRole('button', { name: /Annihilation.*2 members/ }))
+
+    expect(screen.getByText('Issue 31')).toBeInTheDocument()
+    expect(screen.getByText('Thread 22')).toBeInTheDocument()
+    expect(screen.getByRole('list', { name: 'Annihilation members' })).toBeInTheDocument()
+  })
+
+  it('adds a whole thread membership and updates the visible group', async () => {
+    api.addMember.mockResolvedValue({ id: 3, issue_id: null, thread_id: 44 })
+    render(<CrossoversPage />)
+    fireEvent.click(await screen.findByRole('button', { name: /Annihilation.*2 members/ }))
+
+    fireEvent.change(screen.getByLabelText('Whole thread ID'), { target: { value: '44' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add thread' }))
+
+    expect(await screen.findByText('Thread 44')).toBeInTheDocument()
+    expect(api.addMember).toHaveBeenCalledWith(7, { thread_id: 44 })
+    expect(screen.getByRole('status')).toHaveTextContent('Thread added to crossover.')
+    expect(screen.getByLabelText('Whole thread ID')).toHaveValue('')
+  })
+
+  it('rejects an invalid whole-thread ID before calling the API', async () => {
+    render(<CrossoversPage />)
+    fireEvent.click(await screen.findByRole('button', { name: /Annihilation.*2 members/ }))
+
+    fireEvent.change(screen.getByLabelText('Whole thread ID'), { target: { value: '0' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add thread' }))
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Enter a valid thread ID.')
+    expect(api.addMember).not.toHaveBeenCalled()
+  })
+
+  it('removes a membership without changing the crossover itself', async () => {
+    api.removeMember.mockResolvedValue(undefined)
+    render(<CrossoversPage />)
+    fireEvent.click(await screen.findByRole('button', { name: /Annihilation.*2 members/ }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove issue 31 from Annihilation' }))
+
+    await waitFor(() => expect(screen.queryByText('Issue 31')).not.toBeInTheDocument())
+    expect(api.removeMember).toHaveBeenCalledWith(7, 1)
+    expect(screen.getByText('Annihilation')).toBeInTheDocument()
+    expect(screen.getByRole('status')).toHaveTextContent('Comic removed from crossover.')
+  })
+
+  it('keeps membership visible when removal fails', async () => {
+    api.removeMember.mockRejectedValue(new Error('Removal unavailable'))
+    render(<CrossoversPage />)
+    fireEvent.click(await screen.findByRole('button', { name: /Annihilation.*2 members/ }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove issue 31 from Annihilation' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Removal unavailable')
+    expect(screen.getByText('Issue 31')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Closes #613

## Summary
- make crossover memberships individually visible and removable from the existing Crossovers management surface
- allow adding a whole thread directly, alongside the existing issue-range membership flow
- preserve crossover membership as metadata independent from blocking dependencies
- add focused frontend regression coverage for listing, adding, removing, validation, and failure behavior

## Validation
Local command execution is unavailable in this connector runtime, so no local test result is claimed. Exact-head CI must validate the branch before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added editable crossover membership management from the Crossovers screen.
  * View issue and thread memberships, including membership counts.
  * Add entire threads or issue ranges to a crossover.
  * Remove individual comics or threads without deleting the crossover or changing blocking rules.
  * Added operation status feedback and updated empty-state messaging.

* **Bug Fixes**
  * Improved handling of invalid additions, removal failures, and overlapping membership actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->