### PR TITLE
Keep crossover list clear of fixed navigation

### DIFF
--- a/docs/changelog.d/2026-08-09-1015.md
+++ b/docs/changelog.d/2026-08-09-1015.md
@@ -1,0 +1,5 @@
+## 2026-08-09
+
+### Crossovers
+
+- [#1015](https://github.com/JoshCLWren/comic-pile/pull/1015) keeps the bottom of long crossover lists scrollable above ComicPile's fixed navigation, including mobile safe-area space, so the final crossover is no longer hidden behind the footer.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "./styles.css";
+@import "./layout.css";
 
 :root {
   --theme-primary: #d6890e;

--- a/frontend/src/layout.css
+++ b/frontend/src/layout.css
@@ -1,0 +1,14 @@
+/* Keep scrollable page content fully reachable above the fixed bottom navigation. */
+[data-app-shell-ready] > main {
+  padding-bottom: calc(
+    var(--mobile-nav-height) + 1.5rem + env(safe-area-inset-bottom)
+  );
+}
+
+@media (min-width: 768px) {
+  [data-app-shell-ready] > main {
+    padding-bottom: calc(
+      var(--desktop-nav-height) + 2rem + env(safe-area-inset-bottom)
+    );
+  }
+}


### PR DESCRIPTION
Closes #1011

## Summary
- replay the already-reviewed footer-clearance fix onto current main after PR #1012 became non-mergeable
- reserve app-shell bottom space from the same mobile/desktop navigation-height variables used by the fixed footer
- include safe-area inset so the last crossover remains scrollable above the navigation on phones

## Validation
The prior implementation passed CI before main advanced. This replay preserves the same CSS behavior and will be revalidated on its own exact head before merge.