### PR TITLE
Replay bounded cache generation core onto current main

### DIFF
--- a/app/cache_generation.py
+++ b/app/cache_generation.py
@@ -9,31 +9,52 @@ from __future__ import annotations
 
 import functools
 import inspect
+import json
 import logging
 from collections import Counter
-from collections.abc import Awaitable, Callable, Iterable
+from collections.abc import Awaitable, Callable, Iterable, Mapping
 from dataclasses import dataclass, field
-from typing import Any, Protocol, TypeVar, cast
+from typing import ParamSpec, Protocol, TypeVar, cast
 
-from app.cache import TTL, _generate_cache_key, _get_ttl_value, cache
+from app.cache import TTL, UpstashCache, _generate_cache_key, _get_ttl_value, cache
 
 logger = logging.getLogger(__name__)
 
+P = ParamSpec("P")
 T = TypeVar("T")
 
 _GENERATION_PREFIX = "cache:generation:user"
 _VALUE_PREFIX = "cache:user"
+_ATOMIC_GENERATION_READ_SCRIPT = """
+local generation = redis.call('GET', KEYS[1]) or '0'
+local value_key = ARGV[1] .. generation .. ':' .. ARGV[2]
+return {generation, redis.call('GET', value_key)}
+""".strip()
 
 
 class GenerationCacheClient(Protocol):
     """Minimal async Redis contract used by generation operations."""
 
     def get(self, key: str) -> Awaitable[str | int | None]:
-        """Return a generation counter value."""
+        """Return a generation counter value.
+
+        Args:
+            key: Redis generation-counter key.
+
+        Returns:
+            Stored generation value, or ``None`` when the key does not exist.
+        """
         ...
 
     def incr(self, key: str) -> Awaitable[int]:
-        """Increment and return a generation counter value."""
+        """Increment and return a generation counter value.
+
+        Args:
+            key: Redis generation-counter key.
+
+        Returns:
+            Newly incremented generation value.
+        """
         ...
 
 
@@ -50,6 +71,9 @@ class CacheCommandBudget:
             command: Logical cache command name such as ``get`` or ``invalidate``.
             count: Number of commands represented by this operation.
 
+        Returns:
+            ``None``.
+
         Raises:
             ValueError: If ``count`` is negative.
         """
@@ -60,7 +84,11 @@ class CacheCommandBudget:
 
     @property
     def total(self) -> int:
-        """Return the total recorded command count."""
+        """Return the total recorded command count.
+
+        Returns:
+            Sum of all recorded remote cache commands.
+        """
         return sum(self.counts.values())
 
 
@@ -125,8 +153,9 @@ async def get_user_generation(client: GenerationCacheClient, user_id: int) -> in
     Raises:
         ValueError: If Redis returns an invalid generation value.
     """
+    key = generation_key(user_id)
     command_budget.record("generation_get")
-    raw_generation = await client.get(generation_key(user_id))
+    raw_generation = await client.get(key)
     if raw_generation is None:
         return 0
 
@@ -156,8 +185,9 @@ async def bump_user_generation(client: GenerationCacheClient, user_id: int) -> i
     Raises:
         ValueError: If Redis returns an invalid generation value.
     """
+    key = generation_key(user_id)
     command_budget.record("generation_incr")
-    raw_generation = await client.incr(generation_key(user_id))
+    raw_generation = await client.incr(key)
     try:
         generation = int(raw_generation)
     except (TypeError, ValueError) as exc:
@@ -223,7 +253,7 @@ async def invalidate_user_caches(user_ids: Iterable[int]) -> int:
     return invalidated
 
 
-def user_id_from_arguments(arguments: dict[str, Any]) -> int | None:
+def user_id_from_arguments(arguments: Mapping[str, object]) -> int | None:
     """Extract a user identifier from bound cached-function arguments.
 
     Cached functions currently receive ownership either as an explicit ``user_id``
@@ -249,24 +279,91 @@ def user_id_from_arguments(arguments: dict[str, Any]) -> int | None:
     return None
 
 
+def _decode_generation(raw_generation: object) -> int:
+    """Validate a generation returned from an atomic cache read."""
+    try:
+        generation = int(cast(str | int, raw_generation))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Cache generation must be an integer") from exc
+    if generation < 0:
+        raise ValueError("Cache generation cannot be negative")
+    return generation
+
+
+async def _atomic_generation_value_get(
+    user_id: int,
+    logical_key: str,
+) -> tuple[int, object | None]:
+    """Read the active generation and matching cached value atomically.
+
+    Args:
+        user_id: Authenticated user identifier.
+        logical_key: Existing logical cache key.
+
+    Returns:
+        Active generation and reconstructed cached value, if present.
+
+    Raises:
+        RuntimeError: If no cache client is configured.
+        ValueError: If Redis returns an invalid generation value.
+    """
+    client = cache._client
+    if client is None:
+        raise RuntimeError("Cache client is unavailable")
+
+    key = generation_key(user_id)
+    normalized = logical_key.removeprefix("cache:")
+    value_prefix = f"{_VALUE_PREFIX}:{user_id}:g"
+    if cache._is_upstash:
+        raw = await client.eval(
+            _ATOMIC_GENERATION_READ_SCRIPT,
+            keys=[key],
+            args=[value_prefix, normalized],
+        )
+    else:
+        raw = await client.eval(
+            _ATOMIC_GENERATION_READ_SCRIPT,
+            1,
+            key,
+            value_prefix,
+            normalized,
+        )
+
+    command_budget.record("generation_value_get")
+    if not isinstance(raw, (list, tuple)) or len(raw) != 2:
+        raise ValueError("Atomic cache read returned an invalid response")
+
+    generation = _decode_generation(raw[0])
+    raw_value = raw[1]
+    if raw_value is None:
+        return generation, None
+
+    if isinstance(raw_value, bytes):
+        serialized = raw_value.decode()
+    elif isinstance(raw_value, str):
+        serialized = raw_value
+    else:
+        raise ValueError("Cached value must be JSON text")
+
+    return generation, UpstashCache._reconstruct_value(json.loads(serialized))
+
+
 def generation_cached(
     ttl: int | TTL = TTL.MEDIUM,
     *,
     falsy_ttl: int | None = None,
-) -> Callable[[Callable[..., Awaitable[T]]], Callable[..., Awaitable[T]]]:
-    """Cache a user-scoped async function behind one generation lookup.
+) -> Callable[[Callable[P, Awaitable[T]]], Callable[P, Awaitable[T]]]:
+    """Cache a user-scoped async function behind one atomic generation lookup.
 
     The decorator deliberately bypasses caching when it cannot resolve a positive
     user identifier. That keeps ownership explicit and prevents a supposedly
     user-scoped cache entry from falling back to a shared key.
 
-    A cache hit costs at most two remote commands: one generation ``GET`` and one
-    value ``GET``. A cache miss that is stored costs at most three: generation
-    ``GET``, value ``GET``, and value ``SET``.
+    A cache hit costs one remote command. A cache miss that is stored costs at most
+    two: one atomic generation/value read and one value ``SET``.
 
-    Cache failures are fail-open: if the generation lookup fails, the wrapped
-    database read still executes instead of turning optional Redis into a request
-    dependency.
+    Cache failures are fail-open: if the atomic lookup fails, the wrapped database
+    read still executes instead of turning optional Redis into a request dependency.
 
     Args:
         ttl: Time-to-live in seconds or a configured TTL tier.
@@ -276,12 +373,12 @@ def generation_cached(
         Decorator for an async cached function.
     """
 
-    def decorator(func: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]:
+    def decorator(func: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
         actual_ttl = _get_ttl_value(ttl) if isinstance(ttl, TTL) else ttl
         signature = inspect.signature(func)
 
         @functools.wraps(func)
-        async def wrapper(*args: Any, **kwargs: Any) -> T:
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             if not cache.is_initialized:
                 return await func(*args, **kwargs)
 
@@ -290,36 +387,33 @@ def generation_cached(
             except TypeError:
                 return await func(*args, **kwargs)
 
-            user_id = user_id_from_arguments(dict(bound.arguments))
-            if user_id is None:
-                return await func(*args, **kwargs)
-
-            client = cache._client
-            if client is None:
-                return await func(*args, **kwargs)
-
-            try:
-                generation = await get_user_generation(client, user_id)
-            except Exception as exc:
-                logger.warning("Cache generation read failed: %s", exc)
+            user_id = user_id_from_arguments(bound.arguments)
+            if user_id is None or cache._client is None:
                 return await func(*args, **kwargs)
 
             func_name = getattr(func, "__name__", func.__class__.__name__)
             logical_key = _generate_cache_key(func_name, func, args, kwargs)
-            cache_key = namespaced_cache_key(user_id, generation, logical_key)
 
-            command_budget.record("value_get")
-            cached_value = await cache.get(cache_key)
+            try:
+                generation, cached_value = await _atomic_generation_value_get(
+                    user_id,
+                    logical_key,
+                )
+            except Exception as exc:
+                logger.warning("Atomic cache read failed: %s", exc)
+                return await func(*args, **kwargs)
+
             if cached_value is not None:
                 return cast(T, cached_value)
 
             result = await func(*args, **kwargs)
             effective_ttl = falsy_ttl if falsy_ttl is not None and not result else actual_ttl
             if result or falsy_ttl is not None:
+                cache_key = namespaced_cache_key(user_id, generation, logical_key)
                 command_budget.record("value_set")
                 await cache.set(cache_key, result, ttl=effective_ttl)
             return result
 
-        return cast(Callable[..., Awaitable[T]], wrapper)
+        return wrapper
 
     return decorator

--- a/app/cache_generation.py
+++ b/app/cache_generation.py
@@ -1,0 +1,325 @@
+"""Bounded user-scoped cache generation primitives.
+
+The remote cache can be invalidated without scanning Redis by storing one generation
+counter per user. Cached values include the current generation in their key, and a
+mutation invalidates every prior value for that user with one ``INCR`` command.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import logging
+from collections import Counter
+from collections.abc import Awaitable, Callable, Iterable
+from dataclasses import dataclass, field
+from typing import Any, Protocol, TypeVar, cast
+
+from app.cache import TTL, _generate_cache_key, _get_ttl_value, cache
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+_GENERATION_PREFIX = "cache:generation:user"
+_VALUE_PREFIX = "cache:user"
+
+
+class GenerationCacheClient(Protocol):
+    """Minimal async Redis contract used by generation operations."""
+
+    def get(self, key: str) -> Awaitable[str | int | None]:
+        """Return a generation counter value."""
+        ...
+
+    def incr(self, key: str) -> Awaitable[int]:
+        """Increment and return a generation counter value."""
+        ...
+
+
+@dataclass(slots=True)
+class CacheCommandBudget:
+    """Track cache command counts without recording keys or user data."""
+
+    counts: Counter[str] = field(default_factory=Counter)
+
+    def record(self, command: str, count: int = 1) -> None:
+        """Record cache commands for bounded-budget diagnostics.
+
+        Args:
+            command: Logical cache command name such as ``get`` or ``invalidate``.
+            count: Number of commands represented by this operation.
+
+        Raises:
+            ValueError: If ``count`` is negative.
+        """
+        if count < 0:
+            raise ValueError("Cache command count cannot be negative")
+        self.counts[command] += count
+        logger.debug("cache_command command=%s count=%d", command, count)
+
+    @property
+    def total(self) -> int:
+        """Return the total recorded command count."""
+        return sum(self.counts.values())
+
+
+command_budget = CacheCommandBudget()
+
+
+def generation_key(user_id: int) -> str:
+    """Return the deterministic generation-counter key for a user.
+
+    Args:
+        user_id: Authenticated user identifier.
+
+    Returns:
+        Redis key containing only the numeric user identifier.
+
+    Raises:
+        ValueError: If ``user_id`` is not positive.
+    """
+    if user_id <= 0:
+        raise ValueError("user_id must be positive")
+    return f"{_GENERATION_PREFIX}:{user_id}"
+
+
+def namespaced_cache_key(user_id: int, generation: int, logical_key: str) -> str:
+    """Build a user-scoped cache key for one generation.
+
+    Args:
+        user_id: Authenticated user identifier.
+        generation: Current user cache generation.
+        logical_key: Existing logical cache key.
+
+    Returns:
+        User- and generation-scoped cache key.
+
+    Raises:
+        ValueError: If identifiers are invalid or the logical key is empty.
+    """
+    if user_id <= 0:
+        raise ValueError("user_id must be positive")
+    if generation < 0:
+        raise ValueError("generation cannot be negative")
+    if not logical_key:
+        raise ValueError("logical_key cannot be empty")
+
+    normalized = logical_key.removeprefix("cache:")
+    return f"{_VALUE_PREFIX}:{user_id}:g{generation}:{normalized}"
+
+
+async def get_user_generation(client: GenerationCacheClient, user_id: int) -> int:
+    """Read one user's current cache generation with exactly one cache command.
+
+    A missing generation means the user has never invalidated a generation-scoped
+    value, so generation zero is valid without an initialization write.
+
+    Args:
+        client: Async Redis-compatible generation client.
+        user_id: Authenticated user identifier.
+
+    Returns:
+        Current non-negative generation, defaulting to zero when no counter exists.
+
+    Raises:
+        ValueError: If Redis returns an invalid generation value.
+    """
+    command_budget.record("generation_get")
+    raw_generation = await client.get(generation_key(user_id))
+    if raw_generation is None:
+        return 0
+
+    try:
+        generation = int(raw_generation)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Cache generation must be an integer") from exc
+    if generation < 0:
+        raise ValueError("Cache generation cannot be negative")
+    return generation
+
+
+async def bump_user_generation(client: GenerationCacheClient, user_id: int) -> int:
+    """Invalidate all cached values for one user with exactly one cache command.
+
+    Existing value keys are left to expire naturally. Incrementing the generation
+    makes them unreachable immediately across every application instance without a
+    wildcard scan, key inventory, or repeated logical-family deletion.
+
+    Args:
+        client: Async Redis-compatible generation client.
+        user_id: Authenticated user identifier.
+
+    Returns:
+        Newly active positive generation.
+
+    Raises:
+        ValueError: If Redis returns an invalid generation value.
+    """
+    command_budget.record("generation_incr")
+    raw_generation = await client.incr(generation_key(user_id))
+    try:
+        generation = int(raw_generation)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Cache generation must be an integer") from exc
+    if generation <= 0:
+        raise ValueError("Incremented cache generation must be positive")
+    return generation
+
+
+async def invalidate_user_cache(user_id: int) -> bool:
+    """Invalidate every generation-scoped cached value for one user.
+
+    The production entrypoint is deliberately a no-op while remote caching is
+    disabled. When caching is configured, one successful call performs exactly one
+    Redis ``INCR`` through :func:`bump_user_generation`; old value keys expire by
+    TTL and are never scanned or deleted individually.
+
+    Args:
+        user_id: Authenticated user identifier whose cached views became stale.
+
+    Returns:
+        ``True`` when the generation was bumped, otherwise ``False`` when caching
+        is unavailable or the cache command fails.
+    """
+    if not cache.is_initialized or cache._client is None:
+        return False
+
+    try:
+        await bump_user_generation(cache._client, user_id)
+    except Exception as exc:
+        logger.warning("Cache generation invalidation failed: %s", exc)
+        return False
+    return True
+
+
+async def invalidate_user_caches(user_ids: Iterable[int]) -> int:
+    """Invalidate each distinct user namespace at most once.
+
+    Mutation helpers can overlap in the logical cache families they invalidate.
+    Collapsing user IDs before issuing generation bumps prevents nested helpers from
+    multiplying remote commands while preserving cross-user correctness.
+
+    Args:
+        user_ids: User identifiers whose cached views became stale.
+
+    Returns:
+        Number of user namespaces successfully invalidated.
+    """
+    distinct_user_ids = sorted(set(user_ids))
+    if not distinct_user_ids or not cache.is_initialized or cache._client is None:
+        return 0
+
+    invalidated = 0
+    for user_id in distinct_user_ids:
+        if user_id <= 0:
+            raise ValueError("user_id must be positive")
+        try:
+            await bump_user_generation(cache._client, user_id)
+        except Exception as exc:
+            logger.warning("Cache generation invalidation failed: %s", exc)
+            continue
+        invalidated += 1
+    return invalidated
+
+
+def user_id_from_arguments(arguments: dict[str, Any]) -> int | None:
+    """Extract a user identifier from bound cached-function arguments.
+
+    Cached functions currently receive ownership either as an explicit ``user_id``
+    integer or as a user model-like object. Keeping this resolution in one place
+    lets the decorator add user-scoped generations without logging or serializing
+    the user object.
+
+    Args:
+        arguments: Arguments produced by ``inspect.Signature.bind_partial``.
+
+    Returns:
+        Positive user identifier when one can be resolved, otherwise ``None``.
+    """
+    explicit_user_id = arguments.get("user_id")
+    if isinstance(explicit_user_id, int) and explicit_user_id > 0:
+        return explicit_user_id
+
+    for name in ("user", "current_user"):
+        user = arguments.get(name)
+        candidate = getattr(user, "id", None)
+        if isinstance(candidate, int) and candidate > 0:
+            return candidate
+    return None
+
+
+def generation_cached(
+    ttl: int | TTL = TTL.MEDIUM,
+    *,
+    falsy_ttl: int | None = None,
+) -> Callable[[Callable[..., Awaitable[T]]], Callable[..., Awaitable[T]]]:
+    """Cache a user-scoped async function behind one generation lookup.
+
+    The decorator deliberately bypasses caching when it cannot resolve a positive
+    user identifier. That keeps ownership explicit and prevents a supposedly
+    user-scoped cache entry from falling back to a shared key.
+
+    A cache hit costs at most two remote commands: one generation ``GET`` and one
+    value ``GET``. A cache miss that is stored costs at most three: generation
+    ``GET``, value ``GET``, and value ``SET``.
+
+    Cache failures are fail-open: if the generation lookup fails, the wrapped
+    database read still executes instead of turning optional Redis into a request
+    dependency.
+
+    Args:
+        ttl: Time-to-live in seconds or a configured TTL tier.
+        falsy_ttl: Optional alternate TTL for falsy results.
+
+    Returns:
+        Decorator for an async cached function.
+    """
+
+    def decorator(func: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]:
+        actual_ttl = _get_ttl_value(ttl) if isinstance(ttl, TTL) else ttl
+        signature = inspect.signature(func)
+
+        @functools.wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> T:
+            if not cache.is_initialized:
+                return await func(*args, **kwargs)
+
+            try:
+                bound = signature.bind_partial(*args, **kwargs)
+            except TypeError:
+                return await func(*args, **kwargs)
+
+            user_id = user_id_from_arguments(dict(bound.arguments))
+            if user_id is None:
+                return await func(*args, **kwargs)
+
+            client = cache._client
+            if client is None:
+                return await func(*args, **kwargs)
+
+            try:
+                generation = await get_user_generation(client, user_id)
+            except Exception as exc:
+                logger.warning("Cache generation read failed: %s", exc)
+                return await func(*args, **kwargs)
+
+            func_name = getattr(func, "__name__", func.__class__.__name__)
+            logical_key = _generate_cache_key(func_name, func, args, kwargs)
+            cache_key = namespaced_cache_key(user_id, generation, logical_key)
+
+            command_budget.record("value_get")
+            cached_value = await cache.get(cache_key)
+            if cached_value is not None:
+                return cast(T, cached_value)
+
+            result = await func(*args, **kwargs)
+            effective_ttl = falsy_ttl if falsy_ttl is not None and not result else actual_ttl
+            if result or falsy_ttl is not None:
+                command_budget.record("value_set")
+                await cache.set(cache_key, result, ttl=effective_ttl)
+            return result
+
+        return cast(Callable[..., Awaitable[T]], wrapper)
+
+    return decorator

--- a/app/cache_generation.py
+++ b/app/cache_generation.py
@@ -293,7 +293,7 @@ def _decode_generation(raw_generation: object) -> int:
 async def _atomic_generation_value_get(
     user_id: int,
     logical_key: str,
-) -> tuple[int, object | None]:
+) -> tuple[int, bool, object | None]:
     """Read the active generation and matching cached value atomically.
 
     Args:
@@ -301,7 +301,7 @@ async def _atomic_generation_value_get(
         logical_key: Existing logical cache key.
 
     Returns:
-        Active generation and reconstructed cached value, if present.
+        Active generation, whether a cache entry exists, and its reconstructed value.
 
     Raises:
         RuntimeError: If no cache client is configured.
@@ -336,7 +336,7 @@ async def _atomic_generation_value_get(
     generation = _decode_generation(raw[0])
     raw_value = raw[1]
     if raw_value is None:
-        return generation, None
+        return generation, False, None
 
     if isinstance(raw_value, bytes):
         serialized = raw_value.decode()
@@ -345,7 +345,7 @@ async def _atomic_generation_value_get(
     else:
         raise ValueError("Cached value must be JSON text")
 
-    return generation, UpstashCache._reconstruct_value(json.loads(serialized))
+    return generation, True, UpstashCache._reconstruct_value(json.loads(serialized))
 
 
 def generation_cached(
@@ -395,7 +395,7 @@ def generation_cached(
             logical_key = _generate_cache_key(func_name, func, args, kwargs)
 
             try:
-                generation, cached_value = await _atomic_generation_value_get(
+                generation, cache_hit, cached_value = await _atomic_generation_value_get(
                     user_id,
                     logical_key,
                 )
@@ -403,7 +403,7 @@ def generation_cached(
                 logger.warning("Atomic cache read failed: %s", exc)
                 return await func(*args, **kwargs)
 
-            if cached_value is not None:
+            if cache_hit:
                 return cast(T, cached_value)
 
             result = await func(*args, **kwargs)

--- a/docs/MARKDOWN_INVENTORY.md
+++ b/docs/MARKDOWN_INVENTORY.md
@@ -94,6 +94,7 @@
 | docs/changelog.d/2026-08-08-917.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/2026-08-08-918.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/2026-08-08-919.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
+| docs/changelog.d/2026-08-08-923.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/README.md | Product changelog history or generated changelog fragment. | 2026-08-06 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.md | Product changelog history or generated changelog fragment. | 2026-08-06 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/frontend-backend-asset-coupling-audit.md | Repository documentation for frontend backend asset coupling audit. | 2026-07-11 | Human-facing narrative should move out of the active code-coupled documentation set unless linked by the docs hub. | move to Wiki | ComicPile Wiki |

--- a/docs/changelog.d/2026-08-08-923.md
+++ b/docs/changelog.d/2026-08-08-923.md
@@ -1,0 +1,5 @@
+## 2026-08-08
+
+### Performance
+
+- [PR #923](https://github.com/JoshCLWren/comic-pile/pull/923) makes user-scoped Redis cache reads and invalidation deterministic with bounded generation-based commands, reducing quota risk while preserving cross-instance cache correctness.

--- a/tests/test_cache_generation.py
+++ b/tests/test_cache_generation.py
@@ -1,0 +1,123 @@
+"""Regression tests for bounded generation-scoped cache primitives."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.cache_generation import (
+    _atomic_generation_value_get,
+    bump_user_generation,
+    command_budget,
+    generation_key,
+    get_user_generation,
+)
+from app.cache import cache
+
+
+class GenerationClient:
+    """Minimal generation client for command-budget tests."""
+
+    async def get(self, key: str) -> str | None:
+        """Return a fixed generation.
+
+        Args:
+            key: Redis key.
+
+        Returns:
+            Fixed generation text.
+        """
+        return "2"
+
+    async def incr(self, key: str) -> int:
+        """Return a fixed incremented generation.
+
+        Args:
+            key: Redis key.
+
+        Returns:
+            Fixed incremented generation.
+        """
+        return 3
+
+
+class AtomicReadClient:
+    """Fake Redis client that exposes only one atomic read operation."""
+
+    def __init__(self) -> None:
+        """Initialize fake generation and value state."""
+        self.generation = 0
+        self.values = {
+            "cache:user:7:g0:load:7:": json.dumps({"title": "old"}),
+            "cache:user:7:g1:load:7:": json.dumps({"title": "new"}),
+        }
+        self.eval_calls = 0
+
+    async def eval(
+        self,
+        script: str,
+        keys: list[str],
+        args: list[str],
+    ) -> list[object | None]:
+        """Return one generation/value snapshot, then advance the generation.
+
+        Args:
+            script: Lua script under test.
+            keys: Redis keys supplied to the script.
+            args: Script arguments used to construct the value key.
+
+        Returns:
+            Generation and serialized value from one atomic snapshot.
+        """
+        assert "redis.call('GET', KEYS[1])" in script
+        assert keys == [generation_key(7)]
+        self.eval_calls += 1
+        generation = self.generation
+        value = self.values[f"{args[0]}{generation}:{args[1]}"]
+
+        # Model an invalidation that becomes visible immediately after the atomic
+        # read. A split generation-GET/value-GET implementation would be able to
+        # mix these states; the script returns one coherent snapshot instead.
+        self.generation = 1
+        return [str(generation), value]
+
+
+@pytest.fixture(autouse=True)
+def reset_command_budget() -> None:
+    """Reset command instrumentation before each test.
+
+    Returns:
+        ``None``.
+    """
+    command_budget.counts.clear()
+
+
+@pytest.mark.asyncio
+async def test_invalid_user_id_does_not_consume_generation_budget() -> None:
+    """Reject invalid generation keys before recording remote commands."""
+    client = GenerationClient()
+
+    with pytest.raises(ValueError, match="user_id must be positive"):
+        await get_user_generation(client, 0)
+    with pytest.raises(ValueError, match="user_id must be positive"):
+        await bump_user_generation(client, -1)
+
+    assert command_budget.total == 0
+
+
+@pytest.mark.asyncio
+async def test_atomic_read_keeps_generation_and_value_in_one_snapshot(monkeypatch) -> None:
+    """Prevent invalidation from interleaving generation and value lookups."""
+    client = AtomicReadClient()
+    monkeypatch.setattr(cache, "_client", client)
+    monkeypatch.setattr(cache, "_initialized", True)
+    monkeypatch.setattr(cache, "_is_upstash", True)
+
+    generation, value = await _atomic_generation_value_get(7, "cache:load:7:")
+
+    assert generation == 0
+    assert value == {"title": "old"}
+    assert client.generation == 1
+    assert client.eval_calls == 1
+    assert command_budget.counts == {"generation_value_get": 1}

--- a/tests/test_cache_generation.py
+++ b/tests/test_cache_generation.py
@@ -6,14 +6,15 @@ import json
 
 import pytest
 
+from app.cache import cache
 from app.cache_generation import (
     _atomic_generation_value_get,
     bump_user_generation,
     command_budget,
+    generation_cached,
     generation_key,
     get_user_generation,
 )
-from app.cache import cache
 
 
 class GenerationClient:
@@ -83,6 +84,35 @@ class AtomicReadClient:
         return [str(generation), value]
 
 
+class NullValueClient:
+    """Fake Upstash client that can store and return a JSON null cache entry."""
+
+    def __init__(self) -> None:
+        """Initialize an empty generation-zero cache."""
+        self.value: str | None = None
+        self.eval_calls = 0
+        self.set_calls = 0
+
+    async def eval(
+        self,
+        script: str,
+        keys: list[str],
+        args: list[str],
+    ) -> list[object | None]:
+        """Return the current generation and stored serialized value."""
+        assert "redis.call('GET', KEYS[1])" in script
+        assert keys == [generation_key(7)]
+        self.eval_calls += 1
+        return ["0", self.value]
+
+    async def set(self, key: str, value: str, ex: int | None = None) -> None:
+        """Store serialized cache data exactly as the cache wrapper supplies it."""
+        assert key.startswith("cache:user:7:g0:")
+        assert ex == 30
+        self.set_calls += 1
+        self.value = value
+
+
 @pytest.fixture(autouse=True)
 def reset_command_budget() -> None:
     """Reset command instrumentation before each test.
@@ -114,10 +144,36 @@ async def test_atomic_read_keeps_generation_and_value_in_one_snapshot(monkeypatc
     monkeypatch.setattr(cache, "_initialized", True)
     monkeypatch.setattr(cache, "_is_upstash", True)
 
-    generation, value = await _atomic_generation_value_get(7, "cache:load:7:")
+    generation, cache_hit, value = await _atomic_generation_value_get(7, "cache:load:7:")
 
     assert generation == 0
+    assert cache_hit is True
     assert value == {"title": "old"}
     assert client.generation == 1
     assert client.eval_calls == 1
     assert command_budget.counts == {"generation_value_get": 1}
+
+
+@pytest.mark.asyncio
+async def test_generation_cached_preserves_cached_none(monkeypatch) -> None:
+    """Treat a stored JSON null as a cache hit when falsy caching is enabled."""
+    client = NullValueClient()
+    monkeypatch.setattr(cache, "_client", client)
+    monkeypatch.setattr(cache, "_initialized", True)
+    monkeypatch.setattr(cache, "_is_upstash", True)
+
+    executions = 0
+
+    @generation_cached(ttl=300, falsy_ttl=30)
+    async def load_optional(user_id: int) -> None:
+        nonlocal executions
+        executions += 1
+        return None
+
+    assert await load_optional(7) is None
+    assert await load_optional(7) is None
+
+    assert executions == 1
+    assert client.eval_calls == 2
+    assert client.set_calls == 1
+    assert client.value == "null"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-scoped caching with generation-based invalidation.
  * Added support for invalidating one or multiple users’ cached data without removing individual entries.
  * Added asynchronous caching with configurable expiration times, including separate handling for empty results.
  * Added safeguards to bypass caching when user ownership or the cache service is unavailable.
  * Improved cache reads for consistent results during invalidation while reducing Redis command usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->