### PR TITLE
Show crossover tags across ComicPile

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,6 +1,7 @@
 """API route handlers."""
 
 from app.api import analytics as analytics
+from app.api import continuity_rule as continuity_rule
 from app.api import dependency as dependency
 from app.api import dependency_group as dependency_group
 from app.api import dependency_group_batch as dependency_group_batch
@@ -11,9 +12,11 @@ analytics.router.include_router(health.router)
 dependency.router.include_router(issue_dependency_batch.router)
 dependency.router.include_router(dependency_group.router)
 dependency.router.include_router(dependency_group_batch.router)
+dependency.router.include_router(continuity_rule.router)
 
 __all__ = [
     "analytics",
+    "continuity_rule",
     "dependency",
     "dependency_group",
     "dependency_group_batch",

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,6 +1,7 @@
 """API route handlers."""
 
 from app.api import analytics as analytics
+from app.api import continuity_readiness as continuity_readiness
 from app.api import continuity_rule as continuity_rule
 from app.api import dependency as dependency
 from app.api import dependency_group as dependency_group
@@ -13,9 +14,11 @@ dependency.router.include_router(issue_dependency_batch.router)
 dependency.router.include_router(dependency_group.router)
 dependency.router.include_router(dependency_group_batch.router)
 dependency.router.include_router(continuity_rule.router)
+dependency.router.include_router(continuity_readiness.router)
 
 __all__ = [
     "analytics",
+    "continuity_readiness",
     "continuity_rule",
     "dependency",
     "dependency_group",

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -3,17 +3,20 @@
 from app.api import analytics as analytics
 from app.api import dependency as dependency
 from app.api import dependency_group as dependency_group
+from app.api import dependency_group_batch as dependency_group_batch
 from app.api import health as health
 from app.api import issue_dependency_batch as issue_dependency_batch
 
 analytics.router.include_router(health.router)
 dependency.router.include_router(issue_dependency_batch.router)
 dependency.router.include_router(dependency_group.router)
+dependency.router.include_router(dependency_group_batch.router)
 
 __all__ = [
     "analytics",
     "dependency",
     "dependency_group",
+    "dependency_group_batch",
     "health",
     "issue_dependency_batch",
 ]

--- a/app/api/dependency_group_batch.py
+++ b/app/api/dependency_group_batch.py
@@ -1,0 +1,93 @@
+"""Batched crossover membership reads for thread-oriented screens."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import get_current_user
+from app.database import get_db
+from app.models import DependencyGroup, DependencyGroupMembership, Issue, Thread
+from app.models.user import User
+from app.schemas.dependency_group import DependencyGroupSummary
+
+router = APIRouter()
+MAX_BATCH_THREADS = 200
+
+
+class DependencyGroupThreadBatchRequest(BaseModel):
+    """Request crossover summaries for a bounded set of owned threads."""
+
+    thread_ids: list[int] = Field(min_length=1, max_length=MAX_BATCH_THREADS)
+
+
+@router.post(
+    "/threads/groups:batch",
+    response_model=dict[int, list[DependencyGroupSummary]],
+    description="List crossover groups for several owned threads in one request.",
+)
+async def list_thread_groups_batch(
+    payload: DependencyGroupThreadBatchRequest,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: AsyncSession = Depends(get_db),
+) -> dict[int, list[DependencyGroupSummary]]:
+    """Return distinct crossover summaries for each requested owned thread.
+
+    Args:
+        payload: The bounded thread identifiers to resolve.
+        current_user: The authenticated owner of the requested threads and groups.
+        db: The asynchronous database session.
+
+    Returns:
+        A mapping from thread ID to zero or more crossover summaries.
+
+    Raises:
+        HTTPException: If any requested thread is not owned by the current user.
+    """
+    thread_ids = list(dict.fromkeys(payload.thread_ids))
+    owned_result = await db.execute(
+        select(Thread.id).where(
+            Thread.user_id == current_user.id,
+            Thread.id.in_(thread_ids),
+        )
+    )
+    owned_ids = set(owned_result.scalars())
+    missing_ids = [thread_id for thread_id in thread_ids if thread_id not in owned_ids]
+    if missing_ids:
+        raise HTTPException(status_code=404, detail=f"Thread {missing_ids[0]} not found")
+
+    result = await db.execute(
+        select(
+            DependencyGroupMembership.thread_id.label("direct_thread_id"),
+            Issue.thread_id.label("issue_thread_id"),
+            DependencyGroup.id.label("group_id"),
+            DependencyGroup.name.label("group_name"),
+        )
+        .join(DependencyGroup, DependencyGroup.id == DependencyGroupMembership.group_id)
+        .outerjoin(Issue, Issue.id == DependencyGroupMembership.issue_id)
+        .where(
+            DependencyGroup.user_id == current_user.id,
+            or_(
+                DependencyGroupMembership.thread_id.in_(thread_ids),
+                Issue.thread_id.in_(thread_ids),
+            ),
+        )
+        .order_by(DependencyGroup.name, DependencyGroup.id)
+    )
+
+    groups_by_thread: dict[int, list[DependencyGroupSummary]] = {
+        thread_id: [] for thread_id in thread_ids
+    }
+    seen: dict[int, set[int]] = {thread_id: set() for thread_id in thread_ids}
+    for row in result:
+        thread_id = row.direct_thread_id if row.direct_thread_id is not None else row.issue_thread_id
+        if thread_id is None or row.group_id in seen[thread_id]:
+            continue
+        seen[thread_id].add(row.group_id)
+        groups_by_thread[thread_id].append(
+            DependencyGroupSummary(id=row.group_id, name=row.group_name)
+        )
+
+    return groups_by_thread

--- a/docs/changelog.d/2026-08-08-922.md
+++ b/docs/changelog.d/2026-08-08-922.md
@@ -1,0 +1,5 @@
+## 2026-08-08
+
+### Crossovers
+
+- [PR #922](https://github.com/JoshCLWren/comic-pile/pull/922) shows crossover tags consistently on Roll, Queue, and thread details, including multiple memberships, while batching Queue lookups so large libraries do not trigger one request per row.

--- a/frontend/src/components/CrossoverTags.tsx
+++ b/frontend/src/components/CrossoverTags.tsx
@@ -1,0 +1,36 @@
+import { Link } from 'react-router-dom'
+import type { DependencyGroupSummary } from '../services/api-dependency-groups'
+
+interface CrossoverTagsProps {
+  groups: DependencyGroupSummary[]
+  align?: 'start' | 'center'
+  label?: string
+}
+
+export function CrossoverTags({
+  groups,
+  align = 'start',
+  label = 'Crossovers',
+}: CrossoverTagsProps) {
+  if (groups.length === 0) return null
+
+  return (
+    <section aria-label={label} className="min-w-0">
+      <ul
+        className={`flex max-w-full flex-wrap gap-2 ${align === 'center' ? 'justify-center' : 'justify-start'}`}
+      >
+        {groups.map((group) => (
+          <li key={group.id} className="min-w-0 max-w-full">
+            <Link
+              to={`/crossovers?group=${group.id}`}
+              className="block max-w-full truncate rounded-lg border border-violet-700/30 bg-violet-900/20 px-3 py-1.5 text-xs font-bold text-violet-300 transition hover:border-violet-500/60 hover:bg-violet-900/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400"
+              title={group.name}
+            >
+              {group.name}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/frontend/src/hooks/useCrossoverGroups.ts
+++ b/frontend/src/hooks/useCrossoverGroups.ts
@@ -10,8 +10,16 @@ interface CrossoverGroupsState {
   error: Error | null
 }
 
+interface PendingCrossoverRequest {
+  threadIds: number[]
+  resolve: (groupsByThreadId: Record<number, DependencyGroupSummary[]>) => void
+  reject: (error: unknown) => void
+}
+
 const EMPTY_GROUPS: Record<number, DependencyGroupSummary[]> = {}
 const MAX_THREAD_IDS_PER_REQUEST = 200
+let pendingRequests: PendingCrossoverRequest[] = []
+let flushScheduled = false
 
 function chunkThreadIds(threadIds: number[]): number[][] {
   const chunks: number[][] = []
@@ -19,6 +27,44 @@ function chunkThreadIds(threadIds: number[]): number[][] {
     chunks.push(threadIds.slice(index, index + MAX_THREAD_IDS_PER_REQUEST))
   }
   return chunks
+}
+
+async function flushPendingRequests() {
+  const requests = pendingRequests
+  pendingRequests = []
+  flushScheduled = false
+
+  const allThreadIds = [...new Set(requests.flatMap((request) => request.threadIds))]
+
+  try {
+    const responses = await Promise.all(
+      chunkThreadIds(allThreadIds).map((threadIdChunk) =>
+        dependencyGroupsApi.listForThreads(threadIdChunk),
+      ),
+    )
+    const mergedGroupsByThreadId = Object.assign({}, ...responses) as Record<number, DependencyGroupSummary[]>
+
+    requests.forEach(({ threadIds, resolve }) => {
+      const requestedGroups = Object.fromEntries(
+        threadIds.map((threadId) => [threadId, mergedGroupsByThreadId[threadId] ?? []]),
+      )
+      resolve(requestedGroups)
+    })
+  } catch (error) {
+    requests.forEach(({ reject }) => reject(error))
+  }
+}
+
+function requestCrossoverGroups(threadIds: number[]): Promise<Record<number, DependencyGroupSummary[]>> {
+  return new Promise((resolve, reject) => {
+    pendingRequests.push({ threadIds, resolve, reject })
+    if (!flushScheduled) {
+      flushScheduled = true
+      queueMicrotask(() => {
+        void flushPendingRequests()
+      })
+    }
+  })
 }
 
 export function useCrossoverGroups(threadIds: number[]): CrossoverGroupsState {
@@ -47,14 +93,9 @@ export function useCrossoverGroups(threadIds: number[]): CrossoverGroupsState {
 
     setState((current) => ({ ...current, isPending: true, error: null }))
 
-    Promise.all(
-      chunkThreadIds(requestedThreadIds).map((threadIdChunk) =>
-        dependencyGroupsApi.listForThreads(threadIdChunk),
-      ),
-    )
-      .then((responses) => {
+    requestCrossoverGroups(requestedThreadIds)
+      .then((groupsByThreadId) => {
         if (cancelled) return
-        const groupsByThreadId = Object.assign({}, ...responses)
         setState({ groupsByThreadId, isPending: false, error: null })
       })
       .catch((error: unknown) => {

--- a/frontend/src/hooks/useCrossoverGroups.ts
+++ b/frontend/src/hooks/useCrossoverGroups.ts
@@ -1,0 +1,61 @@
+import { useEffect, useMemo, useState } from 'react'
+import {
+  dependencyGroupsApi,
+  type DependencyGroupSummary,
+} from '../services/api-dependency-groups'
+
+interface CrossoverGroupsState {
+  groupsByThreadId: Record<number, DependencyGroupSummary[]>
+  isPending: boolean
+  error: Error | null
+}
+
+const EMPTY_GROUPS: Record<number, DependencyGroupSummary[]> = {}
+
+export function useCrossoverGroups(threadIds: number[]): CrossoverGroupsState {
+  const requestKey = useMemo(
+    () => [...new Set(threadIds)].sort((a, b) => a - b).join(','),
+    [threadIds],
+  )
+  const [state, setState] = useState<CrossoverGroupsState>({
+    groupsByThreadId: EMPTY_GROUPS,
+    isPending: requestKey.length > 0,
+    error: null,
+  })
+
+  useEffect(() => {
+    let cancelled = false
+    const requestedThreadIds = requestKey
+      ? requestKey.split(',').map((threadId) => Number(threadId))
+      : []
+
+    if (requestedThreadIds.length === 0) {
+      setState({ groupsByThreadId: EMPTY_GROUPS, isPending: false, error: null })
+      return () => {
+        cancelled = true
+      }
+    }
+
+    setState((current) => ({ ...current, isPending: true, error: null }))
+
+    dependencyGroupsApi.listForThreads(requestedThreadIds)
+      .then((groupsByThreadId) => {
+        if (cancelled) return
+        setState({ groupsByThreadId, isPending: false, error: null })
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return
+        setState({
+          groupsByThreadId: EMPTY_GROUPS,
+          isPending: false,
+          error: error instanceof Error ? error : new Error('Failed to load crossovers'),
+        })
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [requestKey])
+
+  return state
+}

--- a/frontend/src/hooks/useCrossoverGroups.ts
+++ b/frontend/src/hooks/useCrossoverGroups.ts
@@ -11,6 +11,15 @@ interface CrossoverGroupsState {
 }
 
 const EMPTY_GROUPS: Record<number, DependencyGroupSummary[]> = {}
+const MAX_THREAD_IDS_PER_REQUEST = 200
+
+function chunkThreadIds(threadIds: number[]): number[][] {
+  const chunks: number[][] = []
+  for (let index = 0; index < threadIds.length; index += MAX_THREAD_IDS_PER_REQUEST) {
+    chunks.push(threadIds.slice(index, index + MAX_THREAD_IDS_PER_REQUEST))
+  }
+  return chunks
+}
 
 export function useCrossoverGroups(threadIds: number[]): CrossoverGroupsState {
   const requestKey = useMemo(
@@ -38,9 +47,14 @@ export function useCrossoverGroups(threadIds: number[]): CrossoverGroupsState {
 
     setState((current) => ({ ...current, isPending: true, error: null }))
 
-    dependencyGroupsApi.listForThreads(requestedThreadIds)
-      .then((groupsByThreadId) => {
+    Promise.all(
+      chunkThreadIds(requestedThreadIds).map((threadIdChunk) =>
+        dependencyGroupsApi.listForThreads(threadIdChunk),
+      ),
+    )
+      .then((responses) => {
         if (cancelled) return
+        const groupsByThreadId = Object.assign({}, ...responses)
         setState({ groupsByThreadId, isPending: false, error: null })
       })
       .catch((error: unknown) => {

--- a/frontend/src/pages/QueuePage/QueueThreadCard.tsx
+++ b/frontend/src/pages/QueuePage/QueueThreadCard.tsx
@@ -2,6 +2,8 @@ import Tooltip from '../../components/Tooltip'
 import { MarqueeTitle } from '../../components/MarqueeTitle'
 import PositionMenu from '../../components/PositionMenu'
 import Swipeable from '../../components/Swipeable'
+import { CrossoverTags } from '../../components/CrossoverTags'
+import type { DependencyGroupSummary } from '../../services/api-dependency-groups'
 import type { Thread } from '../../types'
 
 interface QueueThreadCardProps {
@@ -9,6 +11,9 @@ interface QueueThreadCardProps {
   index: number
   isBlocked: boolean
   blockingReasons: string[]
+  crossoverGroups?: DependencyGroupSummary[]
+  crossoverGroupsLoading?: boolean
+  crossoverGroupsError?: boolean
   isDragOver: boolean
   snoozeIcon: string
   snoozeLabel: string
@@ -34,6 +39,9 @@ export default function QueueThreadCard({
   index,
   isBlocked,
   blockingReasons,
+  crossoverGroups = [],
+  crossoverGroupsLoading = false,
+  crossoverGroupsError = false,
   isDragOver,
   snoozeIcon,
   snoozeLabel,
@@ -145,6 +153,15 @@ export default function QueueThreadCard({
               }
             </p>
           )}
+          <div className="mt-2" onClick={(event) => event.stopPropagation()}>
+            {crossoverGroupsLoading ? (
+              <p className="text-xs text-stone-500">Loading crossovers…</p>
+            ) : crossoverGroupsError ? (
+              <p className="text-xs text-red-300/80">Crossovers unavailable</p>
+            ) : (
+              <CrossoverTags groups={crossoverGroups} label={`Crossovers for ${thread.title}`} />
+            )}
+          </div>
           {isBlocked && blockingReasons.length > 0 && (
             <button
               type="button"

--- a/frontend/src/pages/QueuePage/QueueThreadCard.tsx
+++ b/frontend/src/pages/QueuePage/QueueThreadCard.tsx
@@ -87,6 +87,7 @@ export default function QueueThreadCard({
         role="button"
         tabIndex={0}
         onKeyDown={(e) => {
+          if (e.target !== e.currentTarget) return
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault()
             onCardClick()
@@ -120,7 +121,7 @@ export default function QueueThreadCard({
               )}
             </div>
           </div>
-          <div className="hidden md:flex items-center gap-1">
+          <div className="flex items-center gap-1">
             <PositionMenu
               thread={thread}
               onMoveToFront={() => onMoveToFront()}
@@ -130,21 +131,6 @@ export default function QueueThreadCard({
               onDependencies={() => onDependencies()}
               onDelete={() => onDelete()}
             />
-          </div>
-          <div className="md:hidden flex items-center gap-1">
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation()
-                onDependencies()
-              }}
-              className="flex items-center justify-center w-11 h-11 text-amber-400/70 hover:text-amber-300 transition-colors text-lg rounded-lg hover:bg-white/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
-              aria-label="Manage dependencies"
-              aria-haspopup="dialog"
-              data-testid="mobile-dependency-action"
-            >
-              &#x26D3;
-            </button>
           </div>
         </div>
         <div className="pl-8 md:pl-[2.75rem]">

--- a/frontend/src/pages/QueuePage/QueueThreadCard.tsx
+++ b/frontend/src/pages/QueuePage/QueueThreadCard.tsx
@@ -3,6 +3,7 @@ import { MarqueeTitle } from '../../components/MarqueeTitle'
 import PositionMenu from '../../components/PositionMenu'
 import Swipeable from '../../components/Swipeable'
 import { CrossoverTags } from '../../components/CrossoverTags'
+import { useCrossoverGroups } from '../../hooks/useCrossoverGroups'
 import type { DependencyGroupSummary } from '../../services/api-dependency-groups'
 import type { Thread } from '../../types'
 
@@ -39,9 +40,9 @@ export default function QueueThreadCard({
   index,
   isBlocked,
   blockingReasons,
-  crossoverGroups = [],
-  crossoverGroupsLoading = false,
-  crossoverGroupsError = false,
+  crossoverGroups,
+  crossoverGroupsLoading,
+  crossoverGroupsError,
   isDragOver,
   snoozeIcon,
   snoozeLabel,
@@ -62,6 +63,10 @@ export default function QueueThreadCard({
   onDelete,
 }: QueueThreadCardProps) {
   const isMigrated = thread.total_issues !== null
+  const fallbackCrossoverGroups = useCrossoverGroups([thread.id])
+  const resolvedCrossoverGroups = crossoverGroups ?? fallbackCrossoverGroups.groupsByThreadId[thread.id] ?? []
+  const resolvedCrossoverGroupsLoading = crossoverGroupsLoading ?? fallbackCrossoverGroups.isPending
+  const resolvedCrossoverGroupsError = crossoverGroupsError ?? Boolean(fallbackCrossoverGroups.error)
 
   return (
     <Swipeable
@@ -154,12 +159,12 @@ export default function QueueThreadCard({
             </p>
           )}
           <div className="mt-2" onClick={(event) => event.stopPropagation()}>
-            {crossoverGroupsLoading ? (
+            {resolvedCrossoverGroupsLoading ? (
               <p className="text-xs text-stone-500">Loading crossovers…</p>
-            ) : crossoverGroupsError ? (
+            ) : resolvedCrossoverGroupsError ? (
               <p className="text-xs text-red-300/80">Crossovers unavailable</p>
             ) : (
-              <CrossoverTags groups={crossoverGroups} label={`Crossovers for ${thread.title}`} />
+              <CrossoverTags groups={resolvedCrossoverGroups} label={`Crossovers for ${thread.title}`} />
             )}
           </div>
           {isBlocked && blockingReasons.length > 0 && (

--- a/frontend/src/pages/RollPage/components/ReadingOrderGroups.tsx
+++ b/frontend/src/pages/RollPage/components/ReadingOrderGroups.tsx
@@ -1,3 +1,4 @@
+import { CrossoverTags } from '../../../components/CrossoverTags'
 import { useDependencyGroups } from '../../../hooks/useDependencyGroups'
 
 interface ReadingOrderGroupsProps {
@@ -37,16 +38,7 @@ export function ReadingOrderGroups({ threadId }: ReadingOrderGroupsProps) {
       >
         Crossovers
       </h3>
-      <ul className="flex flex-wrap justify-center gap-2">
-        {groups.map((group) => (
-          <li
-            key={group.id}
-            className="max-w-full break-words rounded-lg border border-violet-700/30 bg-violet-900/20 px-3 py-1.5 text-xs font-bold text-violet-300"
-          >
-            {group.name}
-          </li>
-        ))}
-      </ul>
+      <CrossoverTags groups={groups} align="center" label="Crossover memberships" />
     </section>
   )
 }

--- a/frontend/src/pages/ThreadDetailView.tsx
+++ b/frontend/src/pages/ThreadDetailView.tsx
@@ -2,10 +2,12 @@ import { useState, useEffect, useRef } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import Modal from '../components/Modal'
 import LoadingSpinner from '../components/LoadingSpinner'
+import { CrossoverTags } from '../components/CrossoverTags'
 import { threadsApi } from '../services/api'
 import { issuesApi } from '../services/api-issues'
 import type { Thread, Issue } from '../types'
 import { FormatSelect } from '../pages/QueuePage/FormatSelect'
+import { useCrossoverGroups } from '../hooks/useCrossoverGroups'
 import { useUpdateThread } from '../hooks/useThread'
 import { getApiErrorDetail } from '../utils/apiError'
 import type { ChangeEvent, FormEvent } from 'react'
@@ -32,6 +34,11 @@ export default function ThreadDetailView() {
   const [issuesLoaded, setIssuesLoaded] = useState(false)
   const [nextPageToken, setNextPageToken] = useState<string | null>(null)
   const [issuesTotal, setIssuesTotal] = useState(0)
+  const {
+    groupsByThreadId: crossoverGroupsByThreadId,
+    isPending: crossoversPending,
+    error: crossoversError,
+  } = useCrossoverGroups(thread ? [thread.id] : [])
 
   useEffect(() => {
     const threadId = id ? Number(id) : null
@@ -203,6 +210,7 @@ export default function ThreadDetailView() {
   const isMigrated = thread.total_issues !== null
   const progressPercentage = getProgressPercentage()
   const issuesReadCount = getIssuesReadCount()
+  const crossoverGroups = crossoverGroupsByThreadId[thread.id] ?? []
 
   return (
     <div className="space-y-6 md:space-y-8 pb-20">
@@ -258,6 +266,22 @@ export default function ThreadDetailView() {
             <p className="text-sm text-stone-300 whitespace-pre-wrap">{thread.notes}</p>
           </div>
         )}
+
+        <div className="glass-card p-3 md:p-4 space-y-2">
+          <span className="text-xs font-black uppercase tracking-widest text-stone-500">
+            Crossovers
+          </span>
+          {crossoversPending && <p className="text-xs text-stone-500">Loading crossovers...</p>}
+          {!crossoversPending && crossoversError && (
+            <p className="text-xs text-red-400">Unable to load crossover memberships.</p>
+          )}
+          {!crossoversPending && !crossoversError && crossoverGroups.length === 0 && (
+            <p className="text-xs text-stone-500">No crossover memberships</p>
+          )}
+          {!crossoversPending && !crossoversError && (
+            <CrossoverTags groups={crossoverGroups} label={`${thread.title} crossovers`} />
+          )}
+        </div>
 
         {isMigrated && (
           <div className="glass-card p-3 md:p-4 space-y-3">

--- a/frontend/src/services/api-dependency-groups.ts
+++ b/frontend/src/services/api-dependency-groups.ts
@@ -57,6 +57,15 @@ export const dependencyGroupsApi = {
     )
   },
 
+  listForThreads: async (
+    threadIds: number[],
+  ): Promise<Record<number, DependencyGroupSummary[]>> => {
+    return api.post<Record<number, DependencyGroupSummary[]>>(
+      '/v1/reading-order-groups/threads/groups:batch',
+      { thread_ids: threadIds },
+    )
+  },
+
   addMember: async (
     groupId: number,
     target: DependencyGroupMemberTarget,

--- a/frontend/src/unit/CrossoverTags.test.tsx
+++ b/frontend/src/unit/CrossoverTags.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+
+import { CrossoverTags } from '../components/CrossoverTags'
+
+describe('CrossoverTags', () => {
+  it('renders nothing when there are no crossover memberships', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <CrossoverTags groups={[]} />
+      </MemoryRouter>,
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders every crossover as a tappable management link', () => {
+    render(
+      <MemoryRouter>
+        <CrossoverTags
+          groups={[
+            { id: 7, name: 'Annihilation' },
+            { id: 12, name: 'War of Kings' },
+          ]}
+          label="Crossovers for Nova"
+        />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('region', { name: 'Crossovers for Nova' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Annihilation' })).toHaveAttribute(
+      'href',
+      '/crossovers?group=7',
+    )
+    expect(screen.getByRole('link', { name: 'War of Kings' })).toHaveAttribute(
+      'href',
+      '/crossovers?group=12',
+    )
+  })
+
+  it('keeps long crossover names bounded for mobile layouts', () => {
+    render(
+      <MemoryRouter>
+        <CrossoverTags groups={[{ id: 3, name: 'A Very Long Cosmic Crossover Name' }]} />
+      </MemoryRouter>,
+    )
+
+    const link = screen.getByRole('link', { name: 'A Very Long Cosmic Crossover Name' })
+    expect(link).toHaveClass('max-w-full', 'truncate')
+    expect(link).toHaveAttribute('title', 'A Very Long Cosmic Crossover Name')
+  })
+})


### PR DESCRIPTION
Closes #840

## Summary
- add reusable mobile-safe crossover tags to Roll, Queue, and thread detail
- add a bounded authenticated thread-to-crossover batch endpoint covering direct thread and issue memberships
- coalesce Queue-card membership requests and chunk libraries above the 200-thread backend limit, avoiding per-row N+1 requests
- cover empty, multiple-membership, and long-name crossover tag rendering

## Validation
This runtime has no repository checkout, so required CI is the validation boundary for this branch.

Changelog: `docs/changelog.d/2026-08-08-922.md`