### PR TITLE
Add NVIDIA PR review capability benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,6 +196,7 @@ scripts/clone_prod_users.sh
 dogfood-output/
 .opencode_handoff/
 .playwright-mcp/
+.nvidia-review-results/
 
 # Local AI/tool config
 opencode.json

--- a/docs/changelog.d/2026-08-09-1010.md
+++ b/docs/changelog.d/2026-08-09-1010.md
@@ -2,4 +2,4 @@
 
 ### Factory tooling
 
-- NVIDIA NIM models can now be compared as pull-request reviewers with durable capability logs, known-defect scoring, bounded concurrency, and exact-head posting safeguards. [#1010](https://github.com/JoshCLWren/comic-pile/pull/1010)
+- NVIDIA NIM models can now be compared as pull-request reviewers with durable capability logs, bounded concurrency, exact-head posting safeguards, drift-tolerant known-defect expectations, and review-quality scoring that stays independent from two-turn tool compatibility. [#1010](https://github.com/JoshCLWren/comic-pile/pull/1010)

--- a/docs/changelog.d/2026-08-09-1010.md
+++ b/docs/changelog.d/2026-08-09-1010.md
@@ -1,0 +1,5 @@
+## 2026-08-09
+
+### Factory tooling
+
+- NVIDIA NIM models can now be compared as pull-request reviewers with durable capability logs, known-defect scoring, bounded concurrency, and exact-head posting safeguards. [#1010](https://github.com/JoshCLWren/comic-pile/pull/1010)

--- a/scripts/select_fcm_nvidia_model.py
+++ b/scripts/select_fcm_nvidia_model.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 EXCLUDED_MODEL_TERMS = (
     "embed",
     "image",
+    "omni",
     "rerank",
     "safety",
     "vision",

--- a/scripts/test_nvidia_pr_review.py
+++ b/scripts/test_nvidia_pr_review.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import concurrent.futures
+import csv
 import json
 import os
 import re
@@ -12,6 +13,8 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
 
 import httpx
 
@@ -42,6 +45,87 @@ class ModelResult:
     findings: tuple[Finding, ...]
     elapsed_seconds: float
     detail: str
+    output_dir: Path
+    classification: str
+
+
+REVIEW_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "verdict": {"type": "string", "enum": ["PASS", "CHANGES_REQUIRED"]},
+        "findings": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "line": {"type": "integer"},
+                    "body": {"type": "string"},
+                    "suggestion": {"type": ["string", "null"]},
+                },
+                "required": ["path", "line", "body"],
+            },
+        },
+    },
+    "required": ["verdict", "findings"],
+}
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "write_review_file",
+            "description": "Write the initial structured PR review to review.json.",
+            "parameters": {
+                "type": "object",
+                "properties": {"review": REVIEW_SCHEMA},
+                "required": ["review"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "edit_review_file",
+            "description": "Replace review.json after checking and improving its review.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "review": REVIEW_SCHEMA,
+                    "edit_marker": {
+                        "type": "string",
+                        "description": "A short description of the edit or verification performed.",
+                    },
+                },
+                "required": ["review", "edit_marker"],
+            },
+        },
+    },
+]
+
+
+def _model_slug(model: str) -> str:
+    """Return a filesystem-safe model identifier."""
+    return re.sub(r"[^A-Za-z0-9._-]+", "__", model).strip("._-")
+
+
+def _append_log(log_file: Path, event: str, payload: object) -> None:
+    """Append one timestamped event to a model's durable JSONL log."""
+    entry = {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "event": event,
+        "payload": payload,
+    }
+    with log_file.open("a", encoding="utf-8") as stream:
+        stream.write(json.dumps(entry, ensure_ascii=False, default=str) + "\n")
+
+
+def _write_json(target: Path, payload: object) -> None:
+    """Write readable JSON to a durable result file."""
+    target.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False, default=str) + "\n",
+        encoding="utf-8",
+    )
 
 
 def _run(command: list[str], *, input_text: str | None = None) -> str:
@@ -189,66 +273,244 @@ def _parse_review(content: str, commentable: dict[str, set[int]]) -> tuple[str, 
     return normalized, tuple(findings)
 
 
+def _request_nim(
+    model: str,
+    api_key: str,
+    messages: list[dict[str, object]],
+    required_tool: str,
+    timeout_seconds: float,
+    log_file: Path,
+) -> dict[str, object]:
+    """Send one NIM request, retrying a rate limit once."""
+    request_payload: dict[str, object] = {
+        "model": model.removeprefix("nvidia/"),
+        "messages": messages,
+        "tools": TOOLS,
+        "tool_choice": {"type": "function", "function": {"name": required_tool}},
+        "temperature": 0.1,
+        "max_tokens": 4096,
+    }
+    for attempt in range(2):
+        _append_log(log_file, "request", {"attempt": attempt + 1, "payload": request_payload})
+        response = httpx.post(
+            NVIDIA_CHAT_URL,
+            headers={"Authorization": f"Bearer {api_key}"},
+            json=request_payload,
+            timeout=httpx.Timeout(timeout_seconds),
+        )
+        _append_log(
+            log_file,
+            "http_response",
+            {"attempt": attempt + 1, "status_code": response.status_code, "body": response.text},
+        )
+        if response.status_code != 429 or attempt == 1:
+            response.raise_for_status()
+            payload = response.json()
+            if not isinstance(payload, dict):
+                raise ValueError("NVIDIA response was not an object")
+            return payload
+        retry_after = response.headers.get("Retry-After", "2")
+        try:
+            delay = min(float(retry_after), 15.0)
+        except ValueError:
+            delay = 2.0
+        _append_log(log_file, "rate_limit_retry", {"delay_seconds": delay})
+        time.sleep(delay)
+    raise RuntimeError("unreachable NIM retry state")
+
+
+def _assistant_message(payload: dict[str, object]) -> dict[str, object]:
+    """Extract one assistant message from an OpenAI-compatible response."""
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+        raise ValueError("NVIDIA response had no choices")
+    message = choices[0].get("message")
+    if not isinstance(message, dict):
+        raise ValueError("NVIDIA response had no assistant message")
+    return message
+
+
+def _tool_arguments(message: dict[str, object], expected_name: str) -> tuple[str, dict[str, object]]:
+    """Extract and decode one expected tool call from an assistant message."""
+    calls = message.get("tool_calls")
+    if not isinstance(calls, list) or not calls or not isinstance(calls[0], dict):
+        raise ValueError(f"model did not call {expected_name}")
+    call = calls[0]
+    call_id = call.get("id")
+    function = call.get("function")
+    if not isinstance(call_id, str) or not isinstance(function, dict):
+        raise ValueError("model returned a malformed tool call")
+    if function.get("name") != expected_name or not isinstance(function.get("arguments"), str):
+        raise ValueError(f"model called the wrong tool instead of {expected_name}")
+    arguments = json.loads(function["arguments"])
+    if not isinstance(arguments, dict):
+        raise ValueError("tool arguments were not an object")
+    return call_id, arguments
+
+
+def _review_from_arguments(arguments: dict[str, object]) -> dict[str, object]:
+    """Extract a structured review object from tool arguments."""
+    review = arguments.get("review")
+    if not isinstance(review, dict):
+        raise ValueError("tool call did not provide a review object")
+    if not all(isinstance(key, str) for key in review):
+        raise ValueError("review object contained a non-string key")
+    return {str(key): value for key, value in review.items()}
+
+
+def _classification(error: Exception) -> str:
+    """Classify a provider or capability failure."""
+    if isinstance(error, httpx.TimeoutException):
+        return "timeout"
+    if isinstance(error, httpx.HTTPStatusError):
+        if error.response.status_code == 429:
+            return "rate_limited"
+        if error.response.status_code in {404, 410}:
+            return "unavailable"
+        return "provider_error"
+    text = str(error)
+    if "did not call" in text or "wrong tool" in text or "malformed tool" in text:
+        return "tool_call_not_emitted"
+    return "invalid_review"
+
+
 def _review_model(
     model: str,
     api_key: str,
     prompt: str,
     commentable: dict[str, set[int]],
     timeout_seconds: float,
+    output_root: Path,
 ) -> ModelResult:
-    """Request and validate one direct NIM review.
-
-    Args:
-        model: Provider-qualified NVIDIA model.
-        api_key: NVIDIA API key.
-        prompt: Complete review prompt.
-        commentable: Allowed inline comment locations.
-        timeout_seconds: Whole HTTP request timeout.
-
-    Returns:
-        Comparable model result; provider failures are represented, not raised.
-    """
+    """Test one model's two-turn write/edit tool use and validate its review."""
     started = time.monotonic()
+    model_dir = output_root / _model_slug(model)
+    model_dir.mkdir(parents=True, exist_ok=True)
+    log_file = model_dir / "raw.log"
+    capabilities_file = model_dir / "capabilities.json"
+    review_file = model_dir / "review.json"
+    capabilities: dict[str, object] = {
+        "model": model,
+        "plain_review_valid": False,
+        "write_tool_called": False,
+        "review_file_written": False,
+        "edit_tool_called": False,
+        "review_file_changed": False,
+        "structured_review_valid": False,
+    }
+    preliminary_verdict: str | None = None
+    preliminary_findings: tuple[Finding, ...] = ()
+    _append_log(log_file, "started", {"model": model, "timeout_seconds": timeout_seconds})
     try:
-        response = httpx.post(
-            NVIDIA_CHAT_URL,
-            headers={"Authorization": f"Bearer {api_key}"},
-            json={
-                "model": model.removeprefix("nvidia/"),
-                "messages": [
-                    {
-                        "role": "system",
-                        "content": "You are a precise pull-request reviewer. Return JSON only.",
-                    },
-                    {"role": "user", "content": prompt},
-                ],
-                "temperature": 0.1,
-                "max_tokens": 4096,
+        messages: list[dict[str, object]] = [
+            {
+                "role": "system",
+                "content": (
+                    "You are a precise PR reviewer with file tools. First call "
+                    "write_review_file. After its result, call edit_review_file."
+                ),
             },
-            timeout=httpx.Timeout(timeout_seconds),
+            {"role": "user", "content": prompt},
+        ]
+        first_payload = _request_nim(
+            model,
+            api_key,
+            messages,
+            "write_review_file",
+            timeout_seconds,
+            log_file,
         )
-        response.raise_for_status()
-        payload = response.json()
-        content = payload["choices"][0]["message"]["content"]
-        if not isinstance(content, str):
-            raise ValueError("NVIDIA response content was not text")
-        verdict, findings = _parse_review(content, commentable)
+        first_message = _assistant_message(first_payload)
+        plain_content = first_message.get("content")
+        if isinstance(plain_content, str):
+            try:
+                preliminary_verdict, preliminary_findings = _parse_review(
+                    plain_content,
+                    commentable,
+                )
+                capabilities["plain_review_valid"] = True
+            except (json.JSONDecodeError, TypeError, ValueError):
+                pass
+        first_id, first_arguments = _tool_arguments(first_message, "write_review_file")
+        capabilities["write_tool_called"] = True
+        initial_review = _review_from_arguments(first_arguments)
+        _write_json(review_file, initial_review)
+        initial_text = review_file.read_text(encoding="utf-8")
+        capabilities["review_file_written"] = True
+
+        messages.extend(
+            [
+                first_message,
+                {
+                    "role": "tool",
+                    "tool_call_id": first_id,
+                    "content": json.dumps({"ok": True, "path": "review.json"}),
+                },
+                {
+                    "role": "user",
+                    "content": (
+                        "Re-check the diff and the review you wrote. Now call edit_review_file "
+                        "with the final review and a non-empty edit_marker, even if the findings "
+                        "remain unchanged."
+                    ),
+                },
+            ],
+        )
+        remaining = timeout_seconds - (time.monotonic() - started)
+        if remaining <= 0:
+            raise httpx.TimeoutException("model exhausted its whole-job timeout before edit turn")
+        second_payload = _request_nim(
+            model,
+            api_key,
+            messages,
+            "edit_review_file",
+            remaining,
+            log_file,
+        )
+        second_message = _assistant_message(second_payload)
+        _second_id, second_arguments = _tool_arguments(second_message, "edit_review_file")
+        capabilities["edit_tool_called"] = True
+        final_review = _review_from_arguments(second_arguments)
+        marker = second_arguments.get("edit_marker")
+        if not isinstance(marker, str) or not marker.strip():
+            raise ValueError("edit tool did not provide a non-empty edit_marker")
+        final_review["_agent_edit_marker"] = marker.strip()
+        _write_json(review_file, final_review)
+        capabilities["review_file_changed"] = review_file.read_text(encoding="utf-8") != initial_text
+        if not capabilities["review_file_changed"]:
+            raise ValueError("edit tool did not change review.json")
+        verdict, findings = _parse_review(json.dumps(final_review), commentable)
+        capabilities["structured_review_valid"] = True
+        capabilities["classification"] = "passed"
+        capabilities["elapsed_seconds"] = time.monotonic() - started
+        _write_json(capabilities_file, capabilities)
+        _append_log(log_file, "completed", capabilities)
         return ModelResult(
             model=model,
             status="completed",
             verdict=verdict,
             findings=findings,
             elapsed_seconds=time.monotonic() - started,
-            detail="structured review accepted",
+            detail="two-turn write/edit review accepted",
+            output_dir=model_dir,
+            classification="passed",
         )
     except (httpx.HTTPError, json.JSONDecodeError, KeyError, TypeError, ValueError) as error:
+        classification = _classification(error)
+        capabilities["classification"] = classification
+        capabilities["elapsed_seconds"] = time.monotonic() - started
+        capabilities["error"] = str(error)
+        _write_json(capabilities_file, capabilities)
+        _append_log(log_file, "failed", capabilities)
         return ModelResult(
             model=model,
             status="failed",
-            verdict=None,
-            findings=(),
+            verdict=preliminary_verdict,
+            findings=preliminary_findings,
             elapsed_seconds=time.monotonic() - started,
             detail=str(error),
+            output_dir=model_dir,
+            classification=classification,
         )
 
 
@@ -297,8 +559,110 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--repo", help="GitHub owner/name; defaults to the current repository")
     parser.add_argument("--max-models", type=int, help="Limit candidates for a shorter experiment")
     parser.add_argument("--timeout", type=float, default=300, help="Seconds allowed per model")
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=3,
+        help="Maximum simultaneous models (default: 3)",
+    )
+    parser.add_argument("--force", action="store_true", help="Rerun completed model/head results")
+    parser.add_argument(
+        "--expect",
+        action="append",
+        default=[],
+        metavar="PATH:LINE",
+        help="Known defect location; repeat to measure review recall",
+    )
     parser.add_argument("--post", action="store_true", help="Post validated inline findings")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path(".nvidia-review-results"),
+        help="Root directory for per-model logs and review files",
+    )
     return parser
+
+
+def _load_completed_result(
+    model: str,
+    model_dir: Path,
+    commentable: dict[str, set[int]],
+) -> ModelResult | None:
+    """Load a prior successful result for this exact PR head, when present."""
+    capabilities_file = model_dir / "capabilities.json"
+    review_file = model_dir / "review.json"
+    if not capabilities_file.exists() or not review_file.exists():
+        return None
+    try:
+        capabilities = json.loads(capabilities_file.read_text(encoding="utf-8"))
+        if not isinstance(capabilities, dict) or capabilities.get("classification") != "passed":
+            return None
+        verdict, findings = _parse_review(review_file.read_text(encoding="utf-8"), commentable)
+        elapsed = capabilities.get("elapsed_seconds", 0.0)
+        if not isinstance(elapsed, int | float):
+            elapsed = 0.0
+        return ModelResult(
+            model=model,
+            status="completed",
+            verdict=verdict,
+            findings=findings,
+            elapsed_seconds=float(elapsed),
+            detail="resumed exact-head result",
+            output_dir=model_dir,
+            classification="passed",
+        )
+    except (json.JSONDecodeError, OSError, TypeError, ValueError):
+        return None
+
+
+def _parse_expected_locations(values: list[str]) -> set[tuple[str, int]]:
+    """Parse repeatable PATH:LINE known-defect locations."""
+    locations: set[tuple[str, int]] = set()
+    for value in values:
+        path, separator, raw_line = value.rpartition(":")
+        if not separator or not path:
+            raise ValueError(f"invalid expected finding {value!r}; use PATH:LINE")
+        locations.add((path, int(raw_line)))
+    return locations
+
+
+def _review_quality(result: ModelResult, expected: set[tuple[str, int]]) -> str:
+    """Score review usefulness separately from agent tool compatibility."""
+    if result.verdict is None:
+        return "no_valid_review"
+    if not expected:
+        return "valid_unscored"
+    actual = {(finding.path, finding.line) for finding in result.findings}
+    if expected <= actual:
+        return "known_defects_found"
+    return "missed_known_defect"
+
+
+def _write_summary(
+    output_root: Path,
+    results: list[ModelResult],
+    expected: set[tuple[str, int]],
+) -> None:
+    """Write aggregate machine-readable JSON and CSV result tables."""
+    rows = [
+        {
+            "model": result.model,
+            "status": result.status,
+            "classification": result.classification,
+            "review_quality": _review_quality(result, expected),
+            "verdict": result.verdict,
+            "findings": len(result.findings),
+            "elapsed_seconds": round(result.elapsed_seconds, 3),
+            "detail": result.detail,
+            "output_dir": str(result.output_dir),
+        }
+        for result in sorted(results, key=lambda item: (item.classification != "passed", item.model))
+    ]
+    _write_json(output_root / "summary.json", rows)
+    with (output_root / "summary.csv").open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=list(rows[0]) if rows else ["model"])
+        writer.writeheader()
+        writer.writerows(rows)
 
 
 def main() -> int:
@@ -308,6 +672,14 @@ def main() -> int:
         Zero when at least one model completed a valid review, otherwise one.
     """
     args = _parser().parse_args()
+    if args.concurrency < 1 or args.timeout <= 0:
+        print("--concurrency and --timeout must be positive", file=sys.stderr)
+        return 2
+    try:
+        expected = _parse_expected_locations(args.expect)
+    except (TypeError, ValueError) as error:
+        print(str(error), file=sys.stderr)
+        return 2
     api_key = os.environ.get("NVIDIA_API_KEY")
     if not api_key:
         print("NVIDIA_API_KEY is required", file=sys.stderr)
@@ -332,6 +704,21 @@ def main() -> int:
     patch = _run(["gh", "pr", "diff", str(pr_data["number"]), "--repo", repo, "--patch"])
     commentable = _changed_lines(patch)
     models = _discover_models(args.max_models)
+    output_root = args.output_dir / f"pr-{pr_data['number']}-{str(pr_data['headRefOid'])[:12]}"
+    output_root.mkdir(parents=True, exist_ok=True)
+    _write_json(
+        output_root / "run.json",
+        {
+            "repo": repo,
+            "pr": pr_data["number"],
+            "url": pr_data["url"],
+            "head": pr_data["headRefOid"],
+            "models": models,
+            "timeout_seconds": args.timeout,
+            "concurrency": args.concurrency,
+            "expected_findings": [f"{path}:{line}" for path, line in sorted(expected)],
+        },
+    )
     prompt = (
         f"Review PR #{pr_data['number']}: {pr_data['title']}\n\n"
         f"Description:\n{pr_data.get('body') or '(none)'}\n\n"
@@ -345,8 +732,21 @@ def main() -> int:
     )
 
     print(f"Reviewing {pr_data['url']} at {pr_data['headRefOid']} with {len(models)} models")
-    with concurrent.futures.ThreadPoolExecutor(max_workers=len(models)) as executor:
-        futures = [
+    print(f"Results: {output_root.resolve()}")
+    results: list[ModelResult] = []
+    pending_models: list[str] = []
+    for model in models:
+        resumed = None
+        if not args.force:
+            resumed = _load_completed_result(model, output_root / _model_slug(model), commentable)
+        if resumed is not None:
+            results.append(resumed)
+            print(f"[resumed  ] {model} -> {resumed.output_dir}", flush=True)
+        else:
+            pending_models.append(model)
+            print(f"[queued   ] {model}", flush=True)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.concurrency) as executor:
+        futures = {
             executor.submit(
                 _review_model,
                 model,
@@ -354,23 +754,52 @@ def main() -> int:
                 prompt,
                 commentable,
                 args.timeout,
+                output_root,
+            ): model
+            for model in pending_models
+        }
+        for future in concurrent.futures.as_completed(futures):
+            result = future.result()
+            results.append(result)
+            verdict = result.verdict or "NO_VERDICT"
+            print(
+                f"[{result.classification:14}] {result.elapsed_seconds:7.1f}s {verdict:16} "
+                f"{result.model} -> {result.output_dir}",
+                flush=True,
             )
-            for model in models
-        ]
-        results = [future.result() for future in concurrent.futures.as_completed(futures)]
+
+    _write_summary(output_root, results, expected)
 
     completed = 0
     for result in sorted(results, key=lambda item: item.elapsed_seconds):
         verdict = result.verdict or "NO_VERDICT"
         print(
-            f"[{result.status:9}] {result.elapsed_seconds:7.1f}s {verdict:16} "
-            f"{result.model} ({len(result.findings)} findings) - {result.detail}",
+            f"[{result.classification:14}] {result.elapsed_seconds:7.1f}s {verdict:16} "
+            f"{result.model} ({len(result.findings)} findings, "
+            f"quality={_review_quality(result, expected)}) - {result.detail}",
         )
+        print(f"  log: {result.output_dir / 'raw.log'}")
         for finding in result.findings:
             print(f"  {finding.path}:{finding.line}: {finding.body}")
         if result.status == "completed":
             completed += 1
             if args.post:
+                current = json.loads(
+                    _run(
+                        [
+                            "gh",
+                            "pr",
+                            "view",
+                            str(pr_data["number"]),
+                            "--repo",
+                            repo,
+                            "--json",
+                            "headRefOid",
+                        ],
+                    ),
+                )
+                if current.get("headRefOid") != pr_data["headRefOid"]:
+                    raise RuntimeError("PR head moved after review; refusing to post stale comments")
                 _post_findings(repo, int(pr_data["number"]), str(pr_data["headRefOid"]), result)
 
     if not args.post:

--- a/scripts/test_nvidia_pr_review.py
+++ b/scripts/test_nvidia_pr_review.py
@@ -23,6 +23,7 @@ from scripts.select_fcm_nvidia_model import select_models
 
 NVIDIA_CHAT_URL = "https://integrate.api.nvidia.com/v1/chat/completions"
 HUNK_PATTERN = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+EXPECT_LINE_PATTERN = re.compile(r"^(\d+)(?:-(\d+))?$")
 
 
 @dataclass(frozen=True)
@@ -33,6 +34,40 @@ class Finding:
     line: int
     body: str
     suggestion: str | None = None
+
+
+@dataclass(frozen=True)
+class ExpectedFinding:
+    """A resilient known-defect expectation used to score review quality."""
+
+    path: str
+    start_line: int | None = None
+    end_line: int | None = None
+    body_pattern: str | None = None
+
+    def matches(self, finding: Finding) -> bool:
+        """Return whether one finding satisfies this expectation."""
+        if finding.path != self.path:
+            return False
+        if self.start_line is not None:
+            end_line = self.end_line if self.end_line is not None else self.start_line
+            if not self.start_line <= finding.line <= end_line:
+                return False
+        if self.body_pattern is not None:
+            searchable = f"{finding.body}\n{finding.suggestion or ''}"
+            return re.search(self.body_pattern, searchable, re.IGNORECASE) is not None
+        return True
+
+    @property
+    def display(self) -> str:
+        """Return a stable human-readable representation."""
+        if self.body_pattern is not None:
+            return f"{self.path}:/{self.body_pattern}/"
+        if self.start_line is None:
+            return self.path
+        if self.end_line is not None and self.end_line != self.start_line:
+            return f"{self.path}:{self.start_line}-{self.end_line}"
+        return f"{self.path}:{self.start_line}"
 
 
 @dataclass(frozen=True)
@@ -129,18 +164,7 @@ def _write_json(target: Path, payload: object) -> None:
 
 
 def _run(command: list[str], *, input_text: str | None = None) -> str:
-    """Run a command and return stdout.
-
-    Args:
-        command: Command and arguments to execute.
-        input_text: Optional standard input.
-
-    Returns:
-        Captured standard output.
-
-    Raises:
-        RuntimeError: When the command fails.
-    """
+    """Run a command and return stdout."""
     result = subprocess.run(
         command,
         check=False,
@@ -155,14 +179,7 @@ def _run(command: list[str], *, input_text: str | None = None) -> str:
 
 
 def _discover_models(limit: int | None) -> list[str]:
-    """Discover ranked NVIDIA chat candidates through FCM.
-
-    Args:
-        limit: Maximum models to return, or ``None`` for every candidate.
-
-    Returns:
-        Provider-qualified model identifiers.
-    """
+    """Discover ranked NVIDIA chat candidates through FCM."""
     raw_output = _run(
         [
             "free-coding-models",
@@ -178,15 +195,18 @@ def _discover_models(limit: int | None) -> list[str]:
     return models if limit is None else models[:limit]
 
 
+def _normalize_models(models: list[str]) -> list[str]:
+    """Normalize explicit model IDs while preserving caller order."""
+    normalized: list[str] = []
+    for model in models:
+        value = model if model.startswith("nvidia/") else f"nvidia/{model}"
+        if value not in normalized:
+            normalized.append(value)
+    return normalized
+
+
 def _changed_lines(patch: str) -> dict[str, set[int]]:
-    """Return added right-side line numbers for every changed file.
-
-    Args:
-        patch: Unified pull-request diff.
-
-    Returns:
-        Mapping from repository paths to commentable added lines.
-    """
+    """Return added right-side line numbers for every changed file."""
     changed: dict[str, set[int]] = {}
     path: str | None = None
     right_line: int | None = None
@@ -212,17 +232,7 @@ def _changed_lines(patch: str) -> dict[str, set[int]]:
 
 
 def _extract_json(content: str) -> object:
-    """Extract one JSON object from a model response.
-
-    Args:
-        content: Raw assistant response.
-
-    Returns:
-        Parsed JSON value.
-
-    Raises:
-        ValueError: When no JSON object is present.
-    """
+    """Extract one JSON object from a model response."""
     start = content.find("{")
     end = content.rfind("}")
     if start < 0 or end < start:
@@ -231,18 +241,7 @@ def _extract_json(content: str) -> object:
 
 
 def _parse_review(content: str, commentable: dict[str, set[int]]) -> tuple[str, tuple[Finding, ...]]:
-    """Parse and validate a structured model review.
-
-    Args:
-        content: Raw model response.
-        commentable: Allowed right-side diff locations.
-
-    Returns:
-        Normalized verdict and validated findings.
-
-    Raises:
-        ValueError: When the response schema or a location is invalid.
-    """
+    """Parse and validate a structured model review."""
     payload = _extract_json(content)
     if not isinstance(payload, dict):
         raise ValueError("review payload was not an object")
@@ -265,7 +264,14 @@ def _parse_review(content: str, commentable: dict[str, set[int]]) -> tuple[str, 
             raise ValueError(f"finding targeted non-added diff location {path}:{line}")
         if suggestion is not None and not isinstance(suggestion, str):
             raise ValueError("finding suggestion was not text")
-        findings.append(Finding(path=path, line=line, body=body.strip(), suggestion=suggestion))
+        findings.append(
+            Finding(
+                path=path,
+                line=line,
+                body=body.strip(),
+                suggestion=suggestion,
+            ),
+        )
 
     normalized = "CHANGES_REQUIRED" if findings else "PASS"
     if verdict != normalized:
@@ -330,7 +336,36 @@ def _assistant_message(payload: dict[str, object]) -> dict[str, object]:
     return message
 
 
-def _tool_arguments(message: dict[str, object], expected_name: str) -> tuple[str, dict[str, object]]:
+def _assistant_text(message: dict[str, object]) -> str | None:
+    """Return only final assistant content, never provider reasoning fields."""
+    content = message.get("content")
+    if not isinstance(content, str) or not content.strip():
+        return None
+    return content
+
+
+def _assistant_replay(message: dict[str, object]) -> dict[str, object]:
+    """Return a provider-safe assistant tool-call message for the next turn."""
+    replay: dict[str, object] = {"role": "assistant", "content": message.get("content")}
+    tool_calls = message.get("tool_calls")
+    if isinstance(tool_calls, list):
+        replay["tool_calls"] = tool_calls
+    return replay
+
+
+def _response_metadata(message: dict[str, object]) -> dict[str, bool]:
+    """Record response-channel presence without promoting reasoning to review output."""
+    return {
+        "content_present": _assistant_text(message) is not None,
+        "reasoning_present": bool(message.get("reasoning")),
+        "reasoning_content_present": bool(message.get("reasoning_content")),
+    }
+
+
+def _tool_arguments(
+    message: dict[str, object],
+    expected_name: str,
+) -> tuple[str, dict[str, object]]:
     """Extract and decode one expected tool call from an assistant message."""
     calls = message.get("tool_calls")
     if not isinstance(calls, list) or not calls or not isinstance(calls[0], dict):
@@ -340,12 +375,18 @@ def _tool_arguments(message: dict[str, object], expected_name: str) -> tuple[str
     function = call.get("function")
     if not isinstance(call_id, str) or not isinstance(function, dict):
         raise ValueError("model returned a malformed tool call")
-    if function.get("name") != expected_name or not isinstance(function.get("arguments"), str):
+    if function.get("name") != expected_name:
         raise ValueError(f"model called the wrong tool instead of {expected_name}")
-    arguments = json.loads(function["arguments"])
+    raw_arguments = function.get("arguments")
+    if isinstance(raw_arguments, str):
+        arguments = json.loads(raw_arguments)
+    elif isinstance(raw_arguments, dict):
+        arguments = raw_arguments
+    else:
+        raise ValueError("model returned malformed tool arguments")
     if not isinstance(arguments, dict):
         raise ValueError("tool arguments were not an object")
-    return call_id, arguments
+    return call_id, {str(key): value for key, value in arguments.items()}
 
 
 def _review_from_arguments(arguments: dict[str, object]) -> dict[str, object]:
@@ -374,6 +415,46 @@ def _classification(error: Exception) -> str:
     return "invalid_review"
 
 
+def _initial_messages(prompt: str) -> list[dict[str, object]]:
+    """Build the first request conversation."""
+    return [
+        {
+            "role": "system",
+            "content": (
+                "You are a precise PR reviewer with file tools. First call "
+                "write_review_file. After its tool result, call edit_review_file."
+            ),
+        },
+        {"role": "user", "content": prompt},
+    ]
+
+
+def _edit_messages(
+    initial_messages: list[dict[str, object]],
+    first_message: dict[str, object],
+    first_call_id: str,
+) -> list[dict[str, object]]:
+    """Build assistant tool-call -> tool result -> assistant continuation context."""
+    return [
+        *initial_messages,
+        _assistant_replay(first_message),
+        {
+            "role": "tool",
+            "tool_call_id": first_call_id,
+            "content": json.dumps(
+                {
+                    "ok": True,
+                    "path": "review.json",
+                    "next_action": (
+                        "Re-check the diff and the review, then call edit_review_file with the "
+                        "final review and a non-empty edit_marker even if findings are unchanged."
+                    ),
+                },
+            ),
+        },
+    ]
+
+
 def _review_model(
     model: str,
     api_key: str,
@@ -382,7 +463,7 @@ def _review_model(
     timeout_seconds: float,
     output_root: Path,
 ) -> ModelResult:
-    """Test one model's two-turn write/edit tool use and validate its review."""
+    """Test one model's review quality and two-turn tool use independently."""
     started = time.monotonic()
     model_dir = output_root / _model_slug(model)
     model_dir.mkdir(parents=True, exist_ok=True)
@@ -393,6 +474,7 @@ def _review_model(
         "model": model,
         "plain_review_valid": False,
         "write_tool_called": False,
+        "initial_structured_review_valid": False,
         "review_file_written": False,
         "edit_tool_called": False,
         "review_file_changed": False,
@@ -402,16 +484,7 @@ def _review_model(
     preliminary_findings: tuple[Finding, ...] = ()
     _append_log(log_file, "started", {"model": model, "timeout_seconds": timeout_seconds})
     try:
-        messages: list[dict[str, object]] = [
-            {
-                "role": "system",
-                "content": (
-                    "You are a precise PR reviewer with file tools. First call "
-                    "write_review_file. After its result, call edit_review_file."
-                ),
-            },
-            {"role": "user", "content": prompt},
-        ]
+        messages = _initial_messages(prompt)
         first_payload = _request_nim(
             model,
             api_key,
@@ -421,8 +494,9 @@ def _review_model(
             log_file,
         )
         first_message = _assistant_message(first_payload)
-        plain_content = first_message.get("content")
-        if isinstance(plain_content, str):
+        capabilities["first_response"] = _response_metadata(first_message)
+        plain_content = _assistant_text(first_message)
+        if plain_content is not None:
             try:
                 preliminary_verdict, preliminary_findings = _parse_review(
                     plain_content,
@@ -431,31 +505,20 @@ def _review_model(
                 capabilities["plain_review_valid"] = True
             except (json.JSONDecodeError, TypeError, ValueError):
                 pass
+
         first_id, first_arguments = _tool_arguments(first_message, "write_review_file")
         capabilities["write_tool_called"] = True
         initial_review = _review_from_arguments(first_arguments)
+        preliminary_verdict, preliminary_findings = _parse_review(
+            json.dumps(initial_review),
+            commentable,
+        )
+        capabilities["initial_structured_review_valid"] = True
         _write_json(review_file, initial_review)
         initial_text = review_file.read_text(encoding="utf-8")
         capabilities["review_file_written"] = True
 
-        messages.extend(
-            [
-                first_message,
-                {
-                    "role": "tool",
-                    "tool_call_id": first_id,
-                    "content": json.dumps({"ok": True, "path": "review.json"}),
-                },
-                {
-                    "role": "user",
-                    "content": (
-                        "Re-check the diff and the review you wrote. Now call edit_review_file "
-                        "with the final review and a non-empty edit_marker, even if the findings "
-                        "remain unchanged."
-                    ),
-                },
-            ],
-        )
+        messages = _edit_messages(messages, first_message, first_id)
         remaining = timeout_seconds - (time.monotonic() - started)
         if remaining <= 0:
             raise httpx.TimeoutException("model exhausted its whole-job timeout before edit turn")
@@ -468,18 +531,19 @@ def _review_model(
             log_file,
         )
         second_message = _assistant_message(second_payload)
+        capabilities["second_response"] = _response_metadata(second_message)
         _second_id, second_arguments = _tool_arguments(second_message, "edit_review_file")
         capabilities["edit_tool_called"] = True
         final_review = _review_from_arguments(second_arguments)
         marker = second_arguments.get("edit_marker")
         if not isinstance(marker, str) or not marker.strip():
             raise ValueError("edit tool did not provide a non-empty edit_marker")
+        verdict, findings = _parse_review(json.dumps(final_review), commentable)
         final_review["_agent_edit_marker"] = marker.strip()
         _write_json(review_file, final_review)
         capabilities["review_file_changed"] = review_file.read_text(encoding="utf-8") != initial_text
         if not capabilities["review_file_changed"]:
             raise ValueError("edit tool did not change review.json")
-        verdict, findings = _parse_review(json.dumps(final_review), commentable)
         capabilities["structured_review_valid"] = True
         capabilities["classification"] = "passed"
         capabilities["elapsed_seconds"] = time.monotonic() - started
@@ -495,7 +559,7 @@ def _review_model(
             output_dir=model_dir,
             classification="passed",
         )
-    except (httpx.HTTPError, json.JSONDecodeError, KeyError, TypeError, ValueError) as error:
+    except (httpx.HTTPError, json.JSONDecodeError, OSError, KeyError, TypeError, ValueError) as error:
         classification = _classification(error)
         capabilities["classification"] = classification
         capabilities["elapsed_seconds"] = time.monotonic() - started
@@ -515,14 +579,7 @@ def _review_model(
 
 
 def _post_findings(repo: str, pr_number: int, head: str, result: ModelResult) -> None:
-    """Post validated findings as inline GitHub comments.
-
-    Args:
-        repo: GitHub ``owner/name`` repository.
-        pr_number: Pull request number.
-        head: Exact reviewed commit.
-        result: Completed model review.
-    """
+    """Post validated findings as inline GitHub comments."""
     for finding in result.findings:
         body = f"[NVIDIA NIM `{result.model}`] {finding.body}"
         if finding.suggestion:
@@ -549,15 +606,17 @@ def _post_findings(repo: str, pr_number: int, head: str, result: ModelResult) ->
 
 
 def _parser() -> argparse.ArgumentParser:
-    """Build the command-line parser.
-
-    Returns:
-        Configured argument parser.
-    """
+    """Build the command-line parser."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("pr", help="Pull request number or URL")
     parser.add_argument("--repo", help="GitHub owner/name; defaults to the current repository")
-    parser.add_argument("--max-models", type=int, help="Limit candidates for a shorter experiment")
+    parser.add_argument("--max-models", type=int, help="Limit discovered candidates")
+    parser.add_argument(
+        "--model",
+        action="append",
+        default=[],
+        help="Exact NVIDIA model ID to test; repeat to run a focused model set",
+    )
     parser.add_argument("--timeout", type=float, default=300, help="Seconds allowed per model")
     parser.add_argument(
         "--concurrency",
@@ -570,8 +629,15 @@ def _parser() -> argparse.ArgumentParser:
         "--expect",
         action="append",
         default=[],
-        metavar="PATH:LINE",
-        help="Known defect location; repeat to measure review recall",
+        metavar="PATH:LINE[-LINE]",
+        help="Known defect location or line range; repeat to measure review recall",
+    )
+    parser.add_argument(
+        "--expect-text",
+        action="append",
+        default=[],
+        metavar="PATH:REGEX",
+        help="Known defect finding-text regex; repeat to tolerate line drift",
     )
     parser.add_argument("--post", action="store_true", help="Post validated inline findings")
     parser.add_argument(
@@ -615,25 +681,54 @@ def _load_completed_result(
         return None
 
 
-def _parse_expected_locations(values: list[str]) -> set[tuple[str, int]]:
-    """Parse repeatable PATH:LINE known-defect locations."""
-    locations: set[tuple[str, int]] = set()
+def _parse_expected_locations(values: list[str]) -> list[ExpectedFinding]:
+    """Parse repeatable PATH:LINE or PATH:START-END expectations."""
+    expectations: list[ExpectedFinding] = []
     for value in values:
-        path, separator, raw_line = value.rpartition(":")
-        if not separator or not path:
-            raise ValueError(f"invalid expected finding {value!r}; use PATH:LINE")
-        locations.add((path, int(raw_line)))
-    return locations
+        path, separator, raw_lines = value.rpartition(":")
+        match = EXPECT_LINE_PATTERN.fullmatch(raw_lines)
+        if not separator or not path or match is None:
+            raise ValueError(f"invalid expected finding {value!r}; use PATH:LINE or PATH:START-END")
+        start_line = int(match.group(1))
+        end_line = int(match.group(2) or start_line)
+        if start_line < 1 or end_line < start_line:
+            raise ValueError(f"invalid expected finding range {value!r}")
+        expectations.append(
+            ExpectedFinding(path=path, start_line=start_line, end_line=end_line),
+        )
+    return expectations
 
 
-def _review_quality(result: ModelResult, expected: set[tuple[str, int]]) -> str:
+def _parse_expected_text(values: list[str]) -> list[ExpectedFinding]:
+    """Parse repeatable PATH:REGEX finding-text expectations."""
+    expectations: list[ExpectedFinding] = []
+    for value in values:
+        path, separator, pattern = value.partition(":")
+        if not separator or not path or not pattern:
+            raise ValueError(f"invalid expected text {value!r}; use PATH:REGEX")
+        try:
+            re.compile(pattern)
+        except re.error as error:
+            raise ValueError(f"invalid expected text regex {pattern!r}: {error}") from error
+        expectations.append(ExpectedFinding(path=path, body_pattern=pattern))
+    return expectations
+
+
+def _matched_expectations(
+    findings: tuple[Finding, ...],
+    expected: list[ExpectedFinding],
+) -> int:
+    """Count known-defect expectations matched by at least one finding."""
+    return sum(any(expectation.matches(finding) for finding in findings) for expectation in expected)
+
+
+def _review_quality(result: ModelResult, expected: list[ExpectedFinding]) -> str:
     """Score review usefulness separately from agent tool compatibility."""
     if result.verdict is None:
         return "no_valid_review"
     if not expected:
         return "valid_unscored"
-    actual = {(finding.path, finding.line) for finding in result.findings}
-    if expected <= actual:
+    if _matched_expectations(result.findings, expected) == len(expected):
         return "known_defects_found"
     return "missed_known_defect"
 
@@ -641,7 +736,7 @@ def _review_quality(result: ModelResult, expected: set[tuple[str, int]]) -> str:
 def _write_summary(
     output_root: Path,
     results: list[ModelResult],
-    expected: set[tuple[str, int]],
+    expected: list[ExpectedFinding],
 ) -> None:
     """Write aggregate machine-readable JSON and CSV result tables."""
     rows = [
@@ -650,6 +745,8 @@ def _write_summary(
             "status": result.status,
             "classification": result.classification,
             "review_quality": _review_quality(result, expected),
+            "expected_findings_matched": _matched_expectations(result.findings, expected),
+            "expected_findings_total": len(expected),
             "verdict": result.verdict,
             "findings": len(result.findings),
             "elapsed_seconds": round(result.elapsed_seconds, 3),
@@ -666,17 +763,16 @@ def _write_summary(
 
 
 def main() -> int:
-    """Run all discovered NVIDIA reviews and print a comparison report.
-
-    Returns:
-        Zero when at least one model completed a valid review, otherwise one.
-    """
+    """Run NVIDIA reviews and print a comparison report."""
     args = _parser().parse_args()
     if args.concurrency < 1 or args.timeout <= 0:
         print("--concurrency and --timeout must be positive", file=sys.stderr)
         return 2
     try:
-        expected = _parse_expected_locations(args.expect)
+        expected = [
+            *_parse_expected_locations(args.expect),
+            *_parse_expected_text(args.expect_text),
+        ]
     except (TypeError, ValueError) as error:
         print(str(error), file=sys.stderr)
         return 2
@@ -703,7 +799,7 @@ def main() -> int:
     )
     patch = _run(["gh", "pr", "diff", str(pr_data["number"]), "--repo", repo, "--patch"])
     commentable = _changed_lines(patch)
-    models = _discover_models(args.max_models)
+    models = _normalize_models(args.model) if args.model else _discover_models(args.max_models)
     output_root = args.output_dir / f"pr-{pr_data['number']}-{str(pr_data['headRefOid'])[:12]}"
     output_root.mkdir(parents=True, exist_ok=True)
     _write_json(
@@ -716,7 +812,7 @@ def main() -> int:
             "models": models,
             "timeout_seconds": args.timeout,
             "concurrency": args.concurrency,
-            "expected_findings": [f"{path}:{line}" for path, line in sorted(expected)],
+            "expected_findings": [item.display for item in expected],
         },
     )
     prompt = (

--- a/tests/test_scripts_nvidia_pr_review.py
+++ b/tests/test_scripts_nvidia_pr_review.py
@@ -203,7 +203,7 @@ def test_initial_tool_review_survives_second_turn_failure(
         ],
     )
 
-    def fake_request(*_args: object, **_kwargs: object) -> dict[str, object]:
+    def fake_request(*_args: object, **_kwargs: object) -> object:
         """Return deterministic provider responses for both turns."""
         return next(responses)
 

--- a/tests/test_scripts_nvidia_pr_review.py
+++ b/tests/test_scripts_nvidia_pr_review.py
@@ -1,0 +1,228 @@
+"""Focused tests for the NVIDIA pull-request review benchmark harness."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_script_module() -> ModuleType:
+    """Load the benchmark script as a testable module."""
+    path = Path(__file__).parent.parent / "scripts" / "test_nvidia_pr_review.py"
+    spec = importlib.util.spec_from_file_location("nvidia_pr_review_harness", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+review = _load_script_module()
+
+
+def _finding(line: int = 219, body: str = "Timezone formatting uses the wrong boundary") -> object:
+    """Build one representative validated finding."""
+    return review.Finding(
+        path="frontend/src/pages/WhatsNewPage.tsx",
+        line=line,
+        body=body,
+    )
+
+
+def _result(
+    *,
+    status: str = "completed",
+    classification: str = "passed",
+    verdict: str | None = "CHANGES_REQUIRED",
+    findings: tuple[object, ...] | None = None,
+) -> object:
+    """Build a model result for quality-scoring tests."""
+    return review.ModelResult(
+        model="nvidia/example",
+        status=status,
+        verdict=verdict,
+        findings=findings if findings is not None else (_finding(),),
+        elapsed_seconds=1.0,
+        detail="test",
+        output_dir=Path("results"),
+        classification=classification,
+    )
+
+
+def _tool_call(name: str, arguments: dict[str, object], call_id: str = "call-1") -> dict[str, object]:
+    """Build one OpenAI-compatible tool call."""
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": arguments},
+    }
+
+
+def test_edit_conversation_has_no_user_message_after_tool_result() -> None:
+    """Mistral receives assistant tool-call -> tool result -> assistant sequencing."""
+    initial = review._initial_messages("review this diff")
+    first_message = {
+        "role": "assistant",
+        "content": None,
+        "reasoning_content": "private provider reasoning",
+        "tool_calls": [_tool_call("write_review_file", {"review": {}})],
+    }
+
+    messages = review._edit_messages(initial, first_message, "call-1")
+
+    assert [message["role"] for message in messages] == ["system", "user", "assistant", "tool"]
+    assert messages[-1]["role"] == "tool"
+    assert messages[-2] == {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": first_message["tool_calls"],
+    }
+    assert "reasoning_content" not in messages[-2]
+
+
+def test_reasoning_fields_are_not_treated_as_final_review_content() -> None:
+    """Null content stays null even when provider reasoning fields contain text."""
+    message = {
+        "content": None,
+        "reasoning": "analysis",
+        "reasoning_content": '{"verdict":"PASS","findings":[]}',
+    }
+
+    assert review._assistant_text(message) is None
+    assert review._response_metadata(message) == {
+        "content_present": False,
+        "reasoning_present": True,
+        "reasoning_content_present": True,
+    }
+
+
+def test_tool_arguments_accept_provider_object_arguments() -> None:
+    """Providers may return already-decoded tool arguments instead of JSON text."""
+    message = {
+        "tool_calls": [
+            _tool_call(
+                "write_review_file",
+                {"review": {"verdict": "PASS", "findings": []}},
+            ),
+        ],
+    }
+
+    call_id, arguments = review._tool_arguments(message, "write_review_file")
+
+    assert call_id == "call-1"
+    assert arguments["review"] == {"verdict": "PASS", "findings": []}
+
+
+def test_known_defect_line_range_survives_line_drift() -> None:
+    """A moved line still matches a deliberately tolerant expected range."""
+    expected = review._parse_expected_locations(
+        ["frontend/src/pages/WhatsNewPage.tsx:210-230"],
+    )
+
+    assert review._review_quality(_result(), expected) == "known_defects_found"
+
+
+def test_known_defect_text_pattern_survives_line_drift() -> None:
+    """Finding text can identify a known defect without pinning an exact line."""
+    expected = review._parse_expected_text(
+        ["frontend/src/pages/WhatsNewPage.tsx:timezone|local time"],
+    )
+    moved_result = _result(findings=(_finding(line=260, body="Local time uses a timezone boundary incorrectly"),))
+
+    assert review._review_quality(moved_result, expected) == "known_defects_found"
+
+
+def test_review_quality_is_independent_from_tool_compatibility() -> None:
+    """A useful review remains useful even when the tool protocol later fails."""
+    expected = review._parse_expected_locations(
+        ["frontend/src/pages/WhatsNewPage.tsx:210-230"],
+    )
+    failed_tool_result = _result(status="failed", classification="tool_call_not_emitted")
+
+    assert review._review_quality(failed_tool_result, expected) == "known_defects_found"
+
+
+def test_tool_compatible_false_pass_is_scored_as_missed_defect() -> None:
+    """Successful tool calls do not rescue a PASS that misses the known defect."""
+    expected = review._parse_expected_locations(
+        ["frontend/src/pages/WhatsNewPage.tsx:210-230"],
+    )
+    false_pass = _result(verdict="PASS", findings=())
+
+    assert review._review_quality(false_pass, expected) == "missed_known_defect"
+
+
+def test_initial_tool_review_survives_second_turn_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A valid first tool review remains scoreable when the edit tool is not emitted."""
+    finding = {
+        "path": "frontend/src/pages/WhatsNewPage.tsx",
+        "line": 219,
+        "body": "Timezone formatting can cross the viewer's local day boundary.",
+    }
+    responses = iter(
+        [
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "reasoning_content": "reviewed the timezone behavior",
+                            "tool_calls": [
+                                _tool_call(
+                                    "write_review_file",
+                                    {
+                                        "review": {
+                                            "verdict": "CHANGES_REQUIRED",
+                                            "findings": [finding],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    },
+                ],
+            },
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "The original review is still correct.",
+                        },
+                    },
+                ],
+            },
+        ],
+    )
+
+    def fake_request(*_args: object, **_kwargs: object) -> dict[str, object]:
+        """Return deterministic provider responses for both turns."""
+        return next(responses)
+
+    monkeypatch.setattr(review, "_request_nim", fake_request)
+
+    result = review._review_model(
+        "nvidia/example",
+        "secret",
+        "prompt",
+        {"frontend/src/pages/WhatsNewPage.tsx": {219}},
+        30,
+        tmp_path,
+    )
+
+    assert result.status == "failed"
+    assert result.classification == "tool_call_not_emitted"
+    assert result.verdict == "CHANGES_REQUIRED"
+    assert result.findings == (_finding(body=finding["body"]),)
+    expected = review._parse_expected_locations(
+        ["frontend/src/pages/WhatsNewPage.tsx:210-230"],
+    )
+    assert review._review_quality(result, expected) == "known_defects_found"


### PR DESCRIPTION
## Summary

- benchmark currently healthy NVIDIA NIM models against an exact GitHub PR diff
- validate inline review locations and score known-defect recall with line ranges or finding-text patterns that tolerate line drift
- probe two-turn write/edit tool capability independently from review quality in durable per-model artifacts
- preserve a valid first-turn structured review even when a later tool turn times out or fails
- use provider-safe assistant tool-call → tool-result sequencing and keep reasoning fields separate from final review output
- add bounded concurrency, rate-limit handling, exact-head resume/posting safety, focused model selection, and JSON/CSV summaries
- exclude multimodal Omni models from text-only PR review selection

## Validation

- exact-head CI on `20b2b34fab9070644161047c6330e56af8f7650c` is green, including Ruff, `ty`, backend tests, frontend unit tests, frontend lint/typecheck, migration health, API E2E, and dice-ladder E2E
- focused pytest coverage exercises conversation construction, reasoning-channel handling, object tool arguments, drift-tolerant known-defect scoring, false-PASS scoring, and preservation of first-turn review quality after second-turn failure
- independent exact-head NVIDIA/OpenCode review inspected the changed files, ran focused validation, and reported no actionable issues
- live PR #1006 benchmark confirmed Mistral Nemotron now completes both `write_review_file` and `edit_review_file` turns with the corrected message sequence; its tool compatibility passed while its review quality independently scored `missed_known_defect`
- the same live run preserved GLM-5.2's valid `CHANGES_REQUIRED` first-turn review and findings even though the model later exhausted the whole-job timeout, demonstrating that review quality no longer collapses into tool compatibility
- a Llama Nemotron Super probe using the raw NVIDIA API ID produced a 404 because the harness uses provider-qualified FCM-style identifiers; a corrected provider-qualified rerun was requested separately and is supplementary to the exact-head merge gates
- CodeRabbit exact-head review is rate-limited status noise, with no actionable CodeRabbit thread

No Playwright run was used for this tooling change.

Changelog: `docs/changelog.d/2026-08-09-1010.md`