### PR TITLE
Require automatic factory label transitions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,3 +356,22 @@ Agents with the `github-issue-kanban` skill should follow that skill. Other
 agents must read `docs/ISSUE_EXECUTION_PROTOCOL.md`, update the selected
 issue's `ralph-status:*` label before editing, and add a verification comment
 before closing the issue.
+
+### Factory labels are mandatory agent work
+
+All local agents and scheduled factories must apply the canonical issue and PR label state
+machine in `docs/AUTONOMOUS_FACTORY_POLICY.md` automatically. Label reconciliation is part of
+claiming, implementation, review, CI, handoff, blocking, readiness, merge, and closure—not a task
+for Josh.
+
+Before ending a turn involving an issue or PR:
+
+- ensure the issue and PR each have the truthful factory workflow state;
+- ensure exactly one next-action owner (`factory:unowned`, `factory:local`, or `factory:1` through
+  `factory:5`) is present where factory work is involved;
+- remove stale or mutually exclusive state and owner labels;
+- release expired ownership while preserving `factory:review` or `factory:changes-requested` when
+  that remains the truthful next action;
+- use the REST issue-label endpoint when `gh pr edit` fails on Projects Classic GraphQL metadata.
+
+Never wait for the user to request these routine label corrections.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,6 +372,7 @@ Before ending a turn involving an issue or PR:
 - remove stale or mutually exclusive state and owner labels;
 - release expired ownership while preserving `factory:review` or `factory:changes-requested` when
   that remains the truthful next action;
-- use the REST issue-label endpoint when `gh pr edit` fails on Projects Classic GraphQL metadata.
+- when `gh pr edit` fails on Projects Classic GraphQL metadata, use REST to delete every stale
+  workflow and owner label before adding the complete target factory label set.
 
 Never wait for the user to request these routine label corrections.

--- a/docs/AUTONOMOUS_FACTORY_POLICY.md
+++ b/docs/AUTONOMOUS_FACTORY_POLICY.md
@@ -166,6 +166,46 @@ When owned work cannot safely advance now:
 
 Blocked work never authorizes a worker to pause or disable itself.
 
+## Mandatory label state machine
+
+Every worker owns issue and pull-request metadata as part of the work. Reconcile labels when
+claiming, opening or replaying a PR, handing work off, receiving review, starting CI validation,
+becoming ready, blocking, merging, and ending a turn. Josh must never need to request routine
+factory labels.
+
+Apply these states exactly; remove mutually exclusive state and owner labels during every
+transition:
+
+| State | Issue labels | Pull-request labels |
+|---|---|---|
+| Unclaimed executable work | `ralph-task`, `ralph-status:pending`, one priority, `factory`, `factory:unowned` | Not applicable |
+| Actively implemented | `ralph-status:in-progress`, `factory`, `factory:building`, one `factory:<worker>` | `factory`, one `factory:<worker>` when a PR exists |
+| Exact head needs review | `ralph-status:in-review`, `factory`, `factory:review`, current owner or `factory:unowned` | `factory`, `factory:review`, current owner or `factory:unowned` |
+| Actionable review findings | `ralph-status:in-progress` when owned, otherwise `ralph-status:pending`; `factory`, `factory:changes-requested`, current owner or `factory:unowned` | `factory`, `factory:changes-requested`, current owner or `factory:unowned` |
+| Review passed; exact-head CI pending | `ralph-status:validation`, `factory`, `factory:ci`, current owner or `factory:unowned` | `factory`, `factory:ci`, current owner or `factory:unowned` |
+| Every merge gate satisfied | `ralph-status:in-review`, `factory`, `factory:ready`, current owner or `factory:unowned` | `factory`, `factory:ready`, current owner or `factory:unowned` |
+| Human or external blocker | `ralph-status:blocked`, `factory`, `factory:blocked`, `factory:unowned` | Preserve `factory`; add `factory:blocked` only when the PR itself has the external blocker |
+| Lease released or stale | Executable status, `factory`, `factory:unowned`; also preserve `factory:review` or `factory:changes-requested` when applicable | `factory`, `factory:unowned`, plus the truthful review state |
+| Merged and complete | `ralph-status:done`, then close after verification; remove transient factory state/owner labels | Merged PR needs no further transition |
+
+Rules:
+
+- `factory:building`, `factory:review`, `factory:changes-requested`, `factory:ci`,
+  `factory:ready`, and `factory:blocked` are mutually exclusive workflow states.
+- `factory:unowned`, `factory:local`, and `factory:1` through `factory:5` are mutually exclusive
+  next-action owners.
+- Never leave a factory-produced or factory-managed open PR without `factory`, one truthful
+  workflow-state label, and one truthful owner label.
+- A push invalidates `factory:ci` and `factory:ready`; transition the exact new head back to
+  `factory:review` unless review findings already require `factory:changes-requested`.
+- Cross-worker takeover and merge are allowed. The new worker replaces the owner label and may
+  merge work it did not author after every exact-head gate passes.
+- If `gh pr edit` fails because of deprecated Projects Classic GraphQL fields, update PR labels
+  through the issue-compatible REST endpoint, for example
+  `gh api --method POST repos/OWNER/REPO/issues/PR/labels -f 'labels[]=factory'`.
+- Before ending any turn, compare the issue, PR, review, CI, lease, and merge state and repair any
+  metadata contradiction discovered.
+
 ## Repository safety
 
 - Never push directly to `main`.

--- a/docs/AUTONOMOUS_FACTORY_POLICY.md
+++ b/docs/AUTONOMOUS_FACTORY_POLICY.md
@@ -179,12 +179,12 @@ transition:
 | State | Issue labels | Pull-request labels |
 |---|---|---|
 | Unclaimed executable work | `ralph-task`, `ralph-status:pending`, one priority, `factory`, `factory:unowned` | Not applicable |
-| Actively implemented | `ralph-status:in-progress`, `factory`, `factory:building`, one `factory:<worker>` | `factory`, one `factory:<worker>` when a PR exists |
+| Actively implemented | `ralph-status:in-progress`, `factory`, `factory:building`, one `factory:<worker>` | `factory`, `factory:building`, one `factory:<worker>` when a PR exists |
 | Exact head needs review | `ralph-status:in-review`, `factory`, `factory:review`, current owner or `factory:unowned` | `factory`, `factory:review`, current owner or `factory:unowned` |
 | Actionable review findings | `ralph-status:in-progress` when owned, otherwise `ralph-status:pending`; `factory`, `factory:changes-requested`, current owner or `factory:unowned` | `factory`, `factory:changes-requested`, current owner or `factory:unowned` |
 | Review passed; exact-head CI pending | `ralph-status:validation`, `factory`, `factory:ci`, current owner or `factory:unowned` | `factory`, `factory:ci`, current owner or `factory:unowned` |
 | Every merge gate satisfied | `ralph-status:in-review`, `factory`, `factory:ready`, current owner or `factory:unowned` | `factory`, `factory:ready`, current owner or `factory:unowned` |
-| Human or external blocker | `ralph-status:blocked`, `factory`, `factory:blocked`, `factory:unowned` | Preserve `factory`; add `factory:blocked` only when the PR itself has the external blocker |
+| Human or external blocker | `ralph-status:blocked`, `factory`, `factory:blocked`, `factory:unowned` | Issue-only blocker: preserve the truthful PR workflow state with `factory:unowned`; PR-level blocker: `factory`, `factory:blocked`, `factory:unowned` |
 | Lease released or stale | Executable status, `factory`, `factory:unowned`; also preserve `factory:review` or `factory:changes-requested` when applicable | `factory`, `factory:unowned`, plus the truthful review state |
 | Merged and complete | `ralph-status:done`, then close after verification; remove transient factory state/owner labels | Merged PR needs no further transition |
 
@@ -200,9 +200,9 @@ Rules:
   `factory:review` unless review findings already require `factory:changes-requested`.
 - Cross-worker takeover and merge are allowed. The new worker replaces the owner label and may
   merge work it did not author after every exact-head gate passes.
-- If `gh pr edit` fails because of deprecated Projects Classic GraphQL fields, update PR labels
-  through the issue-compatible REST endpoint, for example
-  `gh api --method POST repos/OWNER/REPO/issues/PR/labels -f 'labels[]=factory'`.
+- If `gh pr edit` fails because of deprecated Projects Classic GraphQL fields, use the
+  issue-compatible REST endpoints: delete every stale workflow and owner label first, then add the
+  complete target factory label set. A POST alone only adds labels and is not reconciliation.
 - Before ending any turn, compare the issue, PR, review, CI, lease, and merge state and repair any
   metadata contradiction discovered.
 

--- a/docs/MARKDOWN_INVENTORY.md
+++ b/docs/MARKDOWN_INVENTORY.md
@@ -99,6 +99,7 @@
 | docs/changelog.d/2026-08-08-945.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/2026-08-08-950.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/2026-08-08-951.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
+| docs/changelog.d/2026-08-08-966.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/2026-08-08-968.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/README.md | Product changelog history or generated changelog fragment. | 2026-08-06 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.md | Product changelog history or generated changelog fragment. | 2026-08-06 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |

--- a/docs/MARKDOWN_INVENTORY.md
+++ b/docs/MARKDOWN_INVENTORY.md
@@ -5,7 +5,7 @@
 | .agents/skills/plan-task-handoff/SKILL.md | Repository automation, contribution, or agent execution guidance. | 2026-08-01 | Code-coupled workflow contract that must change atomically with repository behavior. | keep | — |
 | .claude/skills/handoff/SKILL.md | Repository automation, contribution, or agent execution guidance. | 2026-03-26 | Code-coupled workflow contract that must change atomically with repository behavior. | keep | — |
 | .claude/skills/orchestrator/SKILL.md | Repository automation, contribution, or agent execution guidance. | 2026-04-15 | Code-coupled workflow contract that must change atomically with repository behavior. | keep | — |
-| AGENTS.md | Mandatory engineering rules for coding agents. | 2026-08-07 | Code-coupled contract; must not be duplicated in the Wiki. | keep | — |
+| AGENTS.md | Mandatory engineering rules for coding agents. | 2026-08-08 | Code-coupled contract; must not be duplicated in the Wiki. | keep | — |
 | COMIC_DEPENDENCIES_GUIDE.md | Tracked Markdown documentation outside the canonical docs hub. | 2026-04-26 | Standalone narrative documentation should not create another competing repository source of truth. | move to Wiki | ComicPile Wiki |
 | CONTRIBUTING.md | Repository contribution or security contract. | 2026-07-20 | GitHub-facing project policy that belongs beside the code. | keep | — |
 | LOCAL_TESTING.md | Tracked Markdown documentation outside the canonical docs hub. | 2026-03-04 | Standalone narrative documentation should not create another competing repository source of truth. | move to Wiki | ComicPile Wiki |

--- a/docs/changelog.d/2026-08-08-966.md
+++ b/docs/changelog.d/2026-08-08-966.md
@@ -1,0 +1,7 @@
+## 2026-08-08
+
+### Factory automation
+
+- [#966](https://github.com/JoshCLWren/comic-pile/pull/966) makes issue and pull-request
+  ownership labels a mandatory part of every factory transition, so work stays discoverable and
+  competing workers can reliably avoid active documentation and implementation branches.

--- a/scripts/check_markdown_docs.py
+++ b/scripts/check_markdown_docs.py
@@ -22,7 +22,7 @@ ALLOWED_ROOT_MARKDOWN = {
     "TECH_DEBT.md",
     "prd.md",
 }
-IGNORED_DIRECTORIES = {".git", ".venv", "node_modules", "archive"}
+IGNORED_DIRECTORIES = {".git", ".venv", ".vercel", "node_modules", "archive"}
 
 
 def iter_markdown_files(root: Path) -> list[Path]:

--- a/tests/test_markdown_docs.py
+++ b/tests/test_markdown_docs.py
@@ -94,8 +94,8 @@ def test_find_broken_local_links_reports_undefined_explicit_references(tmp_path:
     assert all("ordinary prose" not in error for error in errors)
 
 
-def test_iter_markdown_files_ignores_dependency_directories(tmp_path: Path) -> None:
-    """Exclude generated dependency trees from documentation audits.
+def test_iter_markdown_files_ignores_generated_directories(tmp_path: Path) -> None:
+    """Exclude generated dependency and deployment trees from documentation audits.
 
     Args:
         tmp_path: Temporary repository root supplied by pytest.
@@ -104,6 +104,9 @@ def test_iter_markdown_files_ignores_dependency_directories(tmp_path: Path) -> N
     node_modules = tmp_path / "node_modules" / "package"
     node_modules.mkdir(parents=True)
     (node_modules / "README.md").write_text("# Dependency\n", encoding="utf-8")
+    vercel_output = tmp_path / ".vercel" / "output" / "static"
+    vercel_output.mkdir(parents=True)
+    (vercel_output / "README.md").write_text("[stale](missing.md)\n", encoding="utf-8")
 
     assert iter_markdown_files(tmp_path) == [tmp_path / "README.md"]
 


### PR DESCRIPTION
## Summary

- defines one canonical issue/PR label state machine for factory work;
- makes label reconciliation mandatory at claim, review, CI, handoff, readiness, blocking, merge, and turn end;
- requires exactly one truthful workflow state and next-action owner;
- preserves cross-worker takeover and merge authorization;
- documents the REST fallback when `gh pr edit` fails on deprecated Projects Classic metadata;
- keeps local documentation audits isolated from generated Vercel output.

Closes #965.

Changelog: `docs/changelog.d/2026-08-08-966.md`

## Verification

- `uv run python scripts/check_markdown_docs.py`
- `uv run python -m pytest -q --no-cov tests/test_markdown_docs.py tests/test_generate_markdown_inventory.py` — 14 passed
- `cd frontend && pnpm run build`
- `git diff --check`
- commit hooks — passed