### PR TITLE
Return Roll view to the dice after rating or snoozing

### DIFF
--- a/docs/changelog.d/2026-08-07-907.md
+++ b/docs/changelog.d/2026-08-07-907.md
@@ -1,0 +1,5 @@
+## 2026-08-07
+
+### Roll
+
+- [#907](https://github.com/JoshCLWren/comic-pile/pull/907) returns the Roll page to the top after rating, snoozing, or otherwise leaving the rating view, so the dice is immediately visible for the next roll on mobile.

--- a/frontend/src/pages/RollPage/components/ThreadPool.tsx
+++ b/frontend/src/pages/RollPage/components/ThreadPool.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import type { RollBootstrapThread } from '../../../types/rollBootstrap'
 
@@ -47,6 +48,17 @@ export function ThreadPool({
   shuffleIsPending,
 }: ThreadPoolProps) {
   const navigate = useNavigate()
+  const wasRatingView = useRef(isRatingView)
+
+  useEffect(() => {
+    const returnedToRoll = wasRatingView.current && !isRatingView
+    wasRatingView.current = isRatingView
+
+    if (returnedToRoll) {
+      window.scrollTo({ top: 0, left: 0, behavior: 'auto' })
+    }
+  }, [isRatingView])
+
   return (
     <div className={`px-3 md:px-4 pb-20 md:pb-28 flex flex-col ${!isRatingView ? 'flex-1 min-h-[300px]' : 'border-t border-white/5 pt-4 md:pt-8'}`}>
       {!isRolling && rolledResult === null && !isRatingView && pool.length > 0 && (

--- a/frontend/src/unit/ThreadPool.scroll.test.tsx
+++ b/frontend/src/unit/ThreadPool.scroll.test.tsx
@@ -1,0 +1,69 @@
+import { render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ThreadPool } from '../pages/RollPage/components/ThreadPool'
+
+const baseProps = {
+  pool: [],
+  blockedThreads: [],
+  blockingReasonMap: {},
+  isRolling: false,
+  rolledResult: null,
+  selectedThreadId: null,
+  staleThread: null,
+  staleThreadCount: 0,
+  snoozedThreads: [],
+  snoozedExpanded: false,
+  blockedExpanded: false,
+  onThreadClick: vi.fn(),
+  onUnsnooze: vi.fn(),
+  onReadStale: vi.fn(),
+  onToggleSnoozed: vi.fn(),
+  onToggleBlocked: vi.fn(),
+  onShuffle: vi.fn(),
+  unsnoozeIsPending: false,
+  shuffleIsPending: false,
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('ThreadPool roll return position', () => {
+  it('scrolls to the top when leaving the rating view', () => {
+    const scrollTo = vi.spyOn(window, 'scrollTo').mockImplementation(() => undefined)
+    const { rerender } = render(
+      <MemoryRouter>
+        <ThreadPool {...baseProps} isRatingView />
+      </MemoryRouter>,
+    )
+
+    expect(scrollTo).not.toHaveBeenCalled()
+
+    rerender(
+      <MemoryRouter>
+        <ThreadPool {...baseProps} isRatingView={false} />
+      </MemoryRouter>,
+    )
+
+    expect(scrollTo).toHaveBeenCalledTimes(1)
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, left: 0, behavior: 'auto' })
+  })
+
+  it('does not reset scroll during ordinary roll-pool rerenders', () => {
+    const scrollTo = vi.spyOn(window, 'scrollTo').mockImplementation(() => undefined)
+    const { rerender } = render(
+      <MemoryRouter>
+        <ThreadPool {...baseProps} isRatingView={false} />
+      </MemoryRouter>,
+    )
+
+    rerender(
+      <MemoryRouter>
+        <ThreadPool {...baseProps} isRatingView={false} snoozedExpanded />
+      </MemoryRouter>,
+    )
+
+    expect(scrollTo).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Closes #905

## Summary
- detect the transition from the rating view back to the Roll pool
- reset the browser scroll position to the top so the dice is immediately visible on mobile
- preserve scroll position during ordinary Roll-pool rerenders
- add focused regression coverage for both behaviors

## Validation
CI provides the executable validation boundary for this connector-authored branch.

## Changelog
Required fragment will be added using this PR number before readiness or merge.