### PR TITLE
Add reusable human-facing continuity selectors

### DIFF
--- a/docs/changelog.d/2026-08-09-983.md
+++ b/docs/changelog.d/2026-08-09-983.md
@@ -2,4 +2,4 @@
 
 ### Continuity editing
 
-- Comic selection controls can now use shared human-friendly series and issue pickers, including non-numeric issue labels and ordered ranges, instead of exposing internal database IDs or positions. [#983]
+- Comic selection controls can now use shared human-friendly series and issue pickers, including non-numeric issue labels and ordered ranges, instead of exposing internal database IDs or positions. [#983](https://github.com/JoshCLWren/comic-pile/pull/983)

--- a/docs/changelog.d/2026-08-09-983.md
+++ b/docs/changelog.d/2026-08-09-983.md
@@ -1,0 +1,5 @@
+## 2026-08-09
+
+### Continuity editing
+
+- Comic selection controls can now use shared human-friendly series and issue pickers, including non-numeric issue labels and ordered ranges, instead of exposing internal database IDs or positions. [#983]

--- a/frontend/src/components/continuity/ComicSelectors.tsx
+++ b/frontend/src/components/continuity/ComicSelectors.tsx
@@ -1,0 +1,219 @@
+import { useMemo, useRef, useState } from 'react'
+import type { KeyboardEvent } from 'react'
+import type { Issue, Thread } from '../../types'
+
+export interface SelectedComic {
+  thread: Thread
+  issue: Issue | null
+}
+
+export interface SelectedIssueRange {
+  thread: Thread
+  startIssue: Issue
+  endIssue: Issue
+}
+
+interface SelectorStateProps {
+  isLoading?: boolean
+  error?: string | null
+  disabled?: boolean
+}
+
+interface ContinuityThreadSelectorProps extends SelectorStateProps {
+  threads: Thread[]
+  value: Thread | null
+  onChange: (thread: Thread | null) => void
+  label?: string
+  excludeThreadId?: number | null
+  placeholder?: string
+}
+
+export function ContinuityThreadSelector({
+  threads,
+  value,
+  onChange,
+  label = 'Comic series',
+  excludeThreadId = null,
+  placeholder = 'Search by title',
+  isLoading = false,
+  error = null,
+  disabled = false,
+}: ContinuityThreadSelectorProps) {
+  const [query, setQuery] = useState('')
+  const resultRefs = useRef<Array<HTMLButtonElement | null>>([])
+
+  const results = useMemo(() => {
+    const normalized = query.trim().toLocaleLowerCase()
+    return threads
+      .filter((thread) => thread.id !== excludeThreadId)
+      .filter((thread) => {
+        if (!normalized) return true
+        return `${thread.title} ${thread.format}`.toLocaleLowerCase().includes(normalized)
+      })
+      .slice(0, 50)
+  }, [excludeThreadId, query, threads])
+
+  function handleSearchKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === 'ArrowDown' && results.length > 0) {
+      event.preventDefault()
+      resultRefs.current[0]?.focus()
+    }
+  }
+
+  function selectThread(thread: Thread) {
+    onChange(thread)
+    setQuery(thread.title)
+  }
+
+  return (
+    <div className="space-y-2">
+      <label className="block text-[10px] font-bold uppercase tracking-widest text-stone-500">
+        {label}
+        <input
+          type="search"
+          value={query}
+          onChange={(event) => {
+            setQuery(event.target.value)
+            if (value && event.target.value !== value.title) onChange(null)
+          }}
+          onKeyDown={handleSearchKeyDown}
+          placeholder={placeholder}
+          disabled={disabled}
+          aria-expanded={!disabled && results.length > 0}
+          className="mt-1 w-full rounded-xl border border-solid border-white/20 bg-white/5 px-3 py-2 text-sm text-stone-300 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-500/30 disabled:opacity-50"
+        />
+      </label>
+
+      {isLoading && <p className="text-xs text-stone-500">Loading comics…</p>}
+      {error && <p role="alert" className="text-xs text-red-400">{error}</p>}
+      {!isLoading && !error && !disabled && results.length === 0 && (
+        <p className="text-xs text-stone-500">No matching comics found.</p>
+      )}
+      {!isLoading && !error && !disabled && results.length > 0 && (
+        <div role="listbox" aria-label={`${label} results`} className="max-h-48 overflow-auto rounded-xl border border-white/10 bg-white/5">
+          {results.map((thread, index) => (
+            <button
+              key={thread.id}
+              ref={(element) => { resultRefs.current[index] = element }}
+              type="button"
+              role="option"
+              aria-selected={value?.id === thread.id}
+              onClick={() => selectThread(thread)}
+              className={`w-full border-b border-white/5 px-3 py-2 text-left text-sm last:border-b-0 hover:bg-white/10 ${
+                value?.id === thread.id ? 'bg-white/10 text-white' : 'text-stone-300'
+              }`}
+            >
+              <span className="block font-semibold">{thread.title}</span>
+              <span className="block text-xs text-stone-500">{thread.format}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface ContinuityIssueSelectorProps extends SelectorStateProps {
+  issues: Issue[]
+  value: Issue | null
+  onChange: (issue: Issue | null) => void
+  label?: string
+  emptyMessage?: string
+}
+
+export function ContinuityIssueSelector({
+  issues,
+  value,
+  onChange,
+  label = 'Issue',
+  emptyMessage = 'No issues available',
+  isLoading = false,
+  error = null,
+  disabled = false,
+}: ContinuityIssueSelectorProps) {
+  return (
+    <div className="space-y-1">
+      <label className="block text-[10px] font-bold uppercase tracking-widest text-stone-500">
+        {label}
+        <select
+          value={value?.id ?? ''}
+          onChange={(event) => {
+            const next = issues.find((issue) => issue.id === Number(event.target.value)) ?? null
+            onChange(next)
+          }}
+          disabled={disabled || isLoading || issues.length === 0}
+          className="mt-1 w-full rounded-xl border border-solid border-white/20 bg-white/5 px-3 py-2 text-sm text-stone-300 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-500/30 disabled:opacity-50"
+        >
+          <option value="">{isLoading ? 'Loading issues…' : issues.length === 0 ? emptyMessage : 'Select an issue'}</option>
+          {issues.map((issue) => (
+            <option key={issue.id} value={issue.id}>#{issue.issue_number}</option>
+          ))}
+        </select>
+      </label>
+      {error && <p role="alert" className="text-xs text-red-400">{error}</p>}
+    </div>
+  )
+}
+
+interface ContinuityIssueRangeSelectorProps extends SelectorStateProps {
+  thread: Thread
+  issues: Issue[]
+  value: SelectedIssueRange | null
+  onChange: (range: SelectedIssueRange | null) => void
+  label?: string
+}
+
+export function ContinuityIssueRangeSelector({
+  thread,
+  issues,
+  value,
+  onChange,
+  label = 'Issue range',
+  isLoading = false,
+  error = null,
+  disabled = false,
+}: ContinuityIssueRangeSelectorProps) {
+  const startIssue = value?.startIssue ?? null
+  const endIssue = value?.endIssue ?? null
+  const startIndex = startIssue ? issues.findIndex((issue) => issue.id === startIssue.id) : -1
+  const endIndex = endIssue ? issues.findIndex((issue) => issue.id === endIssue.id) : -1
+  const isReversed = startIndex >= 0 && endIndex >= 0 && startIndex > endIndex
+
+  function updateRange(nextStart: Issue | null, nextEnd: Issue | null) {
+    if (!nextStart || !nextEnd) {
+      onChange(null)
+      return
+    }
+    onChange({ thread, startIssue: nextStart, endIssue: nextEnd })
+  }
+
+  return (
+    <fieldset className="space-y-2" disabled={disabled}>
+      <legend className="text-[10px] font-bold uppercase tracking-widest text-stone-500">{label}</legend>
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <ContinuityIssueSelector
+          label="First issue"
+          issues={issues}
+          value={startIssue}
+          onChange={(issue) => updateRange(issue, endIssue)}
+          isLoading={isLoading}
+          disabled={disabled}
+        />
+        <ContinuityIssueSelector
+          label="Last issue"
+          issues={issues}
+          value={endIssue}
+          onChange={(issue) => updateRange(startIssue, issue)}
+          isLoading={isLoading}
+          disabled={disabled}
+        />
+      </div>
+      {isReversed && (
+        <p role="alert" className="text-xs text-amber-300">
+          #{startIssue?.issue_number} comes after #{endIssue?.issue_number} in {thread.title}. Choose a later ending issue.
+        </p>
+      )}
+      {error && <p role="alert" className="text-xs text-red-400">{error}</p>}
+    </fieldset>
+  )
+}

--- a/frontend/src/components/continuity/ComicSelectors.tsx
+++ b/frontend/src/components/continuity/ComicSelectors.tsx
@@ -194,6 +194,14 @@ export function ContinuityIssueRangeSelector({
       onChange(null)
       return
     }
+
+    const nextStartIndex = issues.findIndex((issue) => issue.id === nextStart.id)
+    const nextEndIndex = issues.findIndex((issue) => issue.id === nextEnd.id)
+    if (nextStartIndex < 0 || nextEndIndex < 0 || nextStartIndex > nextEndIndex) {
+      onChange(null)
+      return
+    }
+
     onChange({ thread, startIssue: nextStart, endIssue: nextEnd })
   }
 

--- a/frontend/src/components/continuity/ComicSelectors.tsx
+++ b/frontend/src/components/continuity/ComicSelectors.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type { KeyboardEvent } from 'react'
 import type { Issue, Thread } from '../../types'
 
@@ -39,8 +39,12 @@ export function ContinuityThreadSelector({
   error = null,
   disabled = false,
 }: ContinuityThreadSelectorProps) {
-  const [query, setQuery] = useState('')
+  const [query, setQuery] = useState(value?.title ?? '')
   const resultRefs = useRef<Array<HTMLButtonElement | null>>([])
+
+  useEffect(() => {
+    if (value) setQuery(value.title)
+  }, [value])
 
   const results = useMemo(() => {
     const normalized = query.trim().toLocaleLowerCase()
@@ -173,13 +177,19 @@ export function ContinuityIssueRangeSelector({
   error = null,
   disabled = false,
 }: ContinuityIssueRangeSelectorProps) {
-  const startIssue = value?.startIssue ?? null
-  const endIssue = value?.endIssue ?? null
-  const startIndex = startIssue ? issues.findIndex((issue) => issue.id === startIssue.id) : -1
-  const endIndex = endIssue ? issues.findIndex((issue) => issue.id === endIssue.id) : -1
+  const [draftStart, setDraftStart] = useState<Issue | null>(value?.startIssue ?? null)
+  const [draftEnd, setDraftEnd] = useState<Issue | null>(value?.endIssue ?? null)
+
+  useEffect(() => {
+    setDraftStart(value?.startIssue ?? null)
+    setDraftEnd(value?.endIssue ?? null)
+  }, [value])
+
+  const startIndex = draftStart ? issues.findIndex((issue) => issue.id === draftStart.id) : -1
+  const endIndex = draftEnd ? issues.findIndex((issue) => issue.id === draftEnd.id) : -1
   const isReversed = startIndex >= 0 && endIndex >= 0 && startIndex > endIndex
 
-  function updateRange(nextStart: Issue | null, nextEnd: Issue | null) {
+  function publishRange(nextStart: Issue | null, nextEnd: Issue | null) {
     if (!nextStart || !nextEnd) {
       onChange(null)
       return
@@ -194,23 +204,29 @@ export function ContinuityIssueRangeSelector({
         <ContinuityIssueSelector
           label="First issue"
           issues={issues}
-          value={startIssue}
-          onChange={(issue) => updateRange(issue, endIssue)}
+          value={draftStart}
+          onChange={(issue) => {
+            setDraftStart(issue)
+            publishRange(issue, draftEnd)
+          }}
           isLoading={isLoading}
           disabled={disabled}
         />
         <ContinuityIssueSelector
           label="Last issue"
           issues={issues}
-          value={endIssue}
-          onChange={(issue) => updateRange(startIssue, issue)}
+          value={draftEnd}
+          onChange={(issue) => {
+            setDraftEnd(issue)
+            publishRange(draftStart, issue)
+          }}
           isLoading={isLoading}
           disabled={disabled}
         />
       </div>
       {isReversed && (
         <p role="alert" className="text-xs text-amber-300">
-          #{startIssue?.issue_number} comes after #{endIssue?.issue_number} in {thread.title}. Choose a later ending issue.
+          #{draftStart?.issue_number} comes after #{draftEnd?.issue_number} in {thread.title}. Choose a later ending issue.
         </p>
       )}
       {error && <p role="alert" className="text-xs text-red-400">{error}</p>}

--- a/frontend/src/components/continuity/index.ts
+++ b/frontend/src/components/continuity/index.ts
@@ -1,0 +1,6 @@
+export {
+  ContinuityIssueRangeSelector,
+  ContinuityIssueSelector,
+  ContinuityThreadSelector,
+} from './ComicSelectors'
+export type { SelectedComic, SelectedIssueRange } from './ComicSelectors'

--- a/frontend/src/unit/ComicSelectors.test.tsx
+++ b/frontend/src/unit/ComicSelectors.test.tsx
@@ -5,7 +5,7 @@ import {
   ContinuityIssueRangeSelector,
   ContinuityIssueSelector,
   ContinuityThreadSelector,
-} from '../components/ComicSelectors'
+} from '../components/continuity/ComicSelectors'
 import type { Issue, Thread } from '../types'
 
 const threads = [

--- a/frontend/src/unit/ComicSelectors.test.tsx
+++ b/frontend/src/unit/ComicSelectors.test.tsx
@@ -1,55 +1,35 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
+
 import {
   ContinuityIssueRangeSelector,
   ContinuityIssueSelector,
   ContinuityThreadSelector,
-} from '../components/continuity'
+} from '../components/ComicSelectors'
 import type { Issue, Thread } from '../types'
 
-const threads: Thread[] = [
-  {
-    id: 1,
-    title: 'Alpha Flight',
-    format: 'single issues',
-    issues_remaining: 3,
-    total_issues: 3,
-    queue_position: 1,
-    status: 'active',
-    is_blocked: false,
-    blocking_reasons: [],
-    created_at: '2026-08-09T00:00:00Z',
-  },
-  {
-    id: 2,
-    title: 'New Mutants',
-    format: 'single issues',
-    issues_remaining: 3,
-    total_issues: 3,
-    queue_position: 2,
-    status: 'active',
-    is_blocked: false,
-    blocking_reasons: [],
-    created_at: '2026-08-09T00:00:00Z',
-  },
-]
+const threads = [
+  { id: 1, title: 'Alpha Flight' },
+  { id: 2, title: 'New Mutants' },
+] as Thread[]
 
-const issues: Issue[] = [
-  { id: 11, thread_id: 1, issue_number: '0', status: 'unread', read_at: null, created_at: '2026-08-09T00:00:00Z' },
-  { id: 12, thread_id: 1, issue_number: 'Annual 1', status: 'unread', read_at: null, created_at: '2026-08-09T00:00:00Z' },
-  { id: 13, thread_id: 1, issue_number: '½', status: 'unread', read_at: null, created_at: '2026-08-09T00:00:00Z' },
-]
+const issues = [
+  { id: 11, issue_number: 'Annual 1' },
+  { id: 12, issue_number: '1/2' },
+  { id: 13, issue_number: 'Omega' },
+] as Issue[]
 
 describe('continuity comic selectors', () => {
   it('searches threads by human-readable title and returns the selected thread object', () => {
     const onChange = vi.fn()
     render(<ContinuityThreadSelector threads={threads} value={null} onChange={onChange} />)
 
-    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'mutants' } })
+    const search = screen.getByRole('searchbox')
+    fireEvent.change(search, { target: { value: 'mutants' } })
 
     expect(screen.queryByText('Alpha Flight')).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('option', { name: /New Mutants/i }))
-    expect(onChange).toHaveBeenLastCalledWith(threads[1])
+    expect(onChange).toHaveBeenCalledWith(threads[1])
   })
 
   it('moves keyboard focus from search to the first matching result', () => {
@@ -76,6 +56,7 @@ describe('continuity comic selectors', () => {
     expect(search).toHaveValue('Alpha Flight')
     expect(screen.queryByText('New Mutants')).not.toBeInTheDocument()
 
+    search.focus()
     fireEvent.change(search, { target: { value: 'no match' } })
     expect(onChange).toHaveBeenLastCalledWith(null)
     expect(screen.getByText('No matching comics found.')).toBeInTheDocument()
@@ -97,27 +78,22 @@ describe('continuity comic selectors', () => {
         threads={threads}
         value={null}
         onChange={onChange}
-        error="Search failed"
+        error="Could not load comics"
       />,
     )
-    expect(screen.getByRole('alert')).toHaveTextContent('Search failed')
+    expect(screen.getByText('Could not load comics')).toBeInTheDocument()
 
     rerender(
-      <ContinuityThreadSelector
-        threads={threads}
-        value={null}
-        onChange={onChange}
-        disabled
-      />,
+      <ContinuityThreadSelector threads={threads} value={null} onChange={onChange} disabled />,
     )
     expect(screen.getByRole('searchbox')).toBeDisabled()
-    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
   })
 
   it('syncs the thread search text when the selected value changes', () => {
     const { rerender } = render(
-      <ContinuityThreadSelector threads={threads} value={null} onChange={vi.fn()} />,
+      <ContinuityThreadSelector threads={threads} value={threads[0]} onChange={vi.fn()} />,
     )
+    expect(screen.getByRole('searchbox')).toHaveValue('Alpha Flight')
 
     rerender(<ContinuityThreadSelector threads={threads} value={threads[1]} onChange={vi.fn()} />)
     expect(screen.getByRole('searchbox')).toHaveValue('New Mutants')
@@ -127,37 +103,29 @@ describe('continuity comic selectors', () => {
     const onChange = vi.fn()
     render(<ContinuityIssueSelector issues={issues} value={null} onChange={onChange} />)
 
-    const select = screen.getByRole('combobox', { name: 'Issue' })
-    expect(screen.getByRole('option', { name: '#Annual 1' })).toBeInTheDocument()
-    expect(screen.getByRole('option', { name: '#½' })).toBeInTheDocument()
-
-    fireEvent.change(select, { target: { value: '13' } })
-    expect(onChange).toHaveBeenLastCalledWith(issues[2])
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '13' } })
+    expect(onChange).toHaveBeenCalledWith(issues[2])
+    expect(screen.getByRole('option', { name: 'Omega' })).toBeInTheDocument()
   })
 
   it('covers issue loading, empty, error, disabled, and cleared-selection states', () => {
     const onChange = vi.fn()
     const { rerender } = render(
-      <ContinuityIssueSelector issues={[]} value={null} onChange={onChange} emptyMessage="Nothing here" />,
+      <ContinuityIssueSelector issues={issues} value={issues[0]} onChange={onChange} />,
     )
-    expect(screen.getByRole('combobox')).toBeDisabled()
-    expect(screen.getByRole('option', { name: 'Nothing here' })).toBeInTheDocument()
-
-    rerender(<ContinuityIssueSelector issues={issues} value={null} onChange={onChange} isLoading />)
-    expect(screen.getByRole('combobox')).toBeDisabled()
-    expect(screen.getByRole('option', { name: 'Loading issues…' })).toBeInTheDocument()
-
-    rerender(
-      <ContinuityIssueSelector
-        issues={issues}
-        value={issues[0]}
-        onChange={onChange}
-        error="Issues failed"
-      />,
-    )
-    expect(screen.getByRole('alert')).toHaveTextContent('Issues failed')
     fireEvent.change(screen.getByRole('combobox'), { target: { value: '' } })
     expect(onChange).toHaveBeenLastCalledWith(null)
+
+    rerender(<ContinuityIssueSelector issues={[]} value={null} onChange={onChange} isLoading />)
+    expect(screen.getByText('Loading issues…')).toBeInTheDocument()
+
+    rerender(
+      <ContinuityIssueSelector issues={[]} value={null} onChange={onChange} error="Issue load failed" />,
+    )
+    expect(screen.getByText('Issue load failed')).toBeInTheDocument()
+
+    rerender(<ContinuityIssueSelector issues={[]} value={null} onChange={onChange} />)
+    expect(screen.getByText('No issues available.')).toBeInTheDocument()
 
     rerender(<ContinuityIssueSelector issues={issues} value={null} onChange={onChange} disabled />)
     expect(screen.getByRole('combobox')).toBeDisabled()
@@ -165,61 +133,47 @@ describe('continuity comic selectors', () => {
 
   it('builds ordered ranges from issue labels and explains reversed order without exposing positions', () => {
     const onChange = vi.fn()
-    render(
-      <ContinuityIssueRangeSelector
-        thread={threads[0]}
-        issues={issues}
-        value={null}
-        onChange={onChange}
-      />,
-    )
+    render(<ContinuityIssueRangeSelector issues={issues} value={null} onChange={onChange} />)
 
-    const first = screen.getByRole('combobox', { name: 'First issue' })
-    const last = screen.getByRole('combobox', { name: 'Last issue' })
+    const [start, end] = screen.getAllByRole('combobox')
+    fireEvent.change(start, { target: { value: '11' } })
+    fireEvent.change(end, { target: { value: '13' } })
 
-    fireEvent.change(first, { target: { value: '13' } })
-    fireEvent.change(last, { target: { value: '11' } })
-
-    expect(screen.getByRole('alert')).toHaveTextContent('#½ comes after #0 in Alpha Flight')
+    expect(onChange).toHaveBeenLastCalledWith({ start: issues[0], end: issues[2] })
+    expect(screen.getByText('Annual 1 through Omega')).toBeInTheDocument()
     expect(screen.queryByText(/position/i)).not.toBeInTheDocument()
-    expect(onChange).toHaveBeenLastCalledWith({
-      thread: threads[0],
-      startIssue: issues[2],
-      endIssue: issues[0],
-    })
+
+    fireEvent.change(start, { target: { value: '13' } })
+    fireEvent.change(end, { target: { value: '11' } })
+    expect(screen.getByText('Start issue must come before end issue.')).toBeInTheDocument()
+    expect(onChange).toHaveBeenLastCalledWith(null)
   })
 
   it('publishes null for incomplete ranges and resyncs draft values from props', () => {
     const onChange = vi.fn()
-    const initialRange = { thread: threads[0], startIssue: issues[0], endIssue: issues[1] }
     const { rerender } = render(
       <ContinuityIssueRangeSelector
-        thread={threads[0]}
         issues={issues}
-        value={initialRange}
+        value={{ start: issues[0], end: issues[2] }}
         onChange={onChange}
       />,
     )
+    const [start, end] = screen.getAllByRole('combobox')
+    expect(start).toHaveValue('11')
+    expect(end).toHaveValue('13')
 
-    expect(screen.getByRole('combobox', { name: 'First issue' })).toHaveValue('11')
-    expect(screen.getByRole('combobox', { name: 'Last issue' })).toHaveValue('12')
-
-    fireEvent.change(screen.getByRole('combobox', { name: 'First issue' }), { target: { value: '' } })
+    fireEvent.change(end, { target: { value: '' } })
     expect(onChange).toHaveBeenLastCalledWith(null)
 
     rerender(
       <ContinuityIssueRangeSelector
-        thread={threads[0]}
         issues={issues}
-        value={{ thread: threads[0], startIssue: issues[1], endIssue: issues[2] }}
+        value={{ start: issues[1], end: issues[2] }}
         onChange={onChange}
-        error="Range failed"
-        disabled
       />,
     )
-    expect(screen.getByRole('combobox', { name: 'First issue' })).toHaveValue('12')
-    expect(screen.getByRole('combobox', { name: 'Last issue' })).toHaveValue('13')
-    expect(screen.getByRole('alert')).toHaveTextContent('Range failed')
-    expect(screen.getByRole('group')).toBeDisabled()
+    const [resyncedStart, resyncedEnd] = screen.getAllByRole('combobox')
+    expect(resyncedStart).toHaveValue('12')
+    expect(resyncedEnd).toHaveValue('13')
   })
 })

--- a/frontend/src/unit/ComicSelectors.test.tsx
+++ b/frontend/src/unit/ComicSelectors.test.tsx
@@ -61,6 +61,68 @@ describe('continuity comic selectors', () => {
     expect(screen.getByRole('option', { name: /Alpha Flight/i })).toHaveFocus()
   })
 
+  it('handles current-value editing, exclusions, empty results, loading, errors, and disabled state', () => {
+    const onChange = vi.fn()
+    const { rerender } = render(
+      <ContinuityThreadSelector
+        threads={threads}
+        value={threads[0]}
+        onChange={onChange}
+        excludeThreadId={2}
+      />,
+    )
+
+    const search = screen.getByRole('searchbox')
+    expect(search).toHaveValue('Alpha Flight')
+    expect(screen.queryByText('New Mutants')).not.toBeInTheDocument()
+
+    fireEvent.change(search, { target: { value: 'no match' } })
+    expect(onChange).toHaveBeenLastCalledWith(null)
+    expect(screen.getByText('No matching comics found.')).toBeInTheDocument()
+    fireEvent.keyDown(search, { key: 'ArrowDown' })
+    expect(search).toHaveFocus()
+
+    rerender(
+      <ContinuityThreadSelector
+        threads={threads}
+        value={null}
+        onChange={onChange}
+        isLoading
+      />,
+    )
+    expect(screen.getByText('Loading comics…')).toBeInTheDocument()
+
+    rerender(
+      <ContinuityThreadSelector
+        threads={threads}
+        value={null}
+        onChange={onChange}
+        error="Search failed"
+      />,
+    )
+    expect(screen.getByRole('alert')).toHaveTextContent('Search failed')
+
+    rerender(
+      <ContinuityThreadSelector
+        threads={threads}
+        value={null}
+        onChange={onChange}
+        disabled
+      />,
+    )
+    expect(screen.getByRole('searchbox')).toBeDisabled()
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('syncs the thread search text when the selected value changes', () => {
+    const { rerender } = render(
+      <ContinuityThreadSelector threads={threads} value={null} onChange={vi.fn()} />,
+    )
+
+    rerender(<ContinuityThreadSelector threads={threads} value={threads[1]} onChange={vi.fn()} />)
+    expect(screen.getByRole('searchbox')).toHaveValue('New Mutants')
+  })
+
   it('selects arbitrary human-facing issue identifiers without numeric parsing', () => {
     const onChange = vi.fn()
     render(<ContinuityIssueSelector issues={issues} value={null} onChange={onChange} />)
@@ -71,6 +133,34 @@ describe('continuity comic selectors', () => {
 
     fireEvent.change(select, { target: { value: '13' } })
     expect(onChange).toHaveBeenLastCalledWith(issues[2])
+  })
+
+  it('covers issue loading, empty, error, disabled, and cleared-selection states', () => {
+    const onChange = vi.fn()
+    const { rerender } = render(
+      <ContinuityIssueSelector issues={[]} value={null} onChange={onChange} emptyMessage="Nothing here" />,
+    )
+    expect(screen.getByRole('combobox')).toBeDisabled()
+    expect(screen.getByRole('option', { name: 'Nothing here' })).toBeInTheDocument()
+
+    rerender(<ContinuityIssueSelector issues={issues} value={null} onChange={onChange} isLoading />)
+    expect(screen.getByRole('combobox')).toBeDisabled()
+    expect(screen.getByRole('option', { name: 'Loading issues…' })).toBeInTheDocument()
+
+    rerender(
+      <ContinuityIssueSelector
+        issues={issues}
+        value={issues[0]}
+        onChange={onChange}
+        error="Issues failed"
+      />,
+    )
+    expect(screen.getByRole('alert')).toHaveTextContent('Issues failed')
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '' } })
+    expect(onChange).toHaveBeenLastCalledWith(null)
+
+    rerender(<ContinuityIssueSelector issues={issues} value={null} onChange={onChange} disabled />)
+    expect(screen.getByRole('combobox')).toBeDisabled()
   })
 
   it('builds ordered ranges from issue labels and explains reversed order without exposing positions', () => {
@@ -97,5 +187,39 @@ describe('continuity comic selectors', () => {
       startIssue: issues[2],
       endIssue: issues[0],
     })
+  })
+
+  it('publishes null for incomplete ranges and resyncs draft values from props', () => {
+    const onChange = vi.fn()
+    const initialRange = { thread: threads[0], startIssue: issues[0], endIssue: issues[1] }
+    const { rerender } = render(
+      <ContinuityIssueRangeSelector
+        thread={threads[0]}
+        issues={issues}
+        value={initialRange}
+        onChange={onChange}
+      />,
+    )
+
+    expect(screen.getByRole('combobox', { name: 'First issue' })).toHaveValue('11')
+    expect(screen.getByRole('combobox', { name: 'Last issue' })).toHaveValue('12')
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'First issue' }), { target: { value: '' } })
+    expect(onChange).toHaveBeenLastCalledWith(null)
+
+    rerender(
+      <ContinuityIssueRangeSelector
+        thread={threads[0]}
+        issues={issues}
+        value={{ thread: threads[0], startIssue: issues[1], endIssue: issues[2] }}
+        onChange={onChange}
+        error="Range failed"
+        disabled
+      />,
+    )
+    expect(screen.getByRole('combobox', { name: 'First issue' })).toHaveValue('12')
+    expect(screen.getByRole('combobox', { name: 'Last issue' })).toHaveValue('13')
+    expect(screen.getByRole('alert')).toHaveTextContent('Range failed')
+    expect(screen.getByRole('group')).toBeDisabled()
   })
 })

--- a/frontend/src/unit/ComicSelectors.test.tsx
+++ b/frontend/src/unit/ComicSelectors.test.tsx
@@ -9,9 +9,10 @@ import {
 import type { Issue, Thread } from '../types'
 
 const threads = [
-  { id: 1, title: 'Alpha Flight' },
-  { id: 2, title: 'New Mutants' },
+  { id: 1, title: 'Alpha Flight', format: 'ongoing' },
+  { id: 2, title: 'New Mutants', format: 'ongoing' },
 ] as Thread[]
+const thread = threads[0]
 
 const issues = [
   { id: 11, issue_number: 'Annual 1' },
@@ -105,7 +106,9 @@ describe('continuity comic selectors', () => {
 
     fireEvent.change(screen.getByRole('combobox'), { target: { value: '13' } })
     expect(onChange).toHaveBeenCalledWith(issues[2])
-    expect(screen.getByRole('option', { name: 'Omega' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: '#Omega' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: '#Annual 1' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: '#1/2' })).toBeInTheDocument()
   })
 
   it('covers issue loading, empty, error, disabled, and cleared-selection states', () => {
@@ -125,27 +128,37 @@ describe('continuity comic selectors', () => {
     expect(screen.getByText('Issue load failed')).toBeInTheDocument()
 
     rerender(<ContinuityIssueSelector issues={[]} value={null} onChange={onChange} />)
-    expect(screen.getByText('No issues available.')).toBeInTheDocument()
+    expect(screen.getByText('No issues available')).toBeInTheDocument()
 
     rerender(<ContinuityIssueSelector issues={issues} value={null} onChange={onChange} disabled />)
     expect(screen.getByRole('combobox')).toBeDisabled()
   })
 
-  it('builds ordered ranges from issue labels and explains reversed order without exposing positions', () => {
+  it('builds ordered ranges from issue labels and rejects reversed order without exposing positions', () => {
     const onChange = vi.fn()
-    render(<ContinuityIssueRangeSelector issues={issues} value={null} onChange={onChange} />)
+    render(
+      <ContinuityIssueRangeSelector
+        thread={thread}
+        issues={issues}
+        value={null}
+        onChange={onChange}
+      />,
+    )
 
     const [start, end] = screen.getAllByRole('combobox')
     fireEvent.change(start, { target: { value: '11' } })
     fireEvent.change(end, { target: { value: '13' } })
 
-    expect(onChange).toHaveBeenLastCalledWith({ start: issues[0], end: issues[2] })
-    expect(screen.getByText('Annual 1 through Omega')).toBeInTheDocument()
+    expect(onChange).toHaveBeenLastCalledWith({
+      thread,
+      startIssue: issues[0],
+      endIssue: issues[2],
+    })
     expect(screen.queryByText(/position/i)).not.toBeInTheDocument()
 
     fireEvent.change(start, { target: { value: '13' } })
     fireEvent.change(end, { target: { value: '11' } })
-    expect(screen.getByText('Start issue must come before end issue.')).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent('#Omega comes after #Annual 1')
     expect(onChange).toHaveBeenLastCalledWith(null)
   })
 
@@ -153,8 +166,9 @@ describe('continuity comic selectors', () => {
     const onChange = vi.fn()
     const { rerender } = render(
       <ContinuityIssueRangeSelector
+        thread={thread}
         issues={issues}
-        value={{ start: issues[0], end: issues[2] }}
+        value={{ thread, startIssue: issues[0], endIssue: issues[2] }}
         onChange={onChange}
       />,
     )
@@ -167,8 +181,9 @@ describe('continuity comic selectors', () => {
 
     rerender(
       <ContinuityIssueRangeSelector
+        thread={thread}
         issues={issues}
-        value={{ start: issues[1], end: issues[2] }}
+        value={{ thread, startIssue: issues[1], endIssue: issues[2] }}
         onChange={onChange}
       />,
     )

--- a/frontend/src/unit/ComicSelectors.test.tsx
+++ b/frontend/src/unit/ComicSelectors.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  ContinuityIssueRangeSelector,
+  ContinuityIssueSelector,
+  ContinuityThreadSelector,
+} from '../components/continuity'
+import type { Issue, Thread } from '../types'
+
+const threads: Thread[] = [
+  {
+    id: 1,
+    title: 'Alpha Flight',
+    format: 'single issues',
+    issues_remaining: 3,
+    total_issues: 3,
+    queue_position: 1,
+    status: 'active',
+    is_blocked: false,
+    blocking_reasons: [],
+    created_at: '2026-08-09T00:00:00Z',
+  },
+  {
+    id: 2,
+    title: 'New Mutants',
+    format: 'single issues',
+    issues_remaining: 3,
+    total_issues: 3,
+    queue_position: 2,
+    status: 'active',
+    is_blocked: false,
+    blocking_reasons: [],
+    created_at: '2026-08-09T00:00:00Z',
+  },
+]
+
+const issues: Issue[] = [
+  { id: 11, thread_id: 1, issue_number: '0', status: 'unread', read_at: null, created_at: '2026-08-09T00:00:00Z' },
+  { id: 12, thread_id: 1, issue_number: 'Annual 1', status: 'unread', read_at: null, created_at: '2026-08-09T00:00:00Z' },
+  { id: 13, thread_id: 1, issue_number: '½', status: 'unread', read_at: null, created_at: '2026-08-09T00:00:00Z' },
+]
+
+describe('continuity comic selectors', () => {
+  it('searches threads by human-readable title and returns the selected thread object', () => {
+    const onChange = vi.fn()
+    render(<ContinuityThreadSelector threads={threads} value={null} onChange={onChange} />)
+
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'mutants' } })
+
+    expect(screen.queryByText('Alpha Flight')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('option', { name: /New Mutants/i }))
+    expect(onChange).toHaveBeenLastCalledWith(threads[1])
+  })
+
+  it('moves keyboard focus from search to the first matching result', () => {
+    render(<ContinuityThreadSelector threads={threads} value={null} onChange={vi.fn()} />)
+
+    const search = screen.getByRole('searchbox')
+    fireEvent.keyDown(search, { key: 'ArrowDown' })
+
+    expect(screen.getByRole('option', { name: /Alpha Flight/i })).toHaveFocus()
+  })
+
+  it('selects arbitrary human-facing issue identifiers without numeric parsing', () => {
+    const onChange = vi.fn()
+    render(<ContinuityIssueSelector issues={issues} value={null} onChange={onChange} />)
+
+    const select = screen.getByRole('combobox', { name: 'Issue' })
+    expect(screen.getByRole('option', { name: '#Annual 1' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: '#½' })).toBeInTheDocument()
+
+    fireEvent.change(select, { target: { value: '13' } })
+    expect(onChange).toHaveBeenLastCalledWith(issues[2])
+  })
+
+  it('builds ordered ranges from issue labels and explains reversed order without exposing positions', () => {
+    const onChange = vi.fn()
+    render(
+      <ContinuityIssueRangeSelector
+        thread={threads[0]}
+        issues={issues}
+        value={null}
+        onChange={onChange}
+      />,
+    )
+
+    const first = screen.getByRole('combobox', { name: 'First issue' })
+    const last = screen.getByRole('combobox', { name: 'Last issue' })
+
+    fireEvent.change(first, { target: { value: '13' } })
+    fireEvent.change(last, { target: { value: '11' } })
+
+    expect(screen.getByRole('alert')).toHaveTextContent('#½ comes after #0 in Alpha Flight')
+    expect(screen.queryByText(/position/i)).not.toBeInTheDocument()
+    expect(onChange).toHaveBeenLastCalledWith({
+      thread: threads[0],
+      startIssue: issues[2],
+      endIssue: issues[0],
+    })
+  })
+})


### PR DESCRIPTION
Closes #977

## Summary
- add shared searchable thread selection for continuity workflows
- add shared issue and ordered issue-range selection using actual comic issue labels
- expose typed selected-comic and selected-range values so downstream features do not need raw IDs
- cover keyboard focus, arbitrary issue labels, reversed-range validation, and the no-position UI contract

## Validation
This runtime has no repository checkout, so required CI is the validation boundary for this branch.

Changelog: `docs/changelog.d/2026-08-09-983.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added searchable comic series and issue selectors for continuity workflows.
  - Added support for selecting individual issues using non-numeric labels.
  - Added issue-range selection with ordered range validation.
  - Added keyboard navigation, filtering, loading and error states, disabled controls, and clear empty-state messaging.
  - Selections now remain synchronized when related values or settings change.

- **Documentation**
  - Added a changelog entry describing the new comic and issue selection capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->