### PR TITLE
Instrument production cold-start phases and first requests

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1,5 +1,10 @@
 """Vercel serverless entry point for ComicPile API requests."""
 
+from app import startup_diagnostics
 from app.main import create_app
+
+# Importing startup_diagnostics before app.main starts the user-code clock as
+# close to the Vercel Python entry boundary as practical.
+startup_diagnostics.startup_event_snapshot()
 
 app = create_app(serve_frontend=False)

--- a/api/index.py
+++ b/api/index.py
@@ -3,8 +3,8 @@
 from app import startup_diagnostics
 from app.main import create_app
 
-# Importing startup_diagnostics before app.main starts the user-code clock as
-# close to the Vercel Python entry boundary as practical.
-startup_diagnostics.startup_event_snapshot()
-
+# startup_diagnostics imports before app.main, so this marker captures the
+# application import phase from the earliest practical Python entry boundary.
+startup_diagnostics.mark_application_import_complete()
 app = create_app(serve_frontend=False)
+startup_diagnostics.mark_application_created()

--- a/app/middleware/request_logging.py
+++ b/app/middleware/request_logging.py
@@ -179,6 +179,11 @@ def _server_timing_header(total_ms: float) -> str:
     return ", ".join(metrics)
 
 
+def _rounded_optional(value: float | None) -> float | None:
+    """Round an optional timing value for structured log output."""
+    return round(value, 2) if value is not None else None
+
+
 def add_request_logging_middleware(app: FastAPI, environment: str) -> None:
     """Register request diagnostics and error logging middleware.
 
@@ -191,14 +196,17 @@ def add_request_logging_middleware(app: FastAPI, environment: str) -> None:
     @app.on_event("startup")
     async def record_startup_completion() -> None:
         """Emit one process-scoped startup timing event after lifespan startup."""
-        startup_duration_ms = mark_startup_complete()
+        mark_startup_complete()
         snapshot = startup_event_snapshot()
         logger.warning(
             "Application startup completed in %.2f ms",
-            startup_duration_ms,
+            snapshot.startup_duration_ms or 0.0,
             extra={
                 "event": "application_startup",
-                "startup_duration_ms": round(startup_duration_ms, 2),
+                "startup_duration_ms": _rounded_optional(snapshot.startup_duration_ms),
+                "application_import_ms": _rounded_optional(snapshot.application_import_ms),
+                "application_creation_ms": _rounded_optional(snapshot.application_creation_ms),
+                "lifespan_ms": _rounded_optional(snapshot.lifespan_ms),
                 "process_age_ms": round(snapshot.process_age_ms, 2),
                 "deployment_id": snapshot.deployment_id,
                 "process_started_at_ns": snapshot.process_started_at_ns,
@@ -249,11 +257,10 @@ def add_request_logging_middleware(app: FastAPI, environment: str) -> None:
                 "process_request_number": startup.invocation,
                 "process_age_ms": round(startup.process_age_ms, 2),
                 "startup_complete": startup.startup_complete,
-                "startup_duration_ms": (
-                    round(startup.startup_duration_ms, 2)
-                    if startup.startup_duration_ms is not None
-                    else None
-                ),
+                "startup_duration_ms": _rounded_optional(startup.startup_duration_ms),
+                "application_import_ms": _rounded_optional(startup.application_import_ms),
+                "application_creation_ms": _rounded_optional(startup.application_creation_ms),
+                "lifespan_ms": _rounded_optional(startup.lifespan_ms),
                 "deployment_id": startup.deployment_id,
                 "process_started_at_ns": startup.process_started_at_ns,
                 "client_host": request.client.host if request.client else None,
@@ -280,13 +287,20 @@ def add_request_logging_middleware(app: FastAPI, environment: str) -> None:
                     f"Client Error: {request.method} {request.url.path} - {status_code}",
                     extra={**log_data, "level": "WARNING"},
                 )
-            elif startup.cold or process_time_ms >= _slow_request_threshold_ms():
+            elif process_time_ms >= _slow_request_threshold_ms():
                 logger.warning(
-                    "HTTP request: %s %s completed in %.2f ms (%s)",
+                    "Slow HTTP request: %s %s completed in %.2f ms",
                     request.method,
                     request.url.path,
                     process_time_ms,
-                    "cold" if startup.cold else "warm",
+                    extra={**log_data, "level": "WARNING"},
+                )
+            elif startup.cold:
+                logger.warning(
+                    "Cold HTTP request: %s %s completed in %.2f ms",
+                    request.method,
+                    request.url.path,
+                    process_time_ms,
                     extra={**log_data, "level": "WARNING"},
                 )
 

--- a/app/middleware/request_logging.py
+++ b/app/middleware/request_logging.py
@@ -132,7 +132,7 @@ def redact_headers(headers: dict) -> dict:
 def sanitize_for_logging(log_data: dict[str, object], environment: str) -> dict[str, object]:
     """Trim request context from logs in production and staging.
 
-    In production and staging, avoid logging request bodies, query params, and session identifiers.
+    In production and staging, avoid logging request bodies, query params, and user/session identifiers.
 
     Args:
         log_data: Log payload.
@@ -145,9 +145,14 @@ def sanitize_for_logging(log_data: dict[str, object], environment: str) -> dict[
         return log_data
 
     trimmed = dict(log_data)
-    for key in ("request_body", "query_params", "session_id", "body"):
+    for key in ("request_body", "query_params", "session_id", "user_id", "body"):
         trimmed.pop(key, None)
     return trimmed
+
+
+def _sanitize_log_path(path: str) -> str:
+    """Neutralize control characters that could forge or split log records."""
+    return path.replace("\r", "\\r").replace("\n", "\\n")
 
 
 def _slow_request_threshold_ms() -> float:
@@ -233,6 +238,7 @@ def add_request_logging_middleware(app: FastAPI, environment: str) -> None:
             process_time_ms = (time.perf_counter() - started_at) * 1000
             status_code = response.status_code
             diagnostics = get_request_diagnostics()
+            log_path = _sanitize_log_path(request.url.path)
 
             response.headers["X-Request-ID"] = request_id
             response.headers["X-App-Cache"] = diagnostics.cache_status
@@ -244,7 +250,7 @@ def add_request_logging_middleware(app: FastAPI, environment: str) -> None:
                 "timestamp": datetime.now(UTC).isoformat(),
                 "request_id": request_id,
                 "method": request.method,
-                "path": request.url.path,
+                "path": log_path,
                 "query_params": str(request.url.query) if request.url.query else None,
                 "status_code": status_code,
                 "process_time_ms": round(process_time_ms, 2),
@@ -279,19 +285,25 @@ def add_request_logging_middleware(app: FastAPI, environment: str) -> None:
 
             if status_code >= 500:
                 logger.error(
-                    f"API Error: {request.method} {request.url.path} - {status_code}",
+                    "API Error: %s %s - %s",
+                    request.method,
+                    log_path,
+                    status_code,
                     extra={**log_data, "level": "ERROR"},
                 )
             elif status_code >= 400:
                 logger.warning(
-                    f"Client Error: {request.method} {request.url.path} - {status_code}",
+                    "Client Error: %s %s - %s",
+                    request.method,
+                    log_path,
+                    status_code,
                     extra={**log_data, "level": "WARNING"},
                 )
             elif process_time_ms >= _slow_request_threshold_ms():
                 logger.warning(
                     "Slow HTTP request: %s %s completed in %.2f ms",
                     request.method,
-                    request.url.path,
+                    log_path,
                     process_time_ms,
                     extra={**log_data, "level": "WARNING"},
                 )
@@ -299,7 +311,7 @@ def add_request_logging_middleware(app: FastAPI, environment: str) -> None:
                 logger.warning(
                     "Cold HTTP request: %s %s completed in %.2f ms",
                     request.method,
-                    request.url.path,
+                    log_path,
                     process_time_ms,
                     extra={**log_data, "level": "WARNING"},
                 )

--- a/app/middleware/request_logging.py
+++ b/app/middleware/request_logging.py
@@ -2,8 +2,8 @@
 
 Provides helpers for safely reading and redacting request bodies before they
 are written to logs. The HTTP middleware also emits request IDs, Server-Timing
-metrics, cache outcomes, database query counts, slow-request logs, and the
-existing error logs.
+metrics, cache outcomes, database query counts, slow-request logs, startup
+phase timing, and cold/warm request classification.
 """
 
 import json
@@ -21,6 +21,11 @@ from app.performance_diagnostics import (
     end_request_diagnostics,
     get_request_diagnostics,
     install_cache_instrumentation,
+)
+from app.startup_diagnostics import (
+    mark_startup_complete,
+    next_request_snapshot,
+    startup_event_snapshot,
 )
 
 logger = logging.getLogger(__name__)
@@ -183,11 +188,30 @@ def add_request_logging_middleware(app: FastAPI, environment: str) -> None:
     """
     install_cache_instrumentation(cache)
 
+    @app.on_event("startup")
+    async def record_startup_completion() -> None:
+        """Emit one process-scoped startup timing event after lifespan startup."""
+        startup_duration_ms = mark_startup_complete()
+        snapshot = startup_event_snapshot()
+        logger.warning(
+            "Application startup completed in %.2f ms",
+            startup_duration_ms,
+            extra={
+                "event": "application_startup",
+                "startup_duration_ms": round(startup_duration_ms, 2),
+                "process_age_ms": round(snapshot.process_age_ms, 2),
+                "deployment_id": snapshot.deployment_id,
+                "process_started_at_ns": snapshot.process_started_at_ns,
+                "level": "WARNING",
+            },
+        )
+
     @app.middleware("http")
     async def log_errors_middleware(request: Request, call_next):
         """Add diagnostics headers and log slow or failed requests."""
         started_at = time.perf_counter()
         request_id = uuid.uuid4().hex
+        startup = next_request_snapshot()
         diagnostics_token = begin_request_diagnostics()
         request.state.request_id = request_id
 
@@ -205,6 +229,7 @@ def add_request_logging_middleware(app: FastAPI, environment: str) -> None:
             response.headers["X-Request-ID"] = request_id
             response.headers["X-App-Cache"] = diagnostics.cache_status
             response.headers["X-App-DB-Queries"] = str(diagnostics.database_queries)
+            response.headers["X-App-Cold-Request"] = "1" if startup.cold else "0"
             response.headers["Server-Timing"] = _server_timing_header(process_time_ms)
 
             log_data = {
@@ -220,6 +245,17 @@ def add_request_logging_middleware(app: FastAPI, environment: str) -> None:
                 "cache_status": diagnostics.cache_status,
                 "cache_calls": diagnostics.cache_calls,
                 "cache_time_ms": round(diagnostics.cache_time_ms, 2),
+                "cold_request": startup.cold,
+                "process_request_number": startup.invocation,
+                "process_age_ms": round(startup.process_age_ms, 2),
+                "startup_complete": startup.startup_complete,
+                "startup_duration_ms": (
+                    round(startup.startup_duration_ms, 2)
+                    if startup.startup_duration_ms is not None
+                    else None
+                ),
+                "deployment_id": startup.deployment_id,
+                "process_started_at_ns": startup.process_started_at_ns,
                 "client_host": request.client.host if request.client else None,
                 "user_agent": request.headers.get("user-agent"),
                 "headers": redact_headers(dict(request.headers)),
@@ -244,12 +280,13 @@ def add_request_logging_middleware(app: FastAPI, environment: str) -> None:
                     f"Client Error: {request.method} {request.url.path} - {status_code}",
                     extra={**log_data, "level": "WARNING"},
                 )
-            elif process_time_ms >= _slow_request_threshold_ms():
+            elif startup.cold or process_time_ms >= _slow_request_threshold_ms():
                 logger.warning(
-                    "Slow HTTP request: %s %s completed in %.2f ms",
+                    "HTTP request: %s %s completed in %.2f ms (%s)",
                     request.method,
                     request.url.path,
                     process_time_ms,
+                    "cold" if startup.cold else "warm",
                     extra={**log_data, "level": "WARNING"},
                 )
 

--- a/app/startup_diagnostics.py
+++ b/app/startup_diagnostics.py
@@ -20,8 +20,9 @@ _DEPLOYMENT_ID: Final[str | None] = os.getenv("VERCEL_DEPLOYMENT_ID") or os.gete
 )
 _lock = threading.Lock()
 _request_count = 0
+_application_import_complete_at: float | None = None
+_application_created_at: float | None = None
 _startup_complete_at: float | None = None
-_startup_duration_ms: float | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -33,34 +34,65 @@ class StartupSnapshot:
     process_age_ms: float
     startup_complete: bool
     startup_duration_ms: float | None
+    application_import_ms: float | None
+    application_creation_ms: float | None
+    lifespan_ms: float | None
     deployment_id: str | None
     process_started_at_ns: int
 
 
+def mark_application_import_complete() -> None:
+    """Mark completion of imports needed to reach the application factory."""
+    global _application_import_complete_at
+
+    with _lock:
+        if _application_import_complete_at is None:
+            _application_import_complete_at = time.perf_counter()
+
+
+def mark_application_created() -> None:
+    """Mark completion of FastAPI application creation."""
+    global _application_created_at
+
+    with _lock:
+        if _application_created_at is None:
+            _application_created_at = time.perf_counter()
+
+
 def mark_startup_complete() -> float:
-    """Record application startup completion once and return its duration."""
-    global _startup_complete_at, _startup_duration_ms
+    """Record lifespan startup completion once and return total user-code startup time."""
+    global _startup_complete_at
 
     with _lock:
         if _startup_complete_at is None:
             _startup_complete_at = time.perf_counter()
-            _startup_duration_ms = (_startup_complete_at - _PROCESS_STARTED_AT) * 1000
-        return _startup_duration_ms or 0.0
+        return (_startup_complete_at - _PROCESS_STARTED_AT) * 1000
+
+
+def _duration_ms(start: float | None, end: float | None) -> float | None:
+    """Return a duration in milliseconds when both phase boundaries are known."""
+    if start is None or end is None:
+        return None
+    return (end - start) * 1000
 
 
 def _snapshot(*, invocation: int, cold: bool) -> StartupSnapshot:
     """Build a snapshot without mutating request state."""
     now = time.perf_counter()
     with _lock:
+        import_complete_at = _application_import_complete_at
+        application_created_at = _application_created_at
         startup_complete_at = _startup_complete_at
-        startup_duration_ms = _startup_duration_ms
 
     return StartupSnapshot(
         invocation=invocation,
         cold=cold,
         process_age_ms=(now - _PROCESS_STARTED_AT) * 1000,
         startup_complete=startup_complete_at is not None,
-        startup_duration_ms=startup_duration_ms,
+        startup_duration_ms=_duration_ms(_PROCESS_STARTED_AT, startup_complete_at),
+        application_import_ms=_duration_ms(_PROCESS_STARTED_AT, import_complete_at),
+        application_creation_ms=_duration_ms(import_complete_at, application_created_at),
+        lifespan_ms=_duration_ms(application_created_at, startup_complete_at),
         deployment_id=_DEPLOYMENT_ID,
         process_started_at_ns=_PROCESS_STARTED_AT_NS,
     )
@@ -84,9 +116,11 @@ def next_request_snapshot() -> StartupSnapshot:
 
 def reset_startup_diagnostics_for_test() -> None:
     """Reset mutable process diagnostics for isolated unit tests."""
-    global _request_count, _startup_complete_at, _startup_duration_ms
+    global _request_count, _application_import_complete_at, _application_created_at
+    global _startup_complete_at
 
     with _lock:
         _request_count = 0
+        _application_import_complete_at = None
+        _application_created_at = None
         _startup_complete_at = None
-        _startup_duration_ms = None

--- a/app/startup_diagnostics.py
+++ b/app/startup_diagnostics.py
@@ -1,0 +1,92 @@
+"""Process-level startup and cold-request diagnostics.
+
+The module is intentionally dependency-free so the Vercel entry point can import
+it before the rest of the application. Normal requests pay only a lock-protected
+counter increment and monotonic clock read.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from dataclasses import dataclass
+from typing import Final
+
+_PROCESS_STARTED_AT: Final[float] = time.perf_counter()
+_PROCESS_STARTED_AT_NS: Final[int] = time.time_ns()
+_DEPLOYMENT_ID: Final[str | None] = os.getenv("VERCEL_DEPLOYMENT_ID") or os.getenv(
+    "VERCEL_GIT_COMMIT_SHA"
+)
+_lock = threading.Lock()
+_request_count = 0
+_startup_complete_at: float | None = None
+_startup_duration_ms: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class StartupSnapshot:
+    """Immutable process-startup state for one startup or request event."""
+
+    invocation: int
+    cold: bool
+    process_age_ms: float
+    startup_complete: bool
+    startup_duration_ms: float | None
+    deployment_id: str | None
+    process_started_at_ns: int
+
+
+def mark_startup_complete() -> float:
+    """Record application startup completion once and return its duration."""
+    global _startup_complete_at, _startup_duration_ms
+
+    with _lock:
+        if _startup_complete_at is None:
+            _startup_complete_at = time.perf_counter()
+            _startup_duration_ms = (_startup_complete_at - _PROCESS_STARTED_AT) * 1000
+        return _startup_duration_ms or 0.0
+
+
+def _snapshot(*, invocation: int, cold: bool) -> StartupSnapshot:
+    """Build a snapshot without mutating request state."""
+    now = time.perf_counter()
+    with _lock:
+        startup_complete_at = _startup_complete_at
+        startup_duration_ms = _startup_duration_ms
+
+    return StartupSnapshot(
+        invocation=invocation,
+        cold=cold,
+        process_age_ms=(now - _PROCESS_STARTED_AT) * 1000,
+        startup_complete=startup_complete_at is not None,
+        startup_duration_ms=startup_duration_ms,
+        deployment_id=_DEPLOYMENT_ID,
+        process_started_at_ns=_PROCESS_STARTED_AT_NS,
+    )
+
+
+def startup_event_snapshot() -> StartupSnapshot:
+    """Return process metadata for startup logging without consuming a request number."""
+    return _snapshot(invocation=0, cold=False)
+
+
+def next_request_snapshot() -> StartupSnapshot:
+    """Advance the process request counter and return cold-start context."""
+    global _request_count
+
+    with _lock:
+        _request_count += 1
+        invocation = _request_count
+
+    return _snapshot(invocation=invocation, cold=invocation == 1)
+
+
+def reset_startup_diagnostics_for_test() -> None:
+    """Reset mutable process diagnostics for isolated unit tests."""
+    global _request_count, _startup_complete_at, _startup_duration_ms
+
+    with _lock:
+        _request_count = 0
+        _startup_complete_at = None
+        _startup_duration_ms = None

--- a/app/startup_diagnostics.py
+++ b/app/startup_diagnostics.py
@@ -16,7 +16,7 @@ from typing import Final
 _PROCESS_STARTED_AT: Final[float] = time.perf_counter()
 _PROCESS_STARTED_AT_NS: Final[int] = time.time_ns()
 _DEPLOYMENT_ID: Final[str | None] = os.getenv("VERCEL_DEPLOYMENT_ID") or os.getenv(
-    "VERCEL_GIT_COMMIT_SHA"
+    "VERCEL_GIT_COMMIT_SHA",
 )
 _lock = threading.Lock()
 _request_count = 0
@@ -60,7 +60,11 @@ def mark_application_created() -> None:
 
 
 def mark_startup_complete() -> float:
-    """Record lifespan startup completion once and return total user-code startup time."""
+    """Record lifespan startup completion once.
+
+    Returns:
+        Total measured startup duration in milliseconds.
+    """
     global _startup_complete_at
 
     with _lock:
@@ -78,8 +82,8 @@ def _duration_ms(start: float | None, end: float | None) -> float | None:
 
 def _snapshot(*, invocation: int, cold: bool) -> StartupSnapshot:
     """Build a snapshot without mutating request state."""
-    now = time.perf_counter()
     with _lock:
+        now = time.perf_counter()
         import_complete_at = _application_import_complete_at
         application_created_at = _application_created_at
         startup_complete_at = _startup_complete_at
@@ -99,12 +103,20 @@ def _snapshot(*, invocation: int, cold: bool) -> StartupSnapshot:
 
 
 def startup_event_snapshot() -> StartupSnapshot:
-    """Return process metadata for startup logging without consuming a request number."""
+    """Return process metadata for startup logging without consuming a request number.
+
+    Returns:
+        StartupSnapshot for the current process startup state.
+    """
     return _snapshot(invocation=0, cold=False)
 
 
 def next_request_snapshot() -> StartupSnapshot:
-    """Advance the process request counter and return cold-start context."""
+    """Advance the process request counter and return cold-start context.
+
+    Returns:
+        StartupSnapshot after incrementing the process invocation count.
+    """
     global _request_count
 
     with _lock:

--- a/docs/PRODUCTION_STARTUP_DIAGNOSTICS.md
+++ b/docs/PRODUCTION_STARTUP_DIAGNOSTICS.md
@@ -1,0 +1,53 @@
+# Production startup diagnostics
+
+ComicPile emits structured process and request timing so a slow first request can be separated into application startup, dependency work, and route execution. The Vercel entry point imports the startup clock before the application factory, which also lets us distinguish time spent before ComicPile user code starts from time spent inside the app.
+
+## Cold versus warm
+
+A request is **cold** only when it is the first request handled by the current application process. Later requests in the same process are **warm**. Use the deployment identifier and process-start timestamp to group events from one process.
+
+The process snapshot records:
+
+- one-based request number;
+- cold/warm classification;
+- process age when the request began;
+- whether application startup completed;
+- total measured startup duration;
+- Vercel deployment or commit identifier when available.
+
+Request diagnostics add total route duration, database query count and time, cache outcome and time, HTTP status, and request ID. Production sanitization removes request bodies, query strings, session identifiers, cookies, and authorization headers.
+
+## Reading a slow request
+
+1. Filter deployment logs to `event=application_startup` for the process startup record.
+2. Find the first request with `cold_request=true` and correlate it by deployment ID plus `process_started_at_ns`.
+3. Compare `startup_duration_ms` with the external time-to-first-byte captured by the timing script.
+4. Compare `process_time_ms`, database time, and cache time inside that first request.
+5. If external TTFB is much larger than startup plus request time, the unmeasured remainder happened before ComicPile user code began executing.
+6. Repeat the same path immediately and compare the warm request (`cold_request=false`).
+
+A cold request is suspicious when measured application startup exceeds 1,000 ms or total request duration exceeds the configured slow-request threshold. A warm request is suspicious when database or cache duration dominates the request, or when unexplained application time remains after subtracting dependency time.
+
+## Reproduced baseline from 2026-08-06
+
+A controlled five-minute idle test reproduced the production delay twice:
+
+- potential cold `GET /`: 8.493 s total;
+- immediate warm `GET /`: 0.261 s total;
+- immediate warm `GET /openapi.json`: 0.651 s total;
+- independent cold `GET /`: 8.546 s TTFB / total;
+- independent warm `GET /`: 0.235 s TTFB / 0.236 s total.
+
+The cold root response reported zero application database queries, so that observed eight-second delay was not route-level database work.
+
+## Repeatable capture
+
+From the repository root with the Vercel CLI authenticated to ComicPile, run:
+
+```bash
+scripts/capture-production-startup-timing.sh
+```
+
+The script writes a bounded artifact containing portable timestamps and `vercel httpstat` output for a potential-cold root request, an immediate warm root request, and a warm OpenAPI request. It does not print response bodies, credentials, environment variables, or user data.
+
+Thresholds are diagnostic defaults, not availability guarantees. Adjust `SLOW_REQUEST_THRESHOLD_MS` only after collecting a representative baseline, and never use a higher threshold to hide a regression.

--- a/docs/PRODUCTION_STARTUP_DIAGNOSTICS.md
+++ b/docs/PRODUCTION_STARTUP_DIAGNOSTICS.md
@@ -15,7 +15,7 @@ The process snapshot records:
 - total measured startup duration;
 - Vercel deployment or commit identifier when available.
 
-Request diagnostics add total route duration, database query count and time, cache outcome and time, HTTP status, and request ID. Production sanitization removes request bodies, query strings, session identifiers, cookies, and authorization headers.
+Request diagnostics add total route duration, database query count and time, cache outcome and time, HTTP status, and request ID. Production sanitization removes request bodies, query strings, user/session identifiers, cookies, and authorization headers.
 
 ## Reading a slow request
 
@@ -23,8 +23,8 @@ Request diagnostics add total route duration, database query count and time, cac
 2. Find the first request with `cold_request=true` and correlate it by deployment ID plus `process_started_at_ns`.
 3. Compare `startup_duration_ms` with the external time-to-first-byte captured by the timing script.
 4. Compare `process_time_ms`, database time, and cache time inside that first request.
-5. If external TTFB is much larger than startup plus request time, the unmeasured remainder happened before ComicPile user code began executing.
-6. Repeat the same path immediately and compare the warm request (`cold_request=false`).
+5. Review the `httpstat` phase breakdown for DNS, TCP, TLS, and other externally visible transport time before attributing latency to application startup. Only the remainder not explained by those phases, measured startup, or measured request work can be treated as pre-application/platform time.
+6. Repeat the same path immediately and verify the response marker before treating it as warm (`X-App-Cold-Request: 0`).
 
 A cold request is suspicious when measured application startup exceeds 1,000 ms or total request duration exceeds the configured slow-request threshold. A warm request is suspicious when database or cache duration dominates the request, or when unexplained application time remains after subtracting dependency time.
 
@@ -33,21 +33,21 @@ A cold request is suspicious when measured application startup exceeds 1,000 ms 
 A controlled five-minute idle test reproduced the production delay twice:
 
 - potential cold `GET /`: 8.493 s total;
-- immediate warm `GET /`: 0.261 s total;
-- immediate warm `GET /openapi.json`: 0.651 s total;
+- subsequent `GET /`: 0.261 s total;
+- subsequent `GET /openapi.json`: 0.651 s total;
 - independent cold `GET /`: 8.546 s TTFB / total;
-- independent warm `GET /`: 0.235 s TTFB / 0.236 s total.
+- independent subsequent `GET /`: 0.235 s TTFB / 0.236 s total.
 
-The cold root response reported zero application database queries, so that observed eight-second delay was not route-level database work.
+The cold root response reported zero application database queries, so that observed eight-second delay was not route-level database work. Historical captures that predate `X-App-Cold-Request` should not be relabeled warm unless the process identity or an equivalent marker proves it.
 
 ## Repeatable capture
 
-From the repository root with the Vercel CLI authenticated to ComicPile, run:
+From the repository root with Vercel CLI 48.9.0+ authenticated to ComicPile and the standalone `httpstat` executable available on `PATH`, run:
 
 ```bash
 scripts/capture-production-startup-timing.sh
 ```
 
-The script writes a bounded artifact containing portable timestamps and `vercel httpstat` output for a potential-cold root request, an immediate warm root request, and a warm OpenAPI request. It does not print response bodies, credentials, environment variables, or user data.
+The script writes a bounded artifact containing portable timestamps and `vercel httpstat` output for a potential-cold root request and two potential-warm follow-ups. Use the captured `X-App-Cold-Request` response header to classify each request and `X-Request-ID` to correlate it with application logs. It does not print response bodies, credentials, environment variables, or user data.
 
 Thresholds are diagnostic defaults, not availability guarantees. Adjust `SLOW_REQUEST_THRESHOLD_MS` only after collecting a representative baseline, and never use a higher threshold to hide a regression.

--- a/docs/changelog.d/2026-08-07-904.md
+++ b/docs/changelog.d/2026-08-07-904.md
@@ -1,0 +1,5 @@
+## 2026-08-07
+
+### Performance and reliability
+
+- [PR #904](https://github.com/JoshCLWren/comic-pile/pull/904) makes slow production wake-ups diagnosable by separating ComicPile startup phases from request, database, and cache time. Cold requests are now identifiable in structured logs, and a repeatable timing capture makes it easier to tell application work from Vercel time before Python code begins.

--- a/docs/changelog.d/2026-08-07-904.md
+++ b/docs/changelog.d/2026-08-07-904.md
@@ -2,4 +2,4 @@
 
 ### Performance and reliability
 
-- [PR #904](https://github.com/JoshCLWren/comic-pile/pull/904) makes slow production wake-ups diagnosable by separating ComicPile startup phases from request, database, and cache time. Cold requests are now identifiable in structured logs, and a repeatable timing capture makes it easier to tell application work from Vercel time before Python code begins.
+- [#904](https://github.com/JoshCLWren/comic-pile/pull/904) makes slow production wake-ups diagnosable by separating ComicPile startup phases from request, database, and cache time. Cold requests are now identifiable in structured logs, and a repeatable timing capture makes it easier to tell application work from Vercel time before Python code begins.

--- a/scripts/capture-production-startup-timing.sh
+++ b/scripts/capture-production-startup-timing.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Capture a small, portable cold/warm timing bundle for ComicPile production.
+#
+# Prerequisites:
+#   - Vercel CLI authenticated for the ComicPile project
+#   - Run from the repository root
+#
+# The output is intentionally limited to request timing and request IDs. It does
+# not print environment variables, credentials, response bodies, or user data.
+
+OUTPUT_DIR="${1:-artifacts/startup-timing}"
+mkdir -p "$OUTPUT_DIR"
+
+STAMP="$(date '+%Y-%m-%dT%H:%M:%S%z')"
+SAFE_STAMP="$(date '+%Y%m%d-%H%M%S')"
+OUT="$OUTPUT_DIR/startup-timing-$SAFE_STAMP.txt"
+
+capture() {
+  local label="$1"
+  local path="$2"
+
+  {
+    printf '\n=== %s ===\n' "$label"
+    printf 'captured_at=%s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')"
+    printf 'path=%s\n' "$path"
+  } | tee -a "$OUT"
+
+  vercel httpstat "$path" 2>&1 | tee -a "$OUT"
+}
+
+{
+  printf 'ComicPile production startup timing capture\n'
+  printf 'started_at=%s\n' "$STAMP"
+  printf 'purpose=cold-vs-warm request timing without response-body or user-data capture\n'
+} > "$OUT"
+
+capture "potential cold root" "/"
+capture "immediate warm root" "/"
+capture "immediate warm OpenAPI" "/openapi.json"
+
+printf '\nSaved timing bundle: %s\n' "$OUT"

--- a/scripts/capture-production-startup-timing.sh
+++ b/scripts/capture-production-startup-timing.sh
@@ -4,11 +4,33 @@ set -euo pipefail
 # Capture a small, portable cold/warm timing bundle for ComicPile production.
 #
 # Prerequisites:
-#   - Vercel CLI authenticated for the ComicPile project
+#   - Vercel CLI 48.9.0+ authenticated for the ComicPile project
+#   - standalone httpstat executable available on PATH
 #   - Run from the repository root
 #
 # The output is intentionally limited to request timing and request IDs. It does
 # not print environment variables, credentials, response bodies, or user data.
+
+if ! command -v vercel >/dev/null 2>&1; then
+  printf 'Vercel CLI is required. Install or upgrade it before running this capture.\n' >&2
+  exit 1
+fi
+
+if ! command -v httpstat >/dev/null 2>&1; then
+  printf 'The standalone httpstat executable is required. Install it (for example, brew install httpstat or pip install httpstat) and retry.\n' >&2
+  exit 1
+fi
+
+VERCEL_VERSION="$(vercel --version 2>/dev/null | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+if [[ -z "$VERCEL_VERSION" ]]; then
+  printf 'Could not determine Vercel CLI version; version 48.9.0 or newer is required.\n' >&2
+  exit 1
+fi
+
+if ! printf '%s\n%s\n' '48.9.0' "$VERCEL_VERSION" | sort -V -C; then
+  printf 'Vercel CLI 48.9.0 or newer is required; found %s. Please upgrade and retry.\n' "$VERCEL_VERSION" >&2
+  exit 1
+fi
 
 OUTPUT_DIR="${1:-artifacts/startup-timing}"
 mkdir -p "$OUTPUT_DIR"
@@ -25,6 +47,8 @@ capture() {
     printf '\n=== %s ===\n' "$label"
     printf 'captured_at=%s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')"
     printf 'path=%s\n' "$path"
+    printf 'classification=verify X-App-Cold-Request in captured response headers (1=cold, 0=warm)\n'
+    printf 'correlate=retain X-Request-ID from captured response headers\n'
   } | tee -a "$OUT"
 
   vercel httpstat "$path" 2>&1 | tee -a "$OUT"
@@ -37,7 +61,7 @@ capture() {
 } > "$OUT"
 
 capture "potential cold root" "/"
-capture "immediate warm root" "/"
-capture "immediate warm OpenAPI" "/openapi.json"
+capture "potential warm root" "/"
+capture "potential warm OpenAPI" "/openapi.json"
 
 printf '\nSaved timing bundle: %s\n' "$OUT"

--- a/tests/test_request_logging_sanitization.py
+++ b/tests/test_request_logging_sanitization.py
@@ -50,10 +50,10 @@ async def test_development_logs_include_request_body_and_session_id(
 
 
 @pytest.mark.asyncio
-async def test_production_logs_drop_request_body_query_params_and_session_id(
+async def test_production_logs_drop_private_request_context(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """In production, request logging should avoid leaking request context."""
+    """In production, request logging should avoid leaking private request context."""
     os.environ["ENVIRONMENT"] = "production"
     os.environ["CORS_ORIGINS"] = "https://example.com"
 
@@ -83,14 +83,14 @@ async def test_production_logs_drop_request_body_query_params_and_session_id(
     assert "request_body" not in record.__dict__
     assert "query_params" not in record.__dict__
     assert "session_id" not in record.__dict__
-    assert record.__dict__["user_id"] == 42
+    assert "user_id" not in record.__dict__
 
 
 @pytest.mark.asyncio
-async def test_staging_logs_drop_request_body_query_params_and_session_id(
+async def test_staging_logs_drop_private_request_context(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """In staging, request logging should avoid leaking request context (same as production)."""
+    """In staging, request logging should avoid leaking private request context."""
     os.environ["ENVIRONMENT"] = "staging"
     os.environ["CORS_ORIGINS"] = "https://example.com"
 
@@ -120,4 +120,4 @@ async def test_staging_logs_drop_request_body_query_params_and_session_id(
     assert "request_body" not in record.__dict__
     assert "query_params" not in record.__dict__
     assert "session_id" not in record.__dict__
-    assert record.__dict__["user_id"] == 42
+    assert "user_id" not in record.__dict__

--- a/tests/test_startup_diagnostics.py
+++ b/tests/test_startup_diagnostics.py
@@ -87,7 +87,9 @@ def test_startup_snapshot_decomposes_measurable_phases() -> None:
     assert snapshot.application_import_ms >= 0
     assert snapshot.application_creation_ms >= 0
     assert snapshot.lifespan_ms >= 0
-    assert snapshot.startup_duration_ms <= snapshot.process_age_ms
+    startup_duration_ms = snapshot.startup_duration_ms
+    assert startup_duration_ms is not None
+    assert startup_duration_ms <= snapshot.process_age_ms
 
 
 def test_request_before_startup_completion_reports_unknown_phases() -> None:

--- a/tests/test_startup_diagnostics.py
+++ b/tests/test_startup_diagnostics.py
@@ -11,12 +11,26 @@ from app.startup_diagnostics import (
 
 
 def setup_function() -> None:
-    """Reset process counters before each test."""
+    """Reset process counters before each test.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+    """
     reset_startup_diagnostics_for_test()
 
 
 def test_first_request_is_cold_and_later_requests_are_warm() -> None:
-    """Only the first request handled by a process is classified as cold."""
+    """Only the first request handled by a process is classified as cold.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+    """
     first = next_request_snapshot()
     second = next_request_snapshot()
 
@@ -29,7 +43,14 @@ def test_first_request_is_cold_and_later_requests_are_warm() -> None:
 
 
 def test_startup_event_does_not_consume_first_request() -> None:
-    """Startup logging must not turn the first HTTP request into a warm request."""
+    """Startup logging must not turn the first HTTP request into a warm request.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+    """
     mark_application_import_complete()
     mark_application_created()
     mark_startup_complete()
@@ -44,7 +65,14 @@ def test_startup_event_does_not_consume_first_request() -> None:
 
 
 def test_startup_snapshot_decomposes_measurable_phases() -> None:
-    """Import, app creation, and lifespan phases are exposed when their markers exist."""
+    """Import, app creation, and lifespan phases are exposed when their markers exist.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+    """
     mark_application_import_complete()
     mark_application_created()
     total = mark_startup_complete()
@@ -59,10 +87,18 @@ def test_startup_snapshot_decomposes_measurable_phases() -> None:
     assert snapshot.application_import_ms >= 0
     assert snapshot.application_creation_ms >= 0
     assert snapshot.lifespan_ms >= 0
+    assert snapshot.startup_duration_ms <= snapshot.process_age_ms
 
 
 def test_request_before_startup_completion_reports_unknown_phases() -> None:
-    """Missing phase markers remain explicit instead of inventing proxy timings."""
+    """Missing phase markers remain explicit instead of inventing proxy timings.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+    """
     snapshot = next_request_snapshot()
 
     assert snapshot.startup_complete is False

--- a/tests/test_startup_diagnostics.py
+++ b/tests/test_startup_diagnostics.py
@@ -1,0 +1,73 @@
+"""Tests for process-level startup and cold-request diagnostics."""
+
+from app.startup_diagnostics import (
+    mark_application_created,
+    mark_application_import_complete,
+    mark_startup_complete,
+    next_request_snapshot,
+    reset_startup_diagnostics_for_test,
+    startup_event_snapshot,
+)
+
+
+def setup_function() -> None:
+    """Reset process counters before each test."""
+    reset_startup_diagnostics_for_test()
+
+
+def test_first_request_is_cold_and_later_requests_are_warm() -> None:
+    """Only the first request handled by a process is classified as cold."""
+    first = next_request_snapshot()
+    second = next_request_snapshot()
+
+    assert first.invocation == 1
+    assert first.cold is True
+    assert first.process_age_ms >= 0
+    assert second.invocation == 2
+    assert second.cold is False
+    assert second.process_age_ms >= first.process_age_ms
+
+
+def test_startup_event_does_not_consume_first_request() -> None:
+    """Startup logging must not turn the first HTTP request into a warm request."""
+    mark_application_import_complete()
+    mark_application_created()
+    mark_startup_complete()
+
+    startup = startup_event_snapshot()
+    first = next_request_snapshot()
+
+    assert startup.invocation == 0
+    assert startup.cold is False
+    assert first.invocation == 1
+    assert first.cold is True
+
+
+def test_startup_snapshot_decomposes_measurable_phases() -> None:
+    """Import, app creation, and lifespan phases are exposed when their markers exist."""
+    mark_application_import_complete()
+    mark_application_created()
+    total = mark_startup_complete()
+    snapshot = startup_event_snapshot()
+
+    assert total >= 0
+    assert snapshot.startup_complete is True
+    assert snapshot.startup_duration_ms == total
+    assert snapshot.application_import_ms is not None
+    assert snapshot.application_creation_ms is not None
+    assert snapshot.lifespan_ms is not None
+    assert snapshot.application_import_ms >= 0
+    assert snapshot.application_creation_ms >= 0
+    assert snapshot.lifespan_ms >= 0
+
+
+def test_request_before_startup_completion_reports_unknown_phases() -> None:
+    """Missing phase markers remain explicit instead of inventing proxy timings."""
+    snapshot = next_request_snapshot()
+
+    assert snapshot.startup_complete is False
+    assert snapshot.startup_duration_ms is None
+    assert snapshot.application_import_ms is None
+    assert snapshot.application_creation_ms is None
+    assert snapshot.lifespan_ms is None
+    assert snapshot.process_started_at_ns > 0

--- a/tests/test_startup_request_observability.py
+++ b/tests/test_startup_request_observability.py
@@ -27,14 +27,11 @@ async def test_first_request_is_correlated_with_startup_event(
         return {"status": "ok"}
 
     caplog.set_level(logging.WARNING, logger="app.middleware.request_logging")
-    await app.router.startup()
-    try:
+    async with app.router.lifespan_context(app):
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             first = await client.get("/fast")
             second = await client.get("/fast")
-    finally:
-        await app.router.shutdown()
 
     assert first.headers["X-App-Cold-Request"] == "1"
     assert second.headers["X-App-Cold-Request"] == "0"

--- a/tests/test_startup_request_observability.py
+++ b/tests/test_startup_request_observability.py
@@ -6,7 +6,11 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
-from app.middleware.request_logging import add_request_logging_middleware
+from app.middleware.request_logging import (
+    _sanitize_log_path,
+    add_request_logging_middleware,
+    sanitize_for_logging,
+)
 from app.startup_diagnostics import reset_startup_diagnostics_for_test
 
 
@@ -15,7 +19,15 @@ async def test_first_request_is_correlated_with_startup_event(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Startup and the first HTTP request share safe process-level timing context."""
+    """Startup and HTTP responses retain process-level timing context.
+
+    Args:
+        monkeypatch: Pytest environment patch helper.
+        caplog: Pytest log capture fixture.
+
+    Returns:
+        None.
+    """
     monkeypatch.setenv("SLOW_REQUEST_THRESHOLD_MS", "100000")
     reset_startup_diagnostics_for_test()
 
@@ -26,15 +38,28 @@ async def test_first_request_is_correlated_with_startup_event(
     async def fast_route() -> dict[str, str]:
         return {"status": "ok"}
 
+    @app.get("/missing")
+    async def missing_route() -> None:
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=404, detail="not found")
+
     caplog.set_level(logging.WARNING, logger="app.middleware.request_logging")
     async with app.router.lifespan_context(app):
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             first = await client.get("/fast")
             second = await client.get("/fast")
+            error = await client.get("/missing")
 
     assert first.headers["X-App-Cold-Request"] == "1"
     assert second.headers["X-App-Cold-Request"] == "0"
+    assert error.status_code == 404
+    assert error.headers["X-App-Cold-Request"] == "0"
+    assert len(error.headers["X-Request-ID"]) == 32
+    assert "Server-Timing" in error.headers
+    assert "X-App-DB-Queries" in error.headers
+    assert "X-App-Cache" in error.headers
 
     startup_records = [
         record for record in caplog.records if getattr(record, "event", None) == "application_startup"
@@ -60,9 +85,14 @@ async def test_first_request_is_correlated_with_startup_event(
 
 
 def test_production_sanitization_removes_user_request_context() -> None:
-    """Startup fields survive production sanitization without retaining private request data."""
-    from app.middleware.request_logging import sanitize_for_logging
+    """Production sanitization removes private request identity and payload data.
 
+    Args:
+        None.
+
+    Returns:
+        None.
+    """
     sanitized = sanitize_for_logging(
         {
             "cold_request": True,
@@ -70,8 +100,25 @@ def test_production_sanitization_removes_user_request_context() -> None:
             "request_body": {"comic": "private"},
             "query_params": "token=secret",
             "session_id": "private-session",
+            "user_id": 42,
         },
         "production",
     )
 
     assert sanitized == {"cold_request": True, "process_started_at_ns": 1}
+
+
+def test_log_path_neutralizes_record_splitting_characters() -> None:
+    """Request paths cannot inject carriage returns or new log lines.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+    """
+    sanitized = _sanitize_log_path("/comics\r\nforged=true")
+
+    assert sanitized == "/comics\\r\\nforged=true"
+    assert "\r" not in sanitized
+    assert "\n" not in sanitized

--- a/tests/test_startup_request_observability.py
+++ b/tests/test_startup_request_observability.py
@@ -1,0 +1,80 @@
+"""Integration coverage for startup and first-request observability."""
+
+import logging
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.middleware.request_logging import add_request_logging_middleware
+from app.startup_diagnostics import reset_startup_diagnostics_for_test
+
+
+@pytest.mark.asyncio
+async def test_first_request_is_correlated_with_startup_event(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Startup and the first HTTP request share safe process-level timing context."""
+    monkeypatch.setenv("SLOW_REQUEST_THRESHOLD_MS", "100000")
+    reset_startup_diagnostics_for_test()
+
+    app = FastAPI()
+    add_request_logging_middleware(app, "test")
+
+    @app.get("/fast")
+    async def fast_route() -> dict[str, str]:
+        return {"status": "ok"}
+
+    caplog.set_level(logging.WARNING, logger="app.middleware.request_logging")
+    await app.router.startup()
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            first = await client.get("/fast")
+            second = await client.get("/fast")
+    finally:
+        await app.router.shutdown()
+
+    assert first.headers["X-App-Cold-Request"] == "1"
+    assert second.headers["X-App-Cold-Request"] == "0"
+
+    startup_records = [
+        record for record in caplog.records if getattr(record, "event", None) == "application_startup"
+    ]
+    assert len(startup_records) == 1
+    startup_record = startup_records[0]
+    assert startup_record.__dict__["startup_duration_ms"] >= 0
+    assert startup_record.__dict__["process_started_at_ns"] > 0
+
+    cold_records = [
+        record
+        for record in caplog.records
+        if record.name == "app.middleware.request_logging"
+        and record.getMessage().startswith("Cold HTTP request:")
+    ]
+    assert len(cold_records) == 1
+    cold_record = cold_records[0]
+    assert cold_record.__dict__["cold_request"] is True
+    assert cold_record.__dict__["process_request_number"] == 1
+    assert cold_record.__dict__["startup_complete"] is True
+    assert cold_record.__dict__["startup_duration_ms"] is not None
+    assert len(cold_record.__dict__["request_id"]) == 32
+
+
+def test_production_sanitization_removes_user_request_context() -> None:
+    """Startup fields survive production sanitization without retaining private request data."""
+    from app.middleware.request_logging import sanitize_for_logging
+
+    sanitized = sanitize_for_logging(
+        {
+            "cold_request": True,
+            "process_started_at_ns": 1,
+            "request_body": {"comic": "private"},
+            "query_params": "token=secret",
+            "session_id": "private-session",
+        },
+        "production",
+    )
+
+    assert sanitized == {"cold_request": True, "process_started_at_ns": 1}


### PR DESCRIPTION
Closes #829

## Summary
- start a process clock at the Vercel Python entry boundary and separate application import, FastAPI creation, and lifespan startup timing
- correlate the first request in each process with startup timing, deployment identity, existing DB/cache timings, and request ID without logging user data
- add an explicit cold-request response marker and preserve existing warm slow-request observability
- add focused unit/integration coverage plus a portable `vercel httpstat` cold/warm capture script
- document the reproduced 8.5-second cold baseline and how to identify time occurring before ComicPile user code starts

Production database startup remains intentionally lazy, so this change does not invent a Neon startup probe. Existing per-request database/cache instrumentation reports those dependencies when they are actually used.

## Validation
CI will provide the executable validation boundary for this connector-authored branch. Focused regression coverage is included for startup phase decomposition, first-request classification, log correlation, and production redaction.

## Changelog
Required fragment will be added using this PR number before readiness or merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visibility into application startup and request timing.
  * Requests now indicate whether they are cold or warm through response headers and structured logs.
  * Added production timing capture for comparing cold and warm requests.

* **Documentation**
  * Added guidance for interpreting startup diagnostics, latency, and sanitized production data.

* **Bug Fixes**
  * Improved identification and logging of slow cold requests while protecting sensitive request information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->