### PR TITLE
Define Queue cursor compatibility contract

### DIFF
--- a/app/services/queue_pagination.py
+++ b/app/services/queue_pagination.py
@@ -1,0 +1,73 @@
+"""Deterministic Queue pagination contracts."""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from typing import Literal
+
+QueueSort = Literal["position", "title", "created"]
+
+
+@dataclass(frozen=True)
+class QueueCursor:
+    """Opaque Queue cursor bound to one search and sort contract."""
+
+    sort: QueueSort
+    search: str
+    values: tuple[str, ...]
+
+
+def normalize_queue_search(search: str | None) -> str:
+    """Normalize Queue search text for cursor compatibility checks."""
+    return search.strip().casefold() if search else ""
+
+
+def encode_queue_cursor(cursor: QueueCursor) -> str:
+    """Encode a Queue cursor as URL-safe opaque text."""
+    payload = {
+        "sort": cursor.sort,
+        "search": cursor.search,
+        "values": list(cursor.values),
+    }
+    raw = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def decode_queue_cursor(
+    token: str,
+    *,
+    sort: QueueSort,
+    search: str | None,
+) -> QueueCursor:
+    """Decode and validate that a Queue cursor matches current query inputs.
+
+    Raises:
+        ValueError: If the token is malformed or belongs to another search/sort contract.
+    """
+    try:
+        padded = token + "=" * (-len(token) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(padded.encode()).decode())
+        cursor_sort = payload["sort"]
+        cursor_search = payload["search"]
+        raw_values = payload["values"]
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise ValueError("Invalid Queue page token") from exc
+
+    if cursor_sort not in {"position", "title", "created"}:
+        raise ValueError("Invalid Queue page token sort")
+    if not isinstance(cursor_search, str) or not isinstance(raw_values, list):
+        raise ValueError("Invalid Queue page token payload")
+    if not all(isinstance(value, str) for value in raw_values):
+        raise ValueError("Invalid Queue page token values")
+
+    normalized_search = normalize_queue_search(search)
+    if cursor_sort != sort or cursor_search != normalized_search:
+        raise ValueError("Queue page token does not match current search or sort")
+
+    return QueueCursor(
+        sort=cursor_sort,
+        search=cursor_search,
+        values=tuple(raw_values),
+    )

--- a/docs/MARKDOWN_INVENTORY.md
+++ b/docs/MARKDOWN_INVENTORY.md
@@ -96,6 +96,7 @@
 | docs/changelog.d/2026-08-08-918.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/2026-08-08-919.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/2026-08-08-941.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
+| docs/changelog.d/2026-08-08-946.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/README.md | Product changelog history or generated changelog fragment. | 2026-08-06 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.md | Product changelog history or generated changelog fragment. | 2026-08-06 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/frontend-backend-asset-coupling-audit.md | Repository documentation for frontend backend asset coupling audit. | 2026-07-11 | Human-facing narrative should move out of the active code-coupled documentation set unless linked by the docs hub. | move to Wiki | ComicPile Wiki |

--- a/docs/changelog.d/2026-08-08-946.md
+++ b/docs/changelog.d/2026-08-08-946.md
@@ -1,0 +1,5 @@
+## 2026-08-08
+
+### Queue
+
+- [PR #946](https://github.com/JoshCLWren/comic-pile/pull/946) adds a deterministic Queue pagination cursor contract that rejects stale cursors when search or sort inputs change, preventing later paged loading from mixing incompatible result sets.

--- a/tests/test_queue_pagination.py
+++ b/tests/test_queue_pagination.py
@@ -1,0 +1,45 @@
+"""Tests for deterministic Queue pagination contracts."""
+
+import pytest
+
+from app.services.queue_pagination import (
+    QueueCursor,
+    decode_queue_cursor,
+    encode_queue_cursor,
+    normalize_queue_search,
+)
+
+
+def test_queue_cursor_round_trips_for_same_query() -> None:
+    cursor = QueueCursor(sort="position", search="batman", values=("10", "42"))
+
+    token = encode_queue_cursor(cursor)
+
+    assert decode_queue_cursor(token, sort="position", search=" Batman ") == cursor
+
+
+def test_queue_cursor_rejects_sort_change() -> None:
+    token = encode_queue_cursor(
+        QueueCursor(sort="position", search="", values=("10", "42")),
+    )
+
+    with pytest.raises(ValueError, match="does not match"):
+        decode_queue_cursor(token, sort="title", search=None)
+
+
+def test_queue_cursor_rejects_search_change() -> None:
+    token = encode_queue_cursor(
+        QueueCursor(sort="title", search="x-men", values=("x-men", "42")),
+    )
+
+    with pytest.raises(ValueError, match="does not match"):
+        decode_queue_cursor(token, sort="title", search="x-force")
+
+
+def test_queue_cursor_rejects_malformed_token() -> None:
+    with pytest.raises(ValueError, match="Invalid Queue page token"):
+        decode_queue_cursor("not-a-valid-token", sort="created", search=None)
+
+
+def test_queue_search_normalization_is_case_insensitive_and_trimmed() -> None:
+    assert normalize_queue_search("  The Flash  ") == "the flash"


### PR DESCRIPTION
Superseded by #950 because this branch became non-mergeable after `main` advanced. The cursor implementation and regression coverage were replayed onto current main rather than discarded.

Refs #931.