### PR TITLE
Replay Queue cursor compatibility contract on current main

### DIFF
--- a/app/services/queue_pagination.py
+++ b/app/services/queue_pagination.py
@@ -1,0 +1,101 @@
+"""Deterministic Queue pagination contracts."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+from dataclasses import dataclass
+from typing import Literal
+
+QueueSort = Literal["position", "title", "created"]
+
+
+@dataclass(frozen=True)
+class QueueCursor:
+    """Opaque Queue cursor bound to one search and sort contract."""
+
+    sort: QueueSort
+    search: str
+    values: tuple[str, ...]
+
+
+def normalize_queue_search(search: str | None) -> str:
+    """Normalize Queue search text for cursor compatibility checks.
+
+    Args:
+        search: Optional user-entered Queue search text.
+
+    Returns:
+        Trimmed, case-folded search text, or an empty string when absent.
+    """
+    return search.strip().casefold() if search else ""
+
+
+def encode_queue_cursor(cursor: QueueCursor) -> str:
+    """Encode a Queue cursor as URL-safe opaque text.
+
+    Args:
+        cursor: Queue cursor contract to serialize.
+
+    Returns:
+        URL-safe base64 text without padding.
+    """
+    payload = {
+        "sort": cursor.sort,
+        "search": cursor.search,
+        "values": list(cursor.values),
+    }
+    raw = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def decode_queue_cursor(
+    token: str,
+    *,
+    sort: QueueSort,
+    search: str | None,
+) -> QueueCursor:
+    """Decode and validate that a Queue cursor matches current query inputs.
+
+    Args:
+        token: URL-safe opaque Queue cursor text.
+        sort: Sort order requested for the current Queue page.
+        search: Optional search text requested for the current Queue page.
+
+    Returns:
+        Validated Queue cursor bound to the current search and sort contract.
+
+    Raises:
+        ValueError: If the token is malformed or belongs to another search/sort contract.
+    """
+    try:
+        padded = token + "=" * (-len(token) % 4)
+        decoded = base64.b64decode(padded.encode(), altchars=b"-_", validate=True)
+        payload = json.loads(decoded.decode())
+        cursor_sort = payload["sort"]
+        cursor_search = payload["search"]
+        raw_values = payload["values"]
+    except (binascii.Error, KeyError, TypeError, UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
+        raise ValueError("Invalid Queue page token") from exc
+
+    if not isinstance(cursor_sort, str) or cursor_sort not in {
+        "position",
+        "title",
+        "created",
+    }:
+        raise ValueError("Invalid Queue page token sort")
+    if not isinstance(cursor_search, str) or not isinstance(raw_values, list):
+        raise ValueError("Invalid Queue page token payload")
+    if not all(isinstance(value, str) for value in raw_values):
+        raise ValueError("Invalid Queue page token values")
+
+    normalized_search = normalize_queue_search(search)
+    if cursor_sort != sort or cursor_search != normalized_search:
+        raise ValueError("Queue page token does not match current search or sort")
+
+    return QueueCursor(
+        sort=cursor_sort,
+        search=cursor_search,
+        values=tuple(raw_values),
+    )

--- a/app/services/queue_pagination.py
+++ b/app/services/queue_pagination.py
@@ -43,7 +43,7 @@ def encode_queue_cursor(cursor: QueueCursor) -> str:
     """
     payload = {
         "sort": cursor.sort,
-        "search": cursor.search,
+        "search": normalize_queue_search(cursor.search),
         "values": list(cursor.values),
     }
     raw = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
@@ -76,7 +76,14 @@ def decode_queue_cursor(
         cursor_sort = payload["sort"]
         cursor_search = payload["search"]
         raw_values = payload["values"]
-    except (binascii.Error, KeyError, TypeError, UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
+    except (
+        binascii.Error,
+        KeyError,
+        TypeError,
+        UnicodeDecodeError,
+        ValueError,
+        json.JSONDecodeError,
+    ) as exc:
         raise ValueError("Invalid Queue page token") from exc
 
     if not isinstance(cursor_sort, str) or cursor_sort not in {

--- a/docs/MARKDOWN_INVENTORY.md
+++ b/docs/MARKDOWN_INVENTORY.md
@@ -97,6 +97,7 @@
 | docs/changelog.d/2026-08-08-919.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/2026-08-08-941.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/2026-08-08-945.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
+| docs/changelog.d/2026-08-08-950.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/2026-08-08-951.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/README.md | Product changelog history or generated changelog fragment. | 2026-08-06 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.md | Product changelog history or generated changelog fragment. | 2026-08-06 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |

--- a/docs/changelog.d/2026-08-08-950.md
+++ b/docs/changelog.d/2026-08-08-950.md
@@ -1,0 +1,5 @@
+## 2026-08-08
+
+### Queue
+
+- [#950](https://github.com/JoshCLWren/comic-pile/pull/950) restores the deterministic Queue pagination cursor work on current main, preventing incompatible search or sort cursors from being reused while the full paged Queue contract is completed.

--- a/tests/test_queue_pagination.py
+++ b/tests/test_queue_pagination.py
@@ -1,0 +1,75 @@
+"""Tests for deterministic Queue pagination contracts."""
+
+import base64
+import json
+
+import pytest
+
+from app.services.queue_pagination import (
+    QueueCursor,
+    decode_queue_cursor,
+    encode_queue_cursor,
+    normalize_queue_search,
+)
+
+
+def test_queue_cursor_round_trips_for_same_query() -> None:
+    """Round-trip a cursor when sort and normalized search are unchanged."""
+    cursor = QueueCursor(sort="position", search="batman", values=("10", "42"))
+
+    token = encode_queue_cursor(cursor)
+
+    assert decode_queue_cursor(token, sort="position", search=" Batman ") == cursor
+
+
+def test_queue_cursor_rejects_sort_change() -> None:
+    """Reject a cursor when the requested sort differs from its contract."""
+    token = encode_queue_cursor(
+        QueueCursor(sort="position", search="", values=("10", "42")),
+    )
+
+    with pytest.raises(ValueError, match="does not match"):
+        decode_queue_cursor(token, sort="title", search=None)
+
+
+def test_queue_cursor_rejects_search_change() -> None:
+    """Reject a cursor when the normalized search differs from its contract."""
+    token = encode_queue_cursor(
+        QueueCursor(sort="title", search="x-men", values=("x-men", "42")),
+    )
+
+    with pytest.raises(ValueError, match="does not match"):
+        decode_queue_cursor(token, sort="title", search="x-force")
+
+
+def test_queue_cursor_rejects_malformed_token() -> None:
+    """Reject malformed Queue cursor tokens with the stable validation error."""
+    with pytest.raises(ValueError, match="Invalid Queue page token"):
+        decode_queue_cursor("not-a-valid-token", sort="created", search=None)
+
+
+def test_queue_cursor_rejects_appended_invalid_base64_bytes() -> None:
+    """Reject tokens containing bytes outside the URL-safe base64 alphabet."""
+    token = encode_queue_cursor(
+        QueueCursor(sort="title", search="", values=("x-men", "42")),
+    )
+
+    with pytest.raises(ValueError, match="Invalid Queue page token"):
+        decode_queue_cursor(f"{token}!", sort="title", search=None)
+
+
+def test_queue_cursor_rejects_non_string_sort() -> None:
+    """Reject malformed cursor payloads whose sort field is not a string."""
+    payload = json.dumps(
+        {"sort": [], "search": "", "values": ["x-men", "42"]},
+        separators=(",", ":"),
+    ).encode()
+    token = base64.urlsafe_b64encode(payload).decode().rstrip("=")
+
+    with pytest.raises(ValueError, match="Invalid Queue page token sort"):
+        decode_queue_cursor(token, sort="title", search=None)
+
+
+def test_queue_search_normalization_is_case_insensitive_and_trimmed() -> None:
+    """Normalize Queue search text before binding it to a pagination cursor."""
+    assert normalize_queue_search("  The Flash  ") == "the flash"

--- a/tests/test_queue_pagination.py
+++ b/tests/test_queue_pagination.py
@@ -13,13 +13,24 @@ from app.services.queue_pagination import (
 )
 
 
+def _encode_payload(payload: object) -> str:
+    """Encode an arbitrary payload as a Queue cursor token for validation tests."""
+    raw = json.dumps(payload, separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
 def test_queue_cursor_round_trips_for_same_query() -> None:
     """Round-trip a cursor when sort and normalized search are unchanged."""
-    cursor = QueueCursor(sort="position", search="batman", values=("10", "42"))
+    cursor = QueueCursor(sort="position", search=" Batman ", values=("10", "42"))
 
     token = encode_queue_cursor(cursor)
 
-    assert decode_queue_cursor(token, sort="position", search=" Batman ") == cursor
+    assert encode_queue_cursor(cursor) == token
+    assert decode_queue_cursor(token, sort="position", search=" BATMAN ") == QueueCursor(
+        sort="position",
+        search="batman",
+        values=("10", "42"),
+    )
 
 
 def test_queue_cursor_rejects_sort_change() -> None:
@@ -58,15 +69,21 @@ def test_queue_cursor_rejects_appended_invalid_base64_bytes() -> None:
         decode_queue_cursor(f"{token}!", sort="title", search=None)
 
 
-def test_queue_cursor_rejects_non_string_sort() -> None:
-    """Reject malformed cursor payloads whose sort field is not a string."""
-    payload = json.dumps(
-        {"sort": [], "search": "", "values": ["x-men", "42"]},
-        separators=(",", ":"),
-    ).encode()
-    token = base64.urlsafe_b64encode(payload).decode().rstrip("=")
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({"sort": [], "search": "", "values": ["x-men", "42"]}, "token sort"),
+        ({"sort": "bogus", "search": "", "values": ["x-men", "42"]}, "token sort"),
+        ({"sort": "title", "search": [], "values": ["x-men", "42"]}, "token payload"),
+        ({"sort": "title", "search": "", "values": "x-men"}, "token payload"),
+        ({"sort": "title", "search": "", "values": ["x-men", 42]}, "token values"),
+    ],
+)
+def test_queue_cursor_rejects_invalid_payload_shapes(payload: object, message: str) -> None:
+    """Reject malformed payload field types and unsupported sort values."""
+    token = _encode_payload(payload)
 
-    with pytest.raises(ValueError, match="Invalid Queue page token sort"):
+    with pytest.raises(ValueError, match=message):
         decode_queue_cursor(token, sort="title", search=None)
 
 


### PR DESCRIPTION
Refs #931

## Summary
- replay the deterministic Queue cursor contract from conflicted PR #946 onto current main
- bind cursors to normalized search text and selected sort
- reject malformed and incompatible cursors with focused regression coverage

This preserves the completed closure-critical cursor work while removing the merge conflict caused by main advancing. Route ordering/filter integration still remains before #931 can close.

Validation: this scheduled connector runtime has no local checkout, so required CI is the validation boundary for the current head.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reliable pagination for queues using URL-safe cursors.
  * Queue searches now normalize whitespace and casing consistently.
  * Prevented pagination cursors from being reused with incompatible searches or sort options.

* **Bug Fixes**
  * Invalid or malformed pagination cursors are now rejected with clear validation errors.

* **Tests**
  * Added coverage for cursor encoding, decoding, validation, and search normalization.

* **Documentation**
  * Added a changelog entry describing the queue pagination improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->