### PR TITLE
Keep mobile feedback form open during interaction

### DIFF
--- a/docs/MARKDOWN_INVENTORY.md
+++ b/docs/MARKDOWN_INVENTORY.md
@@ -103,6 +103,7 @@
 | docs/changelog.d/2026-08-08-968.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/2026-08-08-972.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/2026-08-08-978.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
+| docs/changelog.d/2026-08-08-979.md | Product changelog history or generated changelog fragment. | 2026-08-08 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.d/README.md | Product changelog history or generated changelog fragment. | 2026-08-06 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/changelog.md | Product changelog history or generated changelog fragment. | 2026-08-06 | Canonical What's New source; fragments are assembled into the product surface. | keep | — |
 | docs/frontend-backend-asset-coupling-audit.md | Repository documentation for frontend backend asset coupling audit. | 2026-07-11 | Human-facing narrative should move out of the active code-coupled documentation set unless linked by the docs hub. | move to Wiki | ComicPile Wiki |

--- a/docs/changelog.d/2026-08-08-973.md
+++ b/docs/changelog.d/2026-08-08-973.md
@@ -1,0 +1,5 @@
+## 2026-08-08
+
+### Feedback
+
+- Fixed the mobile feedback form disappearing as soon as you tapped into it, so bug reports and feature requests can be filled out and submitted normally. ([#973](https://github.com/JoshCLWren/comic-pile/pull/973))

--- a/docs/changelog.d/2026-08-08-973.md
+++ b/docs/changelog.d/2026-08-08-973.md
@@ -1,5 +1,0 @@
-## 2026-08-08
-
-### Feedback
-
-- Fixed the mobile feedback form disappearing as soon as you tapped into it, so bug reports and feature requests can be filled out and submitted normally. ([#973](https://github.com/JoshCLWren/comic-pile/pull/973))

--- a/docs/changelog.d/2026-08-08-979.md
+++ b/docs/changelog.d/2026-08-08-979.md
@@ -1,0 +1,5 @@
+## 2026-08-08
+
+### Feedback
+
+- Fixed the mobile feedback form disappearing as soon as you tapped into it, so bug reports and feature requests can be filled out and submitted normally. ([#979](https://github.com/JoshCLWren/comic-pile/pull/979))

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -103,6 +103,8 @@ export default function Navigation({ onBugReportSubmit }: NavigationProps) {
         </nav>
       )}
 
+      <div className="md:hidden"><BugReportButton onSubmit={onBugReportSubmit} variant="nav" /></div>
+
       <div className="fixed top-2 right-2 md:top-4 md:right-4 z-50 flex items-center gap-2 md:gap-3">
         {isLoading ? <span className="hidden md:inline text-xs text-stone-500 font-medium px-2 py-1">Loading...</span> : hasError ? <span className="hidden md:inline text-xs text-amber-500 font-medium px-2 py-1" title="Failed to load user data">User</span> : username ? <span className="hidden md:inline text-xs text-stone-400 font-medium px-2 py-1">{username}</span> : null}
         <button onClick={handleLogout} className="px-2 py-1.5 md:px-3 text-xs font-bold uppercase tracking-widest text-red-400 hover:text-red-300 bg-[#110e0a]/60 hover:bg-[#110e0a]/80 rounded-lg transition-colors" aria-label="Log out"><span className="md:hidden" aria-hidden="true">⎋</span><span className="hidden md:inline">Log Out</span></button>

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -41,6 +41,7 @@ export default function Navigation({ onBugReportSubmit }: NavigationProps) {
       const target = event.target
       if (!(target instanceof Node)) return
       if (moreButtonRef.current?.contains(target) || moreMenuRef.current?.contains(target)) return
+      if (target instanceof Element && target.closest('[data-overlay-layer="dialog"]')) return
       setIsMoreOpen(false)
     }
 
@@ -102,8 +103,6 @@ export default function Navigation({ onBugReportSubmit }: NavigationProps) {
           <div className="border-t border-stone-800 pt-2 md:hidden"><BugReportButton onSubmit={onBugReportSubmit} variant="nav" /></div>
         </nav>
       )}
-
-      <div className="md:hidden"><BugReportButton onSubmit={onBugReportSubmit} variant="nav" /></div>
 
       <div className="fixed top-2 right-2 md:top-4 md:right-4 z-50 flex items-center gap-2 md:gap-3">
         {isLoading ? <span className="hidden md:inline text-xs text-stone-500 font-medium px-2 py-1">Loading...</span> : hasError ? <span className="hidden md:inline text-xs text-amber-500 font-medium px-2 py-1" title="Failed to load user data">User</span> : username ? <span className="hidden md:inline text-xs text-stone-400 font-medium px-2 py-1">{username}</span> : null}


### PR DESCRIPTION
Closes #973

## Summary
- keep the mobile More menu mounted while its portaled feedback dialog receives pointer input
- prevent the menu's outside-click handler from unmounting the dialog on the first tap inside the form
- preserve ordinary outside-click dismissal when no dialog is involved

## Validation
Required CI is the validation boundary for this branch.

Changelog: `docs/changelog.d/2026-08-08-979.md`.