### PR TITLE
Make Retry explicitly restore authentication

### DIFF
--- a/docs/changelog.d/2026-08-09-1024.md
+++ b/docs/changelog.d/2026-08-09-1024.md
@@ -1,0 +1,5 @@
+## 2026-08-09
+
+### Authentication
+
+- [#1024](https://github.com/JoshCLWren/comic-pile/pull/1024) makes the visible Retry button perform a real authentication recovery immediately instead of being swallowed by automatic resume throttling. ComicPile now shows reconnecting progress, refreshes the persistent session, and preserves the reader's current screen while recovery completes.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, createContext, useContext, useState, useEffect, useCallback } from 'react'
+import { lazy, Suspense, createContext, useContext, useState, useEffect, useCallback, useRef } from 'react'
 import type { ReactNode } from 'react'
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom'
 import { QueryClientProvider } from '@tanstack/react-query'
@@ -8,7 +8,7 @@ import BugReportButton from './components/BugReportButton'
 import type { ReportType } from './components/BugReportModal'
 import ResumeRecovery from './components/ResumeRecovery'
 import api, { clearAccessToken, setAccessToken, getAccessToken } from './services/api'
-import type { AuthUser } from './types'
+import type { AuthTokens, AuthUser } from './types'
 import { useBugReport } from './hooks/useBugReport'
 import type { DiagnosticData } from './hooks/useDiagnostics'
 import { ToastProvider } from './contexts/ToastProvider'
@@ -47,6 +47,7 @@ export interface AuthContextValue {
   login: (accessToken: string) => Promise<void>
   logout: () => void
   revalidateSession: (timeout?: number) => Promise<void>
+  recoverSession: (timeout?: number) => Promise<void>
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null)
@@ -62,11 +63,33 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [isAuthenticated, setIsAuthenticated] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
   const [user, setUser] = useState<AuthUser | null>(null)
+  const recoveryPromise = useRef<Promise<void> | null>(null)
 
   const revalidateSession = useCallback(async (timeout?: number) => {
     const response = await api.get<AuthUser>('/v1/auth/me', { timeout, skipAuthRedirect: false })
     setUser(response)
     setIsAuthenticated(true)
+  }, [])
+
+  const recoverSession = useCallback((timeout?: number): Promise<void> => {
+    if (!recoveryPromise.current) {
+      recoveryPromise.current = (async () => {
+        const tokens = await api.post<AuthTokens>('/v1/auth/refresh', undefined, {
+          skipAuthRedirect: false,
+        })
+        setAccessToken(tokens.access_token)
+        const response = await api.get<AuthUser>('/v1/auth/me', {
+          timeout,
+          skipAuthRedirect: false,
+        })
+        setUser(response)
+        setIsAuthenticated(true)
+      })().finally(() => {
+        recoveryPromise.current = null
+      })
+    }
+
+    return recoveryPromise.current
   }, [])
 
   useEffect(() => {
@@ -139,7 +162,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }
 
-  return <AuthContext.Provider value={{ isAuthenticated, isLoading, user, login, logout, revalidateSession }}>{children}</AuthContext.Provider>
+  return <AuthContext.Provider value={{ isAuthenticated, isLoading, user, login, logout, revalidateSession, recoverSession }}>{children}</AuthContext.Provider>
 }
 
 function ProtectedRoute({ children }: { children: ReactNode }) {
@@ -196,8 +219,12 @@ function AppRoutes() {
 }
 
 function AuthResumeBoundary({ children }: { children: ReactNode }) {
-  const { revalidateSession } = useAuth()
-  return <ResumeRecovery revalidateSession={revalidateSession}>{children}</ResumeRecovery>
+  const { revalidateSession, recoverSession } = useAuth()
+  return (
+    <ResumeRecovery revalidateSession={revalidateSession} recoverSession={recoverSession}>
+      {children}
+    </ResumeRecovery>
+  )
 }
 
 function App() {

--- a/frontend/src/components/ResumeRecovery.tsx
+++ b/frontend/src/components/ResumeRecovery.tsx
@@ -6,64 +6,87 @@ const RESUME_RETRY_DELAY_MS = 750
 const MAX_RESUME_ATTEMPTS = 2
 
 type RecoveryState = 'idle' | 'reconnecting' | 'failed'
+type RecoveryMode = 'automatic' | 'explicit'
 
 interface ResumeRecoveryProps {
   children: ReactNode
   revalidateSession: (timeout: number) => Promise<void>
+  recoverSession: (timeout: number) => Promise<void>
 }
 
 function delay(milliseconds: number): Promise<void> {
   return new Promise((resolve) => window.setTimeout(resolve, milliseconds))
 }
 
-export default function ResumeRecovery({ children, revalidateSession }: ResumeRecoveryProps) {
+export default function ResumeRecovery({
+  children,
+  revalidateSession,
+  recoverSession,
+}: ResumeRecoveryProps) {
   const [recoveryState, setRecoveryState] = useState<RecoveryState>('idle')
   const requestSequence = useRef(0)
   const lastValidationAt = useRef(0)
+  const explicitRecoveryActive = useRef(false)
 
-  const revalidate = useCallback(async () => {
-    const now = Date.now()
-    if (now - lastValidationAt.current < 1000) {
-      return
+  const runRecovery = useCallback(async (mode: RecoveryMode) => {
+    if (mode === 'automatic') {
+      if (explicitRecoveryActive.current) {
+        return
+      }
+
+      const now = Date.now()
+      if (now - lastValidationAt.current < 1000) {
+        return
+      }
+      lastValidationAt.current = now
+    } else {
+      explicitRecoveryActive.current = true
     }
-    lastValidationAt.current = now
+
     const sequence = ++requestSequence.current
     setRecoveryState('reconnecting')
+    const recover = mode === 'explicit' ? recoverSession : revalidateSession
 
-    for (let attempt = 1; attempt <= MAX_RESUME_ATTEMPTS; attempt += 1) {
-      try {
-        await revalidateSession(RESUME_REQUEST_TIMEOUT_MS)
-        if (sequence !== requestSequence.current) {
+    try {
+      for (let attempt = 1; attempt <= MAX_RESUME_ATTEMPTS; attempt += 1) {
+        try {
+          await recover(RESUME_REQUEST_TIMEOUT_MS)
+          if (sequence !== requestSequence.current) {
+            return
+          }
+          await queryClient.invalidateQueries()
+          if (sequence !== requestSequence.current) {
+            return
+          }
+          setRecoveryState('idle')
           return
-        }
-        await queryClient.invalidateQueries()
-        if (sequence !== requestSequence.current) {
-          return
-        }
-        setRecoveryState('idle')
-        return
-      } catch (error) {
-        console.error(`ComicPile resume validation failed (attempt ${attempt})`, error)
-        if (attempt < MAX_RESUME_ATTEMPTS) {
-          await delay(RESUME_RETRY_DELAY_MS)
+        } catch (error) {
+          console.error(`ComicPile resume validation failed (attempt ${attempt})`, error)
+          if (attempt < MAX_RESUME_ATTEMPTS) {
+            await delay(RESUME_RETRY_DELAY_MS)
+          }
         }
       }
-    }
 
-    if (sequence === requestSequence.current) {
-      setRecoveryState('failed')
+      if (sequence === requestSequence.current) {
+        setRecoveryState('failed')
+      }
+    } finally {
+      if (mode === 'explicit' && sequence === requestSequence.current) {
+        explicitRecoveryActive.current = false
+      }
     }
-  }, [revalidateSession])
+  }, [recoverSession, revalidateSession])
 
   useEffect(() => {
     const handlePageShow = (event: PageTransitionEvent) => {
       if (event.persisted) {
-        void revalidate()
+        void runRecovery('automatic')
       }
     }
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') {
-        void revalidate()
+        void runRecovery('automatic')
       }
     }
 
@@ -71,10 +94,11 @@ export default function ResumeRecovery({ children, revalidateSession }: ResumeRe
     document.addEventListener('visibilitychange', handleVisibilityChange)
     return () => {
       requestSequence.current += 1
+      explicitRecoveryActive.current = false
       window.removeEventListener('pageshow', handlePageShow)
       document.removeEventListener('visibilitychange', handleVisibilityChange)
     }
-  }, [revalidate])
+  }, [runRecovery])
 
   return (
     <>
@@ -96,7 +120,7 @@ export default function ResumeRecovery({ children, revalidateSession }: ResumeRe
               <div className="mt-3 flex gap-2">
                 <button
                   className="rounded-lg bg-stone-900 px-3 py-2 text-sm font-medium text-white"
-                  onClick={() => void revalidate()}
+                  onClick={() => void runRecovery('explicit')}
                   type="button"
                 >
                   Retry

--- a/frontend/src/test/auth-recovery.spec.ts
+++ b/frontend/src/test/auth-recovery.spec.ts
@@ -1,9 +1,17 @@
 import { expect, test } from './fixtures'
 
-test('Retry explicitly refreshes auth after automatic resume recovery fails', async ({ authenticatedPage }) => {
+test('Retry explicitly refreshes auth after automatic resume recovery fails', async ({
+  authenticatedPage,
+  allowExpectedBrowserFailures,
+}) => {
   const page = authenticatedPage
   let meAttempts = 0
   let refreshAttempts = 0
+
+  allowExpectedBrowserFailures.allow(
+    { category: 'console', message: '503' },
+    { category: 'console', message: 'ComicPile resume validation failed' },
+  )
 
   await page.goto('/')
   await expect(page.locator('[data-app-shell-ready]')).toBeVisible()

--- a/frontend/src/test/auth-recovery.spec.ts
+++ b/frontend/src/test/auth-recovery.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from './fixtures'
+
+test('Retry explicitly refreshes auth after automatic resume recovery fails', async ({ authenticatedPage }) => {
+  const page = authenticatedPage
+  let meAttempts = 0
+  let refreshAttempts = 0
+
+  await page.goto('/')
+  await expect(page.locator('[data-app-shell-ready]')).toBeVisible()
+
+  await page.route('**/api/v1/auth/me', async (route) => {
+    meAttempts += 1
+    if (meAttempts <= 2) {
+      await route.fulfill({
+        status: 503,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'temporarily unavailable' }),
+      })
+      return
+    }
+    await route.continue()
+  })
+
+  await page.route('**/api/v1/auth/refresh', async (route) => {
+    refreshAttempts += 1
+    await route.continue()
+  })
+
+  await page.evaluate(() => {
+    document.dispatchEvent(new Event('visibilitychange'))
+  })
+
+  await expect(page.getByRole('alert')).toContainText('ComicPile could not reconnect')
+
+  await page.getByRole('button', { name: 'Retry' }).click()
+
+  await expect(page.getByRole('status')).toContainText('Reconnecting ComicPile')
+  await expect.poll(() => refreshAttempts).toBe(1)
+  await expect(page.getByRole('alert')).toHaveCount(0)
+  await expect(page.locator('[data-app-shell-ready]')).toBeVisible()
+})

--- a/frontend/src/unit/resume-recovery.test.tsx
+++ b/frontend/src/unit/resume-recovery.test.tsx
@@ -2,8 +2,9 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import ResumeRecovery from '../components/ResumeRecovery'
 
-const { revalidateSession, invalidateQueries } = vi.hoisted(() => ({
+const { revalidateSession, recoverSession, invalidateQueries } = vi.hoisted(() => ({
   revalidateSession: vi.fn(),
+  recoverSession: vi.fn(),
   invalidateQueries: vi.fn(),
 }))
 
@@ -26,7 +27,7 @@ function setVisibilityState(state: DocumentVisibilityState): void {
 
 function renderRecovery() {
   return render(
-    <ResumeRecovery revalidateSession={revalidateSession}>
+    <ResumeRecovery revalidateSession={revalidateSession} recoverSession={recoverSession}>
       <div>Last usable screen</div>
     </ResumeRecovery>,
   )
@@ -35,6 +36,7 @@ function renderRecovery() {
 describe('ResumeRecovery', () => {
   beforeEach(() => {
     revalidateSession.mockReset()
+    recoverSession.mockReset()
     invalidateQueries.mockReset()
     setVisibilityState('visible')
   })
@@ -56,6 +58,7 @@ describe('ResumeRecovery', () => {
     await waitFor(() => expect(revalidateSession).toHaveBeenCalledWith(8000))
     await waitFor(() => expect(invalidateQueries).toHaveBeenCalledOnce())
     await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument())
+    expect(recoverSession).not.toHaveBeenCalled()
   })
 
   it('keeps the application visible and offers recovery after bounded retries fail', async () => {
@@ -74,6 +77,70 @@ describe('ResumeRecovery', () => {
     expect(screen.getByRole('alert')).toHaveTextContent('ComicPile could not reconnect')
     expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Reload' })).toBeInTheDocument()
+  })
+
+  it('runs an explicit auth recovery immediately even inside the automatic throttle window', async () => {
+    vi.useFakeTimers()
+    const now = vi.spyOn(Date, 'now').mockReturnValue(10_000)
+    revalidateSession.mockRejectedValue(new Error('server still waking'))
+    recoverSession.mockResolvedValue(undefined)
+    invalidateQueries.mockResolvedValue(undefined)
+
+    renderRecovery()
+    dispatchPageShow(true)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(750)
+    })
+    expect(screen.getByRole('alert')).toHaveTextContent('ComicPile could not reconnect')
+
+    now.mockReturnValue(10_500)
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(screen.getByRole('status')).toHaveTextContent('Reconnecting ComicPile')
+    expect(recoverSession).toHaveBeenCalledWith(8000)
+    expect(revalidateSession).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(invalidateQueries).toHaveBeenCalledOnce()
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('does not allow automatic lifecycle events to supersede an explicit retry', async () => {
+    vi.useFakeTimers()
+    let finishExplicitRecovery: (() => void) | undefined
+    revalidateSession.mockRejectedValue(new Error('resume failed'))
+    recoverSession.mockImplementation(
+      () => new Promise<void>((resolve) => {
+        finishExplicitRecovery = resolve
+      }),
+    )
+    invalidateQueries.mockResolvedValue(undefined)
+
+    renderRecovery()
+    dispatchPageShow(true)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(750)
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(recoverSession).toHaveBeenCalledOnce()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1100)
+    })
+    fireEvent(document, new Event('visibilitychange'))
+    dispatchPageShow(true)
+    expect(revalidateSession).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      finishExplicitRecovery?.()
+    })
+
+    expect(invalidateQueries).toHaveBeenCalledOnce()
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
   })
 
   it('ignores ordinary page shows and hidden tabs, then recovers on a visible resume with one successful retry', async () => {


### PR DESCRIPTION
Closes #1014

## Summary
- separate human Retry from automatic visibility/pageshow throttling
- make Retry explicitly refresh the persistent auth session before verifying `/me`
- serialize repeated explicit recovery attempts and prevent automatic lifecycle events from superseding them
- preserve the current rendered ComicPile screen while recovery runs
- add deterministic unit coverage and Chromium lifecycle coverage for the immediate-retry path

## Validation
This scheduled connector runtime has no local checkout, so focused unit, type, and Chromium execution are delegated to configured exact-head CI.

Changelog: `docs/changelog.d/2026-08-09-1024.md`.