### PR TITLE
Make factory label reconciliation atomic

### DIFF
--- a/.github/scripts/factory-visibility.cjs
+++ b/.github/scripts/factory-visibility.cjs
@@ -1,0 +1,270 @@
+const DEFINITIONS = {
+  factory: ['5319E7', 'Work owned or produced by an autonomous ComicPile factory'],
+  'factory:1': ['0366D6', 'Current next-action owner is ComicPile Factory 1'],
+  'factory:2': ['0366D6', 'Current next-action owner is ComicPile Factory 2'],
+  'factory:3': ['0366D6', 'Current next-action owner is ComicPile Factory 3'],
+  'factory:4': ['0366D6', 'Current next-action owner is ComicPile Factory 4'],
+  'factory:5': ['0366D6', 'Current next-action owner is ComicPile Factory 5'],
+  'factory:local': ['0366D6', 'Current next-action owner is the local OpenCode factory'],
+  'factory:unowned': ['BFDADC', 'Factory work has no current next-action owner'],
+  'factory:building': ['FBCA04', 'A factory is actively implementing or repairing this work'],
+  'factory:review': ['D4C5F9', 'The exact current head needs review or re-review'],
+  'factory:changes-requested': ['D73A4A', 'Actionable review findings currently block progress'],
+  'factory:ci': ['1D76DB', 'Review passed and required exact-head checks are being verified'],
+  'factory:ready': ['0E8A16', 'All exact-head factory merge gates are satisfied'],
+  'factory:blocked': ['B60205', 'A genuine human, credential, or external blocker remains'],
+};
+
+const OWNER_LABELS = [
+  'factory:1',
+  'factory:2',
+  'factory:3',
+  'factory:4',
+  'factory:5',
+  'factory:local',
+  'factory:unowned',
+];
+const STAGE_LABELS = [
+  'factory:building',
+  'factory:review',
+  'factory:changes-requested',
+  'factory:ci',
+  'factory:ready',
+  'factory:blocked',
+];
+const ADVANCED_PR_STAGES = new Set(['factory:review', 'factory:ci', 'factory:ready']);
+const TRUSTED_ASSOCIATIONS = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+
+function trusted(login, association) {
+  return TRUSTED_ASSOCIATIONS.has(association)
+    || login === 'coderabbitai[bot]'
+    || login === 'coderabbitai';
+}
+
+function workerFrom(body) {
+  for (const pattern of [
+    /comic-pile-factory-implement-(?:claim|progress)-v\d+:issue-\d+:([^:\s>]+):/,
+    /comic-pile-factory-review-claim-v\d+:[^:\s>]+:([^:\s>]+):/,
+    /comic-pile-factory-fix-(?:claim|progress)-v\d+:[^:\s>]+:([^:\s>]+):/,
+    /comic-pile-factory-claim-released-v\d+:[^:\s>]+:([^:\s>]+):/,
+  ]) {
+    const match = body.match(pattern);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+function ownerFor(worker) {
+  const scheduled = worker?.match(/^chatgpt-factory-([1-5])$/);
+  if (scheduled) return `factory:${scheduled[1]}`;
+  if (worker === 'local' || worker === 'local-opencode' || worker?.startsWith('local-opencode-')) {
+    return 'factory:local';
+  }
+  return 'factory:unowned';
+}
+
+function stageFrom(body) {
+  if (/comic-pile-factory-needs-human-v\d+:/.test(body)) return 'factory:blocked';
+  if (/comic-pile-factory-ready-v\d+:/.test(body)) return 'factory:ready';
+  if (/comic-pile-factory-review-v\d+:[^:\s>]+:changes-required/.test(body)) {
+    return 'factory:changes-requested';
+  }
+  if (/comic-pile-factory-review-v\d+:[^:\s>]+:pass/.test(body)) return 'factory:ci';
+  if (/comic-pile-factory-review-claim-v\d+:/.test(body)) return 'factory:review';
+  if (
+    /comic-pile-factory-implement-(?:claim|progress)-v\d+:/.test(body)
+    || /comic-pile-factory-fix-(?:claim|progress)-v\d+:/.test(body)
+  ) return 'factory:building';
+  return null;
+}
+
+function isTransient(error) {
+  return error?.status === 429 || (error?.status >= 500 && error?.status <= 599);
+}
+
+async function withRetry(operation, { attempts = 3, delay = 250 } = {}) {
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      if (!isTransient(error) || attempt === attempts) throw error;
+      await new Promise(resolve => setTimeout(resolve, delay * attempt));
+    }
+  }
+  throw lastError;
+}
+
+async function currentLabels(github, context, number) {
+  const labels = await withRetry(() => github.paginate(github.rest.issues.listLabelsOnIssue, {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: number,
+    per_page: 100,
+  }));
+  return new Set(labels.map(label => label.name));
+}
+
+async function reconcileLabels(github, context, number, { owner, stage }) {
+  const current = await currentLabels(github, context, number);
+  const next = [...current].filter(
+    label => !OWNER_LABELS.includes(label) && !STAGE_LABELS.includes(label),
+  );
+  if (!next.includes('factory')) next.push('factory');
+  if (owner) next.push(owner);
+  if (stage) next.push(stage);
+
+  await withRetry(() => github.rest.issues.setLabels({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: number,
+    labels: next,
+  }));
+}
+
+async function ensureLabels(github, context) {
+  const existing = await withRetry(() => github.paginate(github.rest.issues.listLabelsForRepo, {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    per_page: 100,
+  }));
+  const byName = new Map(existing.map(label => [label.name, label]));
+  for (const [name, [color, description]] of Object.entries(DEFINITIONS)) {
+    const current = byName.get(name);
+    if (!current) {
+      await withRetry(() => github.rest.issues.createLabel({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        name,
+        color,
+        description,
+      }));
+    } else if (
+      current.color.toUpperCase() !== color
+      || (current.description || '') !== description
+    ) {
+      await withRetry(() => github.rest.issues.updateLabel({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        name,
+        new_name: name,
+        color,
+        description,
+      }));
+    }
+  }
+}
+
+async function ownerFromLinkedIssue(github, context, pullRequest) {
+  const branch = pullRequest.head.ref.match(/^factory\/(\d+)(?:-|$)/);
+  const closing = (pullRequest.body || '').match(
+    /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/i,
+  );
+  const issueNumber = Number(branch?.[1] || closing?.[1] || 0);
+  if (!issueNumber) return 'factory:unowned';
+
+  const comments = await withRetry(() => github.paginate(github.rest.issues.listComments, {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: issueNumber,
+    per_page: 100,
+  }));
+  comments.sort((left, right) => new Date(right.created_at) - new Date(left.created_at));
+  for (const comment of comments) {
+    if (!trusted(comment.user?.login, comment.author_association)) continue;
+    const body = comment.body || '';
+    if (/comic-pile-factory-claim-released-v\d+:/.test(body)) return 'factory:unowned';
+    const worker = workerFrom(body);
+    if (worker) return ownerFor(worker);
+  }
+  return 'factory:unowned';
+}
+
+async function reconcile({ github, context }) {
+  await ensureLabels(github, context);
+
+  if (context.eventName === 'issue_comment') {
+    const comment = context.payload.comment;
+    const body = comment?.body || '';
+    if (!body.includes('comic-pile-factory-')) return;
+    if (!trusted(comment?.user?.login, comment?.author_association)) return;
+
+    const number = context.payload.issue.number;
+    const current = await currentLabels(github, context, number);
+    const released = /comic-pile-factory-claim-released-v\d+:/.test(body);
+    const worker = workerFrom(body);
+    const currentOwner = OWNER_LABELS.find(label => current.has(label));
+    const currentStage = STAGE_LABELS.find(label => current.has(label));
+    const requestedStage = stageFrom(body);
+    const preserveAdvancedPrStage = Boolean(context.payload.issue.pull_request)
+      && requestedStage === 'factory:building'
+      && ADVANCED_PR_STAGES.has(currentStage);
+
+    await reconcileLabels(github, context, number, {
+      owner: released ? 'factory:unowned' : worker ? ownerFor(worker) : currentOwner,
+      stage: preserveAdvancedPrStage ? currentStage : requestedStage || currentStage,
+    });
+    return;
+  }
+
+  if (context.eventName === 'pull_request_target') {
+    const pullRequest = context.payload.pull_request;
+    const sameRepo = pullRequest.head.repo?.full_name === context.payload.repository.full_name;
+    const alreadyFactory = (pullRequest.labels || []).some(label => label.name === 'factory');
+    const isFactory = alreadyFactory || (
+      sameRepo
+      && (
+        pullRequest.head.ref.startsWith('factory/')
+        || (pullRequest.body || '').includes('comic-pile-factory-')
+      )
+    );
+    if (!isFactory) return;
+
+    await reconcileLabels(github, context, pullRequest.number, {
+      owner: await ownerFromLinkedIssue(github, context, pullRequest),
+      stage: 'factory:review',
+    });
+    return;
+  }
+
+  if (context.eventName === 'pull_request_review') {
+    const pullRequest = context.payload.pull_request;
+    const current = await currentLabels(github, context, pullRequest.number);
+    const sameRepo = pullRequest.head.repo?.full_name === context.payload.repository.full_name;
+    if (!(current.has('factory') || (sameRepo && pullRequest.head.ref.startsWith('factory/')))) {
+      return;
+    }
+
+    const currentOwner = OWNER_LABELS.find(label => current.has(label));
+    if (context.payload.action === 'dismissed') {
+      await reconcileLabels(github, context, pullRequest.number, {
+        owner: currentOwner || await ownerFromLinkedIssue(github, context, pullRequest),
+        stage: 'factory:review',
+      });
+      return;
+    }
+
+    const review = context.payload.review;
+    if (!trusted(review.user?.login, review.author_association)) return;
+    const state = (review.state || '').toUpperCase();
+    const body = review.body || '';
+    let stage = 'factory:review';
+    if (state === 'CHANGES_REQUESTED') stage = 'factory:changes-requested';
+    else if (state === 'APPROVED') stage = 'factory:ci';
+    else if (/Actionable comments posted:\s*[1-9]\d*/i.test(body)) {
+      stage = 'factory:changes-requested';
+    }
+    await reconcileLabels(github, context, pullRequest.number, {
+      owner: currentOwner || await ownerFromLinkedIssue(github, context, pullRequest),
+      stage,
+    });
+  }
+}
+
+module.exports = reconcile;
+module.exports._test = {
+  ownerFor,
+  reconcileLabels,
+  withRetry,
+};

--- a/.github/scripts/factory-visibility.test.cjs
+++ b/.github/scripts/factory-visibility.test.cjs
@@ -1,0 +1,141 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const reconcile = require('./factory-visibility.cjs');
+const { ownerFor, reconcileLabels, withRetry } = reconcile._test;
+
+function contextFor(eventName, payload) {
+  return {
+    eventName,
+    payload,
+    repo: { owner: 'JoshCLWren', repo: 'comic-pile' },
+  };
+}
+
+function githubFor({ labels = [], comments = [], setLabels } = {}) {
+  const definitions = Object.entries({
+    factory: ['5319E7', 'Work owned or produced by an autonomous ComicPile factory'],
+    'factory:1': ['0366D6', 'Current next-action owner is ComicPile Factory 1'],
+    'factory:2': ['0366D6', 'Current next-action owner is ComicPile Factory 2'],
+    'factory:3': ['0366D6', 'Current next-action owner is ComicPile Factory 3'],
+    'factory:4': ['0366D6', 'Current next-action owner is ComicPile Factory 4'],
+    'factory:5': ['0366D6', 'Current next-action owner is ComicPile Factory 5'],
+    'factory:local': ['0366D6', 'Current next-action owner is the local OpenCode factory'],
+    'factory:unowned': ['BFDADC', 'Factory work has no current next-action owner'],
+    'factory:building': ['FBCA04', 'A factory is actively implementing or repairing this work'],
+    'factory:review': ['D4C5F9', 'The exact current head needs review or re-review'],
+    'factory:changes-requested': ['D73A4A', 'Actionable review findings currently block progress'],
+    'factory:ci': ['1D76DB', 'Review passed and required exact-head checks are being verified'],
+    'factory:ready': ['0E8A16', 'All exact-head factory merge gates are satisfied'],
+    'factory:blocked': ['B60205', 'A genuine human, credential, or external blocker remains'],
+  }).map(([name, [color, description]]) => ({ name, color, description }));
+  const api = {
+    listLabelsForRepo() {},
+    listLabelsOnIssue() {},
+    listComments() {},
+    createLabel: async () => {},
+    updateLabel: async () => {},
+    setLabels: setLabels || (async () => {}),
+  };
+  return {
+    paginate: async operation => {
+      if (operation === api.listLabelsForRepo) return definitions;
+      if (operation === api.listComments) return comments;
+      return labels.map(name => ({ name }));
+    },
+    rest: { issues: api },
+  };
+}
+
+test('canonical local worker tokens map to the local owner', () => {
+  assert.equal(ownerFor('local'), 'factory:local');
+  assert.equal(ownerFor('local-opencode'), 'factory:local');
+  assert.equal(ownerFor('local-opencode-debian'), 'factory:local');
+});
+
+test('label reconciliation replaces both groups with one atomic call', async () => {
+  const calls = [];
+  const github = githubFor({
+    labels: ['bug', 'factory', 'factory:building', 'factory:unowned'],
+    setLabels: async input => calls.push(input),
+  });
+  await reconcileLabels(github, contextFor('workflow_dispatch', {}), 12, {
+    owner: 'factory:local',
+    stage: 'factory:review',
+  });
+  assert.equal(calls.length, 1);
+  assert.deepEqual(
+    new Set(calls[0].labels),
+    new Set(['bug', 'factory', 'factory:local', 'factory:review']),
+  );
+});
+
+test('transient GitHub failures are retried', async () => {
+  let attempts = 0;
+  const result = await withRetry(async () => {
+    attempts += 1;
+    if (attempts === 1) throw Object.assign(new Error('temporary failure'), { status: 502 });
+    return 'ok';
+  }, { delay: 0 });
+  assert.equal(result, 'ok');
+  assert.equal(attempts, 2);
+});
+
+test('PR progress comments preserve an advanced review stage and local owner', async () => {
+  const calls = [];
+  const github = githubFor({
+    labels: ['factory', 'factory:review', 'factory:unowned'],
+    setLabels: async input => calls.push(input),
+  });
+  await reconcile({
+    github,
+    context: contextFor('issue_comment', {
+      issue: { number: 44, pull_request: { url: 'https://api.github.test/pulls/44' } },
+      comment: {
+        author_association: 'OWNER',
+        user: { login: 'JoshCLWren' },
+        body: '<!-- comic-pile-factory-fix-progress-v3:abc:local:123 -->',
+      },
+    }),
+  });
+  assert.equal(calls.length, 1);
+  assert.ok(calls[0].labels.includes('factory:local'));
+  assert.ok(calls[0].labels.includes('factory:review'));
+  assert.ok(!calls[0].labels.includes('factory:building'));
+  assert.ok(!calls[0].labels.includes('factory:unowned'));
+});
+
+test('PR synchronize events refresh owner and stage from the linked issue', async () => {
+  const calls = [];
+  const github = githubFor({
+    labels: ['factory', 'factory:building', 'factory:5'],
+    comments: [{
+      author_association: 'OWNER',
+      body: '<!-- comic-pile-factory-implement-claim-v3:issue-999:local:123:attempt-1 -->',
+      created_at: '2026-08-09T12:00:00Z',
+      user: { login: 'JoshCLWren' },
+    }],
+    setLabels: async input => calls.push(input),
+  });
+  await reconcile({
+    github,
+    context: contextFor('pull_request_target', {
+      action: 'synchronize',
+      repository: { full_name: 'JoshCLWren/comic-pile' },
+      pull_request: {
+        body: 'Closes #999',
+        head: {
+          ref: 'factory/999-atomic-label-reconciliation',
+          repo: { full_name: 'JoshCLWren/comic-pile' },
+        },
+        labels: [{ name: 'factory' }],
+        number: 1000,
+      },
+    }),
+  });
+  assert.equal(calls.length, 1);
+  assert.ok(calls[0].labels.includes('factory:local'));
+  assert.ok(calls[0].labels.includes('factory:review'));
+  assert.ok(!calls[0].labels.includes('factory:5'));
+  assert.ok(!calls[0].labels.includes('factory:building'));
+});

--- a/.github/workflows/factory-visibility.yml
+++ b/.github/workflows/factory-visibility.yml
@@ -14,227 +14,25 @@ permissions:
   issues: write
   pull-requests: write
 
+concurrency:
+  group: >-
+    factory-visibility-${{ github.repository }}-${{
+    github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
 jobs:
   label-factory-work:
     runs-on: ubuntu-latest
     steps:
+      - name: Check out trusted workflow code
+        uses: actions/checkout@v7
+
+      - name: Run factory visibility regression tests
+        run: node --test .github/scripts/factory-visibility.test.cjs
+
       - name: Synchronize factory owner and stage labels
         uses: actions/github-script@v7
         with:
           script: |
-            const definitions = {
-              factory: ['5319E7', 'Work owned or produced by an autonomous ComicPile factory'],
-              'factory:1': ['0366D6', 'Current next-action owner is ComicPile Factory 1'],
-              'factory:2': ['0366D6', 'Current next-action owner is ComicPile Factory 2'],
-              'factory:3': ['0366D6', 'Current next-action owner is ComicPile Factory 3'],
-              'factory:4': ['0366D6', 'Current next-action owner is ComicPile Factory 4'],
-              'factory:5': ['0366D6', 'Current next-action owner is ComicPile Factory 5'],
-              'factory:local': ['0366D6', 'Current next-action owner is the local OpenCode factory'],
-              'factory:unowned': ['BFDADC', 'Factory work has no current next-action owner'],
-              'factory:building': ['FBCA04', 'A factory is actively implementing or repairing this work'],
-              'factory:review': ['D4C5F9', 'The exact current head needs review or re-review'],
-              'factory:changes-requested': ['D73A4A', 'Actionable review findings currently block progress'],
-              'factory:ci': ['1D76DB', 'Review passed and required exact-head checks are being verified'],
-              'factory:ready': ['0E8A16', 'All exact-head factory merge gates are satisfied'],
-              'factory:blocked': ['B60205', 'A genuine human, credential, or external blocker remains'],
-            };
-            const ownerLabels = [
-              'factory:1', 'factory:2', 'factory:3', 'factory:4',
-              'factory:5', 'factory:local', 'factory:unowned',
-            ];
-            const stageLabels = [
-              'factory:building', 'factory:review', 'factory:changes-requested',
-              'factory:ci', 'factory:ready', 'factory:blocked',
-            ];
-            const trustedAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
-
-            function trusted(login, association) {
-              return trustedAssociations.has(association)
-                || login === 'coderabbitai[bot]'
-                || login === 'coderabbitai';
-            }
-
-            function workerFrom(body) {
-              for (const pattern of [
-                /comic-pile-factory-implement-(?:claim|progress)-v\d+:issue-\d+:([^:\s>]+):/,
-                /comic-pile-factory-review-claim-v\d+:[^:\s>]+:([^:\s>]+):/,
-                /comic-pile-factory-fix-(?:claim|progress)-v\d+:[^:\s>]+:([^:\s>]+):/,
-                /comic-pile-factory-claim-released-v\d+:[^:\s>]+:([^:\s>]+):/,
-              ]) {
-                const match = body.match(pattern);
-                if (match) return match[1];
-              }
-              return null;
-            }
-
-            function ownerFor(worker) {
-              const scheduled = worker?.match(/^chatgpt-factory-([1-5])$/);
-              if (scheduled) return `factory:${scheduled[1]}`;
-              if (worker?.startsWith('local-opencode-') || worker === 'local-opencode') {
-                return 'factory:local';
-              }
-              return 'factory:unowned';
-            }
-
-            function stageFrom(body) {
-              if (/comic-pile-factory-needs-human-v\d+:/.test(body)) return 'factory:blocked';
-              if (/comic-pile-factory-ready-v\d+:/.test(body)) return 'factory:ready';
-              if (/comic-pile-factory-review-v\d+:[^:\s>]+:changes-required/.test(body)) {
-                return 'factory:changes-requested';
-              }
-              if (/comic-pile-factory-review-v\d+:[^:\s>]+:pass/.test(body)) return 'factory:ci';
-              if (/comic-pile-factory-review-claim-v\d+:/.test(body)) return 'factory:review';
-              if (
-                /comic-pile-factory-implement-(?:claim|progress)-v\d+:/.test(body)
-                || /comic-pile-factory-fix-(?:claim|progress)-v\d+:/.test(body)
-              ) return 'factory:building';
-              return null;
-            }
-
-            async function ensureLabels() {
-              const existing = await github.paginate(github.rest.issues.listLabelsForRepo, {
-                owner: context.repo.owner, repo: context.repo.repo, per_page: 100,
-              });
-              const byName = new Map(existing.map((label) => [label.name, label]));
-              for (const [name, [color, description]] of Object.entries(definitions)) {
-                const current = byName.get(name);
-                if (!current) {
-                  await github.rest.issues.createLabel({
-                    owner: context.repo.owner, repo: context.repo.repo,
-                    name, color, description,
-                  });
-                } else if (
-                  current.color.toUpperCase() !== color
-                  || (current.description || '') !== description
-                ) {
-                  await github.rest.issues.updateLabel({
-                    owner: context.repo.owner, repo: context.repo.repo,
-                    name, new_name: name, color, description,
-                  });
-                }
-              }
-            }
-
-            async function currentLabels(number) {
-              const labels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
-                owner: context.repo.owner, repo: context.repo.repo,
-                issue_number: number, per_page: 100,
-              });
-              return new Set(labels.map((label) => label.name));
-            }
-
-            async function replaceGroup(number, group, next) {
-              const current = await currentLabels(number);
-              for (const label of group) {
-                if (label !== next && current.has(label)) {
-                  await github.rest.issues.removeLabel({
-                    owner: context.repo.owner, repo: context.repo.repo,
-                    issue_number: number, name: label,
-                  });
-                }
-              }
-              if (next && !current.has(next)) {
-                await github.rest.issues.addLabels({
-                  owner: context.repo.owner, repo: context.repo.repo,
-                  issue_number: number, labels: [next],
-                });
-              }
-            }
-
-            async function markFactory(number) {
-              const current = await currentLabels(number);
-              if (!current.has('factory')) {
-                await github.rest.issues.addLabels({
-                  owner: context.repo.owner, repo: context.repo.repo,
-                  issue_number: number, labels: ['factory'],
-                });
-              }
-            }
-
-            async function ownerFromLinkedIssue(pr) {
-              const branch = pr.head.ref.match(/^factory\/(\d+)(?:-|$)/);
-              const closing = (pr.body || '').match(
-                /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/i,
-              );
-              const issueNumber = Number(branch?.[1] || closing?.[1] || 0);
-              if (!issueNumber) return 'factory:unowned';
-
-              const comments = await github.paginate(github.rest.issues.listComments, {
-                owner: context.repo.owner, repo: context.repo.repo,
-                issue_number: issueNumber, per_page: 100,
-              });
-              comments.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
-              for (const comment of comments) {
-                if (!trusted(comment.user?.login, comment.author_association)) continue;
-                const body = comment.body || '';
-                if (/comic-pile-factory-claim-released-v\d+:/.test(body)) {
-                  return 'factory:unowned';
-                }
-                const worker = workerFrom(body);
-                if (worker) return ownerFor(worker);
-              }
-              return 'factory:unowned';
-            }
-
-            await ensureLabels();
-
-            if (context.eventName === 'issue_comment') {
-              const comment = context.payload.comment;
-              const body = comment?.body || '';
-              if (!body.includes('comic-pile-factory-')) return;
-              if (!trusted(comment?.user?.login, comment?.author_association)) return;
-
-              const number = context.payload.issue.number;
-              await markFactory(number);
-              const released = /comic-pile-factory-claim-released-v\d+:/.test(body);
-              const worker = workerFrom(body);
-              if (released || worker) {
-                await replaceGroup(number, ownerLabels, released ? 'factory:unowned' : ownerFor(worker));
-              }
-              const stage = stageFrom(body);
-              if (stage) await replaceGroup(number, stageLabels, stage);
-              return;
-            }
-
-            if (context.eventName === 'pull_request_target') {
-              const pr = context.payload.pull_request;
-              const sameRepo = pr.head.repo?.full_name === context.payload.repository.full_name;
-              const alreadyFactory = (pr.labels || []).some((label) => label.name === 'factory');
-              const isFactory = alreadyFactory || (
-                sameRepo
-                && (pr.head.ref.startsWith('factory/') || (pr.body || '').includes('comic-pile-factory-'))
-              );
-              if (!isFactory) return;
-
-              await markFactory(pr.number);
-              if (['opened', 'reopened', 'ready_for_review'].includes(context.payload.action)) {
-                await replaceGroup(pr.number, ownerLabels, await ownerFromLinkedIssue(pr));
-              }
-              await replaceGroup(pr.number, stageLabels, 'factory:review');
-              return;
-            }
-
-            if (context.eventName === 'pull_request_review') {
-              const pr = context.payload.pull_request;
-              const current = await currentLabels(pr.number);
-              const sameRepo = pr.head.repo?.full_name === context.payload.repository.full_name;
-              if (!(current.has('factory') || (sameRepo && pr.head.ref.startsWith('factory/')))) return;
-
-              await markFactory(pr.number);
-              if (context.payload.action === 'dismissed') {
-                await replaceGroup(pr.number, stageLabels, 'factory:review');
-                return;
-              }
-
-              const review = context.payload.review;
-              if (!trusted(review.user?.login, review.author_association)) return;
-              const state = (review.state || '').toUpperCase();
-              const body = review.body || '';
-              let stage = 'factory:review';
-              if (state === 'CHANGES_REQUESTED') stage = 'factory:changes-requested';
-              else if (state === 'APPROVED') stage = 'factory:ci';
-              else if (/Actionable comments posted:\s*[1-9]\d*/i.test(body)) {
-                stage = 'factory:changes-requested';
-              }
-              await replaceGroup(pr.number, stageLabels, stage);
-            }
+            const reconcile = require('./.github/scripts/factory-visibility.cjs');
+            await reconcile({ github, context, core });

--- a/docs/changelog.d/2026-08-09-1000.md
+++ b/docs/changelog.d/2026-08-09-1000.md
@@ -1,0 +1,5 @@
+## 2026-08-09
+
+### Operations
+
+- [#1000](https://github.com/JoshCLWren/comic-pile/pull/1000) makes factory ownership and workflow labels atomic, retry-safe, and aware of exact-head review state, preventing scheduled and local workers from receiving stale or contradictory assignments.


### PR DESCRIPTION
Closes #999

## Summary
- recognize canonical `local` worker markers as `factory:local`
- serialize visibility runs per issue or pull request
- reconcile owner and workflow-state labels with one atomic full-label update
- retry transient GitHub 429 and 5xx failures
- refresh ownership on every relevant pull-request event
- prevent delayed PR progress comments from downgrading review, CI, or ready state
- run focused reconciler regression tests inside the workflow

## Validation
- `node --test .github/scripts/factory-visibility.test.cjs` (5 tests)
- parsed `.github/workflows/factory-visibility.yml` with PyYAML
- `git diff --check`

Changelog: `docs/changelog.d/2026-08-09-1000.md`