### PR TITLE
Dismiss the mobile More tray when tapping elsewhere

### DIFF
--- a/docs/changelog.d/2026-08-08-915.md
+++ b/docs/changelog.d/2026-08-08-915.md
@@ -1,0 +1,5 @@
+## 2026-08-08
+
+### Navigation
+
+- [PR #915](https://github.com/JoshCLWren/comic-pile/pull/915) makes the mobile More tray close when you tap elsewhere, so it no longer stays over the roll screen after you are done with it.

--- a/docs/changelog.d/2026-08-08-915.md
+++ b/docs/changelog.d/2026-08-08-915.md
@@ -2,4 +2,4 @@
 
 ### Navigation
 
-- [PR #915](https://github.com/JoshCLWren/comic-pile/pull/915) makes the mobile More tray close when you tap elsewhere, so it no longer stays over the roll screen after you are done with it.
+- [#915](https://github.com/JoshCLWren/comic-pile/pull/915) makes the mobile More tray close when you tap elsewhere, so it no longer stays over the roll screen after you are done with it.

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import axios from 'axios'
 import BugReportButton from './BugReportButton'
 import type { ReportType } from './BugReportModal'
@@ -27,10 +27,26 @@ export default function Navigation({ onBugReportSubmit }: NavigationProps) {
   const [isLoading, setIsLoading] = useState(false)
   const [hasError, setHasError] = useState(false)
   const [isMoreOpen, setIsMoreOpen] = useState(false)
+  const moreButtonRef = useRef<HTMLButtonElement>(null)
+  const moreMenuRef = useRef<HTMLElement>(null)
 
   useEffect(() => {
     setIsMoreOpen(false)
   }, [location.pathname])
+
+  useEffect(() => {
+    if (!isMoreOpen) return
+
+    const dismissMoreMenu = (event: PointerEvent) => {
+      const target = event.target
+      if (!(target instanceof Node)) return
+      if (moreButtonRef.current?.contains(target) || moreMenuRef.current?.contains(target)) return
+      setIsMoreOpen(false)
+    }
+
+    document.addEventListener('pointerdown', dismissMoreMenu)
+    return () => document.removeEventListener('pointerdown', dismissMoreMenu)
+  }, [isMoreOpen])
 
   useEffect(() => {
     if (isAuthenticated) {
@@ -75,12 +91,12 @@ export default function Navigation({ onBugReportSubmit }: NavigationProps) {
           <Link to="/queue" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isActive('/queue') ? 'active' : 'hover:bg-white/5'}`} aria-label="Queue page"><span className="text-2xl" aria-hidden="true">📚</span><span className="hidden md:block text-[10px] uppercase tracking-widest font-bold nav-label">Queue</span></Link>
           <Link to="/history" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isActive('/history') ? 'active' : 'hover:bg-white/5'}`} aria-label="History page"><span className="text-2xl" aria-hidden="true">📜</span><span className="hidden md:block text-[10px] uppercase tracking-widest font-bold nav-label">History</span></Link>
           <Link to="/crossovers" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isActive('/crossovers') ? 'active' : 'hover:bg-white/5'}`} aria-label="Crossovers page"><span className="text-2xl" aria-hidden="true">🔀</span><span className="hidden md:block text-[10px] uppercase tracking-widest font-bold nav-label">Crossovers</span></Link>
-          <button type="button" onClick={() => setIsMoreOpen(value => !value)} aria-expanded={isMoreOpen} aria-controls="secondary-navigation" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isMoreOpen || isActive('/help') || isActive('/whats-new') ? 'active' : 'hover:bg-white/5'}`} aria-label="More pages"><span className="text-2xl" aria-hidden="true">•••</span><span className="hidden md:block text-[10px] uppercase tracking-widest font-bold nav-label">More</span></button>
+          <button ref={moreButtonRef} type="button" onClick={() => setIsMoreOpen(value => !value)} aria-expanded={isMoreOpen} aria-controls="secondary-navigation" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isMoreOpen || isActive('/help') || isActive('/whats-new') ? 'active' : 'hover:bg-white/5'}`} aria-label="More pages"><span className="text-2xl" aria-hidden="true">•••</span><span className="hidden md:block text-[10px] uppercase tracking-widest font-bold nav-label">More</span></button>
         </div>
       </nav>
 
       {isMoreOpen && (
-        <nav id="secondary-navigation" aria-label="More pages" className="fixed bottom-16 right-3 z-50 w-56 rounded-2xl border border-stone-700 bg-stone-950 p-2 shadow-2xl md:bottom-24 md:right-6">
+        <nav ref={moreMenuRef} id="secondary-navigation" aria-label="More pages" className="fixed bottom-16 right-3 z-50 w-56 rounded-2xl border border-stone-700 bg-stone-950 p-2 shadow-2xl md:bottom-24 md:right-6">
           <Link to="/whats-new" className="flex min-h-12 items-center gap-3 rounded-xl px-4 py-3 font-bold text-stone-100 hover:bg-stone-800"><span aria-hidden="true">✨</span><span>What’s New</span></Link>
           <Link to="/help" className="flex min-h-12 items-center gap-3 rounded-xl px-4 py-3 font-bold text-stone-100 hover:bg-stone-800"><span aria-hidden="true">❓</span><span>Help</span></Link>
           <div className="border-t border-stone-800 pt-2 md:hidden"><BugReportButton onSubmit={onBugReportSubmit} variant="nav" /></div>

--- a/frontend/src/unit/Navigation.test.tsx
+++ b/frontend/src/unit/Navigation.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { expect, test, beforeEach, vi } from 'vitest'
 import userEvent from '@testing-library/user-event'
@@ -68,6 +68,28 @@ test('renders retained navigation links when authenticated', async () => {
   expect(screen.getByRole('link', { name: /queue page/i })).toBeInTheDocument()
   expect(screen.getByRole('link', { name: /history page/i })).toBeInTheDocument()
   expect(screen.queryByRole('link', { name: /analytics page/i })).not.toBeInTheDocument()
+})
+
+test('dismisses the More tray only when tapping outside it', async () => {
+  renderWithAuth()
+  const user = userEvent.setup()
+  const moreButton = await screen.findByRole('button', { name: /more pages/i })
+
+  await user.click(moreButton)
+  const moreNavigation = screen.getByRole('navigation', { name: /more pages/i })
+  expect(moreButton).toHaveAttribute('aria-expanded', 'true')
+
+  fireEvent.pointerDown(screen.getByRole('link', { name: /help/i }))
+  expect(moreNavigation).toBeInTheDocument()
+  expect(moreButton).toHaveAttribute('aria-expanded', 'true')
+
+  fireEvent.pointerDown(moreButton)
+  expect(moreNavigation).toBeInTheDocument()
+  expect(moreButton).toHaveAttribute('aria-expanded', 'true')
+
+  fireEvent.pointerDown(document.body)
+  await waitFor(() => expect(moreButton).toHaveAttribute('aria-expanded', 'false'))
+  expect(screen.queryByRole('navigation', { name: /more pages/i })).not.toBeInTheDocument()
 })
 
 test('does not render when not authenticated', async () => {


### PR DESCRIPTION
Closes #910

## Summary
- dismiss the mobile More tray on outside pointer interaction
- keep interactions on the More button and within the tray working normally

## Validation
- CI will validate the exact branch head

Changelog: user-facing