### PR TITLE
Generate core frontend API contracts from OpenAPI

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -19,3 +19,15 @@ export type AuthUser = components['schemas']['UserResponse']
  * drifting from a handwritten copy.
  */
 export type AuthTokens = components['schemas']['TokenResponse']
+
+/** Core API contracts generated from FastAPI's OpenAPI document. */
+export type ThreadCreatePayload = components['schemas']['ThreadCreate']
+export type ThreadUpdatePayload = components['schemas']['ThreadUpdate']
+export type ReactivateThreadPayload = components['schemas']['ReactivateRequest']
+export type RatePayload = components['schemas']['RateRequest']
+export type OverrideRollPayload = components['schemas']['OverrideRequest']
+export type Issue = components['schemas']['IssueResponse']
+export type IssueListResponse = components['schemas']['IssueListResponse']
+export type Dependency = components['schemas']['DependencyResponse']
+export type ThreadDependenciesResponse = components['schemas']['ThreadDependenciesResponse']
+export type RollResponse = components['schemas']['RollResponse']

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -20,14 +20,13 @@ export type AuthUser = components['schemas']['UserResponse']
  */
 export type AuthTokens = components['schemas']['TokenResponse']
 
-/** Core API contracts generated from FastAPI's OpenAPI document. */
-export type ThreadCreatePayload = components['schemas']['ThreadCreate']
+/**
+ * Core contracts whose generated OpenAPI shapes already match the existing
+ * frontend call sites. Keep incompatible ergonomic types handwritten until the
+ * backend schema and frontend contract can be migrated together deliberately.
+ */
 export type ThreadUpdatePayload = components['schemas']['ThreadUpdate']
 export type ReactivateThreadPayload = components['schemas']['ReactivateRequest']
-export type RatePayload = components['schemas']['RateRequest']
 export type OverrideRollPayload = components['schemas']['OverrideRequest']
-export type Issue = components['schemas']['IssueResponse']
-export type IssueListResponse = components['schemas']['IssueListResponse']
 export type Dependency = components['schemas']['DependencyResponse']
 export type ThreadDependenciesResponse = components['schemas']['ThreadDependenciesResponse']
-export type RollResponse = components['schemas']['RollResponse']

--- a/frontend/src/unit/generated-core-api-contracts.test.ts
+++ b/frontend/src/unit/generated-core-api-contracts.test.ts
@@ -1,0 +1,35 @@
+import { describe, expectTypeOf, it } from 'vitest'
+
+import type { components } from '../generated/openapi'
+import type {
+  Dependency,
+  Issue,
+  IssueListResponse,
+  OverrideRollPayload,
+  RatePayload,
+  ReactivateThreadPayload,
+  RollResponse,
+  ThreadCreatePayload,
+  ThreadDependenciesResponse,
+  ThreadUpdatePayload,
+} from '../types'
+
+describe('generated core API contracts', () => {
+  it('exports mutation request types from OpenAPI', () => {
+    expectTypeOf<ThreadCreatePayload>().toEqualTypeOf<components['schemas']['ThreadCreate']>()
+    expectTypeOf<ThreadUpdatePayload>().toEqualTypeOf<components['schemas']['ThreadUpdate']>()
+    expectTypeOf<ReactivateThreadPayload>().toEqualTypeOf<components['schemas']['ReactivateRequest']>()
+    expectTypeOf<RatePayload>().toEqualTypeOf<components['schemas']['RateRequest']>()
+    expectTypeOf<OverrideRollPayload>().toEqualTypeOf<components['schemas']['OverrideRequest']>()
+  })
+
+  it('exports core response types from OpenAPI', () => {
+    expectTypeOf<Issue>().toEqualTypeOf<components['schemas']['IssueResponse']>()
+    expectTypeOf<IssueListResponse>().toEqualTypeOf<components['schemas']['IssueListResponse']>()
+    expectTypeOf<Dependency>().toEqualTypeOf<components['schemas']['DependencyResponse']>()
+    expectTypeOf<ThreadDependenciesResponse>().toEqualTypeOf<
+      components['schemas']['ThreadDependenciesResponse']
+    >()
+    expectTypeOf<RollResponse>().toEqualTypeOf<components['schemas']['RollResponse']>()
+  })
+})

--- a/frontend/src/unit/generated-core-api-contracts.test.ts
+++ b/frontend/src/unit/generated-core-api-contracts.test.ts
@@ -3,33 +3,23 @@ import { describe, expectTypeOf, it } from 'vitest'
 import type { components } from '../generated/openapi'
 import type {
   Dependency,
-  Issue,
-  IssueListResponse,
   OverrideRollPayload,
-  RatePayload,
   ReactivateThreadPayload,
-  RollResponse,
-  ThreadCreatePayload,
   ThreadDependenciesResponse,
   ThreadUpdatePayload,
 } from '../types'
 
 describe('generated core API contracts', () => {
-  it('exports mutation request types from OpenAPI', () => {
-    expectTypeOf<ThreadCreatePayload>().toEqualTypeOf<components['schemas']['ThreadCreate']>()
+  it('exports shape-compatible mutation request types from OpenAPI', () => {
     expectTypeOf<ThreadUpdatePayload>().toEqualTypeOf<components['schemas']['ThreadUpdate']>()
     expectTypeOf<ReactivateThreadPayload>().toEqualTypeOf<components['schemas']['ReactivateRequest']>()
-    expectTypeOf<RatePayload>().toEqualTypeOf<components['schemas']['RateRequest']>()
     expectTypeOf<OverrideRollPayload>().toEqualTypeOf<components['schemas']['OverrideRequest']>()
   })
 
-  it('exports core response types from OpenAPI', () => {
-    expectTypeOf<Issue>().toEqualTypeOf<components['schemas']['IssueResponse']>()
-    expectTypeOf<IssueListResponse>().toEqualTypeOf<components['schemas']['IssueListResponse']>()
+  it('exports shape-compatible dependency response types from OpenAPI', () => {
     expectTypeOf<Dependency>().toEqualTypeOf<components['schemas']['DependencyResponse']>()
     expectTypeOf<ThreadDependenciesResponse>().toEqualTypeOf<
       components['schemas']['ThreadDependenciesResponse']
     >()
-    expectTypeOf<RollResponse>().toEqualTypeOf<components['schemas']['RollResponse']>()
   })
 })


### PR DESCRIPTION
## Summary
- replace five public handwritten request/response contract exports with aliases to the generated FastAPI OpenAPI schemas
- keep the existing frontend type names so callers do not need a migration
- add compile-time Vitest coverage proving each public alias stays identical to its backend schema

## Validation
This runtime has no repository checkout, so required CI is the validation boundary for this branch.

Changelog: not user-facing

Refs #639

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Added shared type definitions for thread actions, ratings, roll overrides, issues, dependencies, and roll responses.
* **Tests**
  * Added contract checks to verify that frontend API types remain aligned with the documented API schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->