### PR TITLE
Keep crossover list clear of fixed navigation

### DIFF
--- a/docs/changelog.d/2026-08-09-1012.md
+++ b/docs/changelog.d/2026-08-09-1012.md
@@ -2,4 +2,4 @@
 
 ### Crossovers
 
-- [PR #1012](https://github.com/JoshCLWren/comic-pile/pull/1012) keeps the bottom of long crossover lists scrollable above ComicPile's fixed navigation, including mobile safe-area space, so the final crossover is no longer hidden behind the footer.
+- [#1012](https://github.com/JoshCLWren/comic-pile/pull/1012) keeps the bottom of long crossover lists scrollable above ComicPile's fixed navigation, including mobile safe-area space, so the final crossover is no longer hidden behind the footer.

--- a/docs/changelog.d/2026-08-09-1012.md
+++ b/docs/changelog.d/2026-08-09-1012.md
@@ -1,0 +1,5 @@
+## 2026-08-09
+
+### Crossovers
+
+- [PR #1012](https://github.com/JoshCLWren/comic-pile/pull/1012) keeps the bottom of long crossover lists scrollable above ComicPile's fixed navigation, including mobile safe-area space, so the final crossover is no longer hidden behind the footer.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "./styles.css";
+@import "./layout.css";
 
 :root {
   --theme-primary: #d6890e;

--- a/frontend/src/layout.css
+++ b/frontend/src/layout.css
@@ -1,0 +1,14 @@
+/* Keep scrollable page content fully reachable above the fixed bottom navigation. */
+[data-app-shell-ready] > main {
+  padding-bottom: calc(
+    var(--mobile-nav-height) + 1.5rem + env(safe-area-inset-bottom)
+  );
+}
+
+@media (min-width: 768px) {
+  [data-app-shell-ready] > main {
+    padding-bottom: calc(
+      var(--desktop-nav-height) + 2rem + env(safe-area-inset-bottom)
+    );
+  }
+}


### PR DESCRIPTION
Closes #1011

## Summary
- reserve app-shell bottom space from the same mobile/desktop navigation-height variables used by the fixed footer
- include safe-area inset so the last crossover remains scrollable above the navigation on phones
- apply the clearance with app-shell specificity instead of relying on utility ordering

## Validation
This scheduled runtime has no local checkout, so focused runtime validation is delegated to configured exact-head CI. The change is isolated CSS/layout behavior and the Vite build will validate the imported stylesheet.