### PR TITLE
Wire thread edits to targeted query-cache updates

### DIFF
--- a/docs/changelog.d/2026-08-09-992.md
+++ b/docs/changelog.d/2026-08-09-992.md
@@ -1,0 +1,5 @@
+## 2026-08-09
+
+### Thread editing
+
+- [#992](https://github.com/JoshCLWren/comic-pile/pull/992) keeps edited thread details in sync immediately while avoiding a broad refresh of unrelated thread data.

--- a/frontend/src/hooks/useThread.ts
+++ b/frontend/src/hooks/useThread.ts
@@ -3,6 +3,8 @@ import axios from 'axios';
 import { threadsApi } from '../services/api';
 import type { ReactivateThreadPayload, Thread, ThreadCreatePayload, ThreadListResponse, ThreadQueryParams, ThreadUpdatePayload } from '../types';
 import { CacheContext } from '../contexts/CacheContextValue';
+import { applyUpdatedThreadCache } from '../query/cacheEffects';
+import { queryClient } from '../query/queryClient';
 
 type UseThreadsOptions = {
   searchTerm?: string;
@@ -218,8 +220,6 @@ export function useCreateThread() {
 }
 
 export function useUpdateThread() {
-  const cache = useContext(CacheContext);
-  const invalidateQueries = useMemo(() => cache?.invalidateQueries ?? (() => {}), [cache]);
   const [isPending, setIsPending] = useState(false);
   const [isError, setIsError] = useState(false);
 
@@ -230,7 +230,7 @@ export function useUpdateThread() {
 
       try {
         const result = await threadsApi.update(id, data);
-        invalidateQueries(['threads']);
+        await applyUpdatedThreadCache(queryClient, result);
         return result;
       } catch (error: unknown) {
         const detail = axios.isAxiosError<{ detail?: string }>(error)
@@ -243,7 +243,7 @@ export function useUpdateThread() {
         setIsPending(false);
       }
     },
-    [invalidateQueries]
+    []
   );
 
   return { mutate, isPending, isError };

--- a/frontend/src/unit/useUpdateThreadCache.test.tsx
+++ b/frontend/src/unit/useUpdateThreadCache.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook, waitFor } from '@testing-library/react'
+import { act, renderHook } from '@testing-library/react'
 import { beforeEach, expect, it, vi } from 'vitest'
 import { useUpdateThread } from '../hooks/useThread'
 import { applyUpdatedThreadCache } from '../query/cacheEffects'
@@ -56,16 +56,20 @@ it('does not touch targeted cache state when the update request fails', async ()
 
   const { result } = renderHook(() => useUpdateThread())
 
-  await expect(
-    act(async () =>
-      result.current.mutate({
+  let caught: unknown
+  await act(async () => {
+    try {
+      await result.current.mutate({
         id: 7,
         data: { title: 'Never saved' },
-      }),
-    ),
-  ).rejects.toBe(failure)
+      })
+    } catch (error) {
+      caught = error
+    }
+  })
 
+  expect(caught).toBe(failure)
   expect(mockedApplyUpdatedThreadCache).not.toHaveBeenCalled()
-  await waitFor(() => expect(result.current.isError).toBe(true))
+  expect(result.current.isError).toBe(true)
   expect(result.current.isPending).toBe(false)
 })

--- a/frontend/src/unit/useUpdateThreadCache.test.tsx
+++ b/frontend/src/unit/useUpdateThreadCache.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, expect, it, vi } from 'vitest'
 import { useUpdateThread } from '../hooks/useThread'
 import { applyUpdatedThreadCache } from '../query/cacheEffects'
@@ -66,6 +66,6 @@ it('does not touch targeted cache state when the update request fails', async ()
   ).rejects.toBe(failure)
 
   expect(mockedApplyUpdatedThreadCache).not.toHaveBeenCalled()
-  expect(result.current.isError).toBe(true)
+  await waitFor(() => expect(result.current.isError).toBe(true))
   expect(result.current.isPending).toBe(false)
 })

--- a/frontend/src/unit/useUpdateThreadCache.test.tsx
+++ b/frontend/src/unit/useUpdateThreadCache.test.tsx
@@ -1,0 +1,71 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, expect, it, vi } from 'vitest'
+import { useUpdateThread } from '../hooks/useThread'
+import { applyUpdatedThreadCache } from '../query/cacheEffects'
+import { queryClient } from '../query/queryClient'
+import { threadsApi } from '../services/api'
+import type { Thread } from '../types'
+
+vi.mock('../services/api', () => ({
+  threadsApi: {
+    update: vi.fn(),
+  },
+}))
+
+vi.mock('../query/cacheEffects', () => ({
+  applyUpdatedThreadCache: vi.fn(),
+}))
+
+const mockedThreadsApi = vi.mocked(threadsApi)
+const mockedApplyUpdatedThreadCache = vi.mocked(applyUpdatedThreadCache)
+
+beforeEach(() => {
+  mockedThreadsApi.update.mockReset()
+  mockedApplyUpdatedThreadCache.mockReset()
+  mockedApplyUpdatedThreadCache.mockResolvedValue(undefined)
+})
+
+it('publishes the authoritative update through the targeted thread-cache contract', async () => {
+  const updatedThread = {
+    id: 7,
+    title: 'Updated title',
+  } as Thread
+  mockedThreadsApi.update.mockResolvedValue(updatedThread)
+
+  const { result } = renderHook(() => useUpdateThread())
+
+  let returnedThread: Thread | undefined
+  await act(async () => {
+    returnedThread = await result.current.mutate({
+      id: 7,
+      data: { title: 'Updated title' },
+    })
+  })
+
+  expect(mockedThreadsApi.update).toHaveBeenCalledWith(7, { title: 'Updated title' })
+  expect(mockedApplyUpdatedThreadCache).toHaveBeenCalledOnce()
+  expect(mockedApplyUpdatedThreadCache).toHaveBeenCalledWith(queryClient, updatedThread)
+  expect(returnedThread).toBe(updatedThread)
+  expect(result.current.isError).toBe(false)
+  expect(result.current.isPending).toBe(false)
+})
+
+it('does not touch targeted cache state when the update request fails', async () => {
+  const failure = new Error('update failed')
+  mockedThreadsApi.update.mockRejectedValue(failure)
+
+  const { result } = renderHook(() => useUpdateThread())
+
+  await expect(
+    act(async () =>
+      result.current.mutate({
+        id: 7,
+        data: { title: 'Never saved' },
+      }),
+    ),
+  ).rejects.toBe(failure)
+
+  expect(mockedApplyUpdatedThreadCache).not.toHaveBeenCalled()
+  expect(result.current.isError).toBe(true)
+  expect(result.current.isPending).toBe(false)
+})


### PR DESCRIPTION
Closes #702

## Summary
- route successful `useUpdateThread` responses through the existing targeted `applyUpdatedThreadCache` contract
- remove the legacy broad `invalidateQueries(['threads'])` dependency from the update mutation path
- add focused regression coverage proving authoritative responses publish to the targeted cache contract and failed updates leave cache state untouched

## Validation
This runtime has no repository checkout, so required CI is the validation boundary for this branch.

Changelog: `docs/changelog.d/2026-08-09-992.md`