### PR TITLE
Keep What's New focused on product changes

### DIFF
--- a/docs/changelog.d/2026-08-09-998.md
+++ b/docs/changelog.d/2026-08-09-998.md
@@ -1,0 +1,5 @@
+## 2026-08-09
+
+### What’s New
+
+- [#998](https://github.com/JoshCLWren/comic-pile/pull/998) keeps the What’s New page focused on features and fixes by hiding internal pull-request references while preserving useful comic issue numbers and the actual product change.

--- a/frontend/src/pages/WhatsNewPage.tsx
+++ b/frontend/src/pages/WhatsNewPage.tsx
@@ -18,6 +18,7 @@ export function isPublicChangelogLink(url: string) {
 
 export function publicChangelogText(text: string) {
   return text
+    .replace(/\s+\b(?:in|via)\s+\[#\d+\]\(https?:\/\/github\.com\/[^)]+\/pull\/\d+\)/gi, '')
     .replace(/\[#\d+\]\(https?:\/\/github\.com\/[^)]+\/pull\/\d+\)\s*/gi, '')
     .replace(/\bPR\s+#\d+\b:?\s*/gi, '')
     .trim()

--- a/frontend/src/pages/WhatsNewPage.tsx
+++ b/frontend/src/pages/WhatsNewPage.tsx
@@ -16,9 +16,17 @@ export function isPublicChangelogLink(url: string) {
   }
 }
 
+export function publicChangelogText(text: string) {
+  return text
+    .replace(/\[#\d+\]\(https?:\/\/github\.com\/[^)]+\/pull\/\d+\)\s*/gi, '')
+    .replace(/\bPR\s+#\d+\b:?\s*/gi, '')
+    .trim()
+}
+
 function renderInline(text: string) {
+  const publicText = publicChangelogText(text)
   const pattern = /(`[^`]+`|\[[^\]]+\]\(https?:\/\/[^)]+\))/g
-  return text.split(pattern).map((part, index) => {
+  return publicText.split(pattern).map((part, index) => {
     const code = part.match(/^`([^`]+)`$/)
     if (code) return <code key={index} className="rounded bg-stone-800 px-1.5 py-0.5 text-amber-200">{code[1]}</code>
     const link = part.match(/^\[([^\]]+)\]\((https?:\/\/[^)]+)\)$/)

--- a/frontend/src/unit/WhatsNewPage.public-copy.test.tsx
+++ b/frontend/src/unit/WhatsNewPage.public-copy.test.tsx
@@ -6,6 +6,10 @@ describe('publicChangelogText', () => {
     expect(publicChangelogText('[#994](https://github.com/JoshCLWren/comic-pile/pull/994) replaces internal fields with comic issue labels.')).toBe('replaces internal fields with comic issue labels.')
   })
 
+  it('removes a dangling preposition before a linked pull request', () => {
+    expect(publicChangelogText('Fixed Queue in [#866](https://github.com/JoshCLWren/comic-pile/pull/866).')).toBe('Fixed Queue.')
+  })
+
   it('removes plain PR references while preserving the user-facing change', () => {
     expect(publicChangelogText('PR #990: Rating retries after login recovery.')).toBe('Rating retries after login recovery.')
   })

--- a/frontend/src/unit/WhatsNewPage.public-copy.test.tsx
+++ b/frontend/src/unit/WhatsNewPage.public-copy.test.tsx
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { publicChangelogText } from '../pages/WhatsNewPage'
+
+describe('publicChangelogText', () => {
+  it('removes linked pull request numbers from release-note entries', () => {
+    expect(publicChangelogText('[#994](https://github.com/JoshCLWren/comic-pile/pull/994) replaces internal fields with comic issue labels.')).toBe('replaces internal fields with comic issue labels.')
+  })
+
+  it('removes plain PR references while preserving the user-facing change', () => {
+    expect(publicChangelogText('PR #990: Rating retries after login recovery.')).toBe('Rating retries after login recovery.')
+  })
+
+  it('leaves ordinary comic issue numbers alone', () => {
+    expect(publicChangelogText('Fantastic Four #583 stays selected after login recovery.')).toBe('Fantastic Four #583 stays selected after login recovery.')
+  })
+})

--- a/frontend/src/unit/WhatsNewPage.test.tsx
+++ b/frontend/src/unit/WhatsNewPage.test.tsx
@@ -32,7 +32,7 @@ describe('WhatsNewPage', () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       text: async () =>
-        '# Changelog\n\nPlain introduction.\n\n## Today\n\n### Queue\n\n- Fixed `Queue` in [#866](https://github.com/JoshCLWren/comic-pile/pull/866). See [ComicPile](https://comic-pile.vercel.app/) for more.',
+        '# Changelog\n\nPlain introduction.\n\n## Today\n\n### Queue\n\n- Fixed `Queue` in [#866](https://github.com/JoshCLWren/comic-pile/pull/866). See [ComicPile](https://comic-pile.vercel.app/) for more. [Internal notes](https://github.com/JoshCLWren/comic-pile/issues/981).',
     })
     vi.stubGlobal('fetch', fetchMock)
 
@@ -48,6 +48,8 @@ describe('WhatsNewPage', () => {
     expect(screen.getByRole('listitem')).not.toHaveTextContent('#866')
     expect(screen.getByRole('listitem')).toHaveTextContent(/Fixed Queue\. See ComicPile.*for more\./)
     expect(screen.queryByRole('link', { name: /#866/ })).not.toBeInTheDocument()
+    expect(screen.getByText(/Internal notes/)).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /Internal notes/ })).not.toBeInTheDocument()
 
     const link = screen.getByRole('link', { name: /ComicPile/ })
     expect(link).toHaveAttribute('href', 'https://comic-pile.vercel.app/')

--- a/frontend/src/unit/WhatsNewPage.test.tsx
+++ b/frontend/src/unit/WhatsNewPage.test.tsx
@@ -28,7 +28,7 @@ describe('parseChangelog', () => {
 })
 
 describe('WhatsNewPage', () => {
-  it('renders GitHub references as text while preserving public external links', async () => {
+  it('removes GitHub pull references while preserving public external links', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       text: async () =>
@@ -45,7 +45,8 @@ describe('WhatsNewPage', () => {
     expect(screen.getByRole('heading', { name: 'Queue' }).tagName).toBe('H3')
     expect(screen.getByText('Plain introduction.')).toBeInTheDocument()
     expect(screen.getByText('Queue', { selector: 'code' })).toBeInTheDocument()
-    expect(screen.getByRole('listitem')).toHaveTextContent('#866')
+    expect(screen.getByRole('listitem')).not.toHaveTextContent('#866')
+    expect(screen.getByRole('listitem')).toHaveTextContent(/Fixed Queue\. See ComicPile.*for more\./)
     expect(screen.queryByRole('link', { name: /#866/ })).not.toBeInTheDocument()
 
     const link = screen.getByRole('link', { name: /ComicPile/ })


### PR DESCRIPTION
Closes #981

## Summary
- hide GitHub pull-request references from the human-facing What’s New page
- preserve comic issue numbers and the actual feature/fix wording
- cover linked and plain PR references with focused regression tests

## Validation
This runtime has no repository checkout, so required CI is the validation boundary for the branch.

Changelog: `docs/changelog.d/2026-08-09-998.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the What’s New page to hide internal pull-request references while preserving product updates and comic issue numbers.
  * Public external links remain visible and functional.

* **Bug Fixes**
  * Removed leftover wording associated with hidden internal references for cleaner changelog text.

* **Tests**
  * Added coverage verifying internal references are hidden and ordinary issue numbers are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->