### PR TITLE
Preserve login on transient token refresh failures

### DIFF
--- a/docs/MARKDOWN_INVENTORY.md
+++ b/docs/MARKDOWN_INVENTORY.md
@@ -98,6 +98,7 @@
 | docs/changelog.d/2026-08-08-941.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/2026-08-08-945.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/2026-08-08-951.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
+| docs/changelog.d/2026-08-08-968.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/README.md | Product changelog history or generated changelog fragment. | 2026-08-06 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.md | Product changelog history or generated changelog fragment. | 2026-08-06 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/frontend-backend-asset-coupling-audit.md | Repository documentation for frontend backend asset coupling audit. | 2026-07-11 | Human-facing narrative should move out of the active code-coupled documentation set unless linked by the docs hub. | move to Wiki | ComicPile Wiki |

--- a/docs/MARKDOWN_INVENTORY.md
+++ b/docs/MARKDOWN_INVENTORY.md
@@ -117,4 +117,4 @@
 | prompts/issue-413-dependency-range-fix.md | Versioned agent or factory execution prompt. | 2026-04-26 | Automation-critical contract that must change atomically with factory behavior. | keep | — |
 | prompts/issue_gantt.md | Versioned agent or factory execution prompt. | 2026-04-17 | Automation-critical contract that must change atomically with factory behavior. | keep | — |
 | scripts/README_thread_management.md | Tracked Markdown documentation outside the canonical docs hub. | 2026-01-25 | Standalone narrative documentation should not create another competing repository source of truth. | move to Wiki | ComicPile Wiki |
-| tests_e2e/README.md | Package- or directory-local documentation for frontend/src/test. | 2026-07-11 | Adjacent package guidance is discoverable where the code lives and can change atomically with it. | keep | — |
+| tests_e2e/README.md | Package- or directory-local documentation for tests_e2e. | 2026-07-11 | Adjacent package guidance is discoverable where the code lives and can change atomically with it. | keep | — |

--- a/docs/MARKDOWN_INVENTORY.md
+++ b/docs/MARKDOWN_INVENTORY.md
@@ -117,4 +117,4 @@
 | prompts/issue-413-dependency-range-fix.md | Versioned agent or factory execution prompt. | 2026-04-26 | Automation-critical contract that must change atomically with factory behavior. | keep | — |
 | prompts/issue_gantt.md | Versioned agent or factory execution prompt. | 2026-04-17 | Automation-critical contract that must change atomically with factory behavior. | keep | — |
 | scripts/README_thread_management.md | Tracked Markdown documentation outside the canonical docs hub. | 2026-01-25 | Standalone narrative documentation should not create another competing repository source of truth. | move to Wiki | ComicPile Wiki |
-| tests_e2e/README.md | Package- or directory-local documentation for tests_e2e. | 2026-07-11 | Adjacent package guidance is discoverable where the code lives and can change atomically with it. | keep | — |
+| tests_e2e/README.md | Package- or directory-local documentation for frontend/src/test. | 2026-07-11 | Adjacent package guidance is discoverable where the code lives and can change atomically with it. | keep | — |

--- a/docs/changelog.d/2026-08-08-968.md
+++ b/docs/changelog.d/2026-08-08-968.md
@@ -2,4 +2,4 @@
 
 ### Authentication
 
-- [PR #968](https://github.com/JoshCLWren/comic-pile/pull/968) keeps ComicPile signed in when token refresh hits a temporary network or server failure. The app now sends you back to login only when the refresh response actually proves the session is no longer valid.
+- [#968](https://github.com/JoshCLWren/comic-pile/pull/968) keeps ComicPile signed in when token refresh hits a temporary network or server failure. The app now sends you back to login only when the refresh response actually proves the session is no longer valid.

--- a/docs/changelog.d/2026-08-08-968.md
+++ b/docs/changelog.d/2026-08-08-968.md
@@ -1,0 +1,5 @@
+## 2026-08-08
+
+### Authentication
+
+- [PR #968](https://github.com/JoshCLWren/comic-pile/pull/968) keeps ComicPile signed in when token refresh hits a temporary network or server failure. The app now sends you back to login only when the refresh response actually proves the session is no longer valid.

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -251,8 +251,7 @@ rawApi.interceptors.response.use(
         isRefreshing = false
         if (
           !originalRequest.skipAuthRedirect &&
-          axios.isAxiosError(refreshError) &&
-          isAuthenticationFailure(refreshError)
+          isAuthenticationFailure(refreshError as AxiosError)
         ) {
           redirectToLogin()
         }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -249,7 +249,11 @@ rawApi.interceptors.response.use(
       } catch (refreshError) {
         processQueue(refreshError, null)
         isRefreshing = false
-        if (!originalRequest.skipAuthRedirect) {
+        if (
+          !originalRequest.skipAuthRedirect &&
+          axios.isAxiosError(refreshError) &&
+          isAuthenticationFailure(refreshError)
+        ) {
           redirectToLogin()
         }
         return Promise.reject(refreshError)

--- a/frontend/src/unit/api-session-persistence.test.ts
+++ b/frontend/src/unit/api-session-persistence.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, expect, it, vi } from 'vitest'
+
+const apiMock = vi.hoisted(() => ({
+  request: vi.fn(),
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+  patch: vi.fn(),
+  interceptors: {
+    request: { use: vi.fn() },
+    response: { use: vi.fn() },
+  },
+}))
+
+vi.mock('axios', () => ({
+  default: {
+    create: vi.fn(() => apiMock),
+  },
+}))
+
+import { clearAccessToken, getAccessToken, setAccessToken } from '../services/api'
+
+const responseInterceptor = apiMock.interceptors.response.use.mock.calls[0][1] as (
+  error: {
+    config: { url: string; headers?: Record<string, string> }
+    response: { status: number; data?: unknown }
+  },
+) => Promise<unknown>
+
+beforeEach(() => {
+  apiMock.post.mockReset()
+  apiMock.request.mockReset()
+  clearAccessToken()
+})
+
+it.each([
+  ['a cold-start server error', Object.assign(new Error('service unavailable'), { response: { status: 503 } })],
+  ['a temporary network failure', new Error('network timeout')],
+])('keeps the current session after %s during token refresh', async (_description, refreshError) => {
+  setAccessToken('preserve-this-token')
+  apiMock.post.mockRejectedValueOnce(refreshError)
+
+  await expect(
+    responseInterceptor({
+      config: { url: '/v1/auth/me', headers: {} },
+      response: { status: 401 },
+    }),
+  ).rejects.toBe(refreshError)
+
+  expect(getAccessToken()).toBe('preserve-this-token')
+  expect(apiMock.request).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
Closes #967

## Summary
- keep the current authenticated state when access-token refresh fails because ComicPile is temporarily unavailable
- redirect to login only when the refresh response itself proves authentication is invalid
- add regression coverage for cold-start/server and network refresh failures

## Validation
This scheduled connector runtime has no local checkout, so required CI is the validation boundary for the current head.

Changelog: `docs/changelog.d/2026-08-08-968.md`.