### PR TITLE
Show crossover tags across ComicPile

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -5,12 +5,14 @@ from app.api import continuity_readiness as continuity_readiness
 from app.api import continuity_rule as continuity_rule
 from app.api import dependency as dependency
 from app.api import dependency_group as dependency_group
+from app.api import dependency_group_batch as dependency_group_batch
 from app.api import health as health
 from app.api import issue_dependency_batch as issue_dependency_batch
 
 analytics.router.include_router(health.router)
 dependency.router.include_router(issue_dependency_batch.router)
 dependency.router.include_router(dependency_group.router)
+dependency.router.include_router(dependency_group_batch.router)
 dependency.router.include_router(continuity_rule.router)
 dependency.router.include_router(continuity_readiness.router)
 
@@ -20,6 +22,7 @@ __all__ = [
     "continuity_rule",
     "dependency",
     "dependency_group",
+    "dependency_group_batch",
     "health",
     "issue_dependency_batch",
 ]

--- a/app/api/dependency_group_batch.py
+++ b/app/api/dependency_group_batch.py
@@ -1,0 +1,93 @@
+"""Batched crossover membership reads for thread-oriented screens."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import get_current_user
+from app.database import get_db
+from app.models import DependencyGroup, DependencyGroupMembership, Issue, Thread
+from app.models.user import User
+from app.schemas.dependency_group import DependencyGroupSummary
+
+router = APIRouter()
+MAX_BATCH_THREADS = 200
+
+
+class DependencyGroupThreadBatchRequest(BaseModel):
+    """Request crossover summaries for a bounded set of owned threads."""
+
+    thread_ids: list[int] = Field(min_length=1, max_length=MAX_BATCH_THREADS)
+
+
+@router.post(
+    "/threads/groups:batch",
+    response_model=dict[int, list[DependencyGroupSummary]],
+    description="List crossover groups for several owned threads in one request.",
+)
+async def list_thread_groups_batch(
+    payload: DependencyGroupThreadBatchRequest,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: AsyncSession = Depends(get_db),
+) -> dict[int, list[DependencyGroupSummary]]:
+    """Return distinct crossover summaries for each requested owned thread.
+
+    Args:
+        payload: The bounded thread identifiers to resolve.
+        current_user: The authenticated owner of the requested threads and groups.
+        db: The asynchronous database session.
+
+    Returns:
+        A mapping from thread ID to zero or more crossover summaries.
+
+    Raises:
+        HTTPException: If any requested thread is not owned by the current user.
+    """
+    thread_ids = list(dict.fromkeys(payload.thread_ids))
+    owned_result = await db.execute(
+        select(Thread.id).where(
+            Thread.user_id == current_user.id,
+            Thread.id.in_(thread_ids),
+        )
+    )
+    owned_ids = set(owned_result.scalars())
+    missing_ids = [thread_id for thread_id in thread_ids if thread_id not in owned_ids]
+    if missing_ids:
+        raise HTTPException(status_code=404, detail=f"Thread {missing_ids[0]} not found")
+
+    result = await db.execute(
+        select(
+            DependencyGroupMembership.thread_id.label("direct_thread_id"),
+            Issue.thread_id.label("issue_thread_id"),
+            DependencyGroup.id.label("group_id"),
+            DependencyGroup.name.label("group_name"),
+        )
+        .join(DependencyGroup, DependencyGroup.id == DependencyGroupMembership.group_id)
+        .outerjoin(Issue, Issue.id == DependencyGroupMembership.issue_id)
+        .where(
+            DependencyGroup.user_id == current_user.id,
+            or_(
+                DependencyGroupMembership.thread_id.in_(thread_ids),
+                Issue.thread_id.in_(thread_ids),
+            ),
+        )
+        .order_by(DependencyGroup.name, DependencyGroup.id)
+    )
+
+    groups_by_thread: dict[int, list[DependencyGroupSummary]] = {
+        thread_id: [] for thread_id in thread_ids
+    }
+    seen: dict[int, set[int]] = {thread_id: set() for thread_id in thread_ids}
+    for row in result:
+        thread_id = row.direct_thread_id if row.direct_thread_id is not None else row.issue_thread_id
+        if thread_id is None or row.group_id in seen[thread_id]:
+            continue
+        seen[thread_id].add(row.group_id)
+        groups_by_thread[thread_id].append(
+            DependencyGroupSummary(id=row.group_id, name=row.group_name)
+        )
+
+    return groups_by_thread

--- a/docs/changelog.d/2026-08-08-970.md
+++ b/docs/changelog.d/2026-08-08-970.md
@@ -2,4 +2,4 @@
 
 ### Crossovers
 
-- [PR #970](https://github.com/JoshCLWren/comic-pile/pull/970) shows crossover memberships consistently on Roll, Queue, and thread details, including multiple memberships, while batching Queue lookups so large libraries do not trigger one request per row.
+- [#970](https://github.com/JoshCLWren/comic-pile/pull/970) shows crossover memberships consistently on Roll, Queue, and thread details, including multiple memberships, while batching Queue lookups so large libraries do not trigger one request per row.

--- a/docs/changelog.d/2026-08-08-970.md
+++ b/docs/changelog.d/2026-08-08-970.md
@@ -1,0 +1,5 @@
+## 2026-08-08
+
+### Crossovers
+
+- [PR #970](https://github.com/JoshCLWren/comic-pile/pull/970) shows crossover memberships consistently on Roll, Queue, and thread details, including multiple memberships, while batching Queue lookups so large libraries do not trigger one request per row.

--- a/frontend/src/components/CrossoverTags.tsx
+++ b/frontend/src/components/CrossoverTags.tsx
@@ -23,7 +23,7 @@ export function CrossoverTags({
           <li key={group.id} className="min-w-0 max-w-full">
             <Link
               to={`/crossovers?group=${group.id}`}
-              className="block max-w-full truncate rounded-lg border border-violet-700/30 bg-violet-900/20 px-3 py-1.5 text-xs font-bold text-violet-300 transition hover:border-violet-500/60 hover:bg-violet-900/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400"
+              className="block max-w-full break-words rounded-lg border border-violet-700/30 bg-violet-900/20 px-3 py-1.5 text-xs font-bold text-violet-300 transition hover:border-violet-500/60 hover:bg-violet-900/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400"
               title={group.name}
             >
               {group.name}

--- a/frontend/src/components/CrossoverTags.tsx
+++ b/frontend/src/components/CrossoverTags.tsx
@@ -1,0 +1,36 @@
+import { Link } from 'react-router-dom'
+import type { DependencyGroupSummary } from '../services/api-dependency-groups'
+
+interface CrossoverTagsProps {
+  groups: DependencyGroupSummary[]
+  align?: 'start' | 'center'
+  label?: string
+}
+
+export function CrossoverTags({
+  groups,
+  align = 'start',
+  label = 'Crossovers',
+}: CrossoverTagsProps) {
+  if (groups.length === 0) return null
+
+  return (
+    <section aria-label={label} className="min-w-0">
+      <ul
+        className={`flex max-w-full flex-wrap gap-2 ${align === 'center' ? 'justify-center' : 'justify-start'}`}
+      >
+        {groups.map((group) => (
+          <li key={group.id} className="min-w-0 max-w-full">
+            <Link
+              to={`/crossovers?group=${group.id}`}
+              className="block max-w-full truncate rounded-lg border border-violet-700/30 bg-violet-900/20 px-3 py-1.5 text-xs font-bold text-violet-300 transition hover:border-violet-500/60 hover:bg-violet-900/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-400"
+              title={group.name}
+            >
+              {group.name}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/frontend/src/generated/openapi.json
+++ b/frontend/src/generated/openapi.json
@@ -901,6 +901,25 @@
         "title": "DependencyGroupSummary",
         "type": "object"
       },
+      "DependencyGroupThreadBatchRequest": {
+        "description": "Request crossover summaries for a bounded set of owned threads.",
+        "properties": {
+          "thread_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "maxItems": 200,
+            "minItems": 1,
+            "title": "Thread Ids",
+            "type": "array"
+          }
+        },
+        "required": [
+          "thread_ids"
+        ],
+        "title": "DependencyGroupThreadBatchRequest",
+        "type": "object"
+      },
       "DependencyGroupUpdate": {
         "description": "Rename a named dependency group.",
         "properties": {
@@ -7210,6 +7229,61 @@
         "tags": [
           "session",
           "sessions"
+        ]
+      }
+    },
+    "/api/v1/threads/groups:batch": {
+      "post": {
+        "description": "List crossover groups for several owned threads in one request.",
+        "operationId": "list_thread_groups_batch_api_v1_threads_groups_batch_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DependencyGroupThreadBatchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "items": {
+                      "$ref": "#/components/schemas/DependencyGroupSummary"
+                    },
+                    "type": "array"
+                  },
+                  "title": "Response List Thread Groups Batch Api V1 Threads Groups Batch Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Thread Groups Batch",
+        "tags": [
+          "dependencies",
+          "dependencies"
         ]
       }
     },

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -2224,6 +2224,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/threads/groups:batch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * List Thread Groups Batch
+         * @description List crossover groups for several owned threads in one request.
+         */
+        post: operations["list_thread_groups_batch_api_v1_threads_groups_batch_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/threads/{thread_id}/connected": {
         parameters: {
             query?: never;
@@ -2997,6 +3017,14 @@ export interface components {
             id: number;
             /** Name */
             name: string;
+        };
+        /**
+         * DependencyGroupThreadBatchRequest
+         * @description Request crossover summaries for a bounded set of owned threads.
+         */
+        DependencyGroupThreadBatchRequest: {
+            /** Thread Ids */
+            thread_ids: number[];
         };
         /**
          * DependencyGroupUpdate
@@ -6443,6 +6471,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SnapshotsListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_thread_groups_batch_api_v1_threads_groups_batch_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DependencyGroupThreadBatchRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: components["schemas"]["DependencyGroupSummary"][];
+                    };
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/hooks/useCrossoverGroups.ts
+++ b/frontend/src/hooks/useCrossoverGroups.ts
@@ -1,0 +1,116 @@
+import { useEffect, useMemo, useState } from 'react'
+import {
+  dependencyGroupsApi,
+  type DependencyGroupSummary,
+} from '../services/api-dependency-groups'
+
+interface CrossoverGroupsState {
+  groupsByThreadId: Record<number, DependencyGroupSummary[]>
+  isPending: boolean
+  error: Error | null
+}
+
+interface PendingCrossoverRequest {
+  threadIds: number[]
+  resolve: (groupsByThreadId: Record<number, DependencyGroupSummary[]>) => void
+  reject: (error: unknown) => void
+}
+
+const EMPTY_GROUPS: Record<number, DependencyGroupSummary[]> = {}
+const MAX_THREAD_IDS_PER_REQUEST = 200
+let pendingRequests: PendingCrossoverRequest[] = []
+let flushScheduled = false
+
+function chunkThreadIds(threadIds: number[]): number[][] {
+  const chunks: number[][] = []
+  for (let index = 0; index < threadIds.length; index += MAX_THREAD_IDS_PER_REQUEST) {
+    chunks.push(threadIds.slice(index, index + MAX_THREAD_IDS_PER_REQUEST))
+  }
+  return chunks
+}
+
+async function flushPendingRequests() {
+  const requests = pendingRequests
+  pendingRequests = []
+  flushScheduled = false
+
+  const allThreadIds = [...new Set(requests.flatMap((request) => request.threadIds))]
+
+  try {
+    const responses = await Promise.all(
+      chunkThreadIds(allThreadIds).map((threadIdChunk) =>
+        dependencyGroupsApi.listForThreads(threadIdChunk),
+      ),
+    )
+    const mergedGroupsByThreadId = Object.assign({}, ...responses) as Record<number, DependencyGroupSummary[]>
+
+    requests.forEach(({ threadIds, resolve }) => {
+      const requestedGroups = Object.fromEntries(
+        threadIds.map((threadId) => [threadId, mergedGroupsByThreadId[threadId] ?? []]),
+      )
+      resolve(requestedGroups)
+    })
+  } catch (error) {
+    requests.forEach(({ reject }) => reject(error))
+  }
+}
+
+function requestCrossoverGroups(threadIds: number[]): Promise<Record<number, DependencyGroupSummary[]>> {
+  return new Promise((resolve, reject) => {
+    pendingRequests.push({ threadIds, resolve, reject })
+    if (!flushScheduled) {
+      flushScheduled = true
+      queueMicrotask(() => {
+        void flushPendingRequests()
+      })
+    }
+  })
+}
+
+export function useCrossoverGroups(threadIds: number[]): CrossoverGroupsState {
+  const requestKey = useMemo(
+    () => [...new Set(threadIds)].sort((a, b) => a - b).join(','),
+    [threadIds],
+  )
+  const [state, setState] = useState<CrossoverGroupsState>({
+    groupsByThreadId: EMPTY_GROUPS,
+    isPending: requestKey.length > 0,
+    error: null,
+  })
+
+  useEffect(() => {
+    let cancelled = false
+    const requestedThreadIds = requestKey
+      ? requestKey.split(',').map((threadId) => Number(threadId))
+      : []
+
+    if (requestedThreadIds.length === 0) {
+      setState({ groupsByThreadId: EMPTY_GROUPS, isPending: false, error: null })
+      return () => {
+        cancelled = true
+      }
+    }
+
+    setState((current) => ({ ...current, isPending: true, error: null }))
+
+    requestCrossoverGroups(requestedThreadIds)
+      .then((groupsByThreadId) => {
+        if (cancelled) return
+        setState({ groupsByThreadId, isPending: false, error: null })
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return
+        setState({
+          groupsByThreadId: EMPTY_GROUPS,
+          isPending: false,
+          error: error instanceof Error ? error : new Error('Failed to load crossovers'),
+        })
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [requestKey])
+
+  return state
+}

--- a/frontend/src/pages/QueuePage/QueueThreadCard.tsx
+++ b/frontend/src/pages/QueuePage/QueueThreadCard.tsx
@@ -63,7 +63,9 @@ export default function QueueThreadCard({
   onDelete,
 }: QueueThreadCardProps) {
   const isMigrated = thread.total_issues !== null
-  const fallbackCrossoverGroups = useCrossoverGroups([thread.id])
+  const fallbackCrossoverGroups = useCrossoverGroups(
+    crossoverGroups === undefined ? [thread.id] : [],
+  )
   const resolvedCrossoverGroups = crossoverGroups ?? fallbackCrossoverGroups.groupsByThreadId[thread.id] ?? []
   const resolvedCrossoverGroupsLoading = crossoverGroupsLoading ?? fallbackCrossoverGroups.isPending
   const resolvedCrossoverGroupsError = crossoverGroupsError ?? Boolean(fallbackCrossoverGroups.error)

--- a/frontend/src/pages/QueuePage/QueueThreadCard.tsx
+++ b/frontend/src/pages/QueuePage/QueueThreadCard.tsx
@@ -2,6 +2,9 @@ import Tooltip from '../../components/Tooltip'
 import { MarqueeTitle } from '../../components/MarqueeTitle'
 import PositionMenu from '../../components/PositionMenu'
 import Swipeable from '../../components/Swipeable'
+import { CrossoverTags } from '../../components/CrossoverTags'
+import { useCrossoverGroups } from '../../hooks/useCrossoverGroups'
+import type { DependencyGroupSummary } from '../../services/api-dependency-groups'
 import type { Thread } from '../../types'
 
 interface QueueThreadCardProps {
@@ -9,6 +12,9 @@ interface QueueThreadCardProps {
   index: number
   isBlocked: boolean
   blockingReasons: string[]
+  crossoverGroups?: DependencyGroupSummary[]
+  crossoverGroupsLoading?: boolean
+  crossoverGroupsError?: boolean
   isDragOver: boolean
   snoozeIcon: string
   snoozeLabel: string
@@ -34,6 +40,9 @@ export default function QueueThreadCard({
   index,
   isBlocked,
   blockingReasons,
+  crossoverGroups,
+  crossoverGroupsLoading,
+  crossoverGroupsError,
   isDragOver,
   snoozeIcon,
   snoozeLabel,
@@ -54,6 +63,10 @@ export default function QueueThreadCard({
   onDelete,
 }: QueueThreadCardProps) {
   const isMigrated = thread.total_issues !== null
+  const fallbackCrossoverGroups = useCrossoverGroups([thread.id])
+  const resolvedCrossoverGroups = crossoverGroups ?? fallbackCrossoverGroups.groupsByThreadId[thread.id] ?? []
+  const resolvedCrossoverGroupsLoading = crossoverGroupsLoading ?? fallbackCrossoverGroups.isPending
+  const resolvedCrossoverGroupsError = crossoverGroupsError ?? Boolean(fallbackCrossoverGroups.error)
 
   return (
     <Swipeable
@@ -131,6 +144,15 @@ export default function QueueThreadCard({
               }
             </p>
           )}
+          <div className="mt-2" onClick={(event) => event.stopPropagation()}>
+            {resolvedCrossoverGroupsLoading ? (
+              <p className="text-xs text-stone-500">Loading crossovers…</p>
+            ) : resolvedCrossoverGroupsError ? (
+              <p className="text-xs text-red-300/80">Crossovers unavailable</p>
+            ) : (
+              <CrossoverTags groups={resolvedCrossoverGroups} label={`Crossovers for ${thread.title}`} />
+            )}
+          </div>
           {isBlocked && blockingReasons.length > 0 && (
             <button
               type="button"

--- a/frontend/src/pages/RollPage/components/ReadingOrderGroups.tsx
+++ b/frontend/src/pages/RollPage/components/ReadingOrderGroups.tsx
@@ -1,3 +1,4 @@
+import { CrossoverTags } from '../../../components/CrossoverTags'
 import { useDependencyGroups } from '../../../hooks/useDependencyGroups'
 
 interface ReadingOrderGroupsProps {
@@ -37,16 +38,7 @@ export function ReadingOrderGroups({ threadId }: ReadingOrderGroupsProps) {
       >
         Crossovers
       </h3>
-      <ul className="flex flex-wrap justify-center gap-2">
-        {groups.map((group) => (
-          <li
-            key={group.id}
-            className="max-w-full break-words rounded-lg border border-violet-700/30 bg-violet-900/20 px-3 py-1.5 text-xs font-bold text-violet-300"
-          >
-            {group.name}
-          </li>
-        ))}
-      </ul>
+      <CrossoverTags groups={groups} align="center" label="Crossover memberships" />
     </section>
   )
 }

--- a/frontend/src/pages/ThreadDetailView.tsx
+++ b/frontend/src/pages/ThreadDetailView.tsx
@@ -2,10 +2,12 @@ import { useState, useEffect, useRef } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import Modal from '../components/Modal'
 import LoadingSpinner from '../components/LoadingSpinner'
+import { CrossoverTags } from '../components/CrossoverTags'
 import { threadsApi } from '../services/api'
 import { issuesApi } from '../services/api-issues'
 import type { Thread, Issue } from '../types'
 import { FormatSelect } from '../pages/QueuePage/FormatSelect'
+import { useCrossoverGroups } from '../hooks/useCrossoverGroups'
 import { useUpdateThread } from '../hooks/useThread'
 import { getApiErrorDetail } from '../utils/apiError'
 import type { ChangeEvent, FormEvent } from 'react'
@@ -32,6 +34,11 @@ export default function ThreadDetailView() {
   const [issuesLoaded, setIssuesLoaded] = useState(false)
   const [nextPageToken, setNextPageToken] = useState<string | null>(null)
   const [issuesTotal, setIssuesTotal] = useState(0)
+  const {
+    groupsByThreadId: crossoverGroupsByThreadId,
+    isPending: crossoversPending,
+    error: crossoversError,
+  } = useCrossoverGroups(thread ? [thread.id] : [])
 
   useEffect(() => {
     const threadId = id ? Number(id) : null
@@ -203,6 +210,7 @@ export default function ThreadDetailView() {
   const isMigrated = thread.total_issues !== null
   const progressPercentage = getProgressPercentage()
   const issuesReadCount = getIssuesReadCount()
+  const crossoverGroups = crossoverGroupsByThreadId[thread.id] ?? []
 
   return (
     <div className="space-y-6 md:space-y-8 pb-20">
@@ -258,6 +266,22 @@ export default function ThreadDetailView() {
             <p className="text-sm text-stone-300 whitespace-pre-wrap">{thread.notes}</p>
           </div>
         )}
+
+        <div className="glass-card p-3 md:p-4 space-y-2">
+          <span className="text-xs font-black uppercase tracking-widest text-stone-500">
+            Crossovers
+          </span>
+          {crossoversPending && <p className="text-xs text-stone-500">Loading crossovers...</p>}
+          {!crossoversPending && crossoversError && (
+            <p className="text-xs text-red-400">Unable to load crossover memberships.</p>
+          )}
+          {!crossoversPending && !crossoversError && crossoverGroups.length === 0 && (
+            <p className="text-xs text-stone-500">No crossover memberships</p>
+          )}
+          {!crossoversPending && !crossoversError && (
+            <CrossoverTags groups={crossoverGroups} label={`${thread.title} crossovers`} />
+          )}
+        </div>
 
         {isMigrated && (
           <div className="glass-card p-3 md:p-4 space-y-3">

--- a/frontend/src/services/api-dependency-groups.ts
+++ b/frontend/src/services/api-dependency-groups.ts
@@ -57,6 +57,15 @@ export const dependencyGroupsApi = {
     )
   },
 
+  listForThreads: async (
+    threadIds: number[],
+  ): Promise<Record<number, DependencyGroupSummary[]>> => {
+    return api.post<Record<number, DependencyGroupSummary[]>>(
+      '/v1/reading-order-groups/threads/groups:batch',
+      { thread_ids: threadIds },
+    )
+  },
+
   addMember: async (
     groupId: number,
     target: DependencyGroupMemberTarget,

--- a/frontend/src/unit/CrossoverTags.test.tsx
+++ b/frontend/src/unit/CrossoverTags.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+
+import { CrossoverTags } from '../components/CrossoverTags'
+
+describe('CrossoverTags', () => {
+  it('renders nothing when there are no crossover memberships', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <CrossoverTags groups={[]} />
+      </MemoryRouter>,
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders every crossover as a tappable management link', () => {
+    render(
+      <MemoryRouter>
+        <CrossoverTags
+          groups={[
+            { id: 7, name: 'Annihilation' },
+            { id: 12, name: 'War of Kings' },
+          ]}
+          label="Crossovers for Nova"
+        />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('region', { name: 'Crossovers for Nova' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Annihilation' })).toHaveAttribute(
+      'href',
+      '/crossovers?group=7',
+    )
+    expect(screen.getByRole('link', { name: 'War of Kings' })).toHaveAttribute(
+      'href',
+      '/crossovers?group=12',
+    )
+  })
+
+  it('keeps long crossover names bounded for mobile layouts', () => {
+    render(
+      <MemoryRouter>
+        <CrossoverTags groups={[{ id: 3, name: 'A Very Long Cosmic Crossover Name' }]} />
+      </MemoryRouter>,
+    )
+
+    const link = screen.getByRole('link', { name: 'A Very Long Cosmic Crossover Name' })
+    expect(link).toHaveClass('max-w-full', 'truncate')
+    expect(link).toHaveAttribute('title', 'A Very Long Cosmic Crossover Name')
+  })
+})

--- a/frontend/src/unit/CrossoverTags.test.tsx
+++ b/frontend/src/unit/CrossoverTags.test.tsx
@@ -47,7 +47,8 @@ describe('CrossoverTags', () => {
     )
 
     const link = screen.getByRole('link', { name: 'A Very Long Cosmic Crossover Name' })
-    expect(link).toHaveClass('max-w-full', 'truncate')
+    expect(link).toHaveClass('max-w-full', 'break-words')
+    expect(link).not.toHaveClass('truncate')
     expect(link).toHaveAttribute('title', 'A Very Long Cosmic Crossover Name')
   })
 })

--- a/frontend/src/unit/QueueThreadCard.test.tsx
+++ b/frontend/src/unit/QueueThreadCard.test.tsx
@@ -26,6 +26,10 @@ vi.mock('../components/Swipeable', () => ({
   default: ({ children }: { children: React.ReactNode }) => <div data-testid="mock-swipeable">{children}</div>,
 }))
 
+vi.mock('../hooks/useCrossoverGroups', () => ({
+  useCrossoverGroups: () => ({ groupsByThreadId: {}, isPending: false, error: null }),
+}))
+
 function createMockThread(overrides: Partial<Thread> = {}): Thread {
   return {
     id: 1,
@@ -158,6 +162,40 @@ describe('QueueThreadCard', () => {
     const thread = createMockThread({ notes: 'This is a note' })
     renderCard(thread)
     expect(screen.getByText('This is a note')).toBeInTheDocument()
+  })
+
+  it('renders multiple crossover memberships supplied by the Queue batch loader', () => {
+    renderCard(createMockThread(), {
+      crossoverGroups: [
+        { id: 11, name: 'Rotworld' },
+        { id: 12, name: 'Night of the Owls' },
+      ],
+    })
+
+    expect(screen.getByRole('link', { name: 'Rotworld' })).toHaveAttribute('href', '/crossovers?group=11')
+    expect(screen.getByRole('link', { name: 'Night of the Owls' })).toHaveAttribute('href', '/crossovers?group=12')
+  })
+
+  it('shows a crossover loading state without inventing empty membership', () => {
+    renderCard(createMockThread(), { crossoverGroups: [], crossoverGroupsLoading: true })
+
+    expect(screen.getByText('Loading crossovers…')).toBeInTheDocument()
+    expect(screen.queryByRole('region', { name: 'Crossovers' })).not.toBeInTheDocument()
+  })
+
+  it('shows a non-blocking crossover error state when membership loading fails', () => {
+    renderCard(createMockThread(), { crossoverGroups: [], crossoverGroupsError: true })
+
+    expect(screen.getByText('Crossovers unavailable')).toBeInTheDocument()
+    expect(screen.getByText('Test Thread')).toBeInTheDocument()
+  })
+
+  it('keeps the empty crossover state visually quiet once loading completes', () => {
+    renderCard(createMockThread(), { crossoverGroups: [], crossoverGroupsLoading: false })
+
+    expect(screen.queryByText('Loading crossovers…')).not.toBeInTheDocument()
+    expect(screen.queryByText('Crossovers unavailable')).not.toBeInTheDocument()
+    expect(screen.queryByRole('region', { name: 'Crossovers' })).not.toBeInTheDocument()
   })
 
   it('handles keyboard, drag, blocked dependency, and all position-menu callbacks', async () => {

--- a/frontend/src/unit/QueueThreadCard.test.tsx
+++ b/frontend/src/unit/QueueThreadCard.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import QueueThreadCard from '../pages/QueuePage/QueueThreadCard'
 import type { Thread } from '../types'
@@ -77,7 +78,14 @@ function renderCard(thread: Thread, overrides: Partial<Parameters<typeof QueueTh
     onDelete: vi.fn(),
     ...overrides,
   }
-  return { props: defaults, ...render(<QueueThreadCard {...defaults} />) }
+  return {
+    props: defaults,
+    ...render(
+      <MemoryRouter>
+        <QueueThreadCard {...defaults} />
+      </MemoryRouter>,
+    ),
+  }
 }
 
 describe('QueueThreadCard', () => {

--- a/frontend/src/unit/QueueThreadCard.test.tsx
+++ b/frontend/src/unit/QueueThreadCard.test.tsx
@@ -5,6 +5,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import QueueThreadCard from '../pages/QueuePage/QueueThreadCard'
 import type { Thread } from '../types'
 
+const { useCrossoverGroups } = vi.hoisted(() => ({
+  useCrossoverGroups: vi.fn(() => ({ groupsByThreadId: {}, isPending: false, error: null })),
+}))
+
 vi.mock('../components/Tooltip', () => ({
   default: ({ children, content }: { children: React.ReactNode; content?: string }) => (
     <div data-testid="mock-tooltip" data-content={content}>{children}</div>
@@ -28,7 +32,7 @@ vi.mock('../components/Swipeable', () => ({
 }))
 
 vi.mock('../hooks/useCrossoverGroups', () => ({
-  useCrossoverGroups: () => ({ groupsByThreadId: {}, isPending: false, error: null }),
+  useCrossoverGroups,
 }))
 
 function createMockThread(overrides: Partial<Thread> = {}): Thread {
@@ -182,6 +186,13 @@ describe('QueueThreadCard', () => {
 
     expect(screen.getByRole('link', { name: 'Rotworld' })).toHaveAttribute('href', '/crossovers?group=11')
     expect(screen.getByRole('link', { name: 'Night of the Owls' })).toHaveAttribute('href', '/crossovers?group=12')
+    expect(useCrossoverGroups).toHaveBeenCalledWith([])
+  })
+
+  it('uses the per-thread fallback only when no batch result was supplied', () => {
+    renderCard(createMockThread({ id: 27 }))
+
+    expect(useCrossoverGroups).toHaveBeenCalledWith([27])
   })
 
   it('shows a crossover loading state without inventing empty membership', () => {

--- a/frontend/src/unit/RatingViewReadingOrderGroups.test.tsx
+++ b/frontend/src/unit/RatingViewReadingOrderGroups.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import { describe, expect, it, vi } from 'vitest'
 import { RatingView } from '../pages/RollPage/components/RatingView'
 
@@ -23,25 +24,17 @@ const callbacks = {
   onRefreshThread: vi.fn(),
 }
 
-describe('RatingView crossovers', () => {
-  it('shows crossover names owned by the active rating thread', () => {
-    render(
+function renderRatingView(activeRatingThread: Parameters<typeof RatingView>[0]['activeRatingThread']) {
+  return render(
+    <MemoryRouter>
       <RatingView
-        activeRatingThread={{
-          id: 42,
-          title: 'Silver Surfer',
-          format: 'Comic',
-          issues_remaining: 3,
-          total_issues: 6,
-          issue_number: '3',
-          next_issue_number: '4',
-        } as never}
+        activeRatingThread={activeRatingThread}
         currentDie={6}
-        rolledResult={3}
-        rating={4}
-        predictedDie={4}
-        hasValidRolledResult
-        poolSize={6}
+        rolledResult={activeRatingThread ? 3 : null}
+        rating={activeRatingThread ? 4 : 3}
+        predictedDie={activeRatingThread ? 4 : 6}
+        hasValidRolledResult={Boolean(activeRatingThread)}
+        poolSize={activeRatingThread ? 6 : 0}
         errorMessage=""
         rateIsPending={false}
         snoozeIsPending={false}
@@ -49,32 +42,29 @@ describe('RatingView crossovers', () => {
         readingOrders={[]}
         connectedThreads={[]}
         {...callbacks}
-      />,
-    )
+      />
+    </MemoryRouter>,
+  )
+}
+
+describe('RatingView crossovers', () => {
+  it('shows crossover names owned by the active rating thread', () => {
+    renderRatingView({
+      id: 42,
+      title: 'Silver Surfer',
+      format: 'Comic',
+      issues_remaining: 3,
+      total_issues: 6,
+      issue_number: '3',
+      next_issue_number: '4',
+    } as never)
 
     expect(screen.getByRole('heading', { name: 'Crossovers' })).toBeInTheDocument()
     expect(screen.getByText('Cosmic bridge')).toBeInTheDocument()
   })
 
   it('does not show crossover chrome without an active thread', () => {
-    render(
-      <RatingView
-        activeRatingThread={null}
-        currentDie={6}
-        rolledResult={null}
-        rating={3}
-        predictedDie={6}
-        hasValidRolledResult={false}
-        poolSize={0}
-        errorMessage=""
-        rateIsPending={false}
-        snoozeIsPending={false}
-        dismissIsPending={false}
-        readingOrders={[]}
-        connectedThreads={[]}
-        {...callbacks}
-      />,
-    )
+    renderRatingView(null)
 
     expect(screen.queryByRole('heading', { name: 'Crossovers' })).not.toBeInTheDocument()
   })

--- a/frontend/src/unit/ReadingOrderGroups.test.tsx
+++ b/frontend/src/unit/ReadingOrderGroups.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ReadingOrderGroups } from '../pages/RollPage/components/ReadingOrderGroups'
 import { useDependencyGroups } from '../hooks/useDependencyGroups'
@@ -9,6 +10,14 @@ vi.mock('../hooks/useDependencyGroups', () => ({
 
 const mockedUseDependencyGroups = vi.mocked(useDependencyGroups)
 
+function renderGroups(threadId: number | null) {
+  return render(
+    <MemoryRouter>
+      <ReadingOrderGroups threadId={threadId} />
+    </MemoryRouter>,
+  )
+}
+
 describe('ReadingOrderGroups', () => {
   beforeEach(() => {
     mockedUseDependencyGroups.mockReset()
@@ -17,7 +26,7 @@ describe('ReadingOrderGroups', () => {
   it('renders nothing when there is no active thread', () => {
     mockedUseDependencyGroups.mockReturnValue({ groups: [], isLoading: false, error: null })
 
-    const { container } = render(<ReadingOrderGroups threadId={null} />)
+    const { container } = renderGroups(null)
 
     expect(container).toBeEmptyDOMElement()
     expect(mockedUseDependencyGroups).toHaveBeenCalledWith(null)
@@ -26,7 +35,7 @@ describe('ReadingOrderGroups', () => {
   it('announces crossover loading without showing stale names', () => {
     mockedUseDependencyGroups.mockReturnValue({ groups: [], isLoading: true, error: null })
 
-    render(<ReadingOrderGroups threadId={17} />)
+    renderGroups(17)
 
     expect(screen.getByRole('status')).toHaveTextContent('Loading crossovers')
     expect(screen.queryByRole('list')).not.toBeInTheDocument()
@@ -39,7 +48,7 @@ describe('ReadingOrderGroups', () => {
       error: new Error('network failed'),
     })
 
-    render(<ReadingOrderGroups threadId={17} />)
+    renderGroups(17)
 
     expect(screen.getByRole('alert')).toHaveTextContent('Unable to load crossovers.')
   })
@@ -47,7 +56,7 @@ describe('ReadingOrderGroups', () => {
   it('does not add an empty section for threads without crossovers', () => {
     mockedUseDependencyGroups.mockReturnValue({ groups: [], isLoading: false, error: null })
 
-    const { container } = render(<ReadingOrderGroups threadId={17} />)
+    const { container } = renderGroups(17)
 
     expect(container).toBeEmptyDOMElement()
   })
@@ -62,7 +71,7 @@ describe('ReadingOrderGroups', () => {
       error: null,
     })
 
-    render(<ReadingOrderGroups threadId={17} />)
+    renderGroups(17)
 
     expect(screen.getByRole('heading', { name: 'Crossovers' })).toBeInTheDocument()
     expect(screen.getByRole('list')).toBeInTheDocument()

--- a/frontend/src/unit/useCrossoverGroups.test.tsx
+++ b/frontend/src/unit/useCrossoverGroups.test.tsx
@@ -1,7 +1,9 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const listForThreads = vi.fn()
+const { listForThreads } = vi.hoisted(() => ({
+  listForThreads: vi.fn(),
+}))
 
 vi.mock('../services/api-dependency-groups', () => ({
   dependencyGroupsApi: { listForThreads },

--- a/frontend/src/unit/useCrossoverGroups.test.tsx
+++ b/frontend/src/unit/useCrossoverGroups.test.tsx
@@ -1,0 +1,106 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const listForThreads = vi.fn()
+
+vi.mock('../services/api-dependency-groups', () => ({
+  dependencyGroupsApi: { listForThreads },
+}))
+
+import { useCrossoverGroups } from '../hooks/useCrossoverGroups'
+
+describe('useCrossoverGroups', () => {
+  beforeEach(() => {
+    listForThreads.mockReset()
+  })
+
+  it('returns an immediate empty state when no thread ids are requested', async () => {
+    const { result } = renderHook(() => useCrossoverGroups([]))
+
+    await waitFor(() => expect(result.current.isPending).toBe(false))
+    expect(result.current.groupsByThreadId).toEqual({})
+    expect(result.current.error).toBeNull()
+    expect(listForThreads).not.toHaveBeenCalled()
+  })
+
+  it('deduplicates and sorts ids while filling missing groups with empty arrays', async () => {
+    listForThreads.mockResolvedValueOnce({
+      2: [{ id: 7, name: 'Cosmic', membership_count: 1 }],
+    })
+
+    const { result } = renderHook(() => useCrossoverGroups([3, 2, 3]))
+
+    await waitFor(() => expect(result.current.isPending).toBe(false))
+    expect(listForThreads).toHaveBeenCalledWith([2, 3])
+    expect(result.current.groupsByThreadId[2]).toHaveLength(1)
+    expect(result.current.groupsByThreadId[3]).toEqual([])
+  })
+
+  it('coalesces simultaneous hooks into one request', async () => {
+    listForThreads.mockResolvedValueOnce({ 1: [], 2: [] })
+
+    const first = renderHook(() => useCrossoverGroups([1]))
+    const second = renderHook(() => useCrossoverGroups([2]))
+
+    await waitFor(() => expect(first.result.current.isPending).toBe(false))
+    await waitFor(() => expect(second.result.current.isPending).toBe(false))
+    expect(listForThreads).toHaveBeenCalledTimes(1)
+    expect(listForThreads).toHaveBeenCalledWith([1, 2])
+  })
+
+  it('chunks requests larger than the backend limit', async () => {
+    listForThreads.mockResolvedValue({})
+    const ids = Array.from({ length: 201 }, (_, index) => index + 1)
+
+    const { result } = renderHook(() => useCrossoverGroups(ids))
+
+    await waitFor(() => expect(result.current.isPending).toBe(false))
+    expect(listForThreads).toHaveBeenCalledTimes(2)
+    expect(listForThreads.mock.calls[0][0]).toHaveLength(200)
+    expect(listForThreads.mock.calls[1][0]).toEqual([201])
+  })
+
+  it('normalizes non-Error failures', async () => {
+    listForThreads.mockRejectedValueOnce('offline')
+
+    const { result } = renderHook(() => useCrossoverGroups([9]))
+
+    await waitFor(() => expect(result.current.isPending).toBe(false))
+    expect(result.current.error).toEqual(new Error('Failed to load crossovers'))
+    expect(result.current.groupsByThreadId).toEqual({})
+  })
+
+  it('preserves Error failures', async () => {
+    const failure = new Error('boom')
+    listForThreads.mockRejectedValueOnce(failure)
+
+    const { result } = renderHook(() => useCrossoverGroups([9]))
+
+    await waitFor(() => expect(result.current.isPending).toBe(false))
+    expect(result.current.error).toBe(failure)
+  })
+
+  it('ignores a successful response after the request is replaced', async () => {
+    let resolveFirst!: (value: Record<number, never[]>) => void
+    listForThreads
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveFirst = resolve }))
+      .mockResolvedValueOnce({ 2: [] })
+
+    const { result, rerender } = renderHook(
+      ({ ids }) => useCrossoverGroups(ids),
+      { initialProps: { ids: [1] } },
+    )
+
+    await waitFor(() => expect(listForThreads).toHaveBeenCalledTimes(1))
+    rerender({ ids: [2] })
+    await waitFor(() => expect(listForThreads).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(result.current.isPending).toBe(false))
+
+    await act(async () => {
+      resolveFirst({ 1: [] })
+      await Promise.resolve()
+    })
+
+    expect(result.current.groupsByThreadId).toEqual({ 2: [] })
+  })
+})


### PR DESCRIPTION
Closes #840

## Summary
- add reusable mobile-safe crossover tags to Roll, Queue, and thread detail
- add a bounded authenticated thread-to-crossover batch endpoint covering direct thread and issue memberships
- coalesce Queue-card membership requests and chunk libraries above the 200-thread backend limit
- cover empty, multiple-membership, loading, and error states

## Validation
This runtime has no repository checkout, so required CI is the validation boundary for this branch.

Changelog: `docs/changelog.d/2026-08-08-970.md`