### PR TITLE
Hide GitHub links from public What’s New

### DIFF
--- a/docs/MARKDOWN_INVENTORY.md
+++ b/docs/MARKDOWN_INVENTORY.md
@@ -2,7 +2,7 @@
 | --- | --- | --- | --- | --- | --- |
 | .agents/skills/github-issue-kanban/SKILL.md | Repository automation, contribution, or agent execution guidance. | 2026-07-20 | Code-coupled workflow contract that must change atomically with repository behavior. | keep | — |
 | .agents/skills/model-recommendation/SKILL.md | Repository automation, contribution, or agent execution guidance. | 2026-03-27 | Code-coupled workflow contract that must change atomically with repository behavior. | keep | — |
-| .agents/skills/plan-task-handoff/SKILL.md | Repository automation, contribution, or agent execution guidance. | 2026-08-01 | Code-coupled workflow contract that must change atomically with factory behavior. | keep | — |
+| .agents/skills/plan-task-handoff/SKILL.md | Repository automation, contribution, or agent execution guidance. | 2026-08-01 | Code-coupled workflow contract that must change atomically with repository behavior. | keep | — |
 | .claude/skills/handoff/SKILL.md | Repository automation, contribution, or agent execution guidance. | 2026-03-26 | Code-coupled workflow contract that must change atomically with repository behavior. | keep | — |
 | .claude/skills/orchestrator/SKILL.md | Repository automation, contribution, or agent execution guidance. | 2026-04-15 | Code-coupled workflow contract that must change atomically with repository behavior. | keep | — |
 | AGENTS.md | Mandatory engineering rules for coding agents. | 2026-08-07 | Code-coupled contract; must not be duplicated in the Wiki. | keep | — |

--- a/docs/MARKDOWN_INVENTORY.md
+++ b/docs/MARKDOWN_INVENTORY.md
@@ -2,7 +2,7 @@
 | --- | --- | --- | --- | --- | --- |
 | .agents/skills/github-issue-kanban/SKILL.md | Repository automation, contribution, or agent execution guidance. | 2026-07-20 | Code-coupled workflow contract that must change atomically with repository behavior. | keep | — |
 | .agents/skills/model-recommendation/SKILL.md | Repository automation, contribution, or agent execution guidance. | 2026-03-27 | Code-coupled workflow contract that must change atomically with repository behavior. | keep | — |
-| .agents/skills/plan-task-handoff/SKILL.md | Repository automation, contribution, or agent execution guidance. | 2026-08-01 | Code-coupled workflow contract that must change atomically with repository behavior. | keep | — |
+| .agents/skills/plan-task-handoff/SKILL.md | Repository automation, contribution, or agent execution guidance. | 2026-08-01 | Code-coupled workflow contract that must change atomically with factory behavior. | keep | — |
 | .claude/skills/handoff/SKILL.md | Repository automation, contribution, or agent execution guidance. | 2026-03-26 | Code-coupled workflow contract that must change atomically with repository behavior. | keep | — |
 | .claude/skills/orchestrator/SKILL.md | Repository automation, contribution, or agent execution guidance. | 2026-04-15 | Code-coupled workflow contract that must change atomically with repository behavior. | keep | — |
 | AGENTS.md | Mandatory engineering rules for coding agents. | 2026-08-07 | Code-coupled contract; must not be duplicated in the Wiki. | keep | — |
@@ -97,6 +97,7 @@
 | docs/changelog.d/2026-08-08-919.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/2026-08-08-941.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/2026-08-08-945.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
+| docs/changelog.d/2026-08-08-948.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/README.md | Product changelog history or generated changelog fragment. | 2026-08-06 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.md | Product changelog history or generated changelog fragment. | 2026-08-06 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/frontend-backend-asset-coupling-audit.md | Repository documentation for frontend backend asset coupling audit. | 2026-07-11 | Human-facing narrative should move out of the active code-coupled documentation set unless linked by the docs hub. | move to Wiki | ComicPile Wiki |

--- a/docs/changelog.d/2026-08-08-948.md
+++ b/docs/changelog.d/2026-08-08-948.md
@@ -1,0 +1,4 @@
+## 2026-08-08
+
+### What’s New
+- [#948](https://github.com/JoshCLWren/comic-pile/pull/948) keeps GitHub repository URLs out of the public What’s New page while preserving readable release-note text.

--- a/frontend/src/pages/WhatsNewPage.test.tsx
+++ b/frontend/src/pages/WhatsNewPage.test.tsx
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { isPublicChangelogLink } from './WhatsNewPage'
+
+describe('isPublicChangelogLink', () => {
+  it('hides GitHub destinations from the public changelog', () => {
+    expect(isPublicChangelogLink('https://github.com/JoshCLWren/comic-pile/pull/948')).toBe(false)
+  })
+
+  it('keeps non-GitHub links available', () => {
+    expect(isPublicChangelogLink('https://comic-pile.vercel.app/help')).toBe(true)
+  })
+
+  it('fails closed for malformed destinations', () => {
+    expect(isPublicChangelogLink('not-a-url')).toBe(false)
+  })
+})

--- a/frontend/src/pages/WhatsNewPage.tsx
+++ b/frontend/src/pages/WhatsNewPage.tsx
@@ -7,6 +7,14 @@ type Block =
 
 const CHANGELOG_ASSET = '/changelog.md'
 
+export function isPublicChangelogLink(url: string) {
+  try {
+    return new URL(url).hostname !== 'github.com'
+  } catch {
+    return false
+  }
+}
+
 function renderInline(text: string) {
   const pattern = /(`[^`]+`|\[[^\]]+\]\(https?:\/\/[^)]+\))/g
   return text.split(pattern).map((part, index) => {
@@ -14,6 +22,7 @@ function renderInline(text: string) {
     if (code) return <code key={index} className="rounded bg-stone-800 px-1.5 py-0.5 text-amber-200">{code[1]}</code>
     const link = part.match(/^\[([^\]]+)\]\((https?:\/\/[^)]+)\)$/)
     if (link) {
+      if (!isPublicChangelogLink(link[2])) return <Fragment key={index}>{link[1]}</Fragment>
       return <a key={index} href={link[2]} target="_blank" rel="noreferrer" className="font-semibold text-amber-300 underline decoration-amber-500/50 underline-offset-4">{link[1]} <span aria-label="opens in a new tab">↗</span></a>
     }
     return <Fragment key={index}>{part}</Fragment>

--- a/frontend/src/unit/WhatsNewPage.test.tsx
+++ b/frontend/src/unit/WhatsNewPage.test.tsx
@@ -46,7 +46,7 @@ describe('WhatsNewPage', () => {
     expect(screen.getByText('Plain introduction.')).toBeInTheDocument()
     expect(screen.getByText('Queue', { selector: 'code' })).toBeInTheDocument()
 
-    expect(screen.getByText('#866')).toBeInTheDocument()
+    expect(screen.getByRole('listitem')).toHaveTextContent('#866')
     expect(screen.queryByRole('link', { name: /#866/ })).not.toBeInTheDocument()
 
     const link = screen.getByRole('link', { name: /ComicPile/ })

--- a/frontend/src/unit/WhatsNewPage.test.tsx
+++ b/frontend/src/unit/WhatsNewPage.test.tsx
@@ -28,11 +28,11 @@ describe('parseChangelog', () => {
 })
 
 describe('WhatsNewPage', () => {
-  it('renders headings, paragraphs, lists, inline code, external links, and plain text', async () => {
+  it('renders GitHub references as text while preserving public external links', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       text: async () =>
-        '# Changelog\n\nPlain introduction.\n\n## Today\n\n### Queue\n\n- Fixed `Queue` in [#866](https://github.com/JoshCLWren/comic-pile/pull/866).',
+        '# Changelog\n\nPlain introduction.\n\n## Today\n\n### Queue\n\n- Fixed `Queue` in [#866](https://github.com/JoshCLWren/comic-pile/pull/866). See [ComicPile](https://comic-pile.vercel.app/) for more.',
     })
     vi.stubGlobal('fetch', fetchMock)
 
@@ -46,11 +46,11 @@ describe('WhatsNewPage', () => {
     expect(screen.getByText('Plain introduction.')).toBeInTheDocument()
     expect(screen.getByText('Queue', { selector: 'code' })).toBeInTheDocument()
 
-    const link = screen.getByRole('link', { name: /#866/ })
-    expect(link).toHaveAttribute(
-      'href',
-      'https://github.com/JoshCLWren/comic-pile/pull/866',
-    )
+    expect(screen.getByText('#866')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /#866/ })).not.toBeInTheDocument()
+
+    const link = screen.getByRole('link', { name: /ComicPile/ })
+    expect(link).toHaveAttribute('href', 'https://comic-pile.vercel.app/')
     expect(link).toHaveAttribute('target', '_blank')
     expect(link).toHaveAttribute('rel', 'noreferrer')
     expect(screen.getByLabelText('opens in a new tab')).toBeInTheDocument()


### PR DESCRIPTION
Superseded by #969, which replays the complete #948 implementation onto current main without carrying the merge conflict forward.