### PR TITLE
Submit bug reports from the mobile keyboard action key

### DIFF
--- a/docs/changelog.d/2026-08-08-913.md
+++ b/docs/changelog.d/2026-08-08-913.md
@@ -1,0 +1,5 @@
+## 2026-08-08
+
+### Bug reports
+
+- [PR #913](https://github.com/JoshCLWren/comic-pile/pull/913) makes the mobile keyboard action key submit a completed bug or feature report, so phone users can send the form directly from the description field instead of dismissing the keyboard and hunting for the button.

--- a/docs/changelog.d/2026-08-08-913.md
+++ b/docs/changelog.d/2026-08-08-913.md
@@ -2,4 +2,4 @@
 
 ### Bug reports
 
-- [PR #913](https://github.com/JoshCLWren/comic-pile/pull/913) makes the mobile keyboard action key submit a completed bug or feature report, so phone users can send the form directly from the description field instead of dismissing the keyboard and hunting for the button.
+- [#913](https://github.com/JoshCLWren/comic-pile/pull/913) makes the mobile keyboard action key submit a completed bug or feature report, so phone users can send the form directly from the description field instead of dismissing the keyboard and hunting for the button.

--- a/frontend/src/components/BugReportModal.tsx
+++ b/frontend/src/components/BugReportModal.tsx
@@ -53,6 +53,22 @@ export default function BugReportModal({
     }
   }
 
+  const handleDescriptionKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (
+      event.key !== 'Enter' ||
+      event.shiftKey ||
+      event.nativeEvent.isComposing ||
+      isSubmitting ||
+      !title.trim() ||
+      !description.trim()
+    ) {
+      return
+    }
+
+    event.preventDefault()
+    event.currentTarget.form?.requestSubmit()
+  }
+
   const isFeature = reportType === 'feature'
 
   return (
@@ -123,6 +139,8 @@ export default function BugReportModal({
             id="report-description"
             value={description}
             onChange={(event) => setDescription(event.target.value)}
+            onKeyDown={handleDescriptionKeyDown}
+            enterKeyHint="send"
             placeholder={isFeature ? 'What would you like ComicPile to do, and how would it help?' : 'What were you doing, what happened, and what did you expect?'}
             className="w-full bg-white/5 border border-stone-700 rounded-xl px-3 py-2 text-sm text-stone-200 min-h-[120px] resize-y focus:outline-none focus:ring-2 focus:ring-amber-500/50"
             rows={4}

--- a/frontend/src/unit/dialog-coverage.test.tsx
+++ b/frontend/src/unit/dialog-coverage.test.tsx
@@ -22,6 +22,22 @@ describe('bug report and issue correction dialogs', () => {
     expect(onClose).toHaveBeenCalled()
   })
 
+  it('submits from the description action key while preserving Shift+Enter for newlines', async () => {
+    const user = userEvent.setup(); const onSubmit = vi.fn().mockResolvedValue(undefined)
+    render(<BugReportModal isOpen onClose={vi.fn()} onSubmit={onSubmit} diagnosticData={null} />)
+
+    await user.type(screen.getByLabelText('Title'), ' Mobile submit ')
+    const description = screen.getByLabelText('Description')
+    await user.type(description, ' Use the keyboard action ')
+    expect(description).toHaveAttribute('enterkeyhint', 'send')
+
+    fireEvent.keyDown(description, { key: 'Enter', shiftKey: true })
+    expect(onSubmit).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(description, { key: 'Enter' })
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith('bug', 'Mobile submit', 'Use the keyboard action'))
+  })
+
   it('switches to feature request copy and submits the selected type', async () => {
     const user = userEvent.setup(); const onSubmit = vi.fn().mockResolvedValue(undefined)
     render(<BugReportModal isOpen onClose={vi.fn()} onSubmit={onSubmit} diagnosticData={null} />)


### PR DESCRIPTION
Closes #912

## Summary
- make the report description field advertise a native mobile `send` action key
- submit the report when that action key is pressed and the form is valid
- preserve Shift+Enter for explicit multiline descriptions
- add focused regression coverage for the keyboard submit path

## Validation
CI provides the executable validation boundary for this connector-authored branch.

## Changelog
- `docs/changelog.d/2026-08-08-913.md`