### PR TITLE
Hide GitHub links from public What’s New

### DIFF
--- a/docs/MARKDOWN_INVENTORY.md
+++ b/docs/MARKDOWN_INVENTORY.md
@@ -101,6 +101,7 @@
 | docs/changelog.d/2026-08-08-951.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/2026-08-08-966.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/2026-08-08-968.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
+| docs/changelog.d/2026-08-08-972.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/README.md | Product changelog history or generated changelog fragment. | 2026-08-06 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.md | Product changelog history or generated changelog fragment. | 2026-08-06 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/frontend-backend-asset-coupling-audit.md | Repository documentation for frontend backend asset coupling audit. | 2026-07-11 | Human-facing narrative should move out of the active code-coupled documentation set unless linked by the docs hub. | move to Wiki | ComicPile Wiki |

--- a/docs/changelog.d/2026-08-08-972.md
+++ b/docs/changelog.d/2026-08-08-972.md
@@ -1,0 +1,4 @@
+## 2026-08-08
+
+### What’s New
+- [#972](https://github.com/JoshCLWren/comic-pile/pull/972) keeps GitHub repository URLs out of the public What’s New page while preserving readable release-note text.

--- a/frontend/src/pages/WhatsNewPage.test.tsx
+++ b/frontend/src/pages/WhatsNewPage.test.tsx
@@ -5,6 +5,8 @@ import { isPublicChangelogLink } from './WhatsNewPage'
 describe('isPublicChangelogLink', () => {
   it('hides GitHub destinations from the public changelog', () => {
     expect(isPublicChangelogLink('https://github.com/JoshCLWren/comic-pile/pull/948')).toBe(false)
+    expect(isPublicChangelogLink('https://www.github.com/JoshCLWren/comic-pile')).toBe(false)
+    expect(isPublicChangelogLink('https://gist.github.com/JoshCLWren/example')).toBe(false)
   })
 
   it('keeps non-GitHub links available', () => {

--- a/frontend/src/pages/WhatsNewPage.test.tsx
+++ b/frontend/src/pages/WhatsNewPage.test.tsx
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { isPublicChangelogLink } from './WhatsNewPage'
+
+describe('isPublicChangelogLink', () => {
+  it('hides GitHub destinations from the public changelog', () => {
+    expect(isPublicChangelogLink('https://github.com/JoshCLWren/comic-pile/pull/948')).toBe(false)
+  })
+
+  it('keeps non-GitHub links available', () => {
+    expect(isPublicChangelogLink('https://comic-pile.vercel.app/help')).toBe(true)
+  })
+
+  it('fails closed for malformed destinations', () => {
+    expect(isPublicChangelogLink('not-a-url')).toBe(false)
+  })
+})

--- a/frontend/src/pages/WhatsNewPage.tsx
+++ b/frontend/src/pages/WhatsNewPage.tsx
@@ -7,6 +7,14 @@ type Block =
 
 const CHANGELOG_ASSET = '/changelog.md'
 
+export function isPublicChangelogLink(url: string) {
+  try {
+    return new URL(url).hostname !== 'github.com'
+  } catch {
+    return false
+  }
+}
+
 function renderInline(text: string) {
   const pattern = /(`[^`]+`|\[[^\]]+\]\(https?:\/\/[^)]+\))/g
   return text.split(pattern).map((part, index) => {
@@ -14,6 +22,7 @@ function renderInline(text: string) {
     if (code) return <code key={index} className="rounded bg-stone-800 px-1.5 py-0.5 text-amber-200">{code[1]}</code>
     const link = part.match(/^\[([^\]]+)\]\((https?:\/\/[^)]+)\)$/)
     if (link) {
+      if (!isPublicChangelogLink(link[2])) return <Fragment key={index}>{link[1]}</Fragment>
       return <a key={index} href={link[2]} target="_blank" rel="noreferrer" className="font-semibold text-amber-300 underline decoration-amber-500/50 underline-offset-4">{link[1]} <span aria-label="opens in a new tab">↗</span></a>
     }
     return <Fragment key={index}>{part}</Fragment>

--- a/frontend/src/pages/WhatsNewPage.tsx
+++ b/frontend/src/pages/WhatsNewPage.tsx
@@ -9,7 +9,8 @@ const CHANGELOG_ASSET = '/changelog.md'
 
 export function isPublicChangelogLink(url: string) {
   try {
-    return new URL(url).hostname !== 'github.com'
+    const hostname = new URL(url).hostname.toLowerCase()
+    return hostname !== 'github.com' && !hostname.endsWith('.github.com')
   } catch {
     return false
   }

--- a/frontend/src/pages/WhatsNewPage.tsx
+++ b/frontend/src/pages/WhatsNewPage.tsx
@@ -9,7 +9,7 @@ const CHANGELOG_ASSET = '/changelog.md'
 
 export function isPublicChangelogLink(url: string) {
   try {
-    const hostname = new URL(url).hostname.toLowerCase()
+    const hostname = new URL(url).hostname.toLowerCase().replace(/\.$/, '')
     return hostname !== 'github.com' && !hostname.endsWith('.github.com')
   } catch {
     return false

--- a/frontend/src/unit/WhatsNewPage.test.tsx
+++ b/frontend/src/unit/WhatsNewPage.test.tsx
@@ -28,11 +28,11 @@ describe('parseChangelog', () => {
 })
 
 describe('WhatsNewPage', () => {
-  it('renders headings, paragraphs, lists, inline code, external links, and plain text', async () => {
+  it('renders GitHub references as text while preserving public external links', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       text: async () =>
-        '# Changelog\n\nPlain introduction.\n\n## Today\n\n### Queue\n\n- Fixed `Queue` in [#866](https://github.com/JoshCLWren/comic-pile/pull/866).',
+        '# Changelog\n\nPlain introduction.\n\n## Today\n\n### Queue\n\n- Fixed `Queue` in [#866](https://github.com/JoshCLWren/comic-pile/pull/866). See [ComicPile](https://comic-pile.vercel.app/) for more.',
     })
     vi.stubGlobal('fetch', fetchMock)
 
@@ -45,12 +45,11 @@ describe('WhatsNewPage', () => {
     expect(screen.getByRole('heading', { name: 'Queue' }).tagName).toBe('H3')
     expect(screen.getByText('Plain introduction.')).toBeInTheDocument()
     expect(screen.getByText('Queue', { selector: 'code' })).toBeInTheDocument()
+    expect(screen.getByRole('listitem')).toHaveTextContent('#866')
+    expect(screen.queryByRole('link', { name: /#866/ })).not.toBeInTheDocument()
 
-    const link = screen.getByRole('link', { name: /#866/ })
-    expect(link).toHaveAttribute(
-      'href',
-      'https://github.com/JoshCLWren/comic-pile/pull/866',
-    )
+    const link = screen.getByRole('link', { name: /ComicPile/ })
+    expect(link).toHaveAttribute('href', 'https://comic-pile.vercel.app/')
     expect(link).toHaveAttribute('target', '_blank')
     expect(link).toHaveAttribute('rel', 'noreferrer')
     expect(screen.getByLabelText('opens in a new tab')).toBeInTheDocument()
@@ -100,9 +99,7 @@ describe('WhatsNewPage', () => {
 
   it('uses the safe fallback for non-Error rejections', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue('offline'))
-
     render(<WhatsNewPage />)
-
     expect(await screen.findByRole('alert')).toHaveTextContent('could not be loaded')
   })
 })


### PR DESCRIPTION
Closes #948

## Summary
- render GitHub changelog links as plain text instead of public anchors
- preserve non-GitHub release-note links
- add regression coverage for GitHub, external, and malformed destinations

## Validation
Required CI is the validation boundary for this scheduled connector runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - GitHub repository and pull-request links on the public What’s New page are now displayed as plain text.
  - Other valid external links remain clickable and open in a new tab.
  - Invalid link destinations are safely rendered as non-clickable text.

- **Tests**
  - Added coverage for GitHub, invalid, and allowed external links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->