### PR TITLE
Expose full queue actions on mobile

### DIFF
--- a/docs/changelog.d/2026-08-07-902.md
+++ b/docs/changelog.d/2026-08-07-902.md
@@ -1,0 +1,5 @@
+## 2026-08-07
+
+### Queue
+
+- [#902](https://github.com/JoshCLWren/comic-pile/pull/902) gives mobile queue cards the same visible Thread actions menu as desktop, so Edit, Dependencies, repositioning, and Delete no longer depend on discovering a swipe gesture.

--- a/frontend/src/pages/QueuePage/QueueThreadCard.tsx
+++ b/frontend/src/pages/QueuePage/QueueThreadCard.tsx
@@ -108,7 +108,7 @@ export default function QueueThreadCard({
               )}
             </div>
           </div>
-          <div className="hidden md:flex items-center gap-1">
+          <div className="flex items-center gap-1">
             <PositionMenu
               thread={thread}
               onMoveToFront={() => onMoveToFront()}
@@ -118,21 +118,6 @@ export default function QueueThreadCard({
               onDependencies={() => onDependencies()}
               onDelete={() => onDelete()}
             />
-          </div>
-          <div className="md:hidden flex items-center gap-1">
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation()
-                onDependencies()
-              }}
-              className="flex items-center justify-center w-11 h-11 text-amber-400/70 hover:text-amber-300 transition-colors text-lg rounded-lg hover:bg-white/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
-              aria-label="Manage dependencies"
-              aria-haspopup="dialog"
-              data-testid="mobile-dependency-action"
-            >
-              &#x26D3;
-            </button>
           </div>
         </div>
         <div className="pl-8 md:pl-[2.75rem]">

--- a/frontend/src/unit/QueueThreadCard.test.tsx
+++ b/frontend/src/unit/QueueThreadCard.test.tsx
@@ -81,45 +81,29 @@ describe('QueueThreadCard', () => {
     vi.clearAllMocks()
   })
 
-  it('renders mobile dependency action button with correct attributes', () => {
-    const thread = createMockThread()
-    renderCard(thread)
+  it('renders the shared thread action menu as the discoverable card action', () => {
+    renderCard(createMockThread())
 
-    const mobileButton = screen.getByTestId('mobile-dependency-action')
-    expect(mobileButton).toBeInTheDocument()
-    expect(mobileButton).toHaveAttribute('aria-label', 'Manage dependencies')
-    expect(mobileButton).toHaveAttribute('aria-haspopup', 'dialog')
-    expect(mobileButton).toHaveAttribute('type', 'button')
+    expect(screen.getAllByTestId('mock-position-menu')).toHaveLength(1)
+    expect(screen.queryByTestId('mobile-dependency-action')).not.toBeInTheDocument()
   })
 
-  it('calls onDependencies when mobile button is clicked', async () => {
+  it('uses the shared action menu for dependency management', async () => {
     const user = userEvent.setup()
-    const thread = createMockThread()
     const onDependencies = vi.fn()
-    renderCard(thread, { onDependencies })
+    renderCard(createMockThread(), { onDependencies })
 
-    await user.click(screen.getByTestId('mobile-dependency-action'))
+    await user.click(screen.getByTestId('mock-position-menu'))
     expect(onDependencies).toHaveBeenCalledTimes(1)
   })
 
-  it('stops propagation when mobile button is clicked', async () => {
-    const user = userEvent.setup()
-    const thread = createMockThread()
+  it('does not treat shared action-menu keyboard activation as card activation', () => {
     const onCardClick = vi.fn()
-    renderCard(thread, { onCardClick })
+    renderCard(createMockThread(), { onCardClick })
 
-    await user.click(screen.getByTestId('mobile-dependency-action'))
-    expect(onCardClick).not.toHaveBeenCalled()
-  })
-
-  it('does not treat nested control keyboard activation as card activation', () => {
-    const onCardClick = vi.fn()
-    const onDependencies = vi.fn()
-    renderCard(createMockThread(), { onCardClick, onDependencies })
-
-    const mobileButton = screen.getByTestId('mobile-dependency-action')
-    fireEvent.keyDown(mobileButton, { key: 'Enter' })
-    fireEvent.keyDown(mobileButton, { key: ' ' })
+    const actionMenu = screen.getByTestId('mock-position-menu')
+    fireEvent.keyDown(actionMenu, { key: 'Enter' })
+    fireEvent.keyDown(actionMenu, { key: ' ' })
 
     expect(onCardClick).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
Tracks #625

## Summary
- use the shared portaled Thread actions menu on mobile as the discoverable primary action surface
- keep swipe actions as a secondary gesture without making Edit/Delete/Dependencies gesture-only
- preserve card keyboard isolation so nested controls cannot trigger card navigation
- update focused QueueThreadCard coverage

## Validation
Local command execution is unavailable in this connector runtime, so no local test result is claimed. Exact-head CI must validate the branch before merge.