### PR TITLE
Return Roll page to top after rating

### DIFF
--- a/docs/changelog.d/2026-08-08-914.md
+++ b/docs/changelog.d/2026-08-08-914.md
@@ -1,0 +1,5 @@
+## 2026-08-08
+
+### Roll
+
+- [#914](https://github.com/JoshCLWren/comic-pile/pull/914) returns the Roll page to the top after leaving the rating view, keeping the dice controls immediately reachable on mobile after a rating is submitted.

--- a/frontend/src/pages/RollPage/useRollPageState.ts
+++ b/frontend/src/pages/RollPage/useRollPageState.ts
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { RollBootstrapThread } from '../../types/rollBootstrap'
 import type { RatingThread } from './types'
 
@@ -88,6 +88,14 @@ export function useRollPageState(): RollPageState & RollPageStateSetters {
   const suppressPendingAutoOpenRef = useRef(false)
   const rollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const rollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const wasRatingViewRef = useRef(false)
+
+  useEffect(() => {
+    if (wasRatingViewRef.current && !isRatingView) {
+      window.scrollTo({ top: 0, left: 0, behavior: 'auto' })
+    }
+    wasRatingViewRef.current = isRatingView
+  }, [isRatingView])
 
   return {
     isRolling,

--- a/frontend/src/unit/useRollPageState.scroll.test.tsx
+++ b/frontend/src/unit/useRollPageState.scroll.test.tsx
@@ -1,0 +1,27 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, expect, it, vi } from 'vitest'
+import { useRollPageState } from '../pages/RollPage/useRollPageState'
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  vi.spyOn(window, 'scrollTo').mockImplementation(() => undefined)
+})
+
+it('returns the document to the top when the rating view closes', () => {
+  const scrollTo = vi.mocked(window.scrollTo)
+  const { result } = renderHook(() => useRollPageState())
+
+  expect(scrollTo).not.toHaveBeenCalled()
+
+  act(() => {
+    result.current.setIsRatingView(true)
+  })
+  expect(scrollTo).not.toHaveBeenCalled()
+
+  act(() => {
+    result.current.setIsRatingView(false)
+  })
+
+  expect(scrollTo).toHaveBeenCalledTimes(1)
+  expect(scrollTo).toHaveBeenCalledWith({ top: 0, left: 0, behavior: 'auto' })
+})


### PR DESCRIPTION
Fixes #911

Successful exits from the rating view now restore the document to the top, so the dice controls are immediately reachable again on mobile instead of leaving the user scrolled down near the queue.

Adds focused hook regression coverage proving that entering rating mode does not scroll and leaving it scrolls the document to `(0, 0)`.
