### PR TITLE
Preserve active reading session across auth recovery

### DIFF
--- a/comic_pile/session.py
+++ b/comic_pile/session.py
@@ -4,7 +4,7 @@ import asyncio
 from datetime import UTC, datetime, timedelta
 import logging
 
-from sqlalchemy import select, text
+from sqlalchemy import or_, select, text
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -26,6 +26,22 @@ def _start_die() -> int:
     return get_session_settings().start_die
 
 
+def _current_session_filter(user_id: int, cutoff_time: datetime):
+    """Build the predicate for a session that should remain authoritative.
+
+    A pending roll is active reading work. Its timestamp, rather than the original session start,
+    keeps the session current while the reader is away from the app reading the selected comic.
+    """
+    return (
+        (Session.user_id == user_id)
+        & Session.ended_at.is_(None)
+        & or_(
+            Session.started_at >= cutoff_time,
+            Session.pending_thread_updated_at >= cutoff_time,
+        )
+    )
+
+
 async def is_active(
     started_at: datetime,
     ended_at: datetime | None,
@@ -40,13 +56,10 @@ async def is_active(
 
 
 async def should_start_new(db: AsyncSession, user_id: int) -> bool:
-    """Check whether no active session exists in the configured gap."""
+    """Check whether no current session exists in the configured gap."""
     cutoff_time = datetime.now(UTC) - timedelta(hours=_session_gap_hours())
     result = await db.execute(
-        select(Session)
-        .where(Session.user_id == user_id)
-        .where(Session.started_at >= cutoff_time)
-        .where(Session.ended_at.is_(None))
+        select(Session).where(_current_session_filter(user_id, cutoff_time))
     )
     return len(result.scalars().all()) == 0
 
@@ -154,9 +167,7 @@ async def get_or_create(db: AsyncSession, user_id: int) -> Session:
             cutoff_time = datetime.now(UTC) - timedelta(hours=session_gap_hours)
             result = await db.execute(
                 select(Session)
-                .where(Session.user_id == user_id)
-                .where(Session.ended_at.is_(None))
-                .where(Session.started_at >= cutoff_time)
+                .where(_current_session_filter(user_id, cutoff_time))
                 .order_by(Session.started_at.desc(), Session.id.desc())
             )
             active_session = result.scalars().first()
@@ -175,9 +186,7 @@ async def get_or_create(db: AsyncSession, user_id: int) -> Session:
 
                 result = await db.execute(
                     select(Session)
-                    .where(Session.user_id == user_id)
-                    .where(Session.ended_at.is_(None))
-                    .where(Session.started_at >= cutoff_time)
+                    .where(_current_session_filter(user_id, cutoff_time))
                     .order_by(Session.started_at.desc(), Session.id.desc())
                 )
                 active_session = result.scalars().first()

--- a/docs/changelog.d/2026-08-09-993.md
+++ b/docs/changelog.d/2026-08-09-993.md
@@ -1,0 +1,5 @@
+## 2026-08-09
+
+### Roll
+
+- [#993](https://github.com/JoshCLWren/comic-pile/pull/993) keeps a recently pending comic attached to the current reading session when authentication recovers, so returning from reading no longer replaces the active session with a blank d6 screen just because the session's original start time crossed the configured gap.

--- a/tests/test_session_continuity.py
+++ b/tests/test_session_continuity.py
@@ -1,0 +1,95 @@
+"""Regression coverage for reading-session continuity across auth/bootstrap recovery."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Session, Thread, User
+from comic_pile.session import get_or_create, should_start_new
+
+
+@pytest.mark.asyncio
+async def test_recent_pending_roll_keeps_old_open_session_authoritative(
+    async_db: AsyncSession,
+    default_user: User,
+) -> None:
+    """A recently pending comic must survive after the session start crosses the gap."""
+    thread = Thread(
+        title="Fantastic Four",
+        format="Comic",
+        issues_remaining=6,
+        queue_position=1,
+        status="active",
+        user_id=default_user.id,
+        created_at=datetime.now(UTC) - timedelta(days=1),
+    )
+    async_db.add(thread)
+    await async_db.flush()
+
+    original_session = Session(
+        user_id=default_user.id,
+        started_at=datetime.now(UTC) - timedelta(hours=7),
+        start_die=6,
+        manual_die=20,
+        pending_thread_id=thread.id,
+        pending_thread_updated_at=datetime.now(UTC) - timedelta(minutes=10),
+        snoozed_thread_ids=[thread.id + 1, thread.id + 2],
+    )
+    async_db.add(original_session)
+    await async_db.commit()
+
+    assert await should_start_new(async_db, default_user.id) is False
+
+    recovered_session = await get_or_create(async_db, default_user.id)
+
+    assert recovered_session.id == original_session.id
+    assert recovered_session.pending_thread_id == thread.id
+    assert recovered_session.manual_die == 20
+    assert recovered_session.snoozed_thread_ids == [thread.id + 1, thread.id + 2]
+
+    open_count = await async_db.scalar(
+        select(func.count())
+        .select_from(Session)
+        .where(Session.user_id == default_user.id)
+        .where(Session.ended_at.is_(None))
+    )
+    assert open_count == 1
+
+
+@pytest.mark.asyncio
+async def test_stale_session_without_recent_pending_activity_can_roll_over(
+    async_db: AsyncSession,
+    default_user: User,
+) -> None:
+    """The configured session gap still starts a new session after genuinely stale activity."""
+    thread = Thread(
+        title="Old Pending Comic",
+        format="Comic",
+        issues_remaining=1,
+        queue_position=1,
+        status="active",
+        user_id=default_user.id,
+        created_at=datetime.now(UTC) - timedelta(days=1),
+    )
+    async_db.add(thread)
+    await async_db.flush()
+
+    stale_session = Session(
+        user_id=default_user.id,
+        started_at=datetime.now(UTC) - timedelta(hours=8),
+        start_die=6,
+        pending_thread_id=thread.id,
+        pending_thread_updated_at=datetime.now(UTC) - timedelta(hours=7),
+    )
+    async_db.add(stale_session)
+    await async_db.commit()
+
+    assert await should_start_new(async_db, default_user.id) is True
+
+    new_session = await get_or_create(async_db, default_user.id)
+
+    assert new_session.id != stale_session.id
+    assert new_session.pending_thread_id is None
+    assert new_session.start_die == 6


### PR DESCRIPTION
Superseded by #995 after this branch became non-mergeable against current `main`. #995 replays the same complete issue #984 implementation and regression coverage from current `main`.