### PR TITLE
Use dedicated credentials for production E2E monitoring

### DIFF
--- a/.github/workflows/production-performance.yml
+++ b/.github/workflows/production-performance.yml
@@ -51,19 +51,6 @@ jobs:
           restore-keys: |
             production-performance-
 
-      - name: Prepare authenticated storage state
-        env:
-          STORAGE_STATE_JSON: ${{ secrets.PROD_E2E_STORAGE_STATE_JSON }}
-        run: |
-          if [ -z "$STORAGE_STATE_JSON" ]; then
-            echo 'Missing PROD_E2E_STORAGE_STATE_JSON repository secret.' >&2
-            exit 1
-          fi
-          storage_state_path="$RUNNER_TEMP/production-storage-state.json"
-          printf '%s' "$STORAGE_STATE_JSON" > "$storage_state_path"
-          chmod 600 "$storage_state_path"
-          echo "PROD_PROFILE_STORAGE_STATE=$storage_state_path" >> "$GITHUB_ENV"
-
       - name: Install backend dependencies
         run: uv sync --frozen
 
@@ -91,6 +78,21 @@ jobs:
       - name: Install Chromium
         working-directory: frontend
         run: pnpm exec playwright install --with-deps chromium
+
+      - name: Authenticate dedicated production E2E account
+        working-directory: frontend
+        env:
+          PROD_E2E_ACCOUNT_USERNAME: ${{ secrets.PROD_E2E_ACCOUNT_USERNAME }}
+          PROD_E2E_ACCOUNT_PASSWORD: ${{ secrets.PROD_E2E_ACCOUNT_PASSWORD }}
+          PROD_PROFILE_STORAGE_STATE: ${{ runner.temp }}/production-storage-state.json
+        run: |
+          if [ -z "$PROD_E2E_ACCOUNT_USERNAME" ] || [ -z "$PROD_E2E_ACCOUNT_PASSWORD" ]; then
+            echo 'Missing dedicated production E2E account credentials.' >&2
+            exit 1
+          fi
+          node scripts/create-production-e2e-storage-state.mjs
+          chmod 600 "$PROD_PROFILE_STORAGE_STATE"
+          echo "PROD_PROFILE_STORAGE_STATE=$PROD_PROFILE_STORAGE_STATE" >> "$GITHUB_ENV"
 
       - name: Measure production milestones
         working-directory: frontend

--- a/docs/PRODUCTION_E2E_DATA.md
+++ b/docs/PRODUCTION_E2E_DATA.md
@@ -2,6 +2,21 @@
 
 Production browser monitoring uses a dedicated account and must never create records under a personal account.
 
+## Dedicated account contract
+
+Create one normal ComicPile production user used only by automated browser monitoring. The account does not need administrative privileges and must not contain personal reading data.
+
+Store its credentials in GitHub Actions repository secrets:
+
+- `PROD_E2E_ACCOUNT_USERNAME`
+- `PROD_E2E_ACCOUNT_PASSWORD`
+- `PROD_E2E_ACCOUNT_EMAIL`
+- `PROD_E2E_DATABASE_URL`
+
+The scheduled production workflow signs in through the real `/login` UI and writes the resulting Playwright storage state only to the GitHub runner temporary directory. Authentication cookies and tokens are therefore short-lived runner files rather than a long-lived storage-state secret. They are never uploaded as artifacts.
+
+`PROD_E2E_ACCOUNT_EMAIL` identifies the same dedicated account to the production-data janitor. `PROD_E2E_DATABASE_URL` is used only for that ownership-scoped cleanup path.
+
 ## Naming contract
 
 Every production-created thread must set `is_test=true` and use this title format:
@@ -23,12 +38,10 @@ Each test that mutates production must delete its own records in a `finally` blo
 - the title strictly matches the production E2E naming contract;
 - the thread is older than 24 hours.
 
-The command is idempotent and supports `--dry-run`. Its output contains only the cutoff, candidate count, account-found state, and dry-run state. It never logs titles, record IDs, email addresses, tokens, or database connection details.
+The command is idempotent and supports `--dry-run`. Its output contains only the cutoff, candidate count, account-found state, and dry-run state. It never logs titles, record IDs, email addresses, tokens, passwords, or database connection details.
 
-Required repository secrets:
+## Rotation and recovery
 
-- `PROD_E2E_ACCOUNT_EMAIL`
-- `PROD_E2E_DATABASE_URL`
-- `PROD_E2E_STORAGE_STATE_JSON`
+Rotate the account password by updating `PROD_E2E_ACCOUNT_PASSWORD`; no checked-in storage-state file needs replacement. If the account username or email changes, update the corresponding repository secrets together. After any credential change, run the Production Performance workflow manually and verify authentication, cleanup, and the production milestones before relying on the next scheduled run.
 
-Credential rotation must update all three boundaries together and verify a manual workflow run before scheduled monitoring resumes.
+If authentication begins failing, do not substitute a personal account. Repair or recreate the dedicated account, update the repository secrets, and rerun the workflow. Test-created data remains recognizable by the `[E2E]` prefix and `is_test=true` boundary.

--- a/docs/changelog.d/2026-08-08-918.md
+++ b/docs/changelog.d/2026-08-08-918.md
@@ -1,0 +1,4 @@
+## 2026-08-08
+
+### Operations
+- [#918](https://github.com/JoshCLWren/comic-pile/pull/918) switches scheduled production monitoring to a dedicated E2E account whose credentials stay in GitHub secrets and whose temporary browser session is created fresh for each run.

--- a/frontend/scripts/create-production-e2e-storage-state.mjs
+++ b/frontend/scripts/create-production-e2e-storage-state.mjs
@@ -1,0 +1,32 @@
+import { chromium } from '@playwright/test'
+
+const baseUrl = process.env.PROD_BASE_URL
+const username = process.env.PROD_E2E_ACCOUNT_USERNAME
+const password = process.env.PROD_E2E_ACCOUNT_PASSWORD
+const output = process.env.PROD_PROFILE_STORAGE_STATE
+
+for (const [name, value] of Object.entries({
+  PROD_BASE_URL: baseUrl,
+  PROD_E2E_ACCOUNT_USERNAME: username,
+  PROD_E2E_ACCOUNT_PASSWORD: password,
+  PROD_PROFILE_STORAGE_STATE: output,
+})) {
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`)
+  }
+}
+
+const browser = await chromium.launch()
+try {
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  await page.goto(`${baseUrl}/login`, { waitUntil: 'domcontentloaded' })
+  await page.getByLabel('Username').fill(username)
+  await page.getByLabel('Password').fill(password)
+  await page.getByRole('button', { name: 'Sign In' }).click()
+  await page.waitForURL((url) => url.pathname === '/', { timeout: 30_000 })
+  await page.locator('[data-app-shell-ready="true"]').waitFor({ state: 'visible', timeout: 30_000 })
+  await context.storageState({ path: output })
+} finally {
+  await browser.close()
+}


### PR DESCRIPTION
Tracks #832

## Summary
- generate Playwright storage state at runtime by signing in through ComicPile with a dedicated production E2E username/password
- keep auth cookies and tokens in the GitHub runner temp directory instead of a long-lived storage-state secret
- document the dedicated account, secret names, rotation, recovery, and test-data isolation contract
- preserve the existing ownership-scoped production E2E janitor

## Remaining external setup
The repository now has the credential and runtime boundary, but the dedicated production account and repository secret values must exist before the scheduled job can authenticate. CI can validate the code path; a live Production Performance run is the final acceptance evidence.

Changelog: `docs/changelog.d/2026-08-08-918.md`.