### PR TITLE
Unify continuity blocked state across Queue and Roll

### DIFF
--- a/app/api/continuity_rule.py
+++ b/app/api/continuity_rule.py
@@ -21,6 +21,7 @@ from app.schemas.continuity_rule import (
     ContinuityRuleCreate,
     ContinuityRuleResponse,
 )
+from comic_pile.dependencies import refresh_user_blocked_status
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["continuity"])
@@ -40,6 +41,13 @@ async def _invalidate_continuity_caches(user_id: int) -> None:
     for result in results:
         if isinstance(result, BaseException):
             logger.warning("Continuity cache invalidation failed", exc_info=result)
+
+
+async def _refresh_blocked_state(user_id: int, db: AsyncSession) -> None:
+    """Persist the unified Queue/Roll blocked projection after graph mutations."""
+    await refresh_user_blocked_status(user_id, db)
+    await db.commit()
+    await _invalidate_continuity_caches(user_id)
 
 
 def _to_response(rule: ContinuityRule) -> ContinuityRuleResponse:
@@ -268,7 +276,7 @@ async def create_continuity_rule(
             detail={"code": "continuity_rule_exists"},
         ) from exc
     await db.refresh(rule)
-    await _invalidate_continuity_caches(current_user.id)
+    await _refresh_blocked_state(current_user.id, db)
     return _to_response(await _get_owned_rule(db, current_user.id, rule.id))
 
 
@@ -330,7 +338,7 @@ async def update_continuity_rule(
             status_code=status.HTTP_409_CONFLICT,
             detail={"code": "continuity_rule_exists"},
         ) from exc
-    await _invalidate_continuity_caches(current_user.id)
+    await _refresh_blocked_state(current_user.id, db)
     return _to_response(await _get_owned_rule(db, current_user.id, rule_id))
 
 
@@ -362,5 +370,5 @@ async def delete_continuity_rule(
     rule = await _get_owned_rule(db, user_id, rule_id)
     await db.delete(rule)
     await db.commit()
-    await _invalidate_continuity_caches(user_id)
+    await _refresh_blocked_state(user_id, db)
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/api/dependency_group.py
+++ b/app/api/dependency_group.py
@@ -1,5 +1,7 @@
 """Authenticated API for user-owned named dependency groups."""
 
+import asyncio
+import logging
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
@@ -10,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.auth import get_current_user
+from app.cache import invalidate_cache
 from app.database import get_db
 from app.models import DependencyGroup, DependencyGroupMembership, Issue, Thread
 from app.models.user import User
@@ -23,7 +26,9 @@ from app.schemas.dependency_group import (
     DependencyGroupSummary,
     DependencyGroupUpdate,
 )
+from comic_pile.dependencies import refresh_user_blocked_status
 
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/reading-order-groups", tags=["reading-order-groups"])
 MAX_RANGE_SIZE = 250
 
@@ -33,6 +38,23 @@ def _normalize_name(name: str) -> str:
     if not normalized:
         raise HTTPException(status_code=422, detail="Group name must not be blank")
     return normalized
+
+
+async def _refresh_crossover_blocked_state(user_id: int, db: AsyncSession) -> None:
+    """Persist blocked-state changes and invalidate dependent read caches."""
+    await refresh_user_blocked_status(user_id, db)
+    await db.commit()
+    results = await asyncio.gather(
+        invalidate_cache(f"cache:continuity:*:User:{user_id}:*"),
+        invalidate_cache(f"cache:get_blocked_thread_ids:{user_id}:"),
+        invalidate_cache(f"cache:list_threads:User:{user_id}:*"),
+        invalidate_cache(f"cache:get_thread_blocking_info:*:User:{user_id}:"),
+        invalidate_cache(f"cache:get_threads_blocking_info:*:User:{user_id}:"),
+        return_exceptions=True,
+    )
+    for result in results:
+        if isinstance(result, BaseException):
+            logger.warning("Crossover cache invalidation failed", exc_info=result)
 
 
 async def _owned_group(db: AsyncSession, group_id: int, user_id: int) -> DependencyGroup:
@@ -223,6 +245,7 @@ async def delete_group(
     group = await _owned_group(db, group_id, current_user.id)
     await db.delete(group)
     await db.commit()
+    await _refresh_crossover_blocked_state(current_user.id, db)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
@@ -289,6 +312,7 @@ async def add_issue_range(
     )
     added_ids = list((await db.execute(statement)).scalars())
     await db.commit()
+    await _refresh_crossover_blocked_state(current_user.id, db)
     added_id_set = set(added_ids)
 
     return DependencyGroupIssueRangeResponse(
@@ -345,6 +369,7 @@ async def add_member(
         await db.rollback()
         raise HTTPException(status_code=409, detail="This member is already in the group") from exc
     await db.refresh(member)
+    await _refresh_crossover_blocked_state(current_user.id, db)
     return member
 
 
@@ -376,4 +401,5 @@ async def remove_member(
         raise HTTPException(status_code=404, detail=f"Member {member_id} not found")
     await db.delete(member)
     await db.commit()
+    await _refresh_crossover_blocked_state(current_user.id, db)
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/continuity_blocking.py
+++ b/app/continuity_blocking.py
@@ -1,0 +1,32 @@
+"""Unified continuity-derived blocked-state helpers."""
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.continuity_readiness import _issue_readiness, _load_snapshot
+
+
+async def get_continuity_blocked_thread_ids(
+    user_id: int,
+    db: AsyncSession,
+) -> set[int]:
+    """Return threads whose current unread issue is blocked by continuity rules.
+
+    The readiness graph is loaded once, then every owned thread is evaluated against
+    the same snapshot. This keeps Queue/Roll blocked-state refreshes bounded instead
+    of issuing one readiness query set per thread.
+
+    Args:
+        user_id: Authenticated thread owner.
+        db: Async database session.
+
+    Returns:
+        IDs of owned threads whose next unread issue has one or more unsatisfied
+        continuity blockers.
+    """
+    snapshot = await _load_snapshot(db, user_id)
+    blocked_thread_ids: set[int] = set()
+    for thread_id, thread in snapshot.threads.items():
+        issue_id = thread.next_unread_issue_id
+        if issue_id is not None and _issue_readiness(issue_id, snapshot):
+            blocked_thread_ids.add(thread_id)
+    return blocked_thread_ids

--- a/comic_pile/dependencies.py
+++ b/comic_pile/dependencies.py
@@ -6,13 +6,14 @@ from sqlalchemy import or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.cache import TTL, cached
+from app.continuity_blocking import get_continuity_blocked_thread_ids
 from app.models.dependency import Dependency
 from app.models.issue import Issue
 from app.models.thread import Thread
 
 
 async def _get_blocked_thread_ids_uncached(user_id: int, db: AsyncSession) -> set[int]:
-    """Read blocked thread IDs directly from the current database transaction."""
+    """Read unified blocked thread IDs directly from the current transaction."""
     source_issue = Issue.__table__.alias("source_issue")
     next_unread_issue = Issue.__table__.alias("next_unread_issue")
     target_thread = Thread.__table__.alias("target_thread")
@@ -33,7 +34,9 @@ async def _get_blocked_thread_ids_uncached(user_id: int, db: AsyncSession) -> se
         .where(target_thread.c.next_unread_issue_id.isnot(None))
         .distinct()
     )
-    return {row[0] for row in issue_result.all()}
+    legacy_blocked_ids = {row[0] for row in issue_result.all()}
+    continuity_blocked_ids = await get_continuity_blocked_thread_ids(user_id, db)
+    return legacy_blocked_ids | continuity_blocked_ids
 
 
 @cached(ttl=TTL.SHORT)
@@ -265,7 +268,7 @@ async def get_dependency_order_conflicts(
 
 
 async def update_thread_blocked_status(thread_id: int, user_id: int, db: AsyncSession) -> None:
-    """Recalculate one thread's denormalized blocked flag."""
+    """Recalculate one thread's denormalized blocked flag from the unified evaluator."""
     blocked_ids = await _get_blocked_thread_ids_uncached(user_id, db)
     await db.execute(
         update(Thread)
@@ -279,7 +282,7 @@ async def refresh_user_blocked_status(
     user_id: int,
     db: AsyncSession,
 ) -> dict[int, bool]:
-    """Recalculate blocked flags and return prior values that changed.
+    """Recalculate unified blocked flags and return prior values that changed.
 
     Args:
         user_id: Thread owner.

--- a/docs/MARKDOWN_INVENTORY.md
+++ b/docs/MARKDOWN_INVENTORY.md
@@ -94,6 +94,7 @@
 | docs/changelog.d/2026-08-08-917.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/2026-08-08-918.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/2026-08-08-919.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
+| docs/changelog.d/2026-08-08-920.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/README.md | Product changelog history or generated changelog fragment. | 2026-08-06 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.md | Product changelog history or generated changelog fragment. | 2026-08-06 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/frontend-backend-asset-coupling-audit.md | Repository documentation for frontend backend asset coupling audit. | 2026-07-11 | Human-facing narrative should move out of the active code-coupled documentation set unless linked by the docs hub. | move to Wiki | ComicPile Wiki |

--- a/docs/changelog.d/2026-08-08-920.md
+++ b/docs/changelog.d/2026-08-08-920.md
@@ -1,0 +1,4 @@
+## 2026-08-08
+
+### Continuity
+- [#920](https://github.com/JoshCLWren/comic-pile/pull/920) keeps Queue and Roll eligibility synchronized with continuity rules and crossover membership changes, so blocked comics update immediately as reading-order requirements change.

--- a/tests/test_continuity_blocked_state.py
+++ b/tests/test_continuity_blocked_state.py
@@ -1,0 +1,140 @@
+"""Regression coverage for the unified Queue/Roll blocked-state projection."""
+
+from datetime import UTC, datetime
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dependency import Dependency
+from app.models.issue import Issue
+from app.models.thread import Thread
+from comic_pile.dependencies import (
+    _get_blocked_thread_ids_uncached,
+    refresh_user_blocked_status,
+)
+from tests.conftest import get_or_create_user_async
+
+
+async def _make_thread_with_issue(
+    db: AsyncSession,
+    *,
+    user_id: int,
+    title: str,
+    queue_position: int,
+) -> tuple[Thread, Issue]:
+    """Create one active owned thread whose first issue is unread."""
+    thread = Thread(
+        title=title,
+        format="comic",
+        issues_remaining=1,
+        total_issues=1,
+        queue_position=queue_position,
+        status="active",
+        user_id=user_id,
+        reading_progress="unstarted",
+        created_at=datetime.now(UTC),
+    )
+    db.add(thread)
+    await db.flush()
+    issue = Issue(
+        thread_id=thread.id,
+        issue_number="1",
+        position=1,
+        status="unread",
+    )
+    db.add(issue)
+    await db.flush()
+    thread.next_unread_issue_id = issue.id
+    await db.flush()
+    return thread, issue
+
+
+@pytest.mark.asyncio
+async def test_continuity_rule_immediately_updates_denormalized_blocked_state(
+    auth_client: AsyncClient,
+    async_db: AsyncSession,
+) -> None:
+    """Creating a continuity rule immediately removes its target from Roll eligibility."""
+    user = await get_or_create_user_async(async_db)
+    source_thread, source_issue = await _make_thread_with_issue(
+        async_db,
+        user_id=user.id,
+        title="Continuity source",
+        queue_position=901,
+    )
+    target_thread, target_issue = await _make_thread_with_issue(
+        async_db,
+        user_id=user.id,
+        title="Continuity target",
+        queue_position=902,
+    )
+    await async_db.commit()
+
+    response = await auth_client.post(
+        "/api/v1/continuity-rules/",
+        json={
+            "source_type": "issue",
+            "source_id": source_issue.id,
+            "target_type": "issue",
+            "target_id": target_issue.id,
+            "satisfaction_type": "item_read",
+            "selected_member_issue_ids": [],
+        },
+    )
+    assert response.status_code == 201, response.text
+
+    await async_db.refresh(target_thread)
+    assert target_thread.is_blocked is True
+
+    readiness_response = await auth_client.post(
+        "/api/v1/continuity/readiness",
+        json={"node_type": "thread", "node_id": target_thread.id},
+    )
+    assert readiness_response.status_code == 200
+    assert readiness_response.json()["is_readable"] is False
+
+    source_issue.status = "read"
+    await async_db.flush()
+    changes = await refresh_user_blocked_status(user.id, async_db)
+    await async_db.commit()
+    await async_db.refresh(target_thread)
+
+    assert changes[target_thread.id] is True
+    assert target_thread.is_blocked is False
+    assert source_thread.is_blocked is False
+
+
+@pytest.mark.asyncio
+async def test_unified_blocked_ids_preserve_legacy_issue_dependencies(
+    async_db: AsyncSession,
+) -> None:
+    """Legacy issue dependencies and continuity rules contribute to one blocked set."""
+    user = await get_or_create_user_async(async_db)
+    _legacy_source_thread, legacy_source_issue = await _make_thread_with_issue(
+        async_db,
+        user_id=user.id,
+        title="Legacy source",
+        queue_position=911,
+    )
+    legacy_target_thread, legacy_target_issue = await _make_thread_with_issue(
+        async_db,
+        user_id=user.id,
+        title="Legacy target",
+        queue_position=912,
+    )
+    async_db.add(
+        Dependency(
+            source_issue_id=legacy_source_issue.id,
+            target_issue_id=legacy_target_issue.id,
+        )
+    )
+    await async_db.commit()
+
+    blocked_ids = await _get_blocked_thread_ids_uncached(user.id, async_db)
+    assert legacy_target_thread.id in blocked_ids
+
+    legacy_source_issue.status = "read"
+    await async_db.commit()
+    blocked_ids = await _get_blocked_thread_ids_uncached(user.id, async_db)
+    assert legacy_target_thread.id not in blocked_ids


### PR DESCRIPTION
Closes #847

## Summary
- keep `Thread.is_blocked` as the denormalized Queue/Roll projection, but derive it from both legacy issue dependencies and continuity readiness
- refresh that projection after continuity-rule and crossover-membership mutations
- invalidate continuity, blocked-thread, Queue, and blocking-info caches when the graph changes
- add regression coverage for immediate rule blocking, prerequisite completion, and legacy issue dependencies

## Validation
This runtime does not provide a repository checkout, so focused local tests could not be executed here. Required CI is the validation boundary for this branch.

Changelog: `docs/changelog.d/2026-08-08-920.md`.