### PR TITLE
Clarify flexible issue starting points

### DIFF
--- a/docs/MARKDOWN_INVENTORY.md
+++ b/docs/MARKDOWN_INVENTORY.md
@@ -102,6 +102,7 @@
 | docs/changelog.d/2026-08-08-966.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/2026-08-08-968.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/2026-08-08-972.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
+| docs/changelog.d/2026-08-08-978.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/README.md | Product changelog history or generated changelog fragment. | 2026-08-06 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.md | Product changelog history or generated changelog fragment. | 2026-08-06 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/frontend-backend-asset-coupling-audit.md | Repository documentation for frontend backend asset coupling audit. | 2026-07-11 | Human-facing narrative should move out of the active code-coupled documentation set unless linked by the docs hub. | move to Wiki | ComicPile Wiki |

--- a/docs/changelog.d/2026-08-08-978.md
+++ b/docs/changelog.d/2026-08-08-978.md
@@ -1,0 +1,7 @@
+## 2026-08-08
+
+### Queue
+
+- [#978](https://github.com/JoshCLWren/comic-pile/pull/978) clarifies that a thread can start
+  with any exact issue number, so adding issue 71 no longer appears to require creating or marking
+  issues 1 through 70 as read.

--- a/frontend/src/pages/QueuePage/QueuePage.tsx
+++ b/frontend/src/pages/QueuePage/QueuePage.tsx
@@ -647,12 +647,15 @@ export default function QueuePage() {
   Will create {issuePreview} issue{issuePreview !== 1 ? 's' : ''}
   </p>
   )}
+  <p className="text-xs text-stone-400">
+  Enter the exact issues you want to track, such as 71. You do not need to add earlier issues.
+  </p>
   {issueParseError && (
   <p className="text-xs text-red-400">{issueParseError}</p>
   )}
   </div>
   <div className="space-y-2">
-  <label htmlFor="create-thread-last-read" className="text-[10px] font-bold uppercase tracking-widest text-stone-500">Last issue read (optional)</label>
+  <label htmlFor="create-thread-last-read" className="text-[10px] font-bold uppercase tracking-widest text-stone-500">Issues already read (optional)</label>
   <input
   id="create-thread-last-read"
   type="number"
@@ -669,6 +672,9 @@ export default function QueuePage() {
   }}
   className="w-full bg-white/5 border border-solid border-white/20 rounded-xl px-3 py-2 text-sm text-stone-300 focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-400 transition-colors"
   />
+            <p className="text-xs text-stone-400">
+              Enter a count from the issue list above, not an issue number.
+            </p>
             {createForm.lastIssueRead > 0 && issuePreview !== null && (
               <p className="text-xs text-stone-400">
                 First {Math.min(createForm.lastIssueRead, issuePreview)} issues (in creation order) of {issuePreview} will be marked as read

--- a/frontend/src/test/issue-list.spec.ts
+++ b/frontend/src/test/issue-list.spec.ts
@@ -183,7 +183,7 @@ test.describe('Thread Creation with Issue Ranges', () => {
     await expect(previewLocator).not.toBeVisible();
   });
 
-  test('should create thread with single issue', async ({ authenticatedPage }) => {
+  test('should create thread starting with a later single issue', async ({ authenticatedPage }) => {
     const timestamp = Date.now();
     const uniqueTitle = `Single Issue Comic ${timestamp}`;
     
@@ -197,8 +197,10 @@ test.describe('Thread Creation with Issue Ranges', () => {
     await authenticatedPage.fill('label:has-text("Title") + input', uniqueTitle);
     await authenticatedPage.selectOption('label:has-text("Format") + select', 'Comics');
 
-    // Fill in single issue
-    await authenticatedPage.fill(SELECTORS.threadCreate.issuesInput, '1');
+    // A later issue can be tracked directly without adding issues 1-70 first.
+    await authenticatedPage.fill(SELECTORS.threadCreate.issuesInput, '71');
+    await expect(authenticatedPage.getByText('You do not need to add earlier issues.')).toBeVisible();
+    await expect(authenticatedPage.getByLabel('Issues already read (optional)')).toHaveValue('0');
     
     // Verify preview shows "Will create 1 issue"
     await expect(authenticatedPage.locator(SELECTORS.threadCreate.issuePreview)).toContainText('Will create 1 issue');

--- a/frontend/src/unit/QueuePage.handlers-coverage.test.tsx
+++ b/frontend/src/unit/QueuePage.handlers-coverage.test.tsx
@@ -193,7 +193,7 @@ describe('QueuePage callback coverage', () => {
     await user.click(screen.getAllByRole('button', { name: /add thread/i })[0])
     await user.type(screen.getByLabelText('Title'), 'Annuals')
     await user.type(screen.getByLabelText('Issues'), 'Annual 1, 3-4')
-    await user.type(screen.getByLabelText(/Last issue read/i), '1')
+    await user.type(screen.getByLabelText(/Issues already read/i), '1')
     expect(screen.getByText(/Will create/)).toBeInTheDocument()
     await user.click(screen.getByRole('button', { name: /create thread/i }))
     await waitFor(() => expect(issuesApi.markRead).toHaveBeenCalledWith(21))
@@ -239,8 +239,8 @@ describe('QueuePage callback coverage', () => {
 
     await user.click(screen.getAllByRole('button', { name: /add thread/i })[0])
     await user.selectOptions(screen.getByLabelText('Format'), 'Graphic Novel')
-    await user.clear(screen.getByLabelText('Last issue read (optional)'))
-    await user.type(screen.getByLabelText('Last issue read (optional)'), '2')
+    await user.clear(screen.getByLabelText('Issues already read (optional)'))
+    await user.type(screen.getByLabelText('Issues already read (optional)'), '2')
     await user.type(screen.getByLabelText('Notes'), 'remember this')
     await user.click(screen.getByRole('button', { name: 'close modal' }))
 

--- a/frontend/src/unit/QueuePage.test.tsx
+++ b/frontend/src/unit/QueuePage.test.tsx
@@ -393,7 +393,7 @@ it('creates a simple issue range and marks the requested issues read', async () 
   await user.type(screen.getByLabelText('Title'), 'New Series')
   await user.clear(screen.getByLabelText('Issues'))
   await user.type(screen.getByLabelText('Issues'), '1-5')
-  await user.type(screen.getByLabelText(/Last issue read/i), '2')
+  await user.type(screen.getByLabelText(/Issues already read/i), '2')
   await user.click(screen.getByRole('button', { name: /create thread/i }))
   await waitFor(() => expect(create).toHaveBeenCalled())
 })
@@ -532,7 +532,7 @@ it('creates a literal issue range and reports create failures', async () => {
   await user.type(screen.getByLabelText('Title'), 'Annuals')
   await user.clear(screen.getByLabelText('Issues'))
   await user.type(screen.getByLabelText('Issues'), 'Annual 1, 5-7')
-  await user.type(screen.getByLabelText(/Last issue read/i), '1')
+  await user.type(screen.getByLabelText(/Issues already read/i), '1')
   await user.click(screen.getByRole('button', { name: /create thread/i }))
   await waitFor(() => expect(create).toHaveBeenCalled())
 
@@ -594,10 +594,37 @@ it('creates complex ranges and marks the requested issues read', async () => {
   await user.click(screen.getAllByRole('button', { name: /add thread/i })[0])
   await user.type(screen.getByLabelText('Title'), 'Complex')
   await user.type(screen.getByLabelText('Issues'), 'Annual 1, 5-7')
-  await user.type(screen.getByLabelText(/Last issue read/i), '2')
+  await user.type(screen.getByLabelText(/Issues already read/i), '2')
   await user.click(screen.getByRole('button', { name: /create thread/i }))
   await waitFor(() => expect(mockedIssuesApi.markRead).toHaveBeenCalledWith(11))
   expect(mockedIssuesApi.markRead).toHaveBeenCalledWith(12)
+})
+
+it('creates a later single issue without requiring earlier issues', async () => {
+  const user = userEvent.setup()
+  const create = vi.fn().mockResolvedValue({ id: 78 })
+  mockedIssuesApi.markRead.mockClear()
+  mockedUseCreateThread.mockReturnValue({ mutate: create, isPending: false })
+  mockedUseThreads.mockReturnValue({ data: [], isPending: false, refetch: vi.fn() })
+  mockedIssuesApi.create.mockResolvedValue({ issues: [{ id: 71, issue_number: '71' }] })
+
+  render(<BrowserRouter><ToastProvider><QueuePage /></ToastProvider></BrowserRouter>)
+  await user.click(screen.getAllByRole('button', { name: /add thread/i })[0])
+  await user.type(screen.getByLabelText('Title'), 'Marvel Graphic Novel')
+  await user.type(screen.getByLabelText('Issues'), '71')
+
+  expect(screen.getByText(/You do not need to add earlier issues/i)).toBeInTheDocument()
+  expect(screen.getByText(/not an issue number/i)).toBeInTheDocument()
+  expect(screen.getByLabelText('Issues already read (optional)')).toHaveValue(0)
+
+  await user.click(screen.getByRole('button', { name: /create thread/i }))
+
+  await waitFor(() => expect(create).toHaveBeenCalledWith(expect.objectContaining({
+    title: 'Marvel Graphic Novel',
+    issues_remaining: 1,
+  })))
+  expect(mockedIssuesApi.create).toHaveBeenCalledWith(78, '71')
+  expect(mockedIssuesApi.markRead).not.toHaveBeenCalled()
 })
 
 it('handles reactivation success and failure from completed threads', async () => {


### PR DESCRIPTION
Closes #974

## Summary
- explain that the Issues field accepts exact later issue numbers without requiring earlier issues
- rename the ambiguous last-read field to make clear it is a count from the entered list
- cover issue 71 as a one-issue thread in unit and Chromium browser tests

## Verification
- `cd frontend && pnpm run lint && pnpm run typecheck`
- `cd frontend && pnpm run build`
- `cd frontend && pnpm test`
- `cd frontend && pnpm exec playwright test src/test/issue-list.spec.ts --project=chromium --grep "starting with a later single issue"`