### PR TITLE
Preserve active reading session across auth recovery

### DIFF
--- a/comic_pile/session.py
+++ b/comic_pile/session.py
@@ -4,7 +4,7 @@ import asyncio
 from datetime import UTC, datetime, timedelta
 import logging
 
-from sqlalchemy import select, text
+from sqlalchemy import or_, select, text
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -26,6 +26,22 @@ def _start_die() -> int:
     return get_session_settings().start_die
 
 
+def _current_session_filter(user_id: int, cutoff_time: datetime):
+    """Build the predicate for a session that should remain authoritative.
+
+    A pending roll is active reading work. Its timestamp, rather than the original session start,
+    keeps the session current while the reader is away from the app reading the selected comic.
+    """
+    return (
+        (Session.user_id == user_id)
+        & Session.ended_at.is_(None)
+        & or_(
+            Session.started_at >= cutoff_time,
+            Session.pending_thread_updated_at >= cutoff_time,
+        )
+    )
+
+
 async def is_active(
     started_at: datetime,
     ended_at: datetime | None,
@@ -40,13 +56,10 @@ async def is_active(
 
 
 async def should_start_new(db: AsyncSession, user_id: int) -> bool:
-    """Check whether no active session exists in the configured gap."""
+    """Check whether no current session exists in the configured gap."""
     cutoff_time = datetime.now(UTC) - timedelta(hours=_session_gap_hours())
     result = await db.execute(
-        select(Session)
-        .where(Session.user_id == user_id)
-        .where(Session.started_at >= cutoff_time)
-        .where(Session.ended_at.is_(None))
+        select(Session).where(_current_session_filter(user_id, cutoff_time))
     )
     return len(result.scalars().all()) == 0
 
@@ -154,9 +167,7 @@ async def get_or_create(db: AsyncSession, user_id: int) -> Session:
             cutoff_time = datetime.now(UTC) - timedelta(hours=session_gap_hours)
             result = await db.execute(
                 select(Session)
-                .where(Session.user_id == user_id)
-                .where(Session.ended_at.is_(None))
-                .where(Session.started_at >= cutoff_time)
+                .where(_current_session_filter(user_id, cutoff_time))
                 .order_by(Session.started_at.desc(), Session.id.desc())
             )
             active_session = result.scalars().first()
@@ -175,9 +186,7 @@ async def get_or_create(db: AsyncSession, user_id: int) -> Session:
 
                 result = await db.execute(
                     select(Session)
-                    .where(Session.user_id == user_id)
-                    .where(Session.ended_at.is_(None))
-                    .where(Session.started_at >= cutoff_time)
+                    .where(_current_session_filter(user_id, cutoff_time))
                     .order_by(Session.started_at.desc(), Session.id.desc())
                 )
                 active_session = result.scalars().first()

--- a/comic_pile/session.py
+++ b/comic_pile/session.py
@@ -4,7 +4,7 @@ import asyncio
 from datetime import UTC, datetime, timedelta
 import logging
 
-from sqlalchemy import or_, select, text
+from sqlalchemy import and_, or_, select, text
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -37,7 +37,10 @@ def _current_session_filter(user_id: int, cutoff_time: datetime):
         & Session.ended_at.is_(None)
         & or_(
             Session.started_at >= cutoff_time,
-            Session.pending_thread_updated_at >= cutoff_time,
+            and_(
+                Session.pending_thread_id.is_not(None),
+                Session.pending_thread_updated_at >= cutoff_time,
+            ),
         )
     )
 
@@ -56,7 +59,15 @@ async def is_active(
 
 
 async def should_start_new(db: AsyncSession, user_id: int) -> bool:
-    """Check whether no current session exists in the configured gap."""
+    """Check whether no current session exists in the configured gap.
+
+    Args:
+        db: Async database session used to resolve current reading sessions.
+        user_id: User whose current reading session should be checked.
+
+    Returns:
+        True when a new reading session should be created.
+    """
     cutoff_time = datetime.now(UTC) - timedelta(hours=_session_gap_hours())
     result = await db.execute(
         select(Session).where(_current_session_filter(user_id, cutoff_time))
@@ -145,7 +156,15 @@ async def create_session_start_snapshot(db: AsyncSession, session: Session) -> N
 
 
 async def get_or_create(db: AsyncSession, user_id: int) -> Session:
-    """Get an active session or create one."""
+    """Get an active session or create one.
+
+    Args:
+        db: Async database session used to resolve or create the reading session.
+        user_id: User whose authoritative reading session should be returned.
+
+    Returns:
+        The user's authoritative current reading session.
+    """
     from app.models import User
 
     max_retries = 3

--- a/docs/changelog.d/2026-08-09-995.md
+++ b/docs/changelog.d/2026-08-09-995.md
@@ -1,0 +1,5 @@
+## 2026-08-09
+
+### Roll
+
+- [#995](https://github.com/JoshCLWren/comic-pile/pull/995) keeps a recently pending comic attached to the current reading session when authentication recovers, so returning from reading no longer replaces the active session with a blank d6 screen just because the session's original start time crossed the configured gap.

--- a/frontend/src/test/issue-984-auth-session-continuity.spec.ts
+++ b/frontend/src/test/issue-984-auth-session-continuity.spec.ts
@@ -49,7 +49,9 @@ test('issue #984: auth recovery keeps the same pending comic and reading session
 
   await expect(page).toHaveURL('/');
   await expect(page.locator(SELECTORS.rate.ratingInput)).toBeVisible({ timeout: 15000 });
-  await expect(page.getByText(initialSession.active_thread!.title!, { exact: true }).first()).toBeVisible();
+  await expect(
+    page.locator('#thread-info h2'),
+  ).toContainText(initialSession.active_thread!.title!);
 
   const tokenAfterRecovery = await page.evaluate(() =>
     localStorage.getItem('auth_token')

--- a/frontend/src/test/issue-984-auth-session-continuity.spec.ts
+++ b/frontend/src/test/issue-984-auth-session-continuity.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from './fixtures';
+import { SELECTORS } from './helpers';
+
+test('issue #984: auth recovery keeps the same pending comic and reading session', async ({
+  authenticatedWithThreadsPage,
+}) => {
+  const page = authenticatedWithThreadsPage;
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect(page.locator('#root')).toBeVisible();
+
+  const firstThreadCard = page.locator('[role="button"]').filter({
+    has: page.locator('p.font-black'),
+  }).first();
+  await expect(firstThreadCard).toBeVisible({ timeout: 10000 });
+  await firstThreadCard.click();
+  await page.getByRole('button', { name: 'Read Now' }).click();
+  await expect(page.locator(SELECTORS.rate.ratingInput)).toBeVisible({ timeout: 10000 });
+
+  const tokenBeforeRecovery = await page.evaluate(() =>
+    localStorage.getItem('auth_token')
+    ?? (window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN
+    ?? '',
+  );
+  expect(tokenBeforeRecovery).toBeTruthy();
+
+  const initialSessionResponse = await page.request.get('/api/sessions/current/', {
+    headers: { Authorization: `Bearer ${tokenBeforeRecovery}` },
+  });
+  expect(initialSessionResponse.ok()).toBeTruthy();
+
+  const initialSession = await initialSessionResponse.json() as {
+    id: number;
+    pending_thread_id: number | null;
+    pending_issue_id?: number | null;
+    current_die?: number;
+    active_thread?: { title?: string; issue_number?: string | null } | null;
+  };
+  expect(initialSession.pending_thread_id).not.toBeNull();
+  expect(initialSession.active_thread?.title).toBeTruthy();
+
+  await page.evaluate(() => {
+    const expiredToken = 'expired.access.token';
+    localStorage.setItem('auth_token', expiredToken);
+    (window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN = expiredToken;
+  });
+
+  await page.reload({ waitUntil: 'domcontentloaded' });
+
+  await expect(page).toHaveURL('/');
+  await expect(page.locator(SELECTORS.rate.ratingInput)).toBeVisible({ timeout: 15000 });
+  await expect(page.getByText(initialSession.active_thread!.title!, { exact: true }).first()).toBeVisible();
+
+  const tokenAfterRecovery = await page.evaluate(() =>
+    localStorage.getItem('auth_token')
+    ?? (window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN
+    ?? '',
+  );
+  expect(tokenAfterRecovery).toBeTruthy();
+  expect(tokenAfterRecovery).not.toBe('expired.access.token');
+
+  const recoveredSessionResponse = await page.request.get('/api/sessions/current/', {
+    headers: { Authorization: `Bearer ${tokenAfterRecovery}` },
+  });
+  expect(recoveredSessionResponse.ok()).toBeTruthy();
+
+  const recoveredSession = await recoveredSessionResponse.json() as {
+    id: number;
+    pending_thread_id: number | null;
+    pending_issue_id?: number | null;
+    current_die?: number;
+    active_thread?: { title?: string; issue_number?: string | null } | null;
+  };
+
+  expect(recoveredSession.id).toBe(initialSession.id);
+  expect(recoveredSession.pending_thread_id).toBe(initialSession.pending_thread_id);
+  expect(recoveredSession.pending_issue_id ?? null).toBe(initialSession.pending_issue_id ?? null);
+  expect(recoveredSession.current_die).toBe(initialSession.current_die);
+  expect(recoveredSession.active_thread?.title).toBe(initialSession.active_thread?.title);
+  expect(recoveredSession.active_thread?.issue_number).toBe(initialSession.active_thread?.issue_number);
+});

--- a/tests/test_session_continuity.py
+++ b/tests/test_session_continuity.py
@@ -1,0 +1,95 @@
+"""Regression coverage for reading-session continuity across auth/bootstrap recovery."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Session, Thread, User
+from comic_pile.session import get_or_create, should_start_new
+
+
+@pytest.mark.asyncio
+async def test_recent_pending_roll_keeps_old_open_session_authoritative(
+    async_db: AsyncSession,
+    default_user: User,
+) -> None:
+    """A recently pending comic must survive after the session start crosses the gap."""
+    thread = Thread(
+        title="Fantastic Four",
+        format="Comic",
+        issues_remaining=6,
+        queue_position=1,
+        status="active",
+        user_id=default_user.id,
+        created_at=datetime.now(UTC) - timedelta(days=1),
+    )
+    async_db.add(thread)
+    await async_db.flush()
+
+    original_session = Session(
+        user_id=default_user.id,
+        started_at=datetime.now(UTC) - timedelta(hours=7),
+        start_die=6,
+        manual_die=20,
+        pending_thread_id=thread.id,
+        pending_thread_updated_at=datetime.now(UTC) - timedelta(minutes=10),
+        snoozed_thread_ids=[thread.id + 1, thread.id + 2],
+    )
+    async_db.add(original_session)
+    await async_db.commit()
+
+    assert await should_start_new(async_db, default_user.id) is False
+
+    recovered_session = await get_or_create(async_db, default_user.id)
+
+    assert recovered_session.id == original_session.id
+    assert recovered_session.pending_thread_id == thread.id
+    assert recovered_session.manual_die == 20
+    assert recovered_session.snoozed_thread_ids == [thread.id + 1, thread.id + 2]
+
+    open_count = await async_db.scalar(
+        select(func.count())
+        .select_from(Session)
+        .where(Session.user_id == default_user.id)
+        .where(Session.ended_at.is_(None))
+    )
+    assert open_count == 1
+
+
+@pytest.mark.asyncio
+async def test_stale_session_without_recent_pending_activity_can_roll_over(
+    async_db: AsyncSession,
+    default_user: User,
+) -> None:
+    """The configured session gap still starts a new session after genuinely stale activity."""
+    thread = Thread(
+        title="Old Pending Comic",
+        format="Comic",
+        issues_remaining=1,
+        queue_position=1,
+        status="active",
+        user_id=default_user.id,
+        created_at=datetime.now(UTC) - timedelta(days=1),
+    )
+    async_db.add(thread)
+    await async_db.flush()
+
+    stale_session = Session(
+        user_id=default_user.id,
+        started_at=datetime.now(UTC) - timedelta(hours=8),
+        start_die=6,
+        pending_thread_id=thread.id,
+        pending_thread_updated_at=datetime.now(UTC) - timedelta(hours=7),
+    )
+    async_db.add(stale_session)
+    await async_db.commit()
+
+    assert await should_start_new(async_db, default_user.id) is True
+
+    new_session = await get_or_create(async_db, default_user.id)
+
+    assert new_session.id != stale_session.id
+    assert new_session.pending_thread_id is None
+    assert new_session.start_die == 6

--- a/tests/test_session_continuity.py
+++ b/tests/test_session_continuity.py
@@ -15,7 +15,12 @@ async def test_recent_pending_roll_keeps_old_open_session_authoritative(
     async_db: AsyncSession,
     default_user: User,
 ) -> None:
-    """A recently pending comic must survive after the session start crosses the gap."""
+    """A recently pending comic must survive after the session start crosses the gap.
+
+    Args:
+        async_db: Async database fixture.
+        default_user: User fixture that owns the reading session.
+    """
     thread = Thread(
         title="Fantastic Four",
         format="Comic",
@@ -63,7 +68,12 @@ async def test_stale_session_without_recent_pending_activity_can_roll_over(
     async_db: AsyncSession,
     default_user: User,
 ) -> None:
-    """The configured session gap still starts a new session after genuinely stale activity."""
+    """The configured session gap still starts a new session after genuinely stale activity.
+
+    Args:
+        async_db: Async database fixture.
+        default_user: User fixture that owns the reading session.
+    """
     thread = Thread(
         title="Old Pending Comic",
         format="Comic",
@@ -93,3 +103,33 @@ async def test_stale_session_without_recent_pending_activity_can_roll_over(
     assert new_session.id != stale_session.id
     assert new_session.pending_thread_id is None
     assert new_session.start_die == 6
+
+
+@pytest.mark.asyncio
+async def test_recent_timestamp_without_pending_thread_does_not_keep_session_active(
+    async_db: AsyncSession,
+    default_user: User,
+) -> None:
+    """A stale pending timestamp cannot keep a cleared reading session authoritative.
+
+    Args:
+        async_db: Async database fixture.
+        default_user: User fixture that owns the reading session.
+    """
+    stale_session = Session(
+        user_id=default_user.id,
+        started_at=datetime.now(UTC) - timedelta(hours=8),
+        start_die=6,
+        pending_thread_id=None,
+        pending_thread_updated_at=datetime.now(UTC) - timedelta(minutes=5),
+    )
+    async_db.add(stale_session)
+    await async_db.commit()
+
+    assert await should_start_new(async_db, default_user.id) is True
+
+    new_session = await get_or_create(async_db, default_user.id)
+
+    assert new_session.id != stale_session.id
+    assert new_session.pending_thread_id is None
+    assert new_session.pending_thread_updated_at is None


### PR DESCRIPTION
Closes #984

## Summary
- treat a recently pending roll as authoritative session activity even after the session's original start time crosses `SESSION_GAP_HOURS`
- preserve pending comic, die state, and snoozed state instead of creating a blank d6 session during auth/bootstrap recovery
- retain the configured rollover behavior for genuinely stale sessions
- add regression coverage for the production-shaped old-session/recent-pending transition

## Root cause
`get_or_create()` filtered current sessions only by `Session.started_at >= cutoff`. A session could therefore be replaced during auth recovery even when its pending comic had been updated only minutes earlier.

## Validation
This runtime has no repository checkout, so required CI is the validation boundary for the branch.

Changelog: `docs/changelog.d/2026-08-09-995.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved the current comic, reading progress, and session identity when authentication recovers after an expired login.
  - Pending reading activity now keeps an open session active within the configured continuity window.
  - Truly stale activity starts a new session as expected.

- **Tests**
  - Added coverage for authentication recovery and reading-session continuity scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->