### PR TITLE
Preserve the current screen during idle auth recovery

### DIFF
--- a/docs/changelog.d/2026-08-08-916.md
+++ b/docs/changelog.d/2026-08-08-916.md
@@ -1,4 +1,4 @@
 ## 2026-08-08
 
 ### Authentication
-- [PR #916](https://github.com/JoshCLWren/comic-pile/pull/916) keeps the current ComicPile screen and signed-in state visible when an idle-app session check temporarily fails, so a cold server or brief network hiccup can recover without unnecessarily dumping the user onto the login page.
+- [#916](https://github.com/JoshCLWren/comic-pile/pull/916) keeps the current ComicPile screen and signed-in state visible when an idle-app session check temporarily fails, so a cold server or brief network hiccup can recover without unnecessarily dumping the user onto the login page.

--- a/docs/changelog.d/2026-08-08-916.md
+++ b/docs/changelog.d/2026-08-08-916.md
@@ -1,0 +1,4 @@
+## 2026-08-08
+
+### Authentication
+- [PR #916](https://github.com/JoshCLWren/comic-pile/pull/916) keeps the current ComicPile screen and signed-in state visible when an idle-app session check temporarily fails, so a cold server or brief network hiccup can recover without unnecessarily dumping the user onto the login page.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -64,16 +64,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(null)
 
   const revalidateSession = useCallback(async (timeout?: number) => {
-    try {
-      const response = await api.get<AuthUser>('/v1/auth/me', { timeout, skipAuthRedirect: false })
-      setUser(response)
-      setIsAuthenticated(true)
-    } catch (error) {
-      clearAccessToken()
-      setIsAuthenticated(false)
-      setUser(null)
-      throw error
-    }
+    const response = await api.get<AuthUser>('/v1/auth/me', { timeout, skipAuthRedirect: false })
+    setUser(response)
+    setIsAuthenticated(true)
   }, [])
 
   useEffect(() => {

--- a/frontend/src/unit/AuthHardRefresh.test.tsx
+++ b/frontend/src/unit/AuthHardRefresh.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { render, waitFor } from '@testing-library/react'
+import { act, render, waitFor } from '@testing-library/react'
 import { useEffect } from 'react'
 import type { AuthContextValue } from '../App'
 
@@ -62,6 +62,33 @@ describe('hard refresh session bootstrap', () => {
       expect(authState?.isAuthenticated).toBe(true)
     })
     expect(mockApiGet).toHaveBeenCalledWith('/auth/me')
+    expect(mockClearAccessToken).not.toHaveBeenCalled()
+  })
+
+  test('preserves the authenticated screen when resume validation is temporarily unavailable', async () => {
+    window.history.replaceState({}, '', '/queue')
+    mockApiGet.mockResolvedValueOnce({ username: 'testuser', email: 'test@example.com' })
+
+    render(
+      <AuthProvider>
+        <AuthStateProbe />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => {
+      expect(authState?.isAuthenticated).toBe(true)
+    })
+
+    mockApiGet.mockRejectedValueOnce(new Error('cold server timeout'))
+
+    await expect(
+      act(async () => {
+        await authState?.revalidateSession(8000)
+      }),
+    ).rejects.toThrow('cold server timeout')
+
+    expect(authState?.isAuthenticated).toBe(true)
+    expect(authState?.user?.username).toBe('testuser')
     expect(mockClearAccessToken).not.toHaveBeenCalled()
   })
 

--- a/frontend/src/unit/AuthHardRefresh.test.tsx
+++ b/frontend/src/unit/AuthHardRefresh.test.tsx
@@ -67,6 +67,7 @@ describe('hard refresh session bootstrap', () => {
 
   test('preserves the authenticated screen when resume validation is temporarily unavailable', async () => {
     window.history.replaceState({}, '', '/queue')
+    mockGetAccessToken.mockReturnValue('preserved-access-token')
     mockApiGet.mockResolvedValueOnce({ username: 'testuser', email: 'test@example.com' })
 
     render(
@@ -78,6 +79,7 @@ describe('hard refresh session bootstrap', () => {
     await waitFor(() => {
       expect(authState?.isAuthenticated).toBe(true)
     })
+    const accessTokenBeforeRevalidation = mockGetAccessToken()
 
     mockApiGet.mockRejectedValueOnce(new Error('cold server timeout'))
 
@@ -89,6 +91,8 @@ describe('hard refresh session bootstrap', () => {
 
     expect(authState?.isAuthenticated).toBe(true)
     expect(authState?.user?.username).toBe('testuser')
+    expect(mockGetAccessToken()).toBe(accessTokenBeforeRevalidation)
+    expect(window.location.pathname).toBe('/queue')
     expect(mockClearAccessToken).not.toHaveBeenCalled()
   })
 


### PR DESCRIPTION
Closes #909

## Summary
- keep the authenticated app state intact while a resume-time session check is temporarily unavailable
- let the existing recovery UI retry without dumping the user onto the login screen during a cold-server/network failure
- add regression coverage for preserving the authenticated user across a transient revalidation failure

## Validation
CI provides the executable validation boundary for this connector-authored branch.

## Changelog
A user-facing fragment will be added using this PR number before readiness or merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the current screen and signed-in state when a temporary idle-session check fails.
  * Prevented access tokens and authentication state from being cleared during failed session revalidation.
  * Authentication errors are now surfaced while the existing session remains intact.

* **Documentation**
  * Added a changelog entry describing the improved authentication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->