### PR TITLE
Add readable daily What's New summaries

### DIFF
--- a/docs/changelog.d/2026-08-09-1006.md
+++ b/docs/changelog.d/2026-08-09-1006.md
@@ -1,0 +1,5 @@
+## 2026-08-09
+
+### What’s New
+
+- What’s New now groups release notes by readable day, adds a short daily summary, and keeps exact source timestamps available for local-time display when release data provides them. [#1006](https://github.com/JoshCLWren/comic-pile/pull/1006)

--- a/frontend/src/pages/WhatsNewPage.tsx
+++ b/frontend/src/pages/WhatsNewPage.tsx
@@ -121,7 +121,8 @@ function summarizeDay(blocks: Block[]) {
     if (block.type === 'paragraph') return count + 1
     return count
   }, 0)
-  const countText = `${updateCount || 1} ${updateCount === 1 ? 'update' : 'updates'}`
+  const effectiveUpdateCount = updateCount || 1
+  const countText = `${effectiveUpdateCount} ${effectiveUpdateCount === 1 ? 'update' : 'updates'}`
   const uniqueAreas = [...new Set(areas)]
 
   if (uniqueAreas.length === 0) return `${countText} published this day.`

--- a/frontend/src/pages/WhatsNewPage.tsx
+++ b/frontend/src/pages/WhatsNewPage.tsx
@@ -146,7 +146,13 @@ export function buildChangelogView(markdown: string, timeZone?: string): Changel
     let cursor = index + 1
     while (cursor < blocks.length) {
       const next = blocks[cursor]
-      if (next.type === 'heading' && next.level === 2 && isSourceDateTime(next.text)) break
+      if (next.type === 'heading' && next.level === 2 && isSourceDateTime(next.text)) {
+        if (next.text === block.text) {
+          cursor += 1
+          continue
+        }
+        break
+      }
       dayBlocks.push(next)
       cursor += 1
     }

--- a/frontend/src/pages/WhatsNewPage.tsx
+++ b/frontend/src/pages/WhatsNewPage.tsx
@@ -1,11 +1,23 @@
-import { Fragment, useCallback, useEffect, useState } from 'react'
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react'
 
 type Block =
   | { type: 'heading'; level: number; text: string }
   | { type: 'list'; items: string[] }
   | { type: 'paragraph'; text: string }
 
+type ChangelogDay = {
+  type: 'day'
+  sourceDateTime: string
+  label: string
+  summary: string
+  blocks: Block[]
+}
+
+type ChangelogViewItem = Block | ChangelogDay
+
 const CHANGELOG_ASSET = '/changelog.md'
+const SOURCE_DATE = /^\d{4}-\d{2}-\d{2}$/
+const SOURCE_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:\d{2})$/
 
 export function isPublicChangelogLink(url: string) {
   try {
@@ -71,10 +83,100 @@ export function parseChangelog(markdown: string): Block[] {
   return blocks
 }
 
+function isSourceDateTime(value: string) {
+  if (SOURCE_DATE.test(value)) return true
+  if (!SOURCE_TIMESTAMP.test(value)) return false
+  return !Number.isNaN(Date.parse(value))
+}
+
+function formatSourceDateTime(value: string, timeZone?: string) {
+  if (SOURCE_DATE.test(value)) {
+    const [year, month, day] = value.split('-').map(Number)
+    return new Intl.DateTimeFormat(undefined, {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      timeZone: 'UTC',
+    }).format(new Date(Date.UTC(year, month - 1, day)))
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone,
+    timeZoneName: 'short',
+  }).format(new Date(value))
+}
+
+function summarizeDay(blocks: Block[]) {
+  const areas = blocks
+    .filter((block): block is Extract<Block, { type: 'heading' }> => block.type === 'heading' && block.level >= 3)
+    .map(block => publicChangelogText(block.text))
+    .filter(Boolean)
+  const updateCount = blocks.reduce((count, block) => {
+    if (block.type === 'list') return count + block.items.length
+    if (block.type === 'paragraph') return count + 1
+    return count
+  }, 0)
+  const countText = `${updateCount || 1} ${updateCount === 1 ? 'update' : 'updates'}`
+  const uniqueAreas = [...new Set(areas)]
+
+  if (uniqueAreas.length === 0) return `${countText} published this day.`
+  if (uniqueAreas.length === 1) return `${countText} for ${uniqueAreas[0]}.`
+  if (uniqueAreas.length === 2) return `${countText} across ${uniqueAreas[0]} and ${uniqueAreas[1]}.`
+  return `${countText} across ${uniqueAreas.slice(0, 2).join(', ')}, and more.`
+}
+
+export function buildChangelogView(markdown: string, timeZone?: string): ChangelogViewItem[] {
+  const blocks = parseChangelog(markdown)
+  const view: ChangelogViewItem[] = []
+
+  for (let index = 0; index < blocks.length; index += 1) {
+    const block = blocks[index]
+    if (block.type !== 'heading' || block.level !== 2 || !isSourceDateTime(block.text)) {
+      view.push(block)
+      continue
+    }
+
+    const dayBlocks: Block[] = []
+    let cursor = index + 1
+    while (cursor < blocks.length) {
+      const next = blocks[cursor]
+      if (next.type === 'heading' && next.level === 2 && isSourceDateTime(next.text)) break
+      dayBlocks.push(next)
+      cursor += 1
+    }
+
+    view.push({
+      type: 'day',
+      sourceDateTime: block.text,
+      label: formatSourceDateTime(block.text, timeZone),
+      summary: summarizeDay(dayBlocks),
+      blocks: dayBlocks,
+    })
+    index = cursor - 1
+  }
+
+  return view
+}
+
+function BlockContent({ block }: { block: Block }) {
+  if (block.type === 'heading') {
+    const Tag = block.level <= 2 ? 'h2' : 'h3'
+    return <Tag className={block.level <= 2 ? 'border-b border-stone-800 pb-2 pt-4 text-2xl font-black text-stone-100 first:pt-0' : 'pt-3 text-lg font-bold text-amber-200'}>{renderInline(block.text)}</Tag>
+  }
+  if (block.type === 'list') return <ul className="list-disc space-y-2 pl-6 leading-7">{block.items.map((item, itemIndex) => <li key={itemIndex}>{renderInline(item)}</li>)}</ul>
+  return <p className="leading-7">{renderInline(block.text)}</p>
+}
+
 export default function WhatsNewPage() {
   const [markdown, setMarkdown] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [attempt, setAttempt] = useState(0)
+  const view = useMemo(() => (markdown ? buildChangelogView(markdown) : []), [markdown])
 
   const load = useCallback(async () => {
     setMarkdown(null)
@@ -112,13 +214,19 @@ export default function WhatsNewPage() {
 
       {markdown && (
         <article className="space-y-4 rounded-2xl border border-stone-800 bg-stone-950/60 p-5 text-stone-300">
-          {parseChangelog(markdown).map((block, index) => {
-            if (block.type === 'heading') {
-              const Tag = block.level <= 2 ? 'h2' : 'h3'
-              return <Tag key={index} className={block.level <= 2 ? 'border-b border-stone-800 pb-2 pt-4 text-2xl font-black text-stone-100 first:pt-0' : 'pt-3 text-lg font-bold text-amber-200'}>{renderInline(block.text)}</Tag>
-            }
-            if (block.type === 'list') return <ul key={index} className="list-disc space-y-2 pl-6 leading-7">{block.items.map((item, itemIndex) => <li key={itemIndex}>{renderInline(item)}</li>)}</ul>
-            return <p key={index} className="leading-7">{renderInline(block.text)}</p>
+          {view.map((item, index) => {
+            if (item.type !== 'day') return <BlockContent key={index} block={item} />
+            return (
+              <section key={`${item.sourceDateTime}-${index}`} aria-labelledby={`release-day-${index}`} className="border-t border-stone-800 pt-5 first:border-t-0 first:pt-0">
+                <h2 id={`release-day-${index}`} className="text-2xl font-black text-stone-100">
+                  <time dateTime={item.sourceDateTime}>{item.label}</time>
+                </h2>
+                <p className="mt-1 text-sm text-stone-400">{item.summary}</p>
+                <div className="mt-3 space-y-3">
+                  {item.blocks.map((block, blockIndex) => <BlockContent key={blockIndex} block={block} />)}
+                </div>
+              </section>
+            )
           })}
         </article>
       )}

--- a/frontend/src/unit/WhatsNewPage.test.tsx
+++ b/frontend/src/unit/WhatsNewPage.test.tsx
@@ -11,11 +11,7 @@ afterEach(() => {
 
 describe('parseChangelog', () => {
   it('parses headings, paragraphs, both list markers, blank lines, and a trailing list', () => {
-    expect(
-      parseChangelog(
-        '# Changelog\n\nIntro paragraph\n## 2026-08-06\n- First item\n* Second item\n\n### Details\nFinal paragraph\n- Trailing item',
-      ),
-    ).toEqual([
+    expect(parseChangelog('# Changelog\n\nIntro paragraph\n## 2026-08-06\n- First item\n* Second item\n\n### Details\nFinal paragraph\n- Trailing item')).toEqual([
       { type: 'heading', level: 1, text: 'Changelog' },
       { type: 'paragraph', text: 'Intro paragraph' },
       { type: 'heading', level: 2, text: '2026-08-06' },
@@ -29,37 +25,27 @@ describe('parseChangelog', () => {
 
 describe('buildChangelogView', () => {
   it('groups multiple entries under one day and summarizes public feature areas', () => {
-    expect(
-      buildChangelogView(
-        '# Changelog\n\n## 2026-08-09\n### Queue\n- Faster loading\n- Clearer controls\n### Roll\n- Preserves the active comic',
-        'UTC',
-      ),
-    ).toEqual([
+    expect(buildChangelogView('# Changelog\n\n## 2026-08-09\n### Queue\n- Faster loading\n- Clearer controls\n### Roll\n- Preserves the active comic', 'UTC')).toEqual([
       { type: 'heading', level: 1, text: 'Changelog' },
-      {
-        type: 'day',
-        sourceDateTime: '2026-08-09',
-        label: 'August 9, 2026',
-        summary: '3 updates across Queue and Roll.',
-        blocks: [
-          { type: 'heading', level: 3, text: 'Queue' },
-          { type: 'list', items: ['Faster loading', 'Clearer controls'] },
-          { type: 'heading', level: 3, text: 'Roll' },
-          { type: 'list', items: ['Preserves the active comic'] },
-        ],
-      },
+      { type: 'day', sourceDateTime: '2026-08-09', label: 'August 9, 2026', summary: '3 updates across Queue and Roll.', blocks: [
+        { type: 'heading', level: 3, text: 'Queue' },
+        { type: 'list', items: ['Faster loading', 'Clearer controls'] },
+        { type: 'heading', level: 3, text: 'Roll' },
+        { type: 'list', items: ['Preserves the active comic'] },
+      ] },
     ])
   })
 
+  it('covers singular, unscoped, and many-area daily summaries', () => {
+    expect(buildChangelogView('## 2026-08-09\n### Queue\nOne change', 'UTC')[0]).toHaveProperty('summary', '1 update for Queue.')
+    expect(buildChangelogView('## 2026-08-09\nOne change', 'UTC')[0]).toHaveProperty('summary', '1 update published this day.')
+    expect(buildChangelogView('## 2026-08-09\n### Queue\n- A\n### Roll\n- B\n### Sessions\n- C', 'UTC')[0]).toHaveProperty('summary', '3 updates across Queue, Roll, and more.')
+    expect(buildChangelogView('## 2026-08-09\n### Queue', 'UTC')[0]).toHaveProperty('summary', '1 update for Queue.')
+  })
+
   it('uses the viewer timezone for exact source timestamps', () => {
-    const view = buildChangelogView(
-      '## 2026-08-09T00:30:00Z\n### Roll\n- Fixed resume behavior',
-      'America/Los_Angeles',
-    )
-    expect(view[0]).toMatchObject({
-      type: 'day',
-      sourceDateTime: '2026-08-09T00:30:00Z',
-    })
+    const view = buildChangelogView('## 2026-08-09T00:30:00Z\n### Roll\n- Fixed resume behavior', 'America/Los_Angeles')
+    expect(view[0]).toMatchObject({ type: 'day', sourceDateTime: '2026-08-09T00:30:00Z' })
     expect(view[0]).toHaveProperty('label', 'August 8, 2026 at 5:30 PM PDT')
   })
 
@@ -68,38 +54,29 @@ describe('buildChangelogView', () => {
       { type: 'heading', level: 2, text: 'Recently' },
       { type: 'list', items: ['Still readable'] },
     ])
+    expect(buildChangelogView('## 2026-99-99T99:99Z\n- Still readable')).toEqual([
+      { type: 'heading', level: 2, text: '2026-99-99T99:99Z' },
+      { type: 'list', items: ['Still readable'] },
+    ])
   })
 })
 
 describe('WhatsNewPage', () => {
   it('groups dated entries with readable time elements and daily summaries', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      text: async () =>
-        '# Changelog\n\n## 2026-08-09\n### Queue\n- Faster loading\n- Clearer controls\n### Roll\n- Preserves the active comic',
-    })
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async () => '# Changelog\n\n## 2026-08-09\n### Queue\n- Faster loading\n- Clearer controls\n### Roll\n- Preserves the active comic' })
     vi.stubGlobal('fetch', fetchMock)
-
     render(<WhatsNewPage />)
-
     const dayHeading = await screen.findByRole('heading', { name: /August 9, 2026/ })
-    const time = dayHeading.querySelector('time')
-    expect(time).toHaveAttribute('datetime', '2026-08-09')
+    expect(dayHeading.querySelector('time')).toHaveAttribute('datetime', '2026-08-09')
     expect(screen.getByText('3 updates across Queue and Roll.')).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'Queue' })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'Roll' })).toBeInTheDocument()
   })
 
   it('removes GitHub pull references while preserving public external links', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      text: async () =>
-        '# Changelog\n\nPlain introduction.\n\n## Today\n\n### Queue\n\n- Fixed `Queue` in [#866](https://github.com/JoshCLWren/comic-pile/pull/866). See [ComicPile](https://comic-pile.vercel.app/) for more. [Internal notes](https://github.com/JoshCLWren/comic-pile/issues/981).',
-    })
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async () => '# Changelog\n\nPlain introduction.\n\n## Today\n\n### Queue\n\n- Fixed `Queue` in [#866](https://github.com/JoshCLWren/comic-pile/pull/866). See [ComicPile](https://comic-pile.vercel.app/) for more. [Internal notes](https://github.com/JoshCLWren/comic-pile/issues/981).' })
     vi.stubGlobal('fetch', fetchMock)
-
     render(<WhatsNewPage />)
-
     expect(screen.getByRole('status')).toHaveTextContent('Loading release notes')
     expect(fetchMock).toHaveBeenCalledWith('/changelog.md', { cache: 'no-cache' })
     expect(await screen.findByRole('heading', { name: 'Changelog' })).toBeInTheDocument()
@@ -112,7 +89,6 @@ describe('WhatsNewPage', () => {
     expect(screen.queryByRole('link', { name: /#866/ })).not.toBeInTheDocument()
     expect(screen.getByText(/Internal notes/)).toBeInTheDocument()
     expect(screen.queryByRole('link', { name: /Internal notes/ })).not.toBeInTheDocument()
-
     const link = screen.getByRole('link', { name: /ComicPile/ })
     expect(link).toHaveAttribute('href', 'https://comic-pile.vercel.app/')
     expect(link).toHaveAttribute('target', '_blank')
@@ -121,14 +97,9 @@ describe('WhatsNewPage', () => {
   })
 
   it('distinguishes a missing changelog from other HTTP failures', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce({ ok: false, status: 404 })
-      .mockResolvedValueOnce({ ok: false, status: 500 })
+    const fetchMock = vi.fn().mockResolvedValueOnce({ ok: false, status: 404 }).mockResolvedValueOnce({ ok: false, status: 500 })
     vi.stubGlobal('fetch', fetchMock)
-
     render(<WhatsNewPage />)
-
     expect(await screen.findByRole('alert')).toHaveTextContent('changelog file is missing')
     await userEvent.click(screen.getByRole('button', { name: 'Try again' }))
     expect(await screen.findByRole('alert')).toHaveTextContent('could not be loaded')
@@ -136,25 +107,15 @@ describe('WhatsNewPage', () => {
   })
 
   it('reports an empty successful response', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({ ok: true, text: async () => '  \n ' }),
-    )
-
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, text: async () => '  \n ' }))
     render(<WhatsNewPage />)
-
     expect(await screen.findByRole('alert')).toHaveTextContent('changelog file is empty')
   })
 
   it('reports thrown Error objects and recovers on retry', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockRejectedValueOnce(new Error('network unavailable'))
-      .mockResolvedValueOnce({ ok: true, text: async () => '## Recovered' })
+    const fetchMock = vi.fn().mockRejectedValueOnce(new Error('network unavailable')).mockResolvedValueOnce({ ok: true, text: async () => '## Recovered' })
     vi.stubGlobal('fetch', fetchMock)
-
     render(<WhatsNewPage />)
-
     expect(await screen.findByRole('alert')).toHaveTextContent('network unavailable')
     await userEvent.click(screen.getByRole('button', { name: 'Try again' }))
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))

--- a/frontend/src/unit/WhatsNewPage.test.tsx
+++ b/frontend/src/unit/WhatsNewPage.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom/vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import WhatsNewPage, { parseChangelog } from '../pages/WhatsNewPage'
+import WhatsNewPage, { buildChangelogView, parseChangelog } from '../pages/WhatsNewPage'
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -27,7 +27,69 @@ describe('parseChangelog', () => {
   })
 })
 
+describe('buildChangelogView', () => {
+  it('groups multiple entries under one day and summarizes public feature areas', () => {
+    expect(
+      buildChangelogView(
+        '# Changelog\n\n## 2026-08-09\n### Queue\n- Faster loading\n- Clearer controls\n### Roll\n- Preserves the active comic',
+        'UTC',
+      ),
+    ).toEqual([
+      { type: 'heading', level: 1, text: 'Changelog' },
+      {
+        type: 'day',
+        sourceDateTime: '2026-08-09',
+        label: 'August 9, 2026',
+        summary: '3 updates across Queue and Roll.',
+        blocks: [
+          { type: 'heading', level: 3, text: 'Queue' },
+          { type: 'list', items: ['Faster loading', 'Clearer controls'] },
+          { type: 'heading', level: 3, text: 'Roll' },
+          { type: 'list', items: ['Preserves the active comic'] },
+        ],
+      },
+    ])
+  })
+
+  it('uses the viewer timezone for exact source timestamps', () => {
+    const view = buildChangelogView(
+      '## 2026-08-09T00:30:00Z\n### Roll\n- Fixed resume behavior',
+      'America/Los_Angeles',
+    )
+    expect(view[0]).toMatchObject({
+      type: 'day',
+      sourceDateTime: '2026-08-09T00:30:00Z',
+    })
+    expect(view[0]).toHaveProperty('label', 'August 8, 2026 at 5:30 PM PDT')
+  })
+
+  it('keeps malformed or missing timestamps usable as ordinary headings', () => {
+    expect(buildChangelogView('## Recently\n- Still readable')).toEqual([
+      { type: 'heading', level: 2, text: 'Recently' },
+      { type: 'list', items: ['Still readable'] },
+    ])
+  })
+})
+
 describe('WhatsNewPage', () => {
+  it('groups dated entries with readable time elements and daily summaries', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () =>
+        '# Changelog\n\n## 2026-08-09\n### Queue\n- Faster loading\n- Clearer controls\n### Roll\n- Preserves the active comic',
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<WhatsNewPage />)
+
+    const dayHeading = await screen.findByRole('heading', { name: /August 9, 2026/ })
+    const time = dayHeading.querySelector('time')
+    expect(time).toHaveAttribute('datetime', '2026-08-09')
+    expect(screen.getByText('3 updates across Queue and Roll.')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Queue' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Roll' })).toBeInTheDocument()
+  })
+
   it('removes GitHub pull references while preserving public external links', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/frontend/src/unit/WhatsNewPage.test.tsx
+++ b/frontend/src/unit/WhatsNewPage.test.tsx
@@ -36,6 +36,21 @@ describe('buildChangelogView', () => {
     ])
   })
 
+  it('merges repeated generated date fragments into one daily section', () => {
+    expect(buildChangelogView('## 2026-08-09\n### Queue\n- Faster loading\n## 2026-08-09\n### Roll\n- Better recovery\n## 2026-08-08\n### Sessions\n- Clearer history', 'UTC')).toEqual([
+      { type: 'day', sourceDateTime: '2026-08-09', label: 'August 9, 2026', summary: '2 updates across Queue and Roll.', blocks: [
+        { type: 'heading', level: 3, text: 'Queue' },
+        { type: 'list', items: ['Faster loading'] },
+        { type: 'heading', level: 3, text: 'Roll' },
+        { type: 'list', items: ['Better recovery'] },
+      ] },
+      { type: 'day', sourceDateTime: '2026-08-08', label: 'August 8, 2026', summary: '1 update for Sessions.', blocks: [
+        { type: 'heading', level: 3, text: 'Sessions' },
+        { type: 'list', items: ['Clearer history'] },
+      ] },
+    ])
+  })
+
   it('covers singular, unscoped, and many-area daily summaries', () => {
     expect(buildChangelogView('## 2026-08-09\n### Queue\nOne change', 'UTC')[0]).toHaveProperty('summary', '1 update for Queue.')
     expect(buildChangelogView('## 2026-08-09\nOne change', 'UTC')[0]).toHaveProperty('summary', '1 update published this day.')


### PR DESCRIPTION
Closes #947

## Summary
- group dated changelog entries into readable daily sections
- render source dates with native time elements and render exact source timestamps in the viewer's timezone when present
- add plain-language daily summaries derived from public feature-area headings rather than commit wording
- preserve malformed or undated historical headings as readable fallback content
- add focused component coverage for grouping, timezone boundaries, and missing timestamps

## Validation
This automation runtime does not expose a local checkout/package execution environment, so focused unit coverage was added and exact-head CI is the configured validation boundary.

Changelog: `docs/changelog.d/2026-08-09-1006.md`