### PR TITLE
Synchronize factory contract v19

### DIFF
--- a/.agents/skills/github-issue-kanban/SKILL.md
+++ b/.agents/skills/github-issue-kanban/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: github-issue-kanban
 description: Use GitHub Issues as the Comic Pile kanban and execution queue. Trigger whenever the user asks an agent to do the next task, pick the next issue, work from the backlog, update issue status, plan issue work, or keep GitHub work synchronized. Use this skill before editing code for any issue-driven task in this repository.
-compatibility: Requires git, gh CLI authentication, and the repository's GitHub remote.
 ---
 
 # GitHub issue workflow
@@ -18,7 +17,11 @@ make next-task
 
 Use the issue selected by that command unless the user explicitly names another issue. The selector prefers open issues with `ralph-status:pending`, highest `ralph-priority:*`, and no unresolved issue dependencies. Epics, blocked issues, issues already in progress/review, duplicates, and issues with unresolved dependencies are not selected.
 
-Then read only the selected issue body, the files it names, `AGENTS.md`, and `docs/ISSUE_EXECUTION_PROTOCOL.md`. Do not load every issue comment. If the issue points to `docs/issue-plans/<number>.md`, read that plan in bounded chunks.
+Then read the selected issue body, the files it names, `AGENTS.md`, and
+`docs/ISSUE_EXECUTION_PROTOCOL.md`. For factory work, also read
+`docs/AUTONOMOUS_FACTORY_POLICY.md` and the latest canonical resume packet. Do not load unrelated
+comment history. If the issue points to `docs/issue-plans/<number>.md`, read that plan in bounded
+chunks.
 
 ## Start work
 
@@ -26,12 +29,18 @@ Before editing code:
 
 1. Confirm the issue is open and still eligible.
 2. Confirm dependencies are closed or explicitly non-blocking.
-3. Move the issue to active work:
+3. Move the issue to active work. For factory work, replace the complete label set atomically so
+   it contains `factory`, `factory:building`, and exactly one owner label without exposing an
+   intermediate contradictory state:
 
    ```bash
-   gh issue edit ISSUE --remove-label "ralph-status:pending" --add-label "ralph-status:in-progress"
+   gh api --method PUT repos/JoshCLWren/comic-pile/issues/ISSUE/labels \
+     --input /path/to/complete-truthful-label-set.json
    gh issue comment ISSUE --body "Starting implementation from the repository issue workflow."
    ```
+
+   Build the JSON label set from the issue's current unrelated labels plus the complete target
+   Ralph status, factory stage, and factory owner. Do not use add-only or sequential label calls.
 
 4. Make the smallest complete change within the issue scope.
 5. If required work is outside the issue, create a linked issue before expanding scope.
@@ -64,12 +73,19 @@ gh issue comment ISSUE --body-file /path/to/verification-comment.md
 
 The verification comment must include changed files, acceptance criteria evidence, commands and results, and follow-up issue numbers.
 
-After the PR is created and all checks and acceptance criteria pass:
+After the PR merges and acceptance criteria and issue closure are verified:
 
 ```bash
-gh issue edit ISSUE --remove-label "ralph-status:in-review" --add-label "ralph-status:done"
+gh api --method PUT repos/JoshCLWren/comic-pile/issues/ISSUE/labels \
+  --input /path/to/complete-done-label-set.json
 gh issue close ISSUE --reason completed
 ```
+
+If claimed work remains unfinished when releasing ownership, switching work, reaching a runtime
+limit, or ending the turn, create or update one `<!-- factory-resume:v1 -->` comment in place. Keep
+it compact: current head, hypothesis, files touched, passed/failed checks, next narrow verification,
+remaining action, worker ID, and UTC timestamp. A takeover worker must verify the recorded head and
+discard or update stale claims before acting.
 
 ## Issue hierarchy
 

--- a/.github/workflows/factory-policy.yml
+++ b/.github/workflows/factory-policy.yml
@@ -6,6 +6,9 @@ on:
       - AGENTS.md
       - docs/AUTONOMOUS_FACTORY_POLICY.md
       - docs/ISSUE_EXECUTION_PROTOCOL.md
+      - docs/CHATGPT_FACTORY_PROMPT.md
+      - prompts/agent-next-task.md
+      - .agents/skills/github-issue-kanban/SKILL.md
       - scripts/comic-pile-opencode-factory.sh
       - scripts/comic-pile-opencode-factory-heartbeat.sh
       - scripts/comic-pile-opencode-factory-overnight.sh
@@ -14,6 +17,10 @@ on:
       - scripts/install-git-hooks.sh
       - .githooks/prepare-commit-msg
       - scripts/check-autonomous-factory-policy.py
+      - scripts/opencode_pipeline.sh
+      - scripts/sync_public_factory_snapshot.py
+      - scripts/tests/test_sync_public_factory_snapshot.py
+      - .github/workflows/sync-public-factory.yml
       - scripts/tests/test_autonomous_factory_policy.py
       - scripts/tests/test_install_git_hooks.py
       - scripts/tests/test_opencode_model_tools.py
@@ -27,6 +34,9 @@ on:
       - AGENTS.md
       - docs/AUTONOMOUS_FACTORY_POLICY.md
       - docs/ISSUE_EXECUTION_PROTOCOL.md
+      - docs/CHATGPT_FACTORY_PROMPT.md
+      - prompts/agent-next-task.md
+      - .agents/skills/github-issue-kanban/SKILL.md
       - scripts/comic-pile-opencode-factory.sh
       - scripts/comic-pile-opencode-factory-heartbeat.sh
       - scripts/comic-pile-opencode-factory-overnight.sh
@@ -35,6 +45,10 @@ on:
       - scripts/install-git-hooks.sh
       - .githooks/prepare-commit-msg
       - scripts/check-autonomous-factory-policy.py
+      - scripts/opencode_pipeline.sh
+      - scripts/sync_public_factory_snapshot.py
+      - scripts/tests/test_sync_public_factory_snapshot.py
+      - .github/workflows/sync-public-factory.yml
       - scripts/tests/test_autonomous_factory_policy.py
       - scripts/tests/test_install_git_hooks.py
       - scripts/tests/test_opencode_model_tools.py
@@ -63,7 +77,9 @@ jobs:
         run: |
           python -m py_compile \
             scripts/check-autonomous-factory-policy.py \
+            scripts/sync_public_factory_snapshot.py \
             scripts/tests/test_autonomous_factory_policy.py \
+            scripts/tests/test_sync_public_factory_snapshot.py \
             scripts/tests/test_install_git_hooks.py \
             scripts/tests/test_opencode_model_tools.py \
             scripts/tests/test_opencode_provider_rotation.py \
@@ -71,7 +87,10 @@ jobs:
       - name: Check canonical factory invariants
         run: python scripts/check-autonomous-factory-policy.py
       - name: Test policy drift detection
-        run: python -m unittest scripts/tests/test_autonomous_factory_policy.py
+        run: >-
+          python -m unittest
+          scripts/tests/test_autonomous_factory_policy.py
+          scripts/tests/test_sync_public_factory_snapshot.py
       - name: Test git hook installer
         run: python -m unittest scripts/tests/test_install_git_hooks.py
       - name: Test model rotation and scout supervision

--- a/.github/workflows/sync-public-factory.yml
+++ b/.github/workflows/sync-public-factory.yml
@@ -1,0 +1,57 @@
+name: Sync public factory snapshot
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - AGENTS.md
+      - docs/CHATGPT_FACTORY_PROMPT.md
+      - docs/AUTONOMOUS_FACTORY_POLICY.md
+      - docs/ISSUE_EXECUTION_PROTOCOL.md
+      - docs/FACTORY_GITHUB_VISIBILITY.md
+      - scripts/sync_public_factory_snapshot.py
+      - .github/workflows/sync-public-factory.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-public-factory-snapshot
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out private canonical source
+        uses: actions/checkout@v4
+        with:
+          path: comic-pile
+
+      - name: Check out public snapshot
+        uses: actions/checkout@v4
+        with:
+          repository: JoshCLWren/factory
+          path: factory
+          ssh-key: ${{ secrets.FACTORY_SYNC_DEPLOY_KEY }}
+
+      - name: Copy allowlisted factory documentation
+        run: python comic-pile/scripts/sync_public_factory_snapshot.py comic-pile factory
+
+      - name: Commit and push synchronization branch
+        working-directory: factory
+        run: |
+          if git diff --quiet; then
+            echo "Public factory snapshot is already current."
+            exit 0
+          fi
+
+          branch="sync/comic-pile-factory"
+          git config user.name "comic-pile-factory-sync[bot]"
+          git config user.email "comic-pile-factory-sync[bot]@users.noreply.github.com"
+          git switch -C "$branch"
+          git add AGENTS.md FACTORY_PROMPT.md docs/
+          git commit -m "Sync ComicPile factory contract"
+          git push --force-with-lease origin "HEAD:$branch"

--- a/docs/AUTONOMOUS_FACTORY_POLICY.md
+++ b/docs/AUTONOMOUS_FACTORY_POLICY.md
@@ -1,6 +1,6 @@
 # ComicPile Autonomous Factory Policy
 
-Version: 18
+Version: 19
 
 This is the canonical policy for every scheduled ChatGPT worker, the local OpenCode factory, and interactive factory repair sessions.
 
@@ -173,8 +173,9 @@ claiming, opening or replaying a PR, handing work off, receiving review, startin
 becoming ready, blocking, merging, and ending a turn. Josh must never need to request routine
 factory labels.
 
-Apply these states exactly; remove mutually exclusive state and owner labels during every
-transition:
+Apply these states exactly. Reconcile each target with one full label-set replacement so stale
+mutually exclusive state and owner labels disappear in the same atomic write that applies the
+complete truthful target set. Never implement a transition as separate remove-then-add calls:
 
 | State | Issue labels | Pull-request labels |
 |---|---|---|
@@ -201,8 +202,8 @@ Rules:
 - Cross-worker takeover and merge are allowed. The new worker replaces the owner label and may
   merge work it did not author after every exact-head gate passes.
 - If `gh pr edit` fails because of deprecated Projects Classic GraphQL fields, use the
-  issue-compatible REST endpoints: delete every stale workflow and owner label first, then add the
-  complete target factory label set. A POST alone only adds labels and is not reconciliation.
+  issue-compatible REST label-replacement endpoint with the complete target label set. A POST that
+  only adds labels, or sequential DELETE/POST calls, is not atomic reconciliation.
 - Before ending any turn, compare the issue, PR, review, CI, lease, and merge state and repair any
   metadata contradiction discovered.
 
@@ -244,6 +245,30 @@ Use the existing canonical marker schemas:
 - ready: `<!-- comic-pile-factory-ready-v2:<sha> -->`
 - needs human: `<!-- comic-pile-factory-needs-human-v2:<sha-or-issue> -->`
 - released: `<!-- comic-pile-factory-claim-released-v3:<target>:<worker>:<epoch>:<reason> -->`
+
+## Durable resume packet
+
+Before releasing ownership, reaching a runtime limit, switching work, or ending with a claimed
+issue or PR unfinished, create or update one canonical GitHub comment in place. Do not create a new
+packet on every heartbeat.
+
+```text
+<!-- factory-resume:v1 -->
+## Factory resume packet
+Head: `<current SHA or none>`
+Current hypothesis: <one or two concrete sentences>
+Files touched: <paths, or none>
+Checks: <passed and failed commands/checks; include the decisive failure>
+Next narrow verification: <one specific command, inspection, or experiment>
+Remaining blocker/action: <what the next worker must resolve>
+Updated by: <durable worker ID and UTC timestamp>
+```
+
+Record observed facts, distinguish local checks from CI, include no secrets, and keep the packet
+short. A takeover worker reads the current packet before reconstructing context, verifies that its
+recorded head still matches, and updates or discards stale claims instead of trusting them blindly.
+The packet is operational state, not a substitute for commits, tests, review markers, issue
+acceptance criteria, or truthful labels. Completed and verified work does not require a packet.
 
 Review leases last 45 minutes. Repair and implementation leases last 60 minutes after the latest real progress. Lease expiry permits another worker to continue that issue but does not require a peer to choose it over higher-priority work.
 

--- a/docs/CHATGPT_FACTORY_PROMPT.md
+++ b/docs/CHATGPT_FACTORY_PROMPT.md
@@ -1,11 +1,11 @@
 # ChatGPT Scheduled Factory Prompt
 
-Version: 18
+Version: 19
 
 Use this template for every scheduled ComicPile ChatGPT factory. Replace `<WORKER_NUMBER>`, `<WORKER_ID>`, and `<CALL_SIGN>` with the worker-specific values. The worker-specific identity is the only intended difference between scheduled factory prompts.
 
 ```text
-FACTORY POLICY V18 + GITHUB VISIBILITY. Act as one high-ownership autonomous software-delivery heartbeat for JoshCLWren/comic-pile. Durable worker ID: `<WORKER_ID>`. Factory call sign: `<CALL_SIGN>`.
+FACTORY POLICY V19 + GITHUB VISIBILITY + DURABLE RESUME PACKET V1. Act as one high-ownership autonomous software-delivery heartbeat for JoshCLWren/comic-pile. Durable worker ID: `<WORKER_ID>`. Factory call sign: `<CALL_SIGN>`.
 
 Read and follow current-main `docs/AUTONOMOUS_FACTORY_POLICY.md`, `docs/ISSUE_EXECUTION_PROTOCOL.md`, relevant `AGENTS.md`, and `docs/FACTORY_GITHUB_VISIBILITY.md` when present. Canonical policy wins over conflicting instructions.
 
@@ -15,13 +15,27 @@ Select branch-caused CI/conflict/actionable-review blockers first; then newest u
 
 Use every available GitHub, file, CI, review-thread, commit, push, and merge path. One failed tool call is not permanent capability loss. Never mutate factory schedules or automations unless Josh explicitly instructs you to do so.
 
-Keep canonical GitHub marker comments exact. Maintain `factory`, exactly one owner label, and exactly one stage label. Your owner label is `factory:<WORKER_NUMBER>`. Labels are internal visibility only.
+Keep canonical GitHub marker comments exact. Maintain `factory`, exactly one owner label, and exactly one stage label. Your owner label is `factory:<WORKER_NUMBER>`. Reconcile labels with one full atomic label-set replacement; never use sequential remove/add calls that expose contradictory intermediate states. Labels are internal visibility only.
 
 Use formal GitHub review state only when truthful and technically possible. Never fake self-approval. Before merging, inspect the current head, required checks, reviews, and inline threads. Fix or resolve every actionable finding. Every push invalidates earlier conclusions.
 
 Merge without asking again only when the current PR is open, non-draft, conflict-free, mergeable, fully green, complete, safe, and free of unresolved actionable findings. Never enable auto-merge or merge a moved head. Verify issue closure afterward.
 
 A heartbeat must deliver substantive implementation, repair a real blocker, open a coherent non-draft PR, perform a fully gated merge, create evidence-backed Chromium bugs when normal executable work is exhausted, or repair delivery infrastructure. Never push directly to main, create drafts without Josh's request, weaken checks, fabricate evidence, or count metadata-only work as progress.
+
+Before releasing ownership, reaching the runtime limit, switching work, or ending with a claimed item unfinished, create or update one canonical GitHub comment in place using this exact compact structure:
+
+`<!-- factory-resume:v1 -->`
+`## Factory resume packet`
+`Head: <current SHA or none>`
+`Current hypothesis: <one or two concrete sentences>`
+`Files touched: <paths, or none>`
+`Checks: <passed and failed commands/checks; include the decisive failure>`
+`Next narrow verification: <one specific command, inspection, or experiment>`
+`Remaining blocker/action: <what the next worker must resolve>`
+`Updated by: <durable worker ID and UTC timestamp>`
+
+Keep it short, factual, secret-free, and explicit about local versus CI evidence. A takeover worker must read it, verify that its head still matches, and update or discard stale claims before acting. It never substitutes for commits, tests, review markers, acceptance criteria, or truthful labels. Completed and verified work needs no packet.
 
 HUMAN-FRIENDLY UPDATE FORMAT
 Every user-visible update must use this exact structure:

--- a/docs/FACTORY_GITHUB_VISIBILITY.md
+++ b/docs/FACTORY_GITHUB_VISIBILITY.md
@@ -21,6 +21,11 @@ Exactly one stage label describes the current state:
 - `factory:ready`: every exact-head merge gate is satisfied;
 - `factory:blocked`: a genuine human, credential, or external blocker remains.
 
+Every transition replaces the complete label set atomically. Preserve unrelated labels, remove all
+stale owner and stage labels, and apply the single truthful owner and stage in one REST label-set
+replacement. Sequential remove/add calls and add-only POST requests are not reconciliation because
+other workers can observe contradictory intermediate state.
+
 The labels are synchronized automatically from existing factory claim, progress, review, ready, release, and needs-human markers. Pull requests on `factory/*` branches are also recognized automatically. A linked issue claim supplies the initial pull-request owner when the branch name starts with `factory/<issue-number>-...`.
 
 Only marker comments from the repository owner, members, or collaborators are trusted. Formal review transitions are accepted from trusted collaborators and CodeRabbit. Public commenters and untrusted fork branches cannot spoof factory ownership or stage labels.

--- a/docs/changelog.d/2026-08-09-1002.md
+++ b/docs/changelog.d/2026-08-09-1002.md
@@ -1,0 +1,7 @@
+## 2026-08-09
+
+### Operations
+
+- [#1002](https://github.com/JoshCLWren/comic-pile/pull/1002) synchronizes scheduled and local
+  factory workers on Version 19, adding compact durable resume packets and preventing interrupted
+  work, unsafe hook bypasses, premature issue closure, and non-atomic label transitions.

--- a/prompts/agent-next-task.md
+++ b/prompts/agent-next-task.md
@@ -6,14 +6,17 @@ Work on the next task in this repository.
 
 1. Read `AGENTS.md`.
 2. Read `docs/ISSUE_EXECUTION_PROTOCOL.md`.
-3. Inspect `git status` and preserve all existing user changes.
-4. Run `make next-task`.
-5. Read the selected GitHub issue and any linked local plan.
-6. If the issue is too large for one implementation pass, split it into linked GitHub task/subtask issues before editing code.
+3. Read `docs/AUTONOMOUS_FACTORY_POLICY.md` when factory work is involved.
+4. Inspect `git status` and preserve all existing user changes.
+5. Run `make next-task`.
+6. Read the selected GitHub issue and any linked local plan.
+7. If the issue is too large for one implementation pass, split it into linked GitHub task/subtask issues before editing code.
 
 ## While working
 
 - Move the selected issue from `ralph-status:pending` to `ralph-status:in-progress`.
+- For factory work, atomically reconcile the complete label set to `factory`, `factory:building`,
+  and exactly one owner label; never transition labels with sequential remove/add calls.
 - Implement only that issue's scope.
 - Add regression tests for changed behavior.
 - Fix failures; never skip tests or use CI as a debugger.
@@ -21,6 +24,9 @@ Work on the next task in this repository.
 - If blocked, mark the issue `ralph-status:blocked`, explain the exact blocker, and stop.
 - Do not use the archived Markdown kanban as a status source.
 - Do not discard, reset, or overwrite unrelated working-tree changes.
+- Before ending with claimed work unfinished, update the canonical `<!-- factory-resume:v1 -->`
+  comment with the current head, hypothesis, files touched, checks, next narrow verification,
+  remaining action, worker ID, and UTC timestamp.
 
 ## Before finishing
 
@@ -28,6 +34,8 @@ Work on the next task in this repository.
 - Move the issue to `ralph-status:in-review`.
 - Add a GitHub comment listing changed files, acceptance-criteria evidence, test commands, and results.
 - Commit the implementation with a descriptive message, push the branch, and open a ready-for-review pull request linked to the issue. This is the default completion workflow for every selected issue; do not leave verified work only in the local working tree.
-- Only after the PR is created and everything passes, mark the issue `ralph-status:done` and close it. If the user explicitly asks for a draft PR, create a draft instead.
+- Leave the issue in review while its PR is open. Mark it `ralph-status:done` and close it only
+  after the PR merges and acceptance criteria and issue closure are verified. If the user
+  explicitly asks for a draft PR, create a draft instead.
 
 Begin by running `make next-task`.

--- a/scripts/check-autonomous-factory-policy.py
+++ b/scripts/check-autonomous-factory-policy.py
@@ -9,6 +9,9 @@ PROTOCOL = ROOT / "docs/ISSUE_EXECUTION_PROTOCOL.md"
 SCHEDULED_PROMPT = ROOT / "docs/CHATGPT_FACTORY_PROMPT.md"
 ENTRYPOINT = ROOT / "scripts/comic-pile-opencode-factory.sh"
 HEARTBEAT_ENTRYPOINT = ROOT / "scripts/comic-pile-opencode-factory-heartbeat.sh"
+NEXT_TASK_PROMPT = ROOT / "prompts/agent-next-task.md"
+ISSUE_SKILL = ROOT / ".agents/skills/github-issue-kanban/SKILL.md"
+LEGACY_PIPELINE = ROOT / "scripts/opencode_pipeline.sh"
 
 
 def require(text: str, needle: str, source: Path) -> None:
@@ -53,7 +56,7 @@ def validate_texts(policy: str, protocol: str, entrypoint: str) -> None:
         None.
     """
     for needle in (
-        "Version: 18",
+        "Version: 19",
         "Every product, behavior, deployment, operational, or factory-tooling PR must update",
         "exactly one isolated Markdown fragment",
         "`docs/changelog.md` is the frozen historical archive",
@@ -83,6 +86,10 @@ def validate_texts(policy: str, protocol: str, entrypoint: str) -> None:
         "Firefox and WebKit may be run manually",
         "Never push directly to `main`.",
         "Never create or convert a draft PR unless Josh explicitly requests a draft.",
+        "## Durable resume packet",
+        "<!-- factory-resume:v1 -->",
+        "one full label-set replacement",
+        "Never implement a transition as separate remove-then-add calls",
     ):
         require(policy, needle, POLICY)
 
@@ -95,6 +102,7 @@ def validate_texts(policy: str, protocol: str, entrypoint: str) -> None:
         "comic-pile-factory-fix-claim-v3",
         "comic-pile-factory-fix-progress-v3",
         "comic-pile-factory-ready-v2",
+        "factory-resume:v1",
         "comic-pile-factory-needs-human-v2",
         "comic-pile-factory-claim-released-v3",
     ):
@@ -179,8 +187,37 @@ def validate_texts(policy: str, protocol: str, entrypoint: str) -> None:
         "full configured E2E matrix",
         "Firefox + WebKit + Chromium",
         "Treat docs/changelog.md as part of the completion contract",
+        "core.hooksPath=/dev/null",
+        "commit even if tests are not fully passing",
+        "commit even if not fully passing",
     ):
         forbid(entrypoint, obsolete, ENTRYPOINT)
+
+
+def validate_local_guidance() -> None:
+    """Validate every local and scheduled factory entry point independently.
+
+    Returns:
+        None.
+    """
+    for source in (SCHEDULED_PROMPT, HEARTBEAT_ENTRYPOINT, NEXT_TASK_PROMPT, ISSUE_SKILL):
+        text = source.read_text(encoding="utf-8")
+        require(text, "factory-resume:v1", source)
+
+    scheduled = SCHEDULED_PROMPT.read_text(encoding="utf-8")
+    require(scheduled, "Version: 19", SCHEDULED_PROMPT)
+    require(scheduled, "one full atomic label-set replacement", SCHEDULED_PROMPT)
+
+    next_task = NEXT_TASK_PROMPT.read_text(encoding="utf-8")
+    require(next_task, "only\n  after the PR merges", NEXT_TASK_PROMPT)
+
+    issue_skill = ISSUE_SKILL.read_text(encoding="utf-8")
+    require(issue_skill, "After the PR merges", ISSUE_SKILL)
+
+    legacy = LEGACY_PIPELINE.read_text(encoding="utf-8")
+    forbid(legacy, "core.hooksPath=/dev/null", LEGACY_PIPELINE)
+    forbid(legacy, "commit even if tests are not fully passing", LEGACY_PIPELINE)
+    forbid(legacy, "commit even if not fully passing", LEGACY_PIPELINE)
 
 
 def read_entrypoint_text() -> str:
@@ -209,6 +246,7 @@ def main() -> None:
         PROTOCOL.read_text(encoding="utf-8"),
         read_entrypoint_text(),
     )
+    validate_local_guidance()
     print("Autonomous factory policy invariants are aligned.")
 
 

--- a/scripts/comic-pile-opencode-factory-heartbeat.sh
+++ b/scripts/comic-pile-opencode-factory-heartbeat.sh
@@ -251,6 +251,28 @@ REPOSITORY SAFETY
   or manufacture evidence.
 - Never mutate schedules or factory topology.
 
+GITHUB VISIBILITY
+Maintain `factory`, exactly one workflow-stage label, and exactly one next-action owner label on
+every managed issue and PR. Reconcile each transition with one full atomic label-set replacement;
+never use sequential remove/add calls that expose contradictory intermediate states. This local
+worker maps to `factory:local`. Labels are visibility metadata and never substitute for merge gates.
+
+DURABLE RESUME PACKET V1
+Before releasing ownership, reaching the runtime limit, switching work, or ending with a claimed
+item unfinished, create or update one canonical GitHub comment in place:
+`<!-- factory-resume:v1 -->`
+`## Factory resume packet`
+`Head: <current SHA or none>`
+`Current hypothesis: <one or two concrete sentences>`
+`Files touched: <paths, or none>`
+`Checks: <passed and failed commands/checks; include the decisive failure>`
+`Next narrow verification: <one specific command, inspection, or experiment>`
+`Remaining blocker/action: <what the next worker must resolve>`
+`Updated by: <durable worker ID and UTC timestamp>`
+Keep it short, factual, secret-free, and explicit about local versus CI evidence. A takeover worker
+must verify that the recorded head still matches and update or discard stale claims before acting.
+The packet never substitutes for commits, tests, review markers, acceptance criteria, or labels.
+
 TOOLING GATE
 Confirm checkout, focused tests, commit, push, GitHub reads/writes, review-thread access,
 CI-log access, and merge access. Print:
@@ -298,7 +320,7 @@ PROMPT
 FACTORY_PROMPT="${FACTORY_PROMPT//__WORKER_ID__/$WORKER_ID}"
 FACTORY_PROMPT="${FACTORY_PROMPT//__MODEL_ID__/$MODEL}"
 
-printf 'ComicPile local factory v17 (backlog-drain, release-note fragments, and gated-merge)\n'
+printf 'ComicPile local factory v19 (atomic labels and durable resume packets)\n'
 printf '  Source repo: %s\n' "$SOURCE_REPO"
 printf '  Worktree:    %s\n' "$WORKTREE"
 printf '  Model:       %s\n' "$MODEL"

--- a/scripts/opencode_pipeline.sh
+++ b/scripts/opencode_pipeline.sh
@@ -721,16 +721,16 @@ The repo is already checked out in your working directory.
 2. Understand the existing code before changing anything — read relevant files first
 3. Implement the fix following EVERY acceptance criterion in the issue
 4. Run: make lint — must pass with zero errors
-5. Run: make pytest — aim for ≥96% coverage; commit even if tests are not fully passing yet
-6. Commit your changes: git add -A && git -c core.hooksPath=/dev/null commit -m 'fix: <description> (closes #${issue})'
+5. Run: make pytest — all tests and the configured coverage gate must pass
+6. Commit your changes: git add -A && git commit -m 'fix: <description> (closes #${issue})'
 7. Write a brief summary of every file you changed and why
 
 STANDARDS:
 - No Any types (ruff ANN401)
 - Mobile-first, touch targets ≥44px for UI changes
-- Update docs/changelog.md
+- Add the required isolated docs/changelog.d fragment when the change is user-facing
 - Do NOT open a PR — stop after committing
-- IMPORTANT: Always use 'git -c core.hooksPath=/dev/null commit' to bypass pre-commit hooks
+- Never bypass pre-commit hooks or commit with failing tests
 
 Start immediately. Do not ask questions."
 
@@ -896,12 +896,12 @@ ${review_summary}
 Your tasks:
 1. Address EVERY numbered problem listed above
 2. Run make lint — must pass
-3. Run make pytest — aim for ≥96% coverage; commit even if not fully passing yet
-4. Commit your changes: git add -A && git -c core.hooksPath=/dev/null commit -m 'fix: address CI/review feedback for #${issue}'
+3. Run make pytest — all tests and the configured coverage gate must pass
+4. Commit your changes: git add -A && git commit -m 'fix: address CI/review feedback for #${issue}'
 5. Push the branch: git push -u origin HEAD
 6. Write a brief summary of what you changed for each item
 
-IMPORTANT: Always use 'git -c core.hooksPath=/dev/null commit' to bypass pre-commit hooks.
+IMPORTANT: Never bypass pre-commit hooks or commit with failing tests.
 Do not skip any item. Do not open a new PR. Do not ask questions."
 
             local reset_state

--- a/scripts/sync_public_factory_snapshot.py
+++ b/scripts/sync_public_factory_snapshot.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Synchronize the allowlisted public factory snapshot from Comic Pile."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+FILE_MAP = {
+    Path("AGENTS.md"): Path("AGENTS.md"),
+    Path("docs/CHATGPT_FACTORY_PROMPT.md"): Path("FACTORY_PROMPT.md"),
+    Path("docs/AUTONOMOUS_FACTORY_POLICY.md"): Path("docs/AUTONOMOUS_FACTORY_POLICY.md"),
+    Path("docs/ISSUE_EXECUTION_PROTOCOL.md"): Path("docs/ISSUE_EXECUTION_PROTOCOL.md"),
+    Path("docs/FACTORY_GITHUB_VISIBILITY.md"): Path("docs/FACTORY_GITHUB_VISIBILITY.md"),
+}
+
+
+def sync_snapshot(source_root: Path, target_root: Path, *, check: bool = False) -> list[Path]:
+    """Copy or verify the explicitly allowlisted factory documentation.
+
+    Args:
+        source_root: Comic Pile repository root.
+        target_root: Public factory snapshot repository root.
+        check: Report drift without writing when true.
+
+    Returns:
+        Target-relative paths that differ from the source.
+    """
+    changed: list[Path] = []
+    for source_relative, target_relative in FILE_MAP.items():
+        source = source_root / source_relative
+        target = target_root / target_relative
+        if not source.is_file() or source.is_symlink():
+            raise ValueError(f"Unsafe or missing source file: {source}")
+        if target.is_symlink():
+            raise ValueError(f"Refusing to replace target symlink: {target}")
+
+        source_bytes = source.read_bytes()
+        target_bytes = target.read_bytes() if target.is_file() else None
+        if source_bytes == target_bytes:
+            continue
+        changed.append(target_relative)
+        if not check:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(source, target)
+    return changed
+
+
+def main() -> None:
+    """Parse command-line arguments and synchronize the snapshot."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", type=Path)
+    parser.add_argument("target", type=Path)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+
+    changed = sync_snapshot(args.source.resolve(), args.target.resolve(), check=args.check)
+    for path in changed:
+        print(path)
+    if args.check and changed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_autonomous_factory_policy.py
+++ b/scripts/tests/test_autonomous_factory_policy.py
@@ -95,20 +95,21 @@ class AutonomousFactoryPolicyTests(unittest.TestCase):
             self.validate(entrypoint=f"{self.entrypoint}\n{rule}\n")
 
     def test_current_sources_are_aligned(self) -> None:
-        """Accept the current V18 policy, protocol, and runtime prompts.
+        """Accept the current V19 policy, protocol, and runtime prompts.
 
         Returns:
             None.
         """
         self.validate()
+        CHECKER.validate_local_guidance()
 
     def test_version_and_backlog_goal_are_required(self) -> None:
-        """Require V18 and issue-backlog closure as the prime directive.
+        """Require V19 and issue-backlog closure as the prime directive.
 
         Returns:
             None.
         """
-        self.assert_policy_change_fails("Version: 18", "Version: 17")
+        self.assert_policy_change_fails("Version: 19", "Version: 18")
         self.assert_policy_change_fails(
             "Drive the open issue backlog to zero",
             "Keep existing pull requests busy",
@@ -301,6 +302,27 @@ class AutonomousFactoryPolicyTests(unittest.TestCase):
         """
         self.assert_runtime_rule_fails("ignore unresolved review threads")
         self.assert_runtime_rule_fails("Firefox + WebKit + Chromium")
+
+    def test_resume_packet_and_atomic_labels_are_required(self) -> None:
+        """Require durable handoff state and atomic label replacement.
+
+        Returns:
+            None.
+        """
+        self.assert_policy_change_fails("<!-- factory-resume:v1 -->", "<!-- resume -->")
+        self.assert_policy_change_fails(
+            "one full label-set replacement",
+            "several label mutations",
+        )
+
+    def test_runtime_rejects_hook_bypass_and_failed_test_commits(self) -> None:
+        """Reject unsafe legacy worker instructions.
+
+        Returns:
+            None.
+        """
+        self.assert_runtime_rule_fails("core.hooksPath=/dev/null")
+        self.assert_runtime_rule_fails("commit even if tests are not fully passing")
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_sync_public_factory_snapshot.py
+++ b/scripts/tests/test_sync_public_factory_snapshot.py
@@ -1,0 +1,63 @@
+"""Tests for the allowlisted public factory snapshot synchronizer."""
+
+import tempfile
+import unittest
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "sync_public_factory_snapshot.py"
+SPEC = spec_from_file_location("sync_public_factory_snapshot", SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Unable to load {SCRIPT}")
+SYNC = module_from_spec(SPEC)
+SPEC.loader.exec_module(SYNC)
+
+
+class SyncPublicFactorySnapshotTests(unittest.TestCase):
+    """Verify allowlisted, deterministic synchronization behavior."""
+
+    def test_sync_copies_only_allowlisted_files_and_detects_drift(self) -> None:
+        """Copy mapped files while preserving unrelated target content."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source"
+            target = root / "target"
+            for index, (source_relative, target_relative) in enumerate(SYNC.FILE_MAP.items()):
+                source_path = source / source_relative
+                source_path.parent.mkdir(parents=True, exist_ok=True)
+                source_path.write_text(f"canonical-{index}\n", encoding="utf-8")
+                target_path = target / target_relative
+                target_path.parent.mkdir(parents=True, exist_ok=True)
+                target_path.write_text("stale\n", encoding="utf-8")
+
+            unrelated = target / "README.md"
+            unrelated.write_text("preserve me\n", encoding="utf-8")
+
+            drift = SYNC.sync_snapshot(source, target, check=True)
+            self.assertEqual(set(drift), set(SYNC.FILE_MAP.values()))
+
+            changed = SYNC.sync_snapshot(source, target)
+            self.assertEqual(set(changed), set(SYNC.FILE_MAP.values()))
+            self.assertEqual(SYNC.sync_snapshot(source, target, check=True), [])
+            self.assertEqual(unrelated.read_text(encoding="utf-8"), "preserve me\n")
+
+    def test_sync_rejects_source_symlinks(self) -> None:
+        """Prevent an allowlisted path from redirecting to unintended private data."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source"
+            target = root / "target"
+            first_source = next(iter(SYNC.FILE_MAP))
+            source_path = source / first_source
+            source_path.parent.mkdir(parents=True, exist_ok=True)
+            private = root / "private"
+            private.write_text("secret\n", encoding="utf-8")
+            source_path.symlink_to(private)
+
+            with self.assertRaisesRegex(ValueError, "Unsafe or missing source"):
+                SYNC.sync_snapshot(source, target)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1001

## Summary

- bump scheduled and local factory guidance to Version 19
- add Durable Resume Packet V1 across canonical prompts and the issue skill
- require single-call atomic label replacement and closure only after verified merge
- remove hook-bypass and failed-test commit instructions from the legacy pipeline
- synchronize the five-file allowlisted public snapshot to `JoshCLWren/factory`
- open and automatically squash-merge public snapshot synchronization PRs
- add regression coverage for policy drift and the public allowlist

## Validation

- `python scripts/check-autonomous-factory-policy.py`
- 34 focused factory-policy, sync, hook, model, and overnight-runner tests
- repository skill validation
- shell syntax validation
- workflow YAML parsing
- `git diff --check`
- pre-commit hooks

## Public snapshot bootstrap

- factory PR #1 published Version 19
- factory PR #3 installed automatic squash merging
- factory PR #4 moved automation to the stable sync branch
- installed a write-scoped deploy key for only `JoshCLWren/factory`

Changelog: `docs/changelog.d/2026-08-09-1002.md`