### PR TITLE
Add crossover membership controls to dependency builder

### DIFF
--- a/docs/changelog.d/2026-08-08-917.md
+++ b/docs/changelog.d/2026-08-08-917.md
@@ -1,0 +1,4 @@
+## 2026-08-08
+
+### Continuity
+- [#917](https://github.com/JoshCLWren/comic-pile/pull/917) adds crossover membership controls to the Dependency Builder, so a prerequisite issue, blocked issue, or both can be added to a new or existing crossover without coupling membership to dependency creation.

--- a/frontend/src/components/DependencyBuilder.tsx
+++ b/frontend/src/components/DependencyBuilder.tsx
@@ -3,6 +3,7 @@ import type { FormEvent } from 'react'
 import Modal from './Modal'
 import DependencyFlowchart from './DependencyFlowchart'
 import ReadingOrderTimeline from './ReadingOrderTimeline'
+import DependencyCrossoverControls from './DependencyCrossoverControls'
 import { dependenciesApi, threadsApi } from '../services/api'
 import { issuesApi } from '../services/api-issues'
 import type { Dependency, FlowchartDependency, FlowchartNode, Issue, Thread, ThreadDependenciesResponse } from '../types'
@@ -844,6 +845,16 @@ const [isSavingNote, setIsSavingNote] = useState(false)
                )}
              </div>
            )}
+
+           {selectedThread && !selectedThreadNeedsMigration && (
+             <DependencyCrossoverControls
+               sourceIssueId={sourceIssueId}
+               targetIssueId={targetIssueId}
+               disabled={isLoadingSourceIssues || isLoadingTargetIssues}
+               onMembershipChanged={onChanged}
+             />
+           )}
+
             <button
               type="button"
               onClick={handleCreateDependency}

--- a/frontend/src/components/DependencyCrossoverControls.tsx
+++ b/frontend/src/components/DependencyCrossoverControls.tsx
@@ -1,0 +1,266 @@
+import { useEffect, useMemo, useState } from 'react'
+import {
+  dependencyGroupsApi,
+  type DependencyGroup,
+} from '../services/api-dependency-groups'
+import { getApiErrorDetail } from '../utils/apiError'
+
+interface DependencyCrossoverControlsProps {
+  sourceIssueId: number | null
+  targetIssueId: number | null
+  disabled?: boolean
+  onMembershipChanged?: () => void
+}
+
+type CrossoverMode = 'none' | 'existing' | 'new'
+
+export default function DependencyCrossoverControls({
+  sourceIssueId,
+  targetIssueId,
+  disabled = false,
+  onMembershipChanged,
+}: DependencyCrossoverControlsProps) {
+  const [mode, setMode] = useState<CrossoverMode>('none')
+  const [groups, setGroups] = useState<DependencyGroup[]>([])
+  const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [newName, setNewName] = useState('')
+  const [includeSource, setIncludeSource] = useState(true)
+  const [includeTarget, setIncludeTarget] = useState(true)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState('')
+  const [result, setResult] = useState('')
+
+  useEffect(() => {
+    if (mode !== 'existing') return
+
+    let isCurrent = true
+    setIsLoading(true)
+    setError('')
+    dependencyGroupsApi
+      .list()
+      .then((loadedGroups) => {
+        if (!isCurrent) return
+        setGroups(loadedGroups)
+        if (!loadedGroups.some((group) => group.id === selectedGroupId)) {
+          setSelectedGroupId(null)
+        }
+      })
+      .catch((loadError: unknown) => {
+        if (!isCurrent) return
+        setGroups([])
+        setSelectedGroupId(null)
+        setError(getApiErrorDetail(loadError))
+      })
+      .finally(() => {
+        if (isCurrent) setIsLoading(false)
+      })
+
+    return () => {
+      isCurrent = false
+    }
+  }, [mode, selectedGroupId])
+
+  useEffect(() => {
+    setResult('')
+    setError('')
+  }, [sourceIssueId, targetIssueId])
+
+  const filteredGroups = useMemo(() => {
+    const query = searchQuery.trim().toLocaleLowerCase()
+    if (!query) return groups
+    return groups.filter((group) => group.name.toLocaleLowerCase().includes(query))
+  }, [groups, searchQuery])
+
+  const hasSelectedMembership =
+    (includeSource && sourceIssueId != null) || (includeTarget && targetIssueId != null)
+
+  async function handleSaveMemberships() {
+    if (!hasSelectedMembership) {
+      setError('Select at least one issue to add to the crossover.')
+      return
+    }
+
+    const normalizedName = newName.trim()
+    if (mode === 'new' && !normalizedName) {
+      setError('Enter a crossover name.')
+      return
+    }
+    if (mode === 'existing' && selectedGroupId == null) {
+      setError('Select an existing crossover.')
+      return
+    }
+
+    setIsSaving(true)
+    setError('')
+    setResult('')
+
+    let group: DependencyGroup | null = null
+    const completedLabels: string[] = []
+    try {
+      group =
+        mode === 'new'
+          ? await dependencyGroupsApi.create(normalizedName)
+          : groups.find((candidate) => candidate.id === selectedGroupId) ?? null
+
+      if (!group) {
+        throw new Error('The selected crossover is no longer available.')
+      }
+
+      if (includeSource && sourceIssueId != null) {
+        await dependencyGroupsApi.addMember(group.id, { issue_id: sourceIssueId })
+        completedLabels.push('prerequisite issue')
+      }
+      if (includeTarget && targetIssueId != null && targetIssueId !== sourceIssueId) {
+        await dependencyGroupsApi.addMember(group.id, { issue_id: targetIssueId })
+        completedLabels.push('blocked issue')
+      }
+
+      setResult(`${completedLabels.join(' and ')} added to ${group.name}.`)
+      if (mode === 'new') {
+        setGroups((current) => [...current, group!])
+        setSelectedGroupId(group.id)
+      }
+      onMembershipChanged?.()
+    } catch (saveError: unknown) {
+      const detail = getApiErrorDetail(saveError)
+      if (group && completedLabels.length > 0) {
+        setError(
+          `${completedLabels.join(' and ')} added to ${group.name}, but the remaining membership failed: ${detail}`,
+        )
+        onMembershipChanged?.()
+      } else if (group && mode === 'new') {
+        setError(`Created ${group.name}, but no issue membership was added: ${detail}`)
+        onMembershipChanged?.()
+      } else {
+        setError(detail)
+      }
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const controlsDisabled = disabled || isSaving
+
+  return (
+    <section
+      className="rounded-lg border border-gray-700 bg-gray-900/60 p-3"
+      aria-label="Crossover membership"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-sm font-semibold text-gray-200">Crossover</span>
+        <button
+          type="button"
+          className={`rounded px-2 py-1 text-xs ${mode === 'none' ? 'bg-blue-600 text-white' : 'bg-gray-800 text-gray-300'}`}
+          onClick={() => setMode('none')}
+          disabled={controlsDisabled}
+        >
+          No membership
+        </button>
+        <button
+          type="button"
+          className={`rounded px-2 py-1 text-xs ${mode === 'existing' ? 'bg-blue-600 text-white' : 'bg-gray-800 text-gray-300'}`}
+          onClick={() => setMode('existing')}
+          disabled={controlsDisabled}
+        >
+          Add to existing
+        </button>
+        <button
+          type="button"
+          className={`rounded px-2 py-1 text-xs ${mode === 'new' ? 'bg-blue-600 text-white' : 'bg-gray-800 text-gray-300'}`}
+          onClick={() => setMode('new')}
+          disabled={controlsDisabled}
+        >
+          Create crossover
+        </button>
+      </div>
+
+      {mode !== 'none' && (
+        <div className="mt-3 space-y-3">
+          {mode === 'existing' ? (
+            <>
+              <label className="block text-xs text-gray-300">
+                Search crossovers
+                <input
+                  className="mt-1 w-full rounded border border-gray-700 bg-gray-950 px-2 py-1 text-sm text-white"
+                  value={searchQuery}
+                  onChange={(event) => setSearchQuery(event.target.value)}
+                  disabled={controlsDisabled}
+                />
+              </label>
+              <label className="block text-xs text-gray-300">
+                Existing crossover
+                <select
+                  className="mt-1 w-full rounded border border-gray-700 bg-gray-950 px-2 py-1 text-sm text-white"
+                  value={selectedGroupId ?? ''}
+                  onChange={(event) => setSelectedGroupId(Number(event.target.value) || null)}
+                  disabled={controlsDisabled || isLoading}
+                >
+                  <option value="">{isLoading ? 'Loading…' : 'Select a crossover'}</option>
+                  {filteredGroups.map((group) => (
+                    <option key={group.id} value={group.id}>
+                      {group.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </>
+          ) : (
+            <label className="block text-xs text-gray-300">
+              Crossover name
+              <input
+                className="mt-1 w-full rounded border border-gray-700 bg-gray-950 px-2 py-1 text-sm text-white"
+                value={newName}
+                onChange={(event) => setNewName(event.target.value)}
+                disabled={controlsDisabled}
+                maxLength={200}
+              />
+            </label>
+          )}
+
+          <div className="flex flex-wrap gap-4 text-sm text-gray-200">
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={includeSource}
+                onChange={(event) => setIncludeSource(event.target.checked)}
+                disabled={controlsDisabled || sourceIssueId == null}
+              />
+              Prerequisite issue
+            </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={includeTarget}
+                onChange={(event) => setIncludeTarget(event.target.checked)}
+                disabled={controlsDisabled || targetIssueId == null}
+              />
+              Blocked issue
+            </label>
+          </div>
+
+          <button
+            type="button"
+            className="rounded bg-purple-600 px-3 py-2 text-sm font-medium text-white disabled:opacity-50"
+            onClick={handleSaveMemberships}
+            disabled={controlsDisabled || !hasSelectedMembership}
+          >
+            {isSaving ? 'Saving membership…' : 'Save crossover membership'}
+          </button>
+        </div>
+      )}
+
+      {error && (
+        <p className="mt-2 text-sm text-red-300" role="alert">
+          {error}
+        </p>
+      )}
+      {result && (
+        <p className="mt-2 text-sm text-green-300" role="status">
+          {result}
+        </p>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/unit/DependencyCrossoverControls.creation-failure.test.tsx
+++ b/frontend/src/unit/DependencyCrossoverControls.creation-failure.test.tsx
@@ -1,0 +1,24 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { expect, it, vi } from 'vitest'
+import DependencyCrossoverControls from '../components/DependencyCrossoverControls'
+import { dependencyGroupsApi } from '../services/api-dependency-groups'
+
+vi.mock('../services/api-dependency-groups', () => ({
+  dependencyGroupsApi: {
+    list: vi.fn(),
+    create: vi.fn(),
+    addMember: vi.fn(),
+  },
+}))
+
+it('reports crossover creation failure before any membership is added', async () => {
+  vi.mocked(dependencyGroupsApi.create).mockRejectedValueOnce(new Error('create unavailable'))
+
+  render(<DependencyCrossoverControls sourceIssueId={101} targetIssueId={202} />)
+  fireEvent.click(screen.getByRole('button', { name: 'Create crossover' }))
+  fireEvent.change(screen.getByLabelText('Crossover name'), { target: { value: 'Inferno' } })
+  fireEvent.click(screen.getByRole('button', { name: 'Save crossover membership' }))
+
+  expect(await screen.findByRole('alert')).toHaveTextContent('create unavailable')
+  expect(dependencyGroupsApi.addMember).not.toHaveBeenCalled()
+})

--- a/frontend/src/unit/DependencyCrossoverControls.disabled.test.tsx
+++ b/frontend/src/unit/DependencyCrossoverControls.disabled.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import DependencyCrossoverControls from '../components/DependencyCrossoverControls'
+
+vi.mock('../services/api-dependency-groups', () => ({
+  dependencyGroupsApi: {
+    list: vi.fn(),
+    create: vi.fn(),
+    addMember: vi.fn(),
+  },
+}))
+
+describe('DependencyCrossoverControls disabled state', () => {
+  it('disables every mode control when the parent disables crossover editing', () => {
+    render(
+      <DependencyCrossoverControls
+        sourceIssueId={101}
+        targetIssueId={202}
+        disabled
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'No membership' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Add to existing' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Create crossover' })).toBeDisabled()
+  })
+})

--- a/frontend/src/unit/DependencyCrossoverControls.test.tsx
+++ b/frontend/src/unit/DependencyCrossoverControls.test.tsx
@@ -93,6 +93,19 @@ describe('DependencyCrossoverControls', () => {
     expect(addMember).toHaveBeenCalledWith(8, { issue_id: 101 })
   })
 
+  it('supports target-only membership when the prerequisite issue is unavailable', async () => {
+    render(<DependencyCrossoverControls sourceIssueId={null} targetIssueId={202} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create crossover' }))
+    expect(screen.getByLabelText('Prerequisite issue')).toBeDisabled()
+    fireEvent.change(screen.getByLabelText('Crossover name'), { target: { value: 'Inferno' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save crossover membership' }))
+
+    await waitFor(() => expect(addMember).toHaveBeenCalledTimes(1))
+    expect(addMember).toHaveBeenCalledWith(8, { issue_id: 202 })
+    expect(await screen.findByRole('status')).toHaveTextContent('blocked issue added to Inferno')
+  })
+
   it('reports partial failure without claiming both memberships succeeded', async () => {
     const onMembershipChanged = vi.fn()
     addMember

--- a/frontend/src/unit/DependencyCrossoverControls.test.tsx
+++ b/frontend/src/unit/DependencyCrossoverControls.test.tsx
@@ -117,4 +117,74 @@ describe('DependencyCrossoverControls', () => {
     expect(screen.queryByRole('status')).not.toBeInTheDocument()
     expect(onMembershipChanged).toHaveBeenCalledTimes(1)
   })
+
+  it('surfaces crossover loading failures and clears the loading state', async () => {
+    listGroups.mockRejectedValueOnce(new Error('crossovers unavailable'))
+
+    render(<DependencyCrossoverControls sourceIssueId={101} targetIssueId={202} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Add to existing' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('crossovers unavailable')
+    await waitFor(() =>
+      expect(screen.getByRole('option', { name: 'Select a crossover' })).toBeInTheDocument(),
+    )
+  })
+
+  it('requires a name for a new crossover before saving', async () => {
+    render(<DependencyCrossoverControls sourceIssueId={101} targetIssueId={202} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Create crossover' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save crossover membership' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Enter a crossover name')
+    expect(createGroup).not.toHaveBeenCalled()
+    expect(addMember).not.toHaveBeenCalled()
+  })
+
+  it('reports when a newly created crossover cannot add its first membership', async () => {
+    const onMembershipChanged = vi.fn()
+    addMember.mockRejectedValueOnce(new Error('membership unavailable'))
+
+    render(
+      <DependencyCrossoverControls
+        sourceIssueId={101}
+        targetIssueId={202}
+        onMembershipChanged={onMembershipChanged}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Create crossover' }))
+    fireEvent.change(screen.getByLabelText('Crossover name'), { target: { value: 'Inferno' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save crossover membership' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Created Inferno, but no issue membership was added: membership unavailable',
+    )
+    expect(onMembershipChanged).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not add the same issue twice when both sides resolve to one issue', async () => {
+    render(<DependencyCrossoverControls sourceIssueId={101} targetIssueId={101} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Create crossover' }))
+    fireEvent.change(screen.getByLabelText('Crossover name'), { target: { value: 'Inferno' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save crossover membership' }))
+
+    await waitFor(() => expect(addMember).toHaveBeenCalledTimes(1))
+    expect(addMember).toHaveBeenCalledWith(8, { issue_id: 101 })
+    expect(await screen.findByRole('status')).toHaveTextContent('prerequisite issue added to Inferno')
+  })
+
+  it('filters existing crossovers and rejects a cleared selection', async () => {
+    render(<DependencyCrossoverControls sourceIssueId={101} targetIssueId={202} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Add to existing' }))
+    await screen.findByRole('option', { name: 'Mutant Massacre' })
+
+    fireEvent.change(screen.getByLabelText('Search crossovers'), { target: { value: 'inferno' } })
+    expect(screen.queryByRole('option', { name: 'Mutant Massacre' })).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Search crossovers'), { target: { value: '' } })
+    fireEvent.change(screen.getByLabelText('Existing crossover'), { target: { value: '' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save crossover membership' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Select an existing crossover')
+    expect(addMember).not.toHaveBeenCalled()
+  })
 })

--- a/frontend/src/unit/DependencyCrossoverControls.test.tsx
+++ b/frontend/src/unit/DependencyCrossoverControls.test.tsx
@@ -1,0 +1,120 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import DependencyCrossoverControls from '../components/DependencyCrossoverControls'
+import { dependencyGroupsApi } from '../services/api-dependency-groups'
+
+vi.mock('../services/api-dependency-groups', () => ({
+  dependencyGroupsApi: {
+    list: vi.fn(),
+    create: vi.fn(),
+    addMember: vi.fn(),
+  },
+}))
+
+const listGroups = vi.mocked(dependencyGroupsApi.list)
+const createGroup = vi.mocked(dependencyGroupsApi.create)
+const addMember = vi.mocked(dependencyGroupsApi.addMember)
+
+const existingGroup = {
+  id: 7,
+  name: 'Mutant Massacre',
+  created_at: '2026-08-06T00:00:00Z',
+  memberships: [],
+}
+
+describe('DependencyCrossoverControls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    listGroups.mockResolvedValue([existingGroup])
+    createGroup.mockResolvedValue({ ...existingGroup, id: 8, name: 'Inferno' })
+    addMember.mockResolvedValue({ id: 11, issue_id: 101, thread_id: null })
+  })
+
+  it('keeps dependency creation independent when no crossover is selected', () => {
+    render(<DependencyCrossoverControls sourceIssueId={101} targetIssueId={202} />)
+
+    expect(screen.getByRole('button', { name: 'No membership' })).toBeEnabled()
+    expect(
+      screen.queryByRole('button', { name: 'Save crossover membership' }),
+    ).not.toBeInTheDocument()
+    expect(createGroup).not.toHaveBeenCalled()
+    expect(addMember).not.toHaveBeenCalled()
+  })
+
+  it('creates a crossover and adds both selected issues', async () => {
+    const onMembershipChanged = vi.fn()
+    render(
+      <DependencyCrossoverControls
+        sourceIssueId={101}
+        targetIssueId={202}
+        onMembershipChanged={onMembershipChanged}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create crossover' }))
+    fireEvent.change(screen.getByLabelText('Crossover name'), { target: { value: 'Inferno' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save crossover membership' }))
+
+    await waitFor(() => expect(createGroup).toHaveBeenCalledWith('Inferno'))
+    expect(addMember).toHaveBeenNthCalledWith(1, 8, { issue_id: 101 })
+    expect(addMember).toHaveBeenNthCalledWith(2, 8, { issue_id: 202 })
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      'prerequisite issue and blocked issue added to Inferno',
+    )
+    expect(onMembershipChanged).toHaveBeenCalledTimes(1)
+  })
+
+  it('searches and adds membership to an existing crossover', async () => {
+    render(<DependencyCrossoverControls sourceIssueId={101} targetIssueId={202} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add to existing' }))
+    await screen.findByRole('option', { name: 'Mutant Massacre' })
+    fireEvent.change(screen.getByLabelText('Search crossovers'), {
+      target: { value: 'mutant' },
+    })
+    fireEvent.change(screen.getByLabelText('Existing crossover'), {
+      target: { value: '7' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save crossover membership' }))
+
+    await waitFor(() => expect(addMember).toHaveBeenCalledTimes(2))
+    expect(createGroup).not.toHaveBeenCalled()
+  })
+
+  it('supports membership-only selection for one side of the dependency', async () => {
+    render(<DependencyCrossoverControls sourceIssueId={101} targetIssueId={202} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create crossover' }))
+    fireEvent.change(screen.getByLabelText('Crossover name'), { target: { value: 'Inferno' } })
+    fireEvent.click(screen.getByLabelText('Blocked issue'))
+    fireEvent.click(screen.getByRole('button', { name: 'Save crossover membership' }))
+
+    await waitFor(() => expect(addMember).toHaveBeenCalledTimes(1))
+    expect(addMember).toHaveBeenCalledWith(8, { issue_id: 101 })
+  })
+
+  it('reports partial failure without claiming both memberships succeeded', async () => {
+    const onMembershipChanged = vi.fn()
+    addMember
+      .mockResolvedValueOnce({ id: 11, issue_id: 101, thread_id: null })
+      .mockRejectedValueOnce(new Error('membership unavailable'))
+
+    render(
+      <DependencyCrossoverControls
+        sourceIssueId={101}
+        targetIssueId={202}
+        onMembershipChanged={onMembershipChanged}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create crossover' }))
+    fireEvent.change(screen.getByLabelText('Crossover name'), { target: { value: 'Inferno' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save crossover membership' }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('prerequisite issue added to Inferno')
+    expect(alert).toHaveTextContent('remaining membership failed')
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(onMembershipChanged).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
Closes #841

Adds create-or-select crossover membership controls directly to the Dependency Builder while keeping dependency creation independent. Users can add the prerequisite issue, blocked issue, or both to a new or existing crossover, with truthful partial-failure feedback and parent refresh after successful membership changes.

Tests cover no-membership, new crossover, existing crossover search, one-sided membership, and partial failure.