### PR TITLE
Use comic issue numbers in crossover ranges

### DIFF
--- a/docs/changelog.d/2026-08-09-994.md
+++ b/docs/changelog.d/2026-08-09-994.md
@@ -1,0 +1,5 @@
+## 2026-08-09
+
+### Crossovers
+
+- [#994](https://github.com/JoshCLWren/comic-pile/pull/994) replaces internal start/end position fields with ComicPile’s shared issue-range picker, so crossover ranges are chosen by real comic issue labels such as `Annual 1` and `½` while canonical positions stay hidden implementation details.

--- a/frontend/src/pages/CrossoversPage.tsx
+++ b/frontend/src/pages/CrossoversPage.tsx
@@ -1,9 +1,43 @@
 import { FormEvent, useCallback, useEffect, useState } from 'react'
 import axios from 'axios'
 import {
+  ContinuityIssueRangeSelector,
+  type SelectedIssueRange,
+} from '../components/continuity'
+import { threadsApi } from '../services/api'
+import {
   dependencyGroupsApi,
   type DependencyGroup,
 } from '../services/api-dependency-groups'
+import { issuesApi } from '../services/api-issues'
+import type { Issue, Thread } from '../types'
+
+type PositionedIssue = Issue & { position: number }
+
+async function fetchAllIssues(threadId: number): Promise<PositionedIssue[]> {
+  const issues: PositionedIssue[] = []
+  const seenPageTokens = new Set<string>()
+  let nextPageToken: string | null = null
+
+  while (true) {
+    const data = await issuesApi.list(threadId, {
+      page_size: 100,
+      ...(nextPageToken ? { page_token: nextPageToken } : {}),
+    })
+    const pageIssues = data.issues as PositionedIssue[]
+    if (pageIssues.some((issue) => !Number.isInteger(issue.position) || issue.position < 1)) {
+      throw new Error('Comic issue order is unavailable for this series.')
+    }
+    issues.push(...pageIssues)
+
+    if (!data.next_page_token || seenPageTokens.has(data.next_page_token)) {
+      return issues
+    }
+
+    seenPageTokens.add(data.next_page_token)
+    nextPageToken = data.next_page_token
+  }
+}
 
 function errorMessage(error: unknown, fallback: string): string {
   if (axios.isAxiosError(error)) {
@@ -27,8 +61,11 @@ export default function CrossoversPage() {
   const [expandedId, setExpandedId] = useState<number | null>(null)
   const [memberThreadId, setMemberThreadId] = useState('')
   const [rangeThreadId, setRangeThreadId] = useState('')
-  const [rangeStart, setRangeStart] = useState('')
-  const [rangeEnd, setRangeEnd] = useState('')
+  const [rangeThread, setRangeThread] = useState<Thread | null>(null)
+  const [rangeIssues, setRangeIssues] = useState<PositionedIssue[]>([])
+  const [rangeSelection, setRangeSelection] = useState<SelectedIssueRange | null>(null)
+  const [isLoadingRangeIssues, setIsLoadingRangeIssues] = useState(false)
+  const [rangeLoadError, setRangeLoadError] = useState<string | null>(null)
   const [membershipMessage, setMembershipMessage] = useState<string | null>(null)
 
   const loadGroups = useCallback(async () => {
@@ -47,11 +84,18 @@ export default function CrossoversPage() {
     void loadGroups()
   }, [loadGroups])
 
+  const clearRangeState = () => {
+    setRangeThreadId('')
+    setRangeThread(null)
+    setRangeIssues([])
+    setRangeSelection(null)
+    setRangeLoadError(null)
+    setIsLoadingRangeIssues(false)
+  }
+
   const clearMembershipState = () => {
     setMemberThreadId('')
-    setRangeThreadId('')
-    setRangeStart('')
-    setRangeEnd('')
+    clearRangeState()
     setMembershipMessage(null)
   }
 
@@ -164,32 +208,71 @@ export default function CrossoversPage() {
     }
   }
 
+  const loadRangeIssues = async () => {
+    const threadId = Number(rangeThreadId)
+    if (!Number.isInteger(threadId) || threadId < 1) {
+      setRangeLoadError('Enter a valid thread ID before choosing issues.')
+      setRangeThread(null)
+      setRangeIssues([])
+      setRangeSelection(null)
+      return
+    }
+
+    setIsLoadingRangeIssues(true)
+    setRangeLoadError(null)
+    setRangeSelection(null)
+    try {
+      const [thread, issues] = await Promise.all([
+        threadsApi.get(threadId),
+        fetchAllIssues(threadId),
+      ])
+      setRangeThread(thread)
+      setRangeIssues(issues)
+      if (issues.length === 0) {
+        setRangeLoadError(`${thread.title} has no issues to add.`)
+      }
+    } catch (error) {
+      setRangeThread(null)
+      setRangeIssues([])
+      setRangeLoadError(errorMessage(error, 'Unable to load issues for this series.'))
+    } finally {
+      setIsLoadingRangeIssues(false)
+    }
+  }
+
   const addRange = async (event: FormEvent<HTMLFormElement>, groupId: number) => {
     event.preventDefault()
     const threadId = Number(rangeThreadId)
-    const start = Number(rangeStart)
-    const end = Number(rangeEnd)
-    if (
-      !Number.isInteger(threadId)
-      || threadId < 1
-      || !Number.isInteger(start)
-      || start < 1
-      || !Number.isInteger(end)
-      || end < start
-    ) {
-      setMutationError('Enter a valid thread ID and an inclusive issue-position range.')
+    if (!rangeThread || !rangeSelection || rangeThread.id !== threadId) {
+      setMutationError('Choose a series and an inclusive first and last issue.')
       return
     }
+
+    const startPosition = (rangeSelection.startIssue as PositionedIssue).position
+    const endPosition = (rangeSelection.endIssue as PositionedIssue).position
+    if (
+      !Number.isInteger(startPosition)
+      || !Number.isInteger(endPosition)
+      || startPosition < 1
+      || endPosition < startPosition
+    ) {
+      setMutationError('Choose a valid issue range in reading order.')
+      return
+    }
+
     setMutationError(null)
     setMembershipMessage(null)
     setBusyId(groupId)
     try {
-      const result = await dependencyGroupsApi.addIssueRange(groupId, threadId, start, end)
+      const result = await dependencyGroupsApi.addIssueRange(
+        groupId,
+        threadId,
+        startPosition,
+        endPosition,
+      )
       const successMessage = `${result.added_issue_ids.length} added, ${result.already_present_issue_ids.length} already present.`
       setMembershipMessage(successMessage)
-      setRangeThreadId('')
-      setRangeStart('')
-      setRangeEnd('')
+      clearRangeState()
       try {
         const refreshed = await dependencyGroupsApi.get(groupId)
         setGroups((current) =>
@@ -383,21 +466,59 @@ export default function CrossoversPage() {
                     <form
                       onSubmit={(event) => void addRange(event, group.id)}
                       aria-label={`Add issue range to ${group.name}`}
-                      className="grid gap-2 rounded-xl border border-stone-800 bg-stone-950/50 p-3 sm:grid-cols-4"
+                      className="grid gap-3 rounded-xl border border-stone-800 bg-stone-950/50 p-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,2fr)_auto]"
                     >
-                      <label className="grid gap-1">
-                        <span className="font-bold text-stone-300">Thread ID</span>
-                        <input inputMode="numeric" value={rangeThreadId} onChange={(event) => setRangeThreadId(event.target.value)} disabled={hasPendingMutation} className="rounded-lg border border-stone-700 bg-stone-950 px-3 py-2 text-stone-100" />
-                      </label>
-                      <label className="grid gap-1">
-                        <span className="font-bold text-stone-300">Start position</span>
-                        <input inputMode="numeric" value={rangeStart} onChange={(event) => setRangeStart(event.target.value)} disabled={hasPendingMutation} className="rounded-lg border border-stone-700 bg-stone-950 px-3 py-2 text-stone-100" />
-                      </label>
-                      <label className="grid gap-1">
-                        <span className="font-bold text-stone-300">End position</span>
-                        <input inputMode="numeric" value={rangeEnd} onChange={(event) => setRangeEnd(event.target.value)} disabled={hasPendingMutation} className="rounded-lg border border-stone-700 bg-stone-950 px-3 py-2 text-stone-100" />
-                      </label>
-                      <button type="submit" disabled={hasPendingMutation} className="self-end rounded-lg bg-amber-500 px-3 py-2 font-bold text-stone-950 disabled:opacity-50">
+                      <div className="grid gap-2">
+                        <label className="grid gap-1">
+                          <span className="font-bold text-stone-300">Thread ID</span>
+                          <input
+                            inputMode="numeric"
+                            value={rangeThreadId}
+                            onChange={(event) => {
+                              setRangeThreadId(event.target.value)
+                              setRangeThread(null)
+                              setRangeIssues([])
+                              setRangeSelection(null)
+                              setRangeLoadError(null)
+                            }}
+                            disabled={hasPendingMutation || isLoadingRangeIssues}
+                            className="rounded-lg border border-stone-700 bg-stone-950 px-3 py-2 text-stone-100"
+                          />
+                        </label>
+                        <button
+                          type="button"
+                          onClick={() => void loadRangeIssues()}
+                          disabled={hasPendingMutation || isLoadingRangeIssues}
+                          className="rounded-lg border border-stone-600 px-3 py-2 font-bold text-stone-300 disabled:opacity-50"
+                        >
+                          {isLoadingRangeIssues ? 'Loading issues…' : 'Choose issues'}
+                        </button>
+                      </div>
+
+                      <div className="min-w-0">
+                        {rangeThread ? (
+                          <ContinuityIssueRangeSelector
+                            thread={rangeThread}
+                            issues={rangeIssues}
+                            value={rangeSelection}
+                            onChange={setRangeSelection}
+                            label={`Issues from ${rangeThread.title}`}
+                            isLoading={isLoadingRangeIssues}
+                            error={rangeLoadError}
+                            disabled={hasPendingMutation}
+                          />
+                        ) : rangeLoadError ? (
+                          <p role="alert" className="text-xs text-red-400">{rangeLoadError}</p>
+                        ) : (
+                          <p className="text-xs text-stone-500">Load a series to choose the first and last issue by comic issue number.</p>
+                        )}
+                      </div>
+
+                      <button
+                        type="submit"
+                        disabled={hasPendingMutation || isLoadingRangeIssues || !rangeSelection}
+                        className="self-end rounded-lg bg-amber-500 px-3 py-2 font-bold text-stone-950 disabled:opacity-50"
+                      >
                         {isBusy ? 'Adding…' : 'Add range'}
                       </button>
                     </form>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -243,6 +243,8 @@ export interface Issue {
   thread_id: number;
   /** Issue number (e.g., '1', '2', 'Annual 1') */
   issue_number: string;
+  /** Canonical one-based reading-order position when supplied by the API */
+  position?: number;
   /** Current reading status */
   status: 'unread' | 'read';
   /** ISO 8601 timestamp when the issue was marked as read (null if unread) */

--- a/frontend/src/unit/CrossoversPage.issue-range.test.tsx
+++ b/frontend/src/unit/CrossoversPage.issue-range.test.tsx
@@ -249,18 +249,40 @@ describe('CrossoversPage issue ranges', () => {
     },
   )
 
-  it('validates the thread id before loading range data', async () => {
+  it.each(['0', '1.5'])(
+    'validates the thread id before loading range data (%s)',
+    async (threadId) => {
+      render(<CrossoversPage />)
+      await screen.findByText('Annihilation')
+      openRangeForm()
+      fireEvent.change(screen.getByLabelText('Thread ID'), { target: { value: threadId } })
+      fireEvent.click(screen.getByRole('button', { name: 'Choose issues' }))
+
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Enter a valid thread ID before choosing issues.',
+      )
+      expect(threadApi.get).not.toHaveBeenCalled()
+      expect(issueApi.list).not.toHaveBeenCalled()
+    },
+  )
+
+  it('explains when the selected thread has no issues to add', async () => {
+    issueApi.list.mockResolvedValue({
+      issues: [],
+      total_count: 0,
+      page_size: 100,
+      next_page_token: null,
+    })
+
     render(<CrossoversPage />)
     await screen.findByText('Annihilation')
     openRangeForm()
-    fireEvent.change(screen.getByLabelText('Thread ID'), { target: { value: '0' } })
+    fireEvent.change(screen.getByLabelText('Thread ID'), { target: { value: '22' } })
     fireEvent.click(screen.getByRole('button', { name: 'Choose issues' }))
 
-    expect(screen.getByRole('alert')).toHaveTextContent(
-      'Enter a valid thread ID before choosing issues.',
-    )
-    expect(threadApi.get).not.toHaveBeenCalled()
-    expect(issueApi.list).not.toHaveBeenCalled()
+    expect(await screen.findByRole('alert')).toHaveTextContent('Nova has no issues to add.')
+    expect(screen.getByLabelText('First issue')).toBeDisabled()
+    expect(screen.getByLabelText('First issue')).toHaveTextContent('No issues available')
   })
 
   it('clears range state when expanding another crossover', async () => {

--- a/frontend/src/unit/CrossoversPage.issue-range.test.tsx
+++ b/frontend/src/unit/CrossoversPage.issue-range.test.tsx
@@ -93,7 +93,7 @@ function openRangeForm(name = /Annihilation.*0 members/) {
 async function loadIssues() {
   fireEvent.change(screen.getByLabelText('Thread ID'), { target: { value: '22' } })
   fireEvent.click(screen.getByRole('button', { name: 'Choose issues' }))
-  await screen.findByText('ISSUES FROM NOVA')
+  await screen.findByText(/Issues from Nova/)
 }
 
 function selectRange(firstIssueId: string, lastIssueId: string) {

--- a/frontend/src/unit/CrossoversPage.issue-range.test.tsx
+++ b/frontend/src/unit/CrossoversPage.issue-range.test.tsx
@@ -1,7 +1,21 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import CrossoversPage from '../pages/CrossoversPage'
+import { threadsApi } from '../services/api'
 import { dependencyGroupsApi } from '../services/api-dependency-groups'
+import { issuesApi } from '../services/api-issues'
+
+vi.mock('../services/api', () => ({
+  threadsApi: {
+    get: vi.fn(),
+  },
+}))
+
+vi.mock('../services/api-issues', () => ({
+  issuesApi: {
+    list: vi.fn(),
+  },
+}))
 
 vi.mock('../services/api-dependency-groups', () => ({
   dependencyGroupsApi: {
@@ -14,7 +28,9 @@ vi.mock('../services/api-dependency-groups', () => ({
   },
 }))
 
-const api = vi.mocked(dependencyGroupsApi)
+const groupsApi = vi.mocked(dependencyGroupsApi)
+const threadApi = vi.mocked(threadsApi)
+const issueApi = vi.mocked(issuesApi)
 
 const crossover = {
   id: 7,
@@ -28,46 +44,98 @@ const secondCrossover = {
   created_at: '2026-08-06T00:00:00Z',
   memberships: [],
 }
+const thread = {
+  id: 22,
+  title: 'Nova',
+  format: 'single issues',
+  issues_remaining: 3,
+  total_issues: 3,
+  queue_position: 4,
+  status: 'active',
+  is_blocked: false,
+  blocking_reasons: [],
+  created_at: '2026-08-01T00:00:00Z',
+}
+const issues = [
+  {
+    id: 31,
+    thread_id: 22,
+    issue_number: '2',
+    position: 3,
+    status: 'read' as const,
+    read_at: '2026-08-02T00:00:00Z',
+    created_at: '2026-08-01T00:00:00Z',
+  },
+  {
+    id: 32,
+    thread_id: 22,
+    issue_number: 'Annual 1',
+    position: 4,
+    status: 'unread' as const,
+    read_at: null,
+    created_at: '2026-08-01T00:00:00Z',
+  },
+  {
+    id: 33,
+    thread_id: 22,
+    issue_number: '½',
+    position: 5,
+    status: 'unread' as const,
+    read_at: null,
+    created_at: '2026-08-01T00:00:00Z',
+  },
+]
 
 function openRangeForm(name = /Annihilation.*0 members/) {
   fireEvent.click(screen.getByRole('button', { name }))
 }
 
-function fillRange(threadId: string, start: string, end: string) {
-  fireEvent.change(screen.getByLabelText('Thread ID'), { target: { value: threadId } })
-  fireEvent.change(screen.getByLabelText('Start position'), { target: { value: start } })
-  fireEvent.change(screen.getByLabelText('End position'), { target: { value: end } })
+async function loadIssues() {
+  fireEvent.change(screen.getByLabelText('Thread ID'), { target: { value: '22' } })
+  fireEvent.click(screen.getByRole('button', { name: 'Choose issues' }))
+  await screen.findByText('ISSUES FROM NOVA')
+}
+
+function selectRange(firstIssueId: string, lastIssueId: string) {
+  fireEvent.change(screen.getByLabelText('First issue'), { target: { value: firstIssueId } })
+  fireEvent.change(screen.getByLabelText('Last issue'), { target: { value: lastIssueId } })
 }
 
 beforeEach(() => {
   vi.clearAllMocks()
-  api.list.mockResolvedValue([crossover])
+  groupsApi.list.mockResolvedValue([crossover])
+  threadApi.get.mockResolvedValue(thread)
+  issueApi.list.mockResolvedValue({
+    issues,
+    total_count: issues.length,
+    page_size: 100,
+    next_page_token: null,
+  })
 })
 
 describe('CrossoversPage issue ranges', () => {
-  it('rejects invalid range values before calling the API', async () => {
+  it('uses shared issue selectors and never exposes issue positions', async () => {
     render(<CrossoversPage />)
     await screen.findByText('Annihilation')
     openRangeForm()
+    await loadIssues()
 
-    fillRange('0', '3', '2')
-    fireEvent.click(screen.getByRole('button', { name: 'Add range' }))
-
-    expect(screen.getByRole('alert')).toHaveTextContent(
-      'Enter a valid thread ID and an inclusive issue-position range.',
-    )
-    expect(api.addIssueRange).not.toHaveBeenCalled()
+    expect(screen.queryByLabelText('Start position')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('End position')).not.toBeInTheDocument()
+    expect(screen.getByLabelText('First issue')).toHaveTextContent('#2')
+    expect(screen.getByLabelText('First issue')).toHaveTextContent('#Annual 1')
+    expect(screen.getByLabelText('First issue')).toHaveTextContent('#½')
   })
 
-  it('adds a range, refreshes membership totals, and clears the form', async () => {
-    api.addIssueRange.mockResolvedValue({
+  it('translates selected issue labels to canonical positions when saving', async () => {
+    groupsApi.addIssueRange.mockResolvedValue({
       thread_id: 22,
       start_position: 3,
       end_position: 5,
-      added_issue_ids: [31, 32],
-      already_present_issue_ids: [33],
+      added_issue_ids: [31, 33],
+      already_present_issue_ids: [32],
     })
-    api.get.mockResolvedValue({
+    groupsApi.get.mockResolvedValue({
       ...crossover,
       memberships: [
         { id: 1, issue_id: 31, thread_id: null },
@@ -79,81 +147,114 @@ describe('CrossoversPage issue ranges', () => {
     render(<CrossoversPage />)
     await screen.findByText('Annihilation')
     openRangeForm()
-    fillRange('22', '3', '5')
+    await loadIssues()
+    selectRange('31', '33')
     fireEvent.click(screen.getByRole('button', { name: 'Add range' }))
 
     expect(await screen.findByRole('status')).toHaveTextContent('2 added, 1 already present.')
-    expect(api.addIssueRange).toHaveBeenCalledWith(7, 22, 3, 5)
-    expect(api.get).toHaveBeenCalledWith(7)
+    expect(groupsApi.addIssueRange).toHaveBeenCalledWith(7, 22, 3, 5)
+    expect(groupsApi.get).toHaveBeenCalledWith(7)
     expect(screen.getByText('3 issue memberships and 0 thread memberships.')).toBeInTheDocument()
     expect(screen.getByLabelText('Thread ID')).toHaveValue('')
-    expect(screen.getByLabelText('Start position')).toHaveValue('')
-    expect(screen.getByLabelText('End position')).toHaveValue('')
+    expect(screen.queryByLabelText('First issue')).not.toBeInTheDocument()
+  })
+
+  it('shows reversed-range validation using comic issue labels', async () => {
+    render(<CrossoversPage />)
+    await screen.findByText('Annihilation')
+    openRangeForm()
+    await loadIssues()
+    selectRange('33', '31')
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      '#½ comes after #2 in Nova. Choose a later ending issue.',
+    )
+    expect(screen.getByRole('button', { name: 'Add range' })).toBeDisabled()
+    expect(groupsApi.addIssueRange).not.toHaveBeenCalled()
+  })
+
+  it('loads every issue page so later specials remain selectable', async () => {
+    issueApi.list
+      .mockResolvedValueOnce({
+        issues: issues.slice(0, 2),
+        total_count: 3,
+        page_size: 2,
+        next_page_token: 'next-page',
+      })
+      .mockResolvedValueOnce({
+        issues: issues.slice(2),
+        total_count: 3,
+        page_size: 2,
+        next_page_token: null,
+      })
+
+    render(<CrossoversPage />)
+    await screen.findByText('Annihilation')
+    openRangeForm()
+    await loadIssues()
+
+    expect(issueApi.list).toHaveBeenNthCalledWith(1, 22, { page_size: 100 })
+    expect(issueApi.list).toHaveBeenNthCalledWith(2, 22, {
+      page_size: 100,
+      page_token: 'next-page',
+    })
+    expect(screen.getByLabelText('Last issue')).toHaveTextContent('#½')
   })
 
   it('clears range state when expanding another crossover', async () => {
-    api.list.mockResolvedValue([crossover, secondCrossover])
+    groupsApi.list.mockResolvedValue([crossover, secondCrossover])
     render(<CrossoversPage />)
     await screen.findByText('Annihilation')
 
     openRangeForm()
-    fillRange('22', '3', '5')
+    await loadIssues()
+    selectRange('31', '33')
     openRangeForm(/Secret Wars.*0 members/)
 
     expect(screen.getByLabelText('Thread ID')).toHaveValue('')
-    expect(screen.getByLabelText('Start position')).toHaveValue('')
-    expect(screen.getByLabelText('End position')).toHaveValue('')
+    expect(screen.queryByLabelText('First issue')).not.toBeInTheDocument()
     expect(screen.getByRole('form', { name: 'Add issue range to Secret Wars' })).toBeInTheDocument()
   })
 
-  it('prevents moving the pending request state to another crossover', async () => {
-    api.list.mockResolvedValue([crossover, secondCrossover])
-    api.addIssueRange.mockImplementation(() => new Promise(() => undefined))
+  it('reports issue-loading failures without exposing position inputs', async () => {
+    issueApi.list.mockRejectedValue(new Error('Issues unavailable'))
     render(<CrossoversPage />)
     await screen.findByText('Annihilation')
-
     openRangeForm()
-    fillRange('22', '3', '5')
-    fireEvent.click(screen.getByRole('button', { name: 'Add range' }))
 
-    const secondToggle = screen.getByRole('button', { name: /Secret Wars.*0 members/ })
-    expect(secondToggle).toBeDisabled()
-    fireEvent.click(secondToggle)
-    expect(screen.getByRole('form', { name: 'Add issue range to Annihilation' })).toBeInTheDocument()
-    expect(screen.queryByRole('form', { name: 'Add issue range to Secret Wars' })).not.toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText('Thread ID'), { target: { value: '22' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Choose issues' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Issues unavailable')
+    expect(screen.queryByLabelText('Start position')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Add range' })).toBeDisabled()
   })
 
-  it('disables range controls while saving and reports API failures', async () => {
-    let rejectRange: ((reason?: unknown) => void) | undefined
-    api.addIssueRange.mockImplementation(
-      () => new Promise((_resolve, reject) => { rejectRange = reject }),
-    )
-
+  it('keeps controls locked while a range save is pending', async () => {
+    groupsApi.addIssueRange.mockImplementation(() => new Promise(() => undefined))
     render(<CrossoversPage />)
     await screen.findByText('Annihilation')
     openRangeForm()
-    fillRange('22', '3', '5')
+    await loadIssues()
+    selectRange('31', '33')
     fireEvent.click(screen.getByRole('button', { name: 'Add range' }))
 
     expect(screen.getByRole('button', { name: 'Adding…' })).toBeDisabled()
     expect(screen.getByLabelText('Thread ID')).toBeDisabled()
-    rejectRange?.(new Error('Range unavailable'))
-
-    expect(await screen.findByRole('alert')).toHaveTextContent('Range unavailable')
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Add range' })).toBeEnabled())
+    expect(screen.getByLabelText('First issue')).toBeDisabled()
   })
 
   it('clears expanded range state when deleting the expanded crossover', async () => {
-    api.delete.mockResolvedValue(undefined)
+    groupsApi.delete.mockResolvedValue(undefined)
     vi.spyOn(window, 'confirm').mockReturnValue(true)
 
     render(<CrossoversPage />)
     await screen.findByText('Annihilation')
     openRangeForm()
-    fillRange('22', '3', '5')
+    await loadIssues()
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
 
-    await waitFor(() => expect(api.delete).toHaveBeenCalledWith(7))
+    await waitFor(() => expect(groupsApi.delete).toHaveBeenCalledWith(7))
     expect(screen.queryByText('Annihilation')).not.toBeInTheDocument()
     expect(screen.queryByRole('form', { name: 'Add issue range to Annihilation' })).not.toBeInTheDocument()
   })

--- a/frontend/src/unit/CrossoversPage.issue-range.test.tsx
+++ b/frontend/src/unit/CrossoversPage.issue-range.test.tsx
@@ -226,25 +226,28 @@ describe('CrossoversPage issue ranges', () => {
     expect(screen.getByLabelText('First issue')).toHaveTextContent('#Annual 1')
   })
 
-  it('rejects issue data that lacks a canonical positive position', async () => {
-    issueApi.list.mockResolvedValue({
-      issues: [{ ...issues[0], position: 0 }],
-      total_count: 1,
-      page_size: 100,
-      next_page_token: null,
-    })
+  it.each([0, 1.5])(
+    'rejects issue data with a non-canonical position (%s)',
+    async (position) => {
+      issueApi.list.mockResolvedValue({
+        issues: [{ ...issues[0], position }],
+        total_count: 1,
+        page_size: 100,
+        next_page_token: null,
+      })
 
-    render(<CrossoversPage />)
-    await screen.findByText('Annihilation')
-    openRangeForm()
-    fireEvent.change(screen.getByLabelText('Thread ID'), { target: { value: '22' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Choose issues' }))
+      render(<CrossoversPage />)
+      await screen.findByText('Annihilation')
+      openRangeForm()
+      fireEvent.change(screen.getByLabelText('Thread ID'), { target: { value: '22' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Choose issues' }))
 
-    expect(await screen.findByRole('alert')).toHaveTextContent(
-      'Comic issue order is unavailable for this series.',
-    )
-    expect(screen.queryByLabelText('First issue')).not.toBeInTheDocument()
-  })
+      expect(await screen.findByRole('alert')).toHaveTextContent(
+        'Comic issue order is unavailable for this series.',
+      )
+      expect(screen.queryByLabelText('First issue')).not.toBeInTheDocument()
+    },
+  )
 
   it('validates the thread id before loading range data', async () => {
     render(<CrossoversPage />)

--- a/frontend/src/unit/CrossoversPage.issue-range.test.tsx
+++ b/frontend/src/unit/CrossoversPage.issue-range.test.tsx
@@ -201,6 +201,65 @@ describe('CrossoversPage issue ranges', () => {
     expect(screen.getByLabelText('Last issue')).toHaveTextContent('#½')
   })
 
+  it('stops pagination safely when an API page token repeats', async () => {
+    issueApi.list
+      .mockResolvedValueOnce({
+        issues: issues.slice(0, 1),
+        total_count: 2,
+        page_size: 1,
+        next_page_token: 'repeat-page',
+      })
+      .mockResolvedValueOnce({
+        issues: issues.slice(1, 2),
+        total_count: 2,
+        page_size: 1,
+        next_page_token: 'repeat-page',
+      })
+
+    render(<CrossoversPage />)
+    await screen.findByText('Annihilation')
+    openRangeForm()
+    await loadIssues()
+
+    expect(issueApi.list).toHaveBeenCalledTimes(2)
+    expect(screen.getByLabelText('First issue')).toHaveTextContent('#2')
+    expect(screen.getByLabelText('First issue')).toHaveTextContent('#Annual 1')
+  })
+
+  it('rejects issue data that lacks a canonical positive position', async () => {
+    issueApi.list.mockResolvedValue({
+      issues: [{ ...issues[0], position: 0 }],
+      total_count: 1,
+      page_size: 100,
+      next_page_token: null,
+    })
+
+    render(<CrossoversPage />)
+    await screen.findByText('Annihilation')
+    openRangeForm()
+    fireEvent.change(screen.getByLabelText('Thread ID'), { target: { value: '22' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Choose issues' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Comic issue order is unavailable for this series.',
+    )
+    expect(screen.queryByLabelText('First issue')).not.toBeInTheDocument()
+  })
+
+  it('validates the thread id before loading range data', async () => {
+    render(<CrossoversPage />)
+    await screen.findByText('Annihilation')
+    openRangeForm()
+    fireEvent.change(screen.getByLabelText('Thread ID'), { target: { value: '0' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Choose issues' }))
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Enter a valid thread ID before choosing issues.',
+    )
+    expect(threadApi.get).not.toHaveBeenCalled()
+    expect(issueApi.list).not.toHaveBeenCalled()
+  })
+
   it('clears range state when expanding another crossover', async () => {
     groupsApi.list.mockResolvedValue([crossover, secondCrossover])
     render(<CrossoversPage />)

--- a/frontend/src/unit/CrossoversPage.memberships.test.tsx
+++ b/frontend/src/unit/CrossoversPage.memberships.test.tsx
@@ -165,7 +165,8 @@ describe('CrossoversPage membership editing', () => {
     fireEvent.change(screen.getByLabelText('Last issue'), { target: { value: '33' } })
     fireEvent.click(screen.getByRole('button', { name: 'Add range' }))
 
-    const status = await screen.findByRole('status')
+    await waitFor(() => expect(api.addIssueRange).toHaveBeenCalledTimes(1))
+    const status = await screen.findByRole('status', undefined, { timeout: 5000 })
     expect(status).toHaveTextContent('1 added, 0 already present.')
     expect(status).toHaveTextContent('latest memberships could not be refreshed: Refresh unavailable')
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
@@ -173,7 +174,6 @@ describe('CrossoversPage membership editing', () => {
     expect(screen.queryByLabelText('First issue')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Last issue')).not.toBeInTheDocument()
     expect(api.addIssueRange).toHaveBeenCalledWith(7, 22, 3, 5)
-    expect(api.addIssueRange).toHaveBeenCalledTimes(1)
   })
 
   it('keeps the whole-thread form usable when adding a membership fails', async () => {

--- a/frontend/src/unit/CrossoversPage.memberships.test.tsx
+++ b/frontend/src/unit/CrossoversPage.memberships.test.tsx
@@ -1,7 +1,21 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import CrossoversPage from '../pages/CrossoversPage'
+import { threadsApi } from '../services/api'
 import { dependencyGroupsApi } from '../services/api-dependency-groups'
+import { issuesApi } from '../services/api-issues'
+
+vi.mock('../services/api', () => ({
+  threadsApi: {
+    get: vi.fn(),
+  },
+}))
+
+vi.mock('../services/api-issues', () => ({
+  issuesApi: {
+    list: vi.fn(),
+  },
+}))
 
 vi.mock('../services/api-dependency-groups', () => ({
   dependencyGroupsApi: {
@@ -17,6 +31,8 @@ vi.mock('../services/api-dependency-groups', () => ({
 }))
 
 const api = vi.mocked(dependencyGroupsApi)
+const threadApi = vi.mocked(threadsApi)
+const issueApi = vi.mocked(issuesApi)
 
 const crossover = {
   id: 7,
@@ -28,9 +44,59 @@ const crossover = {
   ],
 }
 
+const thread = {
+  id: 22,
+  title: 'Nova',
+  format: 'single issues',
+  issues_remaining: 3,
+  total_issues: 3,
+  queue_position: 4,
+  status: 'active',
+  is_blocked: false,
+  blocking_reasons: [],
+  created_at: '2026-08-01T00:00:00Z',
+}
+
+const issues = [
+  {
+    id: 31,
+    thread_id: 22,
+    issue_number: '2',
+    position: 3,
+    status: 'read' as const,
+    read_at: '2026-08-02T00:00:00Z',
+    created_at: '2026-08-01T00:00:00Z',
+  },
+  {
+    id: 32,
+    thread_id: 22,
+    issue_number: 'Annual 1',
+    position: 4,
+    status: 'unread' as const,
+    read_at: null,
+    created_at: '2026-08-01T00:00:00Z',
+  },
+  {
+    id: 33,
+    thread_id: 22,
+    issue_number: '½',
+    position: 5,
+    status: 'unread' as const,
+    read_at: null,
+    created_at: '2026-08-01T00:00:00Z',
+  },
+]
+
 beforeEach(() => {
   vi.clearAllMocks()
   api.list.mockResolvedValue([crossover])
+  threadApi.get.mockResolvedValue(thread)
+  issueApi.list.mockResolvedValue({
+    issues,
+    total_count: issues.length,
+    page_size: 100,
+    next_page_token: null,
+  })
 })
 
 describe('CrossoversPage membership editing', () => {
@@ -93,8 +159,10 @@ describe('CrossoversPage membership editing', () => {
     fireEvent.click(await screen.findByRole('button', { name: /Annihilation.*2 members/ }))
 
     fireEvent.change(screen.getByLabelText('Thread ID'), { target: { value: '22' } })
-    fireEvent.change(screen.getByLabelText('Start position'), { target: { value: '3' } })
-    fireEvent.change(screen.getByLabelText('End position'), { target: { value: '5' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Choose issues' }))
+    await screen.findByText(/Issues from Nova/)
+    fireEvent.change(screen.getByLabelText('First issue'), { target: { value: '31' } })
+    fireEvent.change(screen.getByLabelText('Last issue'), { target: { value: '33' } })
     fireEvent.click(screen.getByRole('button', { name: 'Add range' }))
 
     const status = await screen.findByRole('status')
@@ -102,8 +170,9 @@ describe('CrossoversPage membership editing', () => {
     expect(status).toHaveTextContent('latest memberships could not be refreshed: Refresh unavailable')
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
     expect(screen.getByLabelText('Thread ID')).toHaveValue('')
-    expect(screen.getByLabelText('Start position')).toHaveValue('')
-    expect(screen.getByLabelText('End position')).toHaveValue('')
+    expect(screen.queryByLabelText('First issue')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Last issue')).not.toBeInTheDocument()
+    expect(api.addIssueRange).toHaveBeenCalledWith(7, 22, 3, 5)
     expect(api.addIssueRange).toHaveBeenCalledTimes(1)
   })
 


### PR DESCRIPTION
Fixes #976

## What changed
- replace raw start/end position inputs with the shared continuity issue-range selector
- load the complete ordered issue list for the chosen crossover thread, including read issues and specials
- translate the selected human-facing issue labels back to canonical positions only at the API boundary
- preserve existing duplicate-membership, ownership, range-size, refresh, and pending-mutation behavior
- add regression coverage for numeric issues, `Annual 1`, `½`, reversed ranges, pagination, loading failures, and pending saves

## Validation
The automation runtime does not expose a local repository checkout or package execution environment, so exact-head CI is the configured validation boundary for this branch.

Changelog fragment will be added using this PR number before readiness.