### PR TITLE
Recover Roll mutations after access-token expiry

### DIFF
--- a/docs/changelog.d/2026-08-09-990.md
+++ b/docs/changelog.d/2026-08-09-990.md
@@ -1,0 +1,5 @@
+## 2026-08-09
+
+### Roll
+
+- [#990](https://github.com/JoshCLWren/comic-pile/pull/990) preserves rating and snooze actions when an access token expires while you are reading, safely recovering authentication and replaying only the same still-pending comic instead of silently losing the action.

--- a/frontend/src/hooks/rollMutationReconciliation.ts
+++ b/frontend/src/hooks/rollMutationReconciliation.ts
@@ -6,6 +6,10 @@ export const ROLL_BOOTSTRAP_RECONCILED_EVENT = 'comic-pile:roll-bootstrap-reconc
 
 const AUTH_RECOVERY_DELAYS_MS = [250, 500, 1000, 2000, 4000]
 
+export type ProtectedRollMutationRecovery<T> =
+  | { status: 'retried'; value: T }
+  | { status: 'stale' }
+
 function normalizePendingThreadId(
   value: number | string | null | undefined,
 ): number | null {
@@ -75,7 +79,7 @@ export async function recoverProtectedRollMutation<T>(
   expectedPendingThreadId: number,
   retryMutation: () => Promise<T>,
   wait: (ms: number) => Promise<void> = delay,
-): Promise<T | undefined> {
+): Promise<ProtectedRollMutationRecovery<T>> {
   for (let attempt = 0; attempt <= AUTH_RECOVERY_DELAYS_MS.length; attempt += 1) {
     if (attempt > 0) {
       await wait(AUTH_RECOVERY_DELAYS_MS[attempt - 1])
@@ -94,11 +98,11 @@ export async function recoverProtectedRollMutation<T>(
     publishRollBootstrap(state)
 
     if (normalizePendingThreadId(state.pending_thread_id) !== expectedPendingThreadId) {
-      return undefined
+      return { status: 'stale' }
     }
 
-    return retryMutation()
+    return { status: 'retried', value: await retryMutation() }
   }
 
-  return undefined
+  return { status: 'stale' }
 }

--- a/frontend/src/hooks/rollMutationReconciliation.ts
+++ b/frontend/src/hooks/rollMutationReconciliation.ts
@@ -1,7 +1,10 @@
+import { protectedRollMutationApi } from '../services/protectedRollMutationApi'
 import { rollBootstrapApi } from '../services/rollBootstrapApi'
 import type { RollBootstrapResponse } from '../types/rollBootstrap'
 
 export const ROLL_BOOTSTRAP_RECONCILED_EVENT = 'comic-pile:roll-bootstrap-reconciled'
+
+const AUTH_RECOVERY_DELAYS_MS = [250, 500, 1000, 2000, 4000]
 
 function normalizePendingThreadId(
   value: number | string | null | undefined,
@@ -21,6 +24,17 @@ export function isAmbiguousNetworkFailure(error: unknown): boolean {
     || candidate.code === 'ETIMEDOUT'
     || candidate.message?.toLowerCase().includes('timeout') === true
     || candidate.message === 'Network Error'
+}
+
+export function isAuthenticationMutationFailure(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+
+  const response = (error as {
+    response?: { status?: number; data?: { detail?: unknown } }
+  }).response
+
+  if (response?.status === 401) return true
+  return response?.status === 403 && response.data?.detail === 'Not authenticated'
 }
 
 export function publishRollBootstrap(state: RollBootstrapResponse): void {
@@ -49,4 +63,42 @@ export async function reconcileAmbiguousRollMutation(
   }
 
   return pendingThreadId !== expectedPendingThreadId
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms)
+  })
+}
+
+export async function recoverProtectedRollMutation<T>(
+  expectedPendingThreadId: number,
+  retryMutation: () => Promise<T>,
+  wait: (ms: number) => Promise<void> = delay,
+): Promise<T | undefined> {
+  for (let attempt = 0; attempt <= AUTH_RECOVERY_DELAYS_MS.length; attempt += 1) {
+    if (attempt > 0) {
+      await wait(AUTH_RECOVERY_DELAYS_MS[attempt - 1])
+    }
+
+    let state: RollBootstrapResponse
+    try {
+      state = await protectedRollMutationApi.bootstrap()
+    } catch (error: unknown) {
+      if (isAuthenticationMutationFailure(error) && attempt < AUTH_RECOVERY_DELAYS_MS.length) {
+        continue
+      }
+      throw error
+    }
+
+    publishRollBootstrap(state)
+
+    if (normalizePendingThreadId(state.pending_thread_id) !== expectedPendingThreadId) {
+      return undefined
+    }
+
+    return retryMutation()
+  }
+
+  return undefined
 }

--- a/frontend/src/hooks/useRate.ts
+++ b/frontend/src/hooks/useRate.ts
@@ -1,16 +1,18 @@
 import { useRef, useState } from 'react'
 import { applyRatedThreadCache } from '../query/cacheEffects'
 import { queryClient } from '../query/queryClient'
-import { rateApi } from '../services/api'
+import { protectedRollMutationApi } from '../services/protectedRollMutationApi'
 import { getApiErrorDetail } from '../utils/apiError'
 import type { RatePayload } from '../types'
 import {
   fetchAndPublishRollBootstrap,
   isAmbiguousNetworkFailure,
+  isAuthenticationMutationFailure,
   reconcileAmbiguousRollMutation,
+  recoverProtectedRollMutation,
 } from './rollMutationReconciliation'
 
-type RateResult = Awaited<ReturnType<typeof rateApi.rate>> | undefined
+type RateResult = Awaited<ReturnType<typeof protectedRollMutationApi.rate>> | undefined
 
 export function useRate() {
   const [isPending, setIsPending] = useState(false)
@@ -25,7 +27,7 @@ export function useRate() {
 
     const request: Promise<RateResult> = (async () => {
       try {
-        const result = await rateApi.rate(data)
+        const result = await protectedRollMutationApi.rate(data)
         await applyRatedThreadCache(queryClient, result)
 
         try {
@@ -39,6 +41,25 @@ export function useRate() {
 
         return result
       } catch (error: unknown) {
+        if (isAuthenticationMutationFailure(error)) {
+          try {
+            const recovered = await recoverProtectedRollMutation(
+              data.thread_id,
+              () => protectedRollMutationApi.rate(data),
+            )
+            if (recovered !== undefined) {
+              await applyRatedThreadCache(queryClient, recovered)
+              await fetchAndPublishRollBootstrap()
+              return recovered
+            }
+          } catch (recoveryError: unknown) {
+            console.error(
+              'Failed to recover rating after authentication expiry:',
+              getApiErrorDetail(recoveryError),
+            )
+          }
+        }
+
         if (isAmbiguousNetworkFailure(error)) {
           try {
             const committed = await reconcileAmbiguousRollMutation(data.thread_id)

--- a/frontend/src/hooks/useRate.ts
+++ b/frontend/src/hooks/useRate.ts
@@ -43,14 +43,14 @@ export function useRate() {
       } catch (error: unknown) {
         if (isAuthenticationMutationFailure(error)) {
           try {
-            const recovered = await recoverProtectedRollMutation(
+            const recovery = await recoverProtectedRollMutation(
               data.thread_id,
               () => protectedRollMutationApi.rate(data),
             )
-            if (recovered !== undefined) {
-              await applyRatedThreadCache(queryClient, recovered)
+            if (recovery.status === 'retried') {
+              await applyRatedThreadCache(queryClient, recovery.value)
               await fetchAndPublishRollBootstrap()
-              return recovered
+              return recovery.value
             }
           } catch (recoveryError: unknown) {
             console.error(

--- a/frontend/src/hooks/useSnooze.ts
+++ b/frontend/src/hooks/useSnooze.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from 'react'
 import { invalidateCurrentSessionAfterSnooze } from '../query/cacheEffects'
 import { queryClient } from '../query/queryClient'
+import { snoozeApi } from '../services/api'
 import { protectedRollMutationApi } from '../services/protectedRollMutationApi'
 import { getApiErrorDetail } from '../utils/apiError'
 import {
@@ -85,14 +86,14 @@ export function useSnooze() {
           && isAuthenticationMutationFailure(error)
         ) {
           try {
-            const recovered = await recoverProtectedRollMutation(
+            const recovery = await recoverProtectedRollMutation(
               expectedPendingThreadId,
               () => protectedRollMutationApi.snooze(),
             )
-            if (recovered !== undefined) {
+            if (recovery.status === 'retried') {
               await invalidateCurrentSessionAfterSnooze(queryClient)
               await refreshAuthoritativeState()
-              return recovered
+              return recovery.value
             }
           } catch (recoveryError: unknown) {
             console.error(
@@ -148,7 +149,7 @@ export function useUnsnooze() {
     setIsPending(true)
     setIsError(false)
     try {
-      await protectedRollMutationApi.snooze()
+      await snoozeApi.unsnooze(threadId)
       await invalidateCurrentSessionAfterSnooze(queryClient)
     } catch (error: unknown) {
       setIsError(true)

--- a/frontend/src/hooks/useSnooze.ts
+++ b/frontend/src/hooks/useSnooze.ts
@@ -1,15 +1,17 @@
 import { useCallback, useRef, useState } from 'react'
 import { invalidateCurrentSessionAfterSnooze } from '../query/cacheEffects'
 import { queryClient } from '../query/queryClient'
-import { snoozeApi } from '../services/api'
+import { protectedRollMutationApi } from '../services/protectedRollMutationApi'
 import { getApiErrorDetail } from '../utils/apiError'
 import {
   fetchAndPublishRollBootstrap,
   isAmbiguousNetworkFailure,
+  isAuthenticationMutationFailure,
   reconcileAmbiguousRollMutation,
+  recoverProtectedRollMutation,
 } from './rollMutationReconciliation'
 
-type SnoozeResult = Awaited<ReturnType<typeof snoozeApi.snooze>> | undefined
+type SnoozeResult = Awaited<ReturnType<typeof protectedRollMutationApi.snooze>> | undefined
 
 const SNOOZE_REFRESH_ATTEMPTS = 2
 
@@ -73,11 +75,33 @@ export function useSnooze() {
 
     const request: Promise<SnoozeResult> = (async () => {
       try {
-        const result = await snoozeApi.snooze()
+        const result = await protectedRollMutationApi.snooze()
         await invalidateCurrentSessionAfterSnooze(queryClient)
         await refreshAuthoritativeState()
         return result
       } catch (error: unknown) {
+        if (
+          expectedPendingThreadId !== undefined
+          && isAuthenticationMutationFailure(error)
+        ) {
+          try {
+            const recovered = await recoverProtectedRollMutation(
+              expectedPendingThreadId,
+              () => protectedRollMutationApi.snooze(),
+            )
+            if (recovered !== undefined) {
+              await invalidateCurrentSessionAfterSnooze(queryClient)
+              await refreshAuthoritativeState()
+              return recovered
+            }
+          } catch (recoveryError: unknown) {
+            console.error(
+              'Failed to recover snooze after authentication expiry:',
+              getApiErrorDetail(recoveryError),
+            )
+          }
+        }
+
         if (isAmbiguousNetworkFailure(error)) {
           try {
             const committed = await reconcileAmbiguousRollMutation(expectedPendingThreadId)
@@ -124,7 +148,7 @@ export function useUnsnooze() {
     setIsPending(true)
     setIsError(false)
     try {
-      await snoozeApi.unsnooze(threadId)
+      await protectedRollMutationApi.snooze()
       await invalidateCurrentSessionAfterSnooze(queryClient)
     } catch (error: unknown) {
       setIsError(true)

--- a/frontend/src/services/protectedRollMutationApi.ts
+++ b/frontend/src/services/protectedRollMutationApi.ts
@@ -1,27 +1,14 @@
 import type { RatePayload, Thread } from '../types'
 import type { RollBootstrapResponse } from '../types/rollBootstrap'
-import { rollBootstrapApi } from './rollBootstrapApi'
+import api from './api'
 
 const RECOVERY_CONFIG = { skipAuthRedirect: true }
 
-async function loadApiModule() {
-  return import('./api')
-}
-
 export const protectedRollMutationApi = {
-  rate: async (data: RatePayload): Promise<Thread> => {
-    const apiModule = await loadApiModule()
-    if (!('default' in apiModule)) return apiModule.rateApi.rate(data)
-    return apiModule.default.post<Thread, RatePayload>('/rate/', data, RECOVERY_CONFIG)
-  },
-  snooze: async (): Promise<void> => {
-    const apiModule = await loadApiModule()
-    if (!('default' in apiModule)) return apiModule.snoozeApi.snooze()
-    return apiModule.default.post<void>('/snooze/', undefined, RECOVERY_CONFIG)
-  },
-  bootstrap: async (): Promise<RollBootstrapResponse> => {
-    const apiModule = await loadApiModule()
-    if (!('default' in apiModule)) return rollBootstrapApi.get()
-    return apiModule.default.get<RollBootstrapResponse>('/roll/bootstrap', RECOVERY_CONFIG)
-  },
+  rate: (data: RatePayload): Promise<Thread> =>
+    api.post<Thread, RatePayload>('/rate/', data, RECOVERY_CONFIG),
+  snooze: (): Promise<void> =>
+    api.post<void>('/snooze/', undefined, RECOVERY_CONFIG),
+  bootstrap: (): Promise<RollBootstrapResponse> =>
+    api.get<RollBootstrapResponse>('/roll/bootstrap', RECOVERY_CONFIG),
 }

--- a/frontend/src/services/protectedRollMutationApi.ts
+++ b/frontend/src/services/protectedRollMutationApi.ts
@@ -1,25 +1,27 @@
 import type { RatePayload, Thread } from '../types'
 import type { RollBootstrapResponse } from '../types/rollBootstrap'
-import api, { rateApi, snoozeApi } from './api'
 import { rollBootstrapApi } from './rollBootstrapApi'
 
 const RECOVERY_CONFIG = { skipAuthRedirect: true }
 
-function hasConfiguredClient(): boolean {
-  return api !== undefined && typeof api.post === 'function' && typeof api.get === 'function'
+async function loadApiModule() {
+  return import('./api')
 }
 
 export const protectedRollMutationApi = {
-  rate: (data: RatePayload): Promise<Thread> => {
-    if (!hasConfiguredClient()) return rateApi.rate(data)
-    return api.post<Thread, RatePayload>('/rate/', data, RECOVERY_CONFIG)
+  rate: async (data: RatePayload): Promise<Thread> => {
+    const apiModule = await loadApiModule()
+    if (!('default' in apiModule)) return apiModule.rateApi.rate(data)
+    return apiModule.default.post<Thread, RatePayload>('/rate/', data, RECOVERY_CONFIG)
   },
-  snooze: (): Promise<void> => {
-    if (!hasConfiguredClient()) return snoozeApi.snooze()
-    return api.post<void>('/snooze/', undefined, RECOVERY_CONFIG)
+  snooze: async (): Promise<void> => {
+    const apiModule = await loadApiModule()
+    if (!('default' in apiModule)) return apiModule.snoozeApi.snooze()
+    return apiModule.default.post<void>('/snooze/', undefined, RECOVERY_CONFIG)
   },
-  bootstrap: (): Promise<RollBootstrapResponse> => {
-    if (!hasConfiguredClient()) return rollBootstrapApi.get()
-    return api.get<RollBootstrapResponse>('/roll/bootstrap', RECOVERY_CONFIG)
+  bootstrap: async (): Promise<RollBootstrapResponse> => {
+    const apiModule = await loadApiModule()
+    if (!('default' in apiModule)) return rollBootstrapApi.get()
+    return apiModule.default.get<RollBootstrapResponse>('/roll/bootstrap', RECOVERY_CONFIG)
   },
 }

--- a/frontend/src/services/protectedRollMutationApi.ts
+++ b/frontend/src/services/protectedRollMutationApi.ts
@@ -1,0 +1,12 @@
+import type { RatePayload, Thread } from '../types'
+import type { RollBootstrapResponse } from '../types/rollBootstrap'
+import api from './api'
+
+const RECOVERY_CONFIG = { skipAuthRedirect: true }
+
+export const protectedRollMutationApi = {
+  rate: (data: RatePayload) =>
+    api.post<Thread, RatePayload>('/rate/', data, RECOVERY_CONFIG),
+  snooze: () => api.post<void>('/snooze/', undefined, RECOVERY_CONFIG),
+  bootstrap: () => api.get<RollBootstrapResponse>('/roll/bootstrap', RECOVERY_CONFIG),
+}

--- a/frontend/src/services/protectedRollMutationApi.ts
+++ b/frontend/src/services/protectedRollMutationApi.ts
@@ -1,12 +1,25 @@
 import type { RatePayload, Thread } from '../types'
 import type { RollBootstrapResponse } from '../types/rollBootstrap'
-import api from './api'
+import api, { rateApi, snoozeApi } from './api'
+import { rollBootstrapApi } from './rollBootstrapApi'
 
 const RECOVERY_CONFIG = { skipAuthRedirect: true }
 
+function hasConfiguredClient(): boolean {
+  return api !== undefined && typeof api.post === 'function' && typeof api.get === 'function'
+}
+
 export const protectedRollMutationApi = {
-  rate: (data: RatePayload) =>
-    api.post<Thread, RatePayload>('/rate/', data, RECOVERY_CONFIG),
-  snooze: () => api.post<void>('/snooze/', undefined, RECOVERY_CONFIG),
-  bootstrap: () => api.get<RollBootstrapResponse>('/roll/bootstrap', RECOVERY_CONFIG),
+  rate: (data: RatePayload): Promise<Thread> => {
+    if (!hasConfiguredClient()) return rateApi.rate(data)
+    return api.post<Thread, RatePayload>('/rate/', data, RECOVERY_CONFIG)
+  },
+  snooze: (): Promise<void> => {
+    if (!hasConfiguredClient()) return snoozeApi.snooze()
+    return api.post<void>('/snooze/', undefined, RECOVERY_CONFIG)
+  },
+  bootstrap: (): Promise<RollBootstrapResponse> => {
+    if (!hasConfiguredClient()) return rollBootstrapApi.get()
+    return api.get<RollBootstrapResponse>('/roll/bootstrap', RECOVERY_CONFIG)
+  },
 }

--- a/frontend/src/test/roll-auth-recovery.spec.ts
+++ b/frontend/src/test/roll-auth-recovery.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from './fixtures';
+import { SELECTORS, setRangeInput } from './helpers';
+
+async function openPendingThread(page: import('@playwright/test').Page): Promise<void> {
+  await page.goto('/');
+  await expect(page.locator('#root')).toBeVisible();
+
+  const firstThreadCard = page.locator('[role="button"]').filter({
+    has: page.locator('p.font-black'),
+  }).first();
+  await expect(firstThreadCard).toBeVisible({ timeout: 10000 });
+  await firstThreadCard.click();
+  await page.getByText('Read Now', { exact: true }).click();
+  await page.waitForSelector(SELECTORS.rate.ratingInput, { timeout: 10000 });
+}
+
+async function injectExpiredMutationOnce(
+  page: import('@playwright/test').Page,
+  endpoint: '/api/rate/' | '/api/snooze/',
+): Promise<() => { attempts: number; committedAttempts: number }> {
+  let attempts = 0;
+  let committedAttempts = 0;
+
+  await page.route(`**${endpoint}`, async (route) => {
+    if (route.request().method() !== 'POST') {
+      await route.continue();
+      return;
+    }
+
+    attempts += 1;
+    if (attempts === 1) {
+      await route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'Invalid or expired token' }),
+      });
+      return;
+    }
+
+    committedAttempts += 1;
+    await route.continue();
+  });
+
+  return () => ({ attempts, committedAttempts });
+}
+
+test.describe('Roll mutation authentication recovery', () => {
+  test('retries an expired-token rating once without losing or duplicating it', async ({
+    authenticatedWithThreadsPage,
+  }) => {
+    await openPendingThread(authenticatedWithThreadsPage);
+    const getCounts = await injectExpiredMutationOnce(authenticatedWithThreadsPage, '/api/rate/');
+
+    await setRangeInput(authenticatedWithThreadsPage, SELECTORS.rate.ratingInput, '4.5');
+    await authenticatedWithThreadsPage.click(SELECTORS.rate.submitButton);
+
+    await expect(authenticatedWithThreadsPage.locator(SELECTORS.roll.mainDie)).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(authenticatedWithThreadsPage).not.toHaveURL(/\/login(?:\?|$)/);
+    await expect.poll(() => getCounts()).toEqual({ attempts: 2, committedAttempts: 1 });
+  });
+
+  test('retries an expired-token snooze once without a login detour', async ({
+    authenticatedWithThreadsPage,
+  }) => {
+    await openPendingThread(authenticatedWithThreadsPage);
+    const getCounts = await injectExpiredMutationOnce(authenticatedWithThreadsPage, '/api/snooze/');
+
+    await authenticatedWithThreadsPage.click(SELECTORS.rate.snoozeButton);
+
+    await expect(authenticatedWithThreadsPage.locator(SELECTORS.roll.mainDie)).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(authenticatedWithThreadsPage.locator(SELECTORS.rate.ratingInput)).toHaveCount(0);
+    await expect(authenticatedWithThreadsPage).not.toHaveURL(/\/login(?:\?|$)/);
+    await expect.poll(() => getCounts()).toEqual({ attempts: 2, committedAttempts: 1 });
+  });
+});

--- a/frontend/src/unit/hook-coverage.test.tsx
+++ b/frontend/src/unit/hook-coverage.test.tsx
@@ -11,8 +11,10 @@ const api = vi.hoisted(() => ({
   threadsApi: { listStale: vi.fn() },
   sessionApi: { getCurrent: vi.fn(), list: vi.fn(), getDetails: vi.fn(), getSnapshots: vi.fn(), restoreSessionStart: vi.fn() },
 }))
+const protectedApi = vi.hoisted(() => ({ rate: vi.fn(), snooze: vi.fn(), bootstrap: vi.fn() }))
 const bootstrapApi = vi.hoisted(() => ({ get: vi.fn() }))
 vi.mock('../services/api', () => api)
+vi.mock('../services/protectedRollMutationApi', () => ({ protectedRollMutationApi: protectedApi }))
 vi.mock('../services/rollBootstrapApi', () => ({ rollBootstrapApi: bootstrapApi }))
 const toast = vi.hoisted(() => ({ showToast: vi.fn() }))
 const cache = vi.hoisted(() => ({ invalidateQueries: vi.fn() }))
@@ -31,6 +33,18 @@ import { useStaleThreads } from '../hooks/useThread'
 beforeEach(() => {
   vi.clearAllMocks()
   Object.values(api).forEach((group) => Object.values(group).forEach((fn) => fn.mockResolvedValue({})))
+  protectedApi.rate.mockResolvedValue({
+    id: 1,
+    title: 'Test',
+    format: 'issue',
+    issues_remaining: 1,
+    total_issues: 1,
+    queue_position: 1,
+    status: 'active',
+    is_blocked: false,
+    blocking_reasons: [],
+    created_at: '2026-08-09T00:00:00Z',
+  })
   bootstrapApi.get.mockResolvedValue({})
   api.rollApi.roll.mockResolvedValue({ result: 4 })
 })
@@ -44,7 +58,7 @@ describe('mutation hook success and failure paths', () => {
     expect(front.result.current.isError).toBe(false)
     const rate = renderHook(() => useRate())
     await act(async () => await rate.result.current.mutate({ thread_id: 1, rating: 4 }))
-    expect(api.rateApi.rate).toHaveBeenCalled()
+    expect(protectedApi.rate).toHaveBeenCalled()
   })
 
   it('sets error state and rethrows mutation failures', async () => {
@@ -65,7 +79,7 @@ describe('mutation hook success and failure paths', () => {
     api.queueApi.shuffle.mockRejectedValueOnce(new Error('shuffle failed'))
     const shuffle = renderHook(() => useShuffleQueue())
     await act(async () => expect(shuffle.result.current.mutate()).rejects.toThrow('shuffle failed'))
-    api.rateApi.rate.mockRejectedValueOnce(new Error('rate failed'))
+    protectedApi.rate.mockRejectedValueOnce(new Error('rate failed'))
     const rate = renderHook(() => useRate())
     await act(async () => expect(rate.result.current.mutate({ thread_id: 1, rating: 1 })).rejects.toThrow('rate failed'))
   })

--- a/frontend/src/unit/protectedRollMutationRecovery.test.ts
+++ b/frontend/src/unit/protectedRollMutationRecovery.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  isAuthenticationMutationFailure,
+  recoverProtectedRollMutation,
+} from '../hooks/rollMutationReconciliation'
+import { protectedRollMutationApi } from '../services/protectedRollMutationApi'
+import type { RollBootstrapResponse } from '../types/rollBootstrap'
+
+vi.mock('../services/protectedRollMutationApi', () => ({
+  protectedRollMutationApi: {
+    bootstrap: vi.fn(),
+  },
+}))
+
+const mockedProtectedApi = vi.mocked(protectedRollMutationApi)
+
+function bootstrapState(pendingThreadId: number | null): RollBootstrapResponse {
+  return {
+    session_id: 1,
+    user_id: 1,
+    current_die: 6,
+    manual_die: null,
+    pending_thread_id: pendingThreadId,
+    last_rolled_result: pendingThreadId === null ? null : 1,
+    active_thread: null,
+    roll_pool: [],
+    snoozed_threads: [],
+    snoozed_count: 0,
+    blocked_count: 0,
+    blocked_threads: [],
+    stale_thread_count: 0,
+    stale_thread: null,
+  }
+}
+
+const authFailure = {
+  response: { status: 403, data: { detail: 'Not authenticated' } },
+}
+
+describe('protected Roll mutation recovery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('recognizes only authentication-shaped mutation failures', () => {
+    expect(isAuthenticationMutationFailure({ response: { status: 401 } })).toBe(true)
+    expect(isAuthenticationMutationFailure(authFailure)).toBe(true)
+    expect(isAuthenticationMutationFailure({ response: { status: 403, data: { detail: 'Forbidden' } } })).toBe(false)
+    expect(isAuthenticationMutationFailure({ response: { status: 500 } })).toBe(false)
+  })
+
+  it('waits through recoverable auth failures then retries the same pending mutation once', async () => {
+    mockedProtectedApi.bootstrap
+      .mockRejectedValueOnce(authFailure)
+      .mockRejectedValueOnce(authFailure)
+      .mockResolvedValueOnce(bootstrapState(7))
+    const retry = vi.fn().mockResolvedValue(undefined)
+    const wait = vi.fn().mockResolvedValue(undefined)
+
+    await expect(recoverProtectedRollMutation(7, retry, wait)).resolves.toEqual({
+      status: 'retried',
+      value: undefined,
+    })
+
+    expect(mockedProtectedApi.bootstrap).toHaveBeenCalledTimes(3)
+    expect(wait).toHaveBeenCalledTimes(2)
+    expect(retry).toHaveBeenCalledTimes(1)
+  })
+
+  it('refuses to replay after authoritative pending state advances', async () => {
+    mockedProtectedApi.bootstrap.mockResolvedValueOnce(bootstrapState(9))
+    const retry = vi.fn()
+
+    await expect(recoverProtectedRollMutation(7, retry, vi.fn())).resolves.toEqual({
+      status: 'stale',
+    })
+
+    expect(retry).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a definitive recovery failure without replaying', async () => {
+    const revoked = { response: { status: 403, data: { detail: 'Revoked token' } } }
+    mockedProtectedApi.bootstrap.mockRejectedValueOnce(revoked)
+    const retry = vi.fn()
+
+    await expect(recoverProtectedRollMutation(7, retry, vi.fn())).rejects.toBe(revoked)
+    expect(retry).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/unit/useRate.test.tsx
+++ b/frontend/src/unit/useRate.test.tsx
@@ -9,190 +9,48 @@ import { rollBootstrapApi } from '../services/rollBootstrapApi'
 import type { RatePayload, Thread } from '../types'
 import type { RollBootstrapResponse } from '../types/rollBootstrap'
 
-vi.mock('../services/protectedRollMutationApi', () => ({
-  protectedRollMutationApi: {
-    rate: vi.fn(),
-    snooze: vi.fn(),
-    bootstrap: vi.fn(),
-  },
-}))
-
-vi.mock('../services/rollBootstrapApi', () => ({
-  rollBootstrapApi: {
-    get: vi.fn(),
-  },
-}))
-
-vi.mock('../query/cacheEffects', () => ({
-  applyRatedThreadCache: vi.fn(),
-}))
+vi.mock('../services/protectedRollMutationApi', () => ({ protectedRollMutationApi: { rate: vi.fn(), snooze: vi.fn(), bootstrap: vi.fn() } }))
+vi.mock('../services/rollBootstrapApi', () => ({ rollBootstrapApi: { get: vi.fn() } }))
+vi.mock('../query/cacheEffects', () => ({ applyRatedThreadCache: vi.fn() }))
 
 const mockedProtectedApi = vi.mocked(protectedRollMutationApi)
 const mockedRollBootstrapApi = vi.mocked(rollBootstrapApi)
 const mockedApplyRatedThreadCache = vi.mocked(applyRatedThreadCache)
+const thread: Thread = { id: 1, title: 'Saga', format: 'issue', issues_remaining: 3, total_issues: 10, queue_position: 2, status: 'active', is_blocked: false, blocking_reasons: [], created_at: '2026-08-03T00:00:00Z' }
+const bootstrapState = (pendingThreadId: number | null, currentDie: RollBootstrapResponse['current_die'] = 8): RollBootstrapResponse => ({ session_id: 1, user_id: 1, current_die: currentDie, manual_die: null, pending_thread_id: pendingThreadId, last_rolled_result: pendingThreadId === null ? null : 1, active_thread: null, roll_pool: [], blocked_threads: [], blocked_count: 0, snoozed_threads: [], snoozed_count: 0, stale_thread: null, stale_thread_count: 0 })
 
-const thread: Thread = {
-  id: 1,
-  title: 'Saga',
-  format: 'issue',
-  issues_remaining: 3,
-  total_issues: 10,
-  queue_position: 2,
-  status: 'active',
-  is_blocked: false,
-  blocking_reasons: [],
-  created_at: '2026-08-03T00:00:00Z',
-}
-
-const bootstrapState = (
-  pendingThreadId: number | null,
-  currentDie: RollBootstrapResponse['current_die'] = 8,
-): RollBootstrapResponse => ({
-  session_id: 1,
-  user_id: 1,
-  current_die: currentDie,
-  manual_die: null,
-  pending_thread_id: pendingThreadId,
-  last_rolled_result: pendingThreadId === null ? null : 1,
-  active_thread: null,
-  roll_pool: [],
-  blocked_threads: [],
-  blocked_count: 0,
-  snoozed_threads: [],
-  snoozed_count: 0,
-  stale_thread: null,
-  stale_thread_count: 0,
-})
-
-beforeEach(() => {
-  vi.clearAllMocks()
-  mockedProtectedApi.rate.mockResolvedValue(thread)
-  mockedRollBootstrapApi.get.mockResolvedValue(bootstrapState(null))
-  mockedApplyRatedThreadCache.mockResolvedValue()
-})
+beforeEach(() => { vi.clearAllMocks(); mockedProtectedApi.rate.mockResolvedValue(thread); mockedRollBootstrapApi.get.mockResolvedValue(bootstrapState(null)); mockedApplyRatedThreadCache.mockResolvedValue() })
 
 it('submits ratings, applies the authoritative thread cache, and publishes Roll state', async () => {
-  const reconciled = vi.fn()
-  window.addEventListener(ROLL_BOOTSTRAP_RECONCILED_EVENT, reconciled)
-
-  try {
-    const { result } = renderHook(() => useRate())
-    const payload: RatePayload = { thread_id: 1, rating: 4 }
-
-    let response: Thread | undefined
-    await act(async () => {
-      response = await result.current.mutate(payload)
-    })
-
-    expect(mockedProtectedApi.rate).toHaveBeenCalledWith(payload)
-    expect(mockedApplyRatedThreadCache).toHaveBeenCalledWith(queryClient, thread)
-    expect(response).toBe(thread)
-    expect(mockedRollBootstrapApi.get).toHaveBeenCalledTimes(1)
-    expect(reconciled).toHaveBeenCalledTimes(1)
-    expect(result.current.isError).toBe(false)
-  } finally {
-    window.removeEventListener(ROLL_BOOTSTRAP_RECONCILED_EVENT, reconciled)
-  }
+  const reconciled = vi.fn(); window.addEventListener(ROLL_BOOTSTRAP_RECONCILED_EVENT, reconciled)
+  try { const { result } = renderHook(() => useRate()); const payload: RatePayload = { thread_id: 1, rating: 4 }; let response: Thread | undefined; await act(async () => { response = await result.current.mutate(payload) }); expect(mockedProtectedApi.rate).toHaveBeenCalledWith(payload); expect(mockedApplyRatedThreadCache).toHaveBeenCalledWith(queryClient, thread); expect(response).toBe(thread); expect(mockedRollBootstrapApi.get).toHaveBeenCalledTimes(1); expect(reconciled).toHaveBeenCalledTimes(1); expect(result.current.isError).toBe(false) } finally { window.removeEventListener(ROLL_BOOTSTRAP_RECONCILED_EVENT, reconciled) }
 })
 
 it('shares one in-flight request across repeated submissions', async () => {
-  let resolveRequest: (() => void) | undefined
-  mockedProtectedApi.rate.mockReturnValue(new Promise((resolve) => {
-    resolveRequest = () => resolve(undefined as never)
-  }))
-
-  const { result } = renderHook(() => useRate())
-  const payload: RatePayload = { thread_id: 1, rating: 4 }
-  let firstRequest: Promise<unknown> | undefined
-  let secondRequest: Promise<unknown> | undefined
-
-  act(() => {
-    firstRequest = result.current.mutate(payload)
-    secondRequest = result.current.mutate(payload)
-  })
-
-  expect(mockedProtectedApi.rate).toHaveBeenCalledTimes(1)
-  expect(result.current.isPending).toBe(true)
-
-  await act(async () => {
-    resolveRequest?.()
-    await Promise.all([firstRequest, secondRequest])
-  })
-
-  expect(mockedApplyRatedThreadCache).toHaveBeenCalledTimes(1)
-  expect(mockedRollBootstrapApi.get).toHaveBeenCalledTimes(1)
-  expect(result.current.isPending).toBe(false)
-  expect(result.current.isError).toBe(false)
+  let resolveRequest: (() => void) | undefined; mockedProtectedApi.rate.mockReturnValue(new Promise((resolve) => { resolveRequest = () => resolve(undefined as never) })); const { result } = renderHook(() => useRate()); const payload: RatePayload = { thread_id: 1, rating: 4 }; let firstRequest: Promise<unknown> | undefined; let secondRequest: Promise<unknown> | undefined; act(() => { firstRequest = result.current.mutate(payload); secondRequest = result.current.mutate(payload) }); expect(mockedProtectedApi.rate).toHaveBeenCalledTimes(1); expect(result.current.isPending).toBe(true); await act(async () => { resolveRequest?.(); await Promise.all([firstRequest, secondRequest]) }); expect(mockedApplyRatedThreadCache).toHaveBeenCalledTimes(1); expect(mockedRollBootstrapApi.get).toHaveBeenCalledTimes(1); expect(result.current.isPending).toBe(false); expect(result.current.isError).toBe(false)
 })
 
 it('reconciles a committed rating after the delayed response crosses the client timeout', async () => {
-  vi.useFakeTimers()
-  const timeout = Object.assign(new Error('timeout of 10000ms exceeded'), {
-    code: 'ECONNABORTED',
-  })
-  mockedProtectedApi.rate.mockImplementation(() => new Promise((_, reject) => {
-    setTimeout(() => reject(timeout), 10_000)
-  }))
-  mockedRollBootstrapApi.get.mockResolvedValue(bootstrapState(null, 10))
-
-  try {
-    const { result } = renderHook(() => useRate())
-    const payload: RatePayload = { thread_id: 1, rating: 3 }
-    let firstRequest: Promise<unknown> | undefined
-    let secondRequest: Promise<unknown> | undefined
-
-    act(() => {
-      firstRequest = result.current.mutate(payload)
-      secondRequest = result.current.mutate(payload)
-    })
-
-    expect(mockedProtectedApi.rate).toHaveBeenCalledTimes(1)
-    expect(result.current.isPending).toBe(true)
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(10_000)
-      await Promise.all([firstRequest, secondRequest])
-    })
-
-    expect(mockedApplyRatedThreadCache).not.toHaveBeenCalled()
-    expect(mockedRollBootstrapApi.get).toHaveBeenCalledTimes(1)
-    expect(result.current.isError).toBe(false)
-    expect(result.current.isPending).toBe(false)
-  } finally {
-    vi.useRealTimers()
-  }
+  vi.useFakeTimers(); const timeout = Object.assign(new Error('timeout of 10000ms exceeded'), { code: 'ECONNABORTED' }); mockedProtectedApi.rate.mockImplementation(() => new Promise((_, reject) => { setTimeout(() => reject(timeout), 10_000) })); mockedRollBootstrapApi.get.mockResolvedValue(bootstrapState(null, 10));
+  try { const { result } = renderHook(() => useRate()); const payload: RatePayload = { thread_id: 1, rating: 3 }; let firstRequest: Promise<unknown> | undefined; let secondRequest: Promise<unknown> | undefined; act(() => { firstRequest = result.current.mutate(payload); secondRequest = result.current.mutate(payload) }); expect(mockedProtectedApi.rate).toHaveBeenCalledTimes(1); expect(result.current.isPending).toBe(true); await act(async () => { await vi.advanceTimersByTimeAsync(10_000); await Promise.all([firstRequest, secondRequest]) }); expect(mockedApplyRatedThreadCache).not.toHaveBeenCalled(); expect(mockedRollBootstrapApi.get).toHaveBeenCalledTimes(1); expect(result.current.isError).toBe(false); expect(result.current.isPending).toBe(false) } finally { vi.useRealTimers() }
 })
 
 it('surfaces a delayed timeout when authoritative state still has the same pending thread', async () => {
-  vi.useFakeTimers()
-  const timeout = Object.assign(new Error('timeout of 10000ms exceeded'), {
-    code: 'ECONNABORTED',
-  })
-  mockedProtectedApi.rate.mockImplementation(() => new Promise((_, reject) => {
-    setTimeout(() => reject(timeout), 10_000)
-  }))
-  mockedRollBootstrapApi.get.mockResolvedValue(bootstrapState(1))
+  vi.useFakeTimers(); const timeout = Object.assign(new Error('timeout of 10000ms exceeded'), { code: 'ECONNABORTED' }); mockedProtectedApi.rate.mockImplementation(() => new Promise((_, reject) => { setTimeout(() => reject(timeout), 10_000) })); mockedRollBootstrapApi.get.mockResolvedValue(bootstrapState(1));
+  try { const { result } = renderHook(() => useRate()); const payload: RatePayload = { thread_id: 1, rating: 3 }; let request!: Promise<unknown>; act(() => { request = result.current.mutate(payload) }); const rejection = expect(request).rejects.toBe(timeout); await act(async () => { await vi.advanceTimersByTimeAsync(10_000); await rejection }); expect(mockedApplyRatedThreadCache).not.toHaveBeenCalled(); expect(mockedRollBootstrapApi.get).toHaveBeenCalledTimes(1); expect(result.current.isError).toBe(true); expect(result.current.isPending).toBe(false) } finally { vi.useRealTimers() }
+})
 
-  try {
-    const { result } = renderHook(() => useRate())
-    const payload: RatePayload = { thread_id: 1, rating: 3 }
-    let request!: Promise<unknown>
+it('keeps a successful rating successful when the follow-up bootstrap refresh fails', async () => {
+  mockedRollBootstrapApi.get.mockRejectedValue(new Error('refresh unavailable'))
+  const { result } = renderHook(() => useRate())
+  await act(async () => { await expect(result.current.mutate({ thread_id: 1, rating: 4 })).resolves.toBe(thread) })
+  expect(result.current.isError).toBe(false)
+})
 
-    act(() => {
-      request = result.current.mutate(payload)
-    })
-
-    const rejection = expect(request).rejects.toBe(timeout)
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(10_000)
-      await rejection
-    })
-
-    expect(mockedApplyRatedThreadCache).not.toHaveBeenCalled()
-    expect(mockedRollBootstrapApi.get).toHaveBeenCalledTimes(1)
-    expect(result.current.isError).toBe(true)
-    expect(result.current.isPending).toBe(false)
-  } finally {
-    vi.useRealTimers()
-  }
+it('marks ordinary rating failures as errors and rethrows them', async () => {
+  const failure = new Error('rating unavailable'); mockedProtectedApi.rate.mockRejectedValue(failure)
+  const { result } = renderHook(() => useRate()); let request!: Promise<unknown>
+  act(() => { request = result.current.mutate({ thread_id: 1, rating: 2 }) })
+  await act(async () => { await expect(request).rejects.toBe(failure) })
+  expect(result.current.isError).toBe(true); expect(result.current.isPending).toBe(false)
 })

--- a/frontend/src/unit/useRate.test.tsx
+++ b/frontend/src/unit/useRate.test.tsx
@@ -4,14 +4,16 @@ import { useRate } from '../hooks/useRate'
 import { ROLL_BOOTSTRAP_RECONCILED_EVENT } from '../hooks/rollMutationReconciliation'
 import { applyRatedThreadCache } from '../query/cacheEffects'
 import { queryClient } from '../query/queryClient'
-import { rateApi } from '../services/api'
+import { protectedRollMutationApi } from '../services/protectedRollMutationApi'
 import { rollBootstrapApi } from '../services/rollBootstrapApi'
 import type { RatePayload, Thread } from '../types'
 import type { RollBootstrapResponse } from '../types/rollBootstrap'
 
-vi.mock('../services/api', () => ({
-  rateApi: {
+vi.mock('../services/protectedRollMutationApi', () => ({
+  protectedRollMutationApi: {
     rate: vi.fn(),
+    snooze: vi.fn(),
+    bootstrap: vi.fn(),
   },
 }))
 
@@ -25,7 +27,7 @@ vi.mock('../query/cacheEffects', () => ({
   applyRatedThreadCache: vi.fn(),
 }))
 
-const mockedRateApi = vi.mocked(rateApi)
+const mockedProtectedApi = vi.mocked(protectedRollMutationApi)
 const mockedRollBootstrapApi = vi.mocked(rollBootstrapApi)
 const mockedApplyRatedThreadCache = vi.mocked(applyRatedThreadCache)
 
@@ -64,7 +66,7 @@ const bootstrapState = (
 
 beforeEach(() => {
   vi.clearAllMocks()
-  mockedRateApi.rate.mockResolvedValue(thread)
+  mockedProtectedApi.rate.mockResolvedValue(thread)
   mockedRollBootstrapApi.get.mockResolvedValue(bootstrapState(null))
   mockedApplyRatedThreadCache.mockResolvedValue()
 })
@@ -82,7 +84,7 @@ it('submits ratings, applies the authoritative thread cache, and publishes Roll 
       response = await result.current.mutate(payload)
     })
 
-    expect(mockedRateApi.rate).toHaveBeenCalledWith(payload)
+    expect(mockedProtectedApi.rate).toHaveBeenCalledWith(payload)
     expect(mockedApplyRatedThreadCache).toHaveBeenCalledWith(queryClient, thread)
     expect(response).toBe(thread)
     expect(mockedRollBootstrapApi.get).toHaveBeenCalledTimes(1)
@@ -95,7 +97,7 @@ it('submits ratings, applies the authoritative thread cache, and publishes Roll 
 
 it('shares one in-flight request across repeated submissions', async () => {
   let resolveRequest: (() => void) | undefined
-  mockedRateApi.rate.mockReturnValue(new Promise((resolve) => {
+  mockedProtectedApi.rate.mockReturnValue(new Promise((resolve) => {
     resolveRequest = () => resolve(undefined as never)
   }))
 
@@ -109,7 +111,7 @@ it('shares one in-flight request across repeated submissions', async () => {
     secondRequest = result.current.mutate(payload)
   })
 
-  expect(mockedRateApi.rate).toHaveBeenCalledTimes(1)
+  expect(mockedProtectedApi.rate).toHaveBeenCalledTimes(1)
   expect(result.current.isPending).toBe(true)
 
   await act(async () => {
@@ -128,7 +130,7 @@ it('reconciles a committed rating after the delayed response crosses the client 
   const timeout = Object.assign(new Error('timeout of 10000ms exceeded'), {
     code: 'ECONNABORTED',
   })
-  mockedRateApi.rate.mockImplementation(() => new Promise((_, reject) => {
+  mockedProtectedApi.rate.mockImplementation(() => new Promise((_, reject) => {
     setTimeout(() => reject(timeout), 10_000)
   }))
   mockedRollBootstrapApi.get.mockResolvedValue(bootstrapState(null, 10))
@@ -144,7 +146,7 @@ it('reconciles a committed rating after the delayed response crosses the client 
       secondRequest = result.current.mutate(payload)
     })
 
-    expect(mockedRateApi.rate).toHaveBeenCalledTimes(1)
+    expect(mockedProtectedApi.rate).toHaveBeenCalledTimes(1)
     expect(result.current.isPending).toBe(true)
 
     await act(async () => {
@@ -166,7 +168,7 @@ it('surfaces a delayed timeout when authoritative state still has the same pendi
   const timeout = Object.assign(new Error('timeout of 10000ms exceeded'), {
     code: 'ECONNABORTED',
   })
-  mockedRateApi.rate.mockImplementation(() => new Promise((_, reject) => {
+  mockedProtectedApi.rate.mockImplementation(() => new Promise((_, reject) => {
     setTimeout(() => reject(timeout), 10_000)
   }))
   mockedRollBootstrapApi.get.mockResolvedValue(bootstrapState(1))

--- a/frontend/src/unit/useSnooze.test.tsx
+++ b/frontend/src/unit/useSnooze.test.tsx
@@ -6,10 +6,16 @@ import { queryClient } from '../query/queryClient'
 import type { RollBootstrapResponse } from '../types/rollBootstrap'
 
 const snoozeApi = vi.hoisted(() => ({ snooze: vi.fn(), unsnooze: vi.fn() }))
+const protectedRollMutationApi = vi.hoisted(() => ({
+  rate: vi.fn(),
+  snooze: vi.fn(),
+  bootstrap: vi.fn(),
+}))
 const rollBootstrapApi = vi.hoisted(() => ({ get: vi.fn() }))
 const invalidateCurrentSessionAfterSnooze = vi.hoisted(() => vi.fn())
 
 vi.mock('../services/api', () => ({ snoozeApi }))
+vi.mock('../services/protectedRollMutationApi', () => ({ protectedRollMutationApi }))
 vi.mock('../services/rollBootstrapApi', () => ({ rollBootstrapApi }))
 vi.mock('../query/cacheEffects', () => ({ invalidateCurrentSessionAfterSnooze }))
 
@@ -39,7 +45,7 @@ describe('snooze hooks', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     invalidateCurrentSessionAfterSnooze.mockReset()
-    snoozeApi.snooze.mockResolvedValue(undefined)
+    protectedRollMutationApi.snooze.mockResolvedValue(undefined)
     snoozeApi.unsnooze.mockResolvedValue(undefined)
     rollBootstrapApi.get.mockResolvedValue(bootstrapState(null))
   })
@@ -52,7 +58,7 @@ describe('snooze hooks', () => {
       const snooze = renderHook(() => useSnooze())
       await act(async () => await snooze.result.current.mutate(7))
 
-      expect(snoozeApi.snooze).toHaveBeenCalledTimes(1)
+      expect(protectedRollMutationApi.snooze).toHaveBeenCalledTimes(1)
       expect(rollBootstrapApi.get).toHaveBeenCalledTimes(1)
       expect(reconciled).toHaveBeenCalledTimes(1)
       expect(invalidateCurrentSessionAfterSnooze).toHaveBeenCalledWith(queryClient)
@@ -70,7 +76,7 @@ describe('snooze hooks', () => {
 
   it('shares one in-flight snooze request across repeated submissions', async () => {
     let resolveRequest: (() => void) | undefined
-    snoozeApi.snooze.mockReturnValue(new Promise((resolve) => {
+    protectedRollMutationApi.snooze.mockReturnValue(new Promise((resolve) => {
       resolveRequest = () => resolve(undefined)
     }))
 
@@ -83,7 +89,7 @@ describe('snooze hooks', () => {
       secondRequest = snooze.result.current.mutate(7)
     })
 
-    expect(snoozeApi.snooze).toHaveBeenCalledTimes(1)
+    expect(protectedRollMutationApi.snooze).toHaveBeenCalledTimes(1)
     expect(snooze.result.current.isPending).toBe(true)
 
     await act(async () => {
@@ -108,7 +114,7 @@ describe('snooze hooks', () => {
       const snooze = renderHook(() => useSnooze())
       await act(async () => await snooze.result.current.mutate(7))
 
-      expect(snoozeApi.snooze).toHaveBeenCalledTimes(1)
+      expect(protectedRollMutationApi.snooze).toHaveBeenCalledTimes(1)
       expect(rollBootstrapApi.get).toHaveBeenCalledTimes(2)
       expect(reconciled).toHaveBeenCalledTimes(1)
       expect(snooze.result.current.isError).toBe(false)
@@ -125,7 +131,7 @@ describe('snooze hooks', () => {
 
     await act(async () => await snooze.result.current.mutate(7))
 
-    expect(snoozeApi.snooze).toHaveBeenCalledTimes(1)
+    expect(protectedRollMutationApi.snooze).toHaveBeenCalledTimes(1)
     expect(rollBootstrapApi.get).toHaveBeenCalledTimes(2)
     expect(snooze.result.current.isError).toBe(false)
     expect(snooze.result.current.hasRefreshError).toBe(true)
@@ -136,7 +142,7 @@ describe('snooze hooks', () => {
       await expect(snooze.result.current.retryRefresh()).resolves.toBe(true)
     })
 
-    expect(snoozeApi.snooze).toHaveBeenCalledTimes(1)
+    expect(protectedRollMutationApi.snooze).toHaveBeenCalledTimes(1)
     expect(rollBootstrapApi.get).toHaveBeenCalledTimes(3)
     expect(snooze.result.current.hasRefreshError).toBe(false)
     expect(snooze.result.current.isPending).toBe(false)
@@ -161,7 +167,7 @@ describe('snooze hooks', () => {
       duplicateRequest = snooze.result.current.mutate(7)
     })
 
-    expect(snoozeApi.snooze).toHaveBeenCalledTimes(1)
+    expect(protectedRollMutationApi.snooze).toHaveBeenCalledTimes(1)
     expect(snooze.result.current.isPending).toBe(true)
 
     await act(async () => {
@@ -169,7 +175,7 @@ describe('snooze hooks', () => {
       await Promise.all([retryRequest, duplicateRequest])
     })
 
-    expect(snoozeApi.snooze).toHaveBeenCalledTimes(1)
+    expect(protectedRollMutationApi.snooze).toHaveBeenCalledTimes(1)
     expect(snooze.result.current.isPending).toBe(false)
     expect(snooze.result.current.hasRefreshError).toBe(false)
   })
@@ -179,7 +185,7 @@ describe('snooze hooks', () => {
     const timeout = Object.assign(new Error('timeout of 10000ms exceeded'), {
       code: 'ECONNABORTED',
     })
-    snoozeApi.snooze.mockImplementation(() => new Promise((_, reject) => {
+    protectedRollMutationApi.snooze.mockImplementation(() => new Promise((_, reject) => {
       setTimeout(() => reject(timeout), 10_000)
     }))
     rollBootstrapApi.get.mockResolvedValue(bootstrapState(null, 20))
@@ -197,7 +203,7 @@ describe('snooze hooks', () => {
         await request
       })
 
-      expect(snoozeApi.snooze).toHaveBeenCalledTimes(1)
+      expect(protectedRollMutationApi.snooze).toHaveBeenCalledTimes(1)
       expect(rollBootstrapApi.get).toHaveBeenCalledTimes(1)
       expect(snooze.result.current.isError).toBe(false)
       expect(snooze.result.current.isPending).toBe(false)
@@ -211,7 +217,7 @@ describe('snooze hooks', () => {
     const timeout = Object.assign(new Error('timeout of 10000ms exceeded'), {
       code: 'ECONNABORTED',
     })
-    snoozeApi.snooze.mockImplementation(() => new Promise((_, reject) => {
+    protectedRollMutationApi.snooze.mockImplementation(() => new Promise((_, reject) => {
       setTimeout(() => reject(timeout), 10_000)
     }))
     rollBootstrapApi.get.mockResolvedValue(bootstrapState(7, 10))
@@ -239,7 +245,7 @@ describe('snooze hooks', () => {
   })
 
   it('tracks and rethrows ordinary failures', async () => {
-    snoozeApi.snooze.mockRejectedValueOnce(new Error('snooze failed'))
+    protectedRollMutationApi.snooze.mockRejectedValueOnce(new Error('snooze failed'))
     const snooze = renderHook(() => useSnooze())
     await act(async () => await expect(snooze.result.current.mutate(7)).rejects.toThrow('snooze failed'))
     await waitFor(() => expect(snooze.result.current.isError).toBe(true))

--- a/tests/test_roll_mutation_auth_replay.py
+++ b/tests/test_roll_mutation_auth_replay.py
@@ -1,0 +1,135 @@
+"""Regression coverage for auth-expired Roll mutation replay safety."""
+
+from datetime import timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import create_access_token
+from app.models import Event, Thread
+from app.models import Session as SessionModel
+from tests.conftest import get_or_create_user_async
+
+
+async def _pending_roll(async_db: AsyncSession, *, start_die: int = 6) -> tuple[SessionModel, Thread]:
+    """Create one active session with one pending rolled thread."""
+    user = await get_or_create_user_async(async_db)
+    session = SessionModel(start_die=start_die, user_id=user.id)
+    thread = Thread(
+        title="Auth replay thread",
+        format="Comic",
+        issues_remaining=5,
+        queue_position=1,
+        status="active",
+        user_id=user.id,
+    )
+    async_db.add_all([session, thread])
+    await async_db.flush()
+    session.pending_thread_id = thread.id
+    async_db.add(
+        Event(
+            type="roll",
+            die=start_die,
+            result=1,
+            selected_thread_id=thread.id,
+            selection_method="random",
+            session_id=session.id,
+            thread_id=thread.id,
+        )
+    )
+    await async_db.commit()
+    return session, thread
+
+
+def _set_access_token(client: AsyncClient, username: str, *, expired: bool) -> None:
+    """Replace the client's access token with a deterministic valid or expired token."""
+    lifetime = timedelta(minutes=-1 if expired else 5)
+    token = create_access_token(
+        data={"sub": username, "jti": "expired-replay" if expired else "fresh-replay"},
+        expires_delta=lifetime,
+    )
+    client.headers.update({"Authorization": f"Bearer {token}"})
+
+
+@pytest.mark.asyncio
+async def test_rate_expired_token_has_no_partial_write_and_replay_commits_once(
+    auth_client: AsyncClient,
+    async_db: AsyncSession,
+    test_username: str,
+) -> None:
+    """A rejected rate can be replayed after auth recovery without a duplicate transition."""
+    session, thread = await _pending_roll(async_db)
+
+    _set_access_token(auth_client, test_username, expired=True)
+    rejected = await auth_client.post("/api/rate/", json={"rating": 4.5})
+    assert rejected.status_code == 401
+
+    await async_db.refresh(session)
+    await async_db.refresh(thread)
+    assert session.pending_thread_id == thread.id
+    assert thread.issues_remaining == 5
+    assert thread.last_rating is None
+    result = await async_db.execute(
+        select(Event).where(Event.session_id == session.id, Event.type == "rate")
+    )
+    assert result.scalars().all() == []
+
+    _set_access_token(auth_client, test_username, expired=False)
+    replay = await auth_client.post("/api/rate/", json={"rating": 4.5})
+    assert replay.status_code == 200
+
+    duplicate = await auth_client.post("/api/rate/", json={"rating": 4.5})
+    assert duplicate.status_code == 400
+
+    await async_db.refresh(session)
+    await async_db.refresh(thread)
+    assert session.pending_thread_id is None
+    assert thread.issues_remaining == 4
+    assert thread.last_rating == 4.5
+    result = await async_db.execute(
+        select(Event).where(Event.session_id == session.id, Event.type == "rate")
+    )
+    rate_events = result.scalars().all()
+    assert len(rate_events) == 1
+    assert rate_events[0].thread_id == thread.id
+
+
+@pytest.mark.asyncio
+async def test_snooze_expired_token_has_no_partial_write_and_replay_commits_once(
+    auth_client: AsyncClient,
+    async_db: AsyncSession,
+    test_username: str,
+) -> None:
+    """A rejected snooze can be replayed after auth recovery without a duplicate transition."""
+    session, thread = await _pending_roll(async_db)
+
+    _set_access_token(auth_client, test_username, expired=True)
+    rejected = await auth_client.post("/api/snooze/")
+    assert rejected.status_code == 401
+
+    await async_db.refresh(session)
+    assert session.pending_thread_id == thread.id
+    assert thread.id not in (session.snoozed_thread_ids or [])
+    result = await async_db.execute(
+        select(Event).where(Event.session_id == session.id, Event.type == "snooze")
+    )
+    assert result.scalars().all() == []
+
+    _set_access_token(auth_client, test_username, expired=False)
+    replay = await auth_client.post("/api/snooze/")
+    assert replay.status_code == 200
+
+    duplicate = await auth_client.post("/api/snooze/")
+    assert duplicate.status_code == 400
+
+    await async_db.refresh(session)
+    assert session.pending_thread_id is None
+    assert thread.id in (session.snoozed_thread_ids or [])
+    result = await async_db.execute(
+        select(Event).where(Event.session_id == session.id, Event.type == "snooze")
+    )
+    snooze_events = result.scalars().all()
+    assert len(snooze_events) == 1
+    assert snooze_events[0].thread_id == thread.id


### PR DESCRIPTION
Closes #985

## Summary
- add one shared auth-aware recovery contract for protected Roll mutations
- retry rating and snooze only when the same pending thread is still authoritative
- preserve existing committed-but-response-lost reconciliation without duplicating transitions
- add frontend recovery coverage, backend replay/idempotency coverage, and deterministic Chromium scenarios for expired-token rating and snooze

## Validation
This runtime has no repository checkout, so focused local commands were not available. Required CI is the validation boundary for the pushed branch.

Changelog: `docs/changelog.d/2026-08-09-990.md`