### PR TITLE
Add copy comic reference action to rating view

### DIFF
--- a/docs/changelog.d/2026-08-08-908.md
+++ b/docs/changelog.d/2026-08-08-908.md
@@ -2,4 +2,4 @@
 
 ### Roll
 
-- [PR #908](https://github.com/JoshCLWren/comic-pile/pull/908) adds a Copy action to the rating screen so the current series and issue number can be copied as one review-ready string, such as `Ultimate X-Men 12`.
+- [#908](https://github.com/JoshCLWren/comic-pile/pull/908) adds a Copy action to the rating screen so the current series and issue number can be copied as one review-ready string, such as `Ultimate X-Men 12`.

--- a/docs/changelog.d/2026-08-08-908.md
+++ b/docs/changelog.d/2026-08-08-908.md
@@ -1,0 +1,5 @@
+## 2026-08-08
+
+### Roll
+
+- [PR #908](https://github.com/JoshCLWren/comic-pile/pull/908) adds a Copy action to the rating screen so the current series and issue number can be copied as one review-ready string, such as `Ultimate X-Men 12`.

--- a/frontend/src/pages/RollPage/components/RatingView.tsx
+++ b/frontend/src/pages/RollPage/components/RatingView.tsx
@@ -52,12 +52,24 @@ export function RatingView({
   onRefreshThread,
 }: RatingViewProps) {
   const [isCorrectionDialogOpen, setIsCorrectionDialogOpen] = useState(false)
+  const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'failed'>('idle')
   const previewDie = isDiceSide(currentDie) ? currentDie : 6
   const threadTitle = activeRatingThread?.title ?? 'Loading...'
   const issueNumber = activeRatingThread?.next_issue_number ?? activeRatingThread?.issue_number ?? null
   const totalIssues = activeRatingThread?.total_issues ?? null
   const issuesRemaining = activeRatingThread?.issues_remaining ?? 0
   const readingProgress = activeRatingThread?.reading_progress ?? null
+
+  async function handleCopyComicReference() {
+    if (!activeRatingThread?.title || issueNumber == null) return
+
+    try {
+      await navigator.clipboard.writeText(`${activeRatingThread.title} ${issueNumber}`)
+      setCopyStatus('copied')
+    } catch {
+      setCopyStatus('failed')
+    }
+  }
 
   return (
     <div className="p-3 md:p-4 space-y-5 md:space-y-8 relative z-10">
@@ -72,18 +84,36 @@ export function RatingView({
         </h2>
         <div className="flex items-center justify-center gap-3 flex-wrap">
           {issueNumber != null && (
-            <button
-              type="button"
-              onClick={() => setIsCorrectionDialogOpen(true)}
-              disabled={!activeRatingThread?.id}
-              className="w-11 h-11 min-w-[44px] flex items-center justify-center bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg text-stone-400 hover:text-stone-300 transition-all disabled:opacity-30 disabled:cursor-not-allowed focus:ring-2 focus:ring-amber-500"
-              aria-label="Correct issue number"
-              title="Correct issue number"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
-                <path d="M2.695 14.763l-1.262 3.154a.5.5 0 00.65.65l3.155-1.262a4 4 0 001.343-.885L17.5 5.5a2.121 2.121 0 00-3-3L3.58 13.42a4 4 0 00-.885 1.343z" />
-              </svg>
-            </button>
+            <>
+              <button
+                type="button"
+                onClick={handleCopyComicReference}
+                disabled={!activeRatingThread?.title}
+                className="min-h-11 px-3 flex items-center justify-center gap-2 bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg text-stone-400 hover:text-stone-300 transition-all disabled:opacity-30 disabled:cursor-not-allowed focus:ring-2 focus:ring-amber-500"
+                aria-label={`Copy ${threadTitle} ${issueNumber}`}
+                title="Copy comic reference"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4" aria-hidden="true">
+                  <path d="M6 2a2 2 0 00-2 2v8a2 2 0 002 2h1v-2H6V4h8v1h2V4a2 2 0 00-2-2H6z" />
+                  <path d="M9 6a2 2 0 00-2 2v8a2 2 0 002 2h7a2 2 0 002-2V8a2 2 0 00-2-2H9zm0 2h7v8H9V8z" />
+                </svg>
+                <span className="text-[10px] font-black uppercase tracking-wider">
+                  {copyStatus === 'copied' ? 'Copied' : copyStatus === 'failed' ? 'Copy failed' : 'Copy'}
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={() => setIsCorrectionDialogOpen(true)}
+                disabled={!activeRatingThread?.id}
+                className="w-11 h-11 min-w-[44px] flex items-center justify-center bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg text-stone-400 hover:text-stone-300 transition-all disabled:opacity-30 disabled:cursor-not-allowed focus:ring-2 focus:ring-amber-500"
+                aria-label="Correct issue number"
+                title="Correct issue number"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
+                  <path d="M2.695 14.763l-1.262 3.154a.5.5 0 00.65.65l3.155-1.262a4 4 0 001.343-.885L17.5 5.5a2.121 2.121 0 00-3-3L3.58 13.42a4 4 0 00-.885 1.343z" />
+                </svg>
+              </button>
+            </>
           )}
           {totalIssues && issueNumber != null && (
             <span className="text-stone-400 text-xs font-bold">

--- a/frontend/src/unit/RatingView.copy.test.tsx
+++ b/frontend/src/unit/RatingView.copy.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { RatingView } from '../pages/RollPage/components/RatingView'
+
+vi.mock('../components/LazyDice3D', () => ({ default: () => <div data-testid="dice" /> }))
+vi.mock('../components/Tooltip', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+vi.mock('../components/IssueCorrectionDialog', () => ({ default: () => null }))
+vi.mock('../pages/RollPage/components/ReadingOrderGroups', () => ({
+  ReadingOrderGroups: () => null,
+}))
+
+const callbacks = {
+  onUpdateRating: vi.fn(),
+  onSubmitRating: vi.fn(),
+  onSnooze: vi.fn(),
+  onCancel: vi.fn(),
+  onRefreshThread: vi.fn(),
+}
+
+function renderRatingView() {
+  render(
+    <RatingView
+      activeRatingThread={{
+        id: 1,
+        title: 'Ultimate X-Men',
+        format: 'Comic',
+        issues_remaining: 4,
+        total_issues: 12,
+        issue_number: '11',
+        next_issue_number: '12',
+      } as never}
+      currentDie={6}
+      rolledResult={2}
+      rating={4}
+      predictedDie={4}
+      hasValidRolledResult
+      poolSize={6}
+      errorMessage=""
+      rateIsPending={false}
+      snoozeIsPending={false}
+      dismissIsPending={false}
+      readingOrders={[]}
+      connectedThreads={[]}
+      {...callbacks}
+    />,
+  )
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('RatingView copy comic reference', () => {
+  it('copies the series title and active issue number without a hash', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+
+    renderRatingView()
+    await userEvent.setup().click(screen.getByRole('button', { name: 'Copy Ultimate X-Men 12' }))
+
+    expect(writeText).toHaveBeenCalledWith('Ultimate X-Men 12')
+    expect(screen.getByText('Copied')).toBeInTheDocument()
+  })
+
+  it('shows a failure state when clipboard writing fails', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn().mockRejectedValue(new Error('clipboard denied')) },
+    })
+
+    renderRatingView()
+    await userEvent.setup().click(screen.getByRole('button', { name: 'Copy Ultimate X-Men 12' }))
+
+    expect(screen.getByText('Copy failed')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/unit/RatingView.copy.test.tsx
+++ b/frontend/src/unit/RatingView.copy.test.tsx
@@ -55,27 +55,22 @@ afterEach(() => {
 
 describe('RatingView copy comic reference', () => {
   it('copies the series title and active issue number without a hash', async () => {
-    const writeText = vi.fn().mockResolvedValue(undefined)
-    Object.defineProperty(navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText },
-    })
+    const user = userEvent.setup()
+    const writeText = vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined)
 
     renderRatingView()
-    await userEvent.setup().click(screen.getByRole('button', { name: 'Copy Ultimate X-Men 12' }))
+    await user.click(screen.getByRole('button', { name: 'Copy Ultimate X-Men 12' }))
 
     expect(writeText).toHaveBeenCalledWith('Ultimate X-Men 12')
     expect(screen.getByText('Copied')).toBeInTheDocument()
   })
 
   it('shows a failure state when clipboard writing fails', async () => {
-    Object.defineProperty(navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText: vi.fn().mockRejectedValue(new Error('clipboard denied')) },
-    })
+    const user = userEvent.setup()
+    vi.spyOn(navigator.clipboard, 'writeText').mockRejectedValue(new Error('clipboard denied'))
 
     renderRatingView()
-    await userEvent.setup().click(screen.getByRole('button', { name: 'Copy Ultimate X-Men 12' }))
+    await user.click(screen.getByRole('button', { name: 'Copy Ultimate X-Men 12' }))
 
     expect(screen.getByText('Copy failed')).toBeInTheDocument()
   })


### PR DESCRIPTION
Closes #906

## Summary
- add a mobile-friendly Copy action beside the issue-number controls on the Roll rating screen
- copy the current series title and issue number as a single plain string, for example `Ultimate X-Men 12`
- show clear `Copied` or `Copy failed` feedback
- add focused clipboard success and failure regression tests

## Validation
CI provides the executable validation boundary for this connector-authored branch.

## Changelog
A required user-facing fragment will be added using this PR number before readiness or merge.