### PR TITLE
Preserve authentication through transient backend failures

### DIFF
--- a/docs/changelog.d/2026-08-09-1027.md
+++ b/docs/changelog.d/2026-08-09-1027.md
@@ -1,0 +1,5 @@
+## 2026-08-09
+
+### Authentication
+
+- [#1027](https://github.com/JoshCLWren/comic-pile/pull/1027) stops cold starts, network interruptions, and temporary server failures from being mistaken for a logout. ComicPile now keeps recovering instead of discarding the reader's authenticated state, and resume checks have enough timeout headroom for observed production cold starts.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import BugReportButton from './components/BugReportButton'
 import type { ReportType } from './components/BugReportModal'
 import ResumeRecovery from './components/ResumeRecovery'
 import api, { clearAccessToken, setAccessToken, getAccessToken } from './services/api'
+import { isDefinitiveAuthenticationFailure } from './services/authFailure'
 import type { AuthTokens, AuthUser } from './types'
 import { useBugReport } from './hooks/useBugReport'
 import type { DiagnosticData } from './hooks/useDiagnostics'
@@ -28,6 +29,9 @@ type BugReportSubmit = (
   description: string,
   diagnosticData: DiagnosticData | null,
 ) => Promise<void>
+
+const AUTH_BOOTSTRAP_TIMEOUT_MS = 15000
+const AUTH_BOOTSTRAP_RETRY_DELAY_MS = 1000
 
 const RollPage = lazy(() => import('./pages/RollPage'))
 const QueuePage = lazy(() => import('./pages/QueuePage'))
@@ -65,35 +69,59 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(null)
   const recoveryPromise = useRef<Promise<void> | null>(null)
 
-  const revalidateSession = useCallback(async (timeout?: number) => {
-    const response = await api.get<AuthUser>('/v1/auth/me', { timeout, skipAuthRedirect: false })
-    setUser(response)
-    setIsAuthenticated(true)
+  const markDefinitivelyUnauthenticated = useCallback(() => {
+    clearAccessToken()
+    setIsAuthenticated(false)
+    setUser(null)
   }, [])
+
+  const revalidateSession = useCallback(async (timeout?: number) => {
+    try {
+      const response = await api.get<AuthUser>('/v1/auth/me', {
+        timeout,
+        skipAuthRedirect: true,
+      })
+      setUser(response)
+      setIsAuthenticated(true)
+    } catch (error) {
+      if (isDefinitiveAuthenticationFailure(error)) {
+        markDefinitivelyUnauthenticated()
+      }
+      throw error
+    }
+  }, [markDefinitivelyUnauthenticated])
 
   const recoverSession = useCallback((timeout?: number): Promise<void> => {
     if (!recoveryPromise.current) {
       recoveryPromise.current = (async () => {
-        const tokens = await api.post<AuthTokens>('/v1/auth/refresh', undefined, {
-          skipAuthRedirect: false,
-        })
-        setAccessToken(tokens.access_token)
-        const response = await api.get<AuthUser>('/v1/auth/me', {
-          timeout,
-          skipAuthRedirect: false,
-        })
-        setUser(response)
-        setIsAuthenticated(true)
+        try {
+          const tokens = await api.post<AuthTokens>('/v1/auth/refresh', undefined, {
+            skipAuthRedirect: true,
+          })
+          setAccessToken(tokens.access_token)
+          const response = await api.get<AuthUser>('/v1/auth/me', {
+            timeout,
+            skipAuthRedirect: true,
+          })
+          setUser(response)
+          setIsAuthenticated(true)
+        } catch (error) {
+          if (isDefinitiveAuthenticationFailure(error)) {
+            markDefinitivelyUnauthenticated()
+          }
+          throw error
+        }
       })().finally(() => {
         recoveryPromise.current = null
       })
     }
 
     return recoveryPromise.current
-  }, [])
+  }, [markDefinitivelyUnauthenticated])
 
   useEffect(() => {
     let isMounted = true
+    let retryTimer: number | undefined
     const authChannel = typeof BroadcastChannel !== 'undefined' ? new BroadcastChannel('comic-pile-auth') : null
     const validateSession = async () => {
       const isPublicAuthPage = window.location.pathname === '/login' || window.location.pathname === '/register'
@@ -106,41 +134,52 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         delete window.__COMIC_PILE_ACCESS_TOKEN
       }
       try {
-        const response = await api.get<AuthUser>('/auth/me')
+        const response = await api.get<AuthUser>('/v1/auth/me', {
+          timeout: AUTH_BOOTSTRAP_TIMEOUT_MS,
+          skipAuthRedirect: true,
+        })
         if (isMounted) {
           setUser(response)
           setIsAuthenticated(true)
+          setIsLoading(false)
         }
-      } catch {
-        if (isMounted) {
-          clearAccessToken()
-          setIsAuthenticated(false)
-          setUser(null)
+      } catch (error) {
+        if (!isMounted) {
+          return
         }
-      } finally {
-        if (isMounted) setIsLoading(false)
+        if (isDefinitiveAuthenticationFailure(error)) {
+          markDefinitivelyUnauthenticated()
+          setIsLoading(false)
+          return
+        }
+
+        retryTimer = window.setTimeout(() => {
+          void validateSession()
+        }, AUTH_BOOTSTRAP_RETRY_DELAY_MS)
       }
     }
     if (authChannel) {
       authChannel.onmessage = (event: MessageEvent<{ type?: string }>) => {
         if (event.data?.type === 'logout') {
-          clearAccessToken()
-          setIsAuthenticated(false)
-          setUser(null)
+          markDefinitivelyUnauthenticated()
+          setIsLoading(false)
         }
       }
     }
     void validateSession()
     return () => {
       isMounted = false
+      if (retryTimer !== undefined) {
+        window.clearTimeout(retryTimer)
+      }
       authChannel?.close()
     }
-  }, [])
+  }, [markDefinitivelyUnauthenticated])
 
   const login = async (accessToken: string) => {
     setAccessToken(accessToken)
     try {
-      const response = await api.get<AuthUser>('/auth/me')
+      const response = await api.get<AuthUser>('/v1/auth/me', { skipAuthRedirect: true })
       setUser(response)
       setIsAuthenticated(true)
     } catch (error) {
@@ -152,9 +191,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }
 
   const logout = () => {
-    clearAccessToken()
-    setIsAuthenticated(false)
-    setUser(null)
+    markDefinitivelyUnauthenticated()
     if (typeof BroadcastChannel !== 'undefined') {
       const authChannel = new BroadcastChannel('comic-pile-auth')
       authChannel.postMessage({ type: 'logout' })

--- a/frontend/src/components/ResumeRecovery.tsx
+++ b/frontend/src/components/ResumeRecovery.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import { queryClient } from '../query/queryClient'
 
-const RESUME_REQUEST_TIMEOUT_MS = 8000
+const RESUME_REQUEST_TIMEOUT_MS = 15000
 const RESUME_RETRY_DELAY_MS = 750
 const MAX_RESUME_ATTEMPTS = 2
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -235,9 +235,9 @@ rawApi.interceptors.response.use(
       isRefreshing = true
 
       try {
-        const response = await api.post<AuthTokens>('/v1/auth/refresh', undefined, {
-          skipAuthRedirect: originalRequest.skipAuthRedirect,
-        })
+        const response = originalRequest.skipAuthRedirect
+          ? await api.post<AuthTokens>('/v1/auth/refresh', undefined, { skipAuthRedirect: true })
+          : await api.post<AuthTokens>('/v1/auth/refresh')
 
         const { access_token } = response
         setAccessToken(access_token)

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -214,7 +214,7 @@ rawApi.interceptors.response.use(
     if (isAuthenticationFailure(error) && !originalRequest._retry) {
       const requestPathname = getRequestPathname(originalRequest.url ?? '')
       if (AUTH_ENDPOINT_PATHS.has(requestPathname)) {
-        if (requestPathname === '/v1/auth/refresh') {
+        if (requestPathname === '/v1/auth/refresh' && !originalRequest.skipAuthRedirect) {
           redirectToLogin()
         }
         return Promise.reject(error)
@@ -235,7 +235,9 @@ rawApi.interceptors.response.use(
       isRefreshing = true
 
       try {
-        const response = await api.post<AuthTokens>('/v1/auth/refresh')
+        const response = await api.post<AuthTokens>('/v1/auth/refresh', undefined, {
+          skipAuthRedirect: originalRequest.skipAuthRedirect,
+        })
 
         const { access_token } = response
         setAccessToken(access_token)

--- a/frontend/src/services/authFailure.ts
+++ b/frontend/src/services/authFailure.ts
@@ -1,0 +1,10 @@
+import axios from 'axios'
+
+/** Return true only when the server has definitively rejected the persistent session. */
+export function isDefinitiveAuthenticationFailure(error: unknown): boolean {
+  if (!axios.isAxiosError(error)) {
+    return false
+  }
+
+  return error.response?.status === 401
+}

--- a/frontend/src/unit/App.test.tsx
+++ b/frontend/src/unit/App.test.tsx
@@ -9,6 +9,11 @@ const mockSetAccessToken = vi.fn()
 const mockClearAccessToken = vi.fn()
 const mockGetAccessToken = vi.fn<() => string | null>(() => 'test-token')
 
+const unauthenticatedError = () => Object.assign(new Error('unauthenticated'), {
+  isAxiosError: true,
+  response: { status: 401 },
+})
+
 vi.mock('../services/api', () => {
   return {
     default: {
@@ -108,7 +113,7 @@ test('logs in successfully and logs out without BroadcastChannel support', async
 })
 
 test('mounts the application shell', async () => {
-  mockApiGet.mockRejectedValue(new Error('unauthenticated'))
+  mockApiGet.mockRejectedValue(unauthenticatedError())
   render(<App />)
   await waitFor(() => expect(screen.getByTestId('login-page')).toBeInTheDocument())
 })
@@ -185,7 +190,7 @@ describe('route guards', () => {
     mockApiGet.mockReset()
     mockSetAccessToken.mockReset()
     mockClearAccessToken.mockReset()
-    mockApiGet.mockRejectedValue(new Error('unauthenticated'))
+    mockApiGet.mockRejectedValue(unauthenticatedError())
     delete (window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN
   })
 
@@ -209,7 +214,7 @@ describe('route guards', () => {
   })
 
   test('allows unauthenticated users to access /login', async () => {
-    mockApiGet.mockRejectedValue(new Error('unauthenticated'))
+    mockApiGet.mockRejectedValue(unauthenticatedError())
     renderWithAuth('/login')
 
     await waitFor(() => {
@@ -218,7 +223,7 @@ describe('route guards', () => {
   })
 
   test('allows unauthenticated users to access /register', async () => {
-    mockApiGet.mockRejectedValue(new Error('unauthenticated'))
+    mockApiGet.mockRejectedValue(unauthenticatedError())
     renderWithAuth('/register')
 
     await waitFor(() => {
@@ -255,13 +260,13 @@ describe('auth state race condition regression', () => {
     mockApiGet.mockReset()
     mockSetAccessToken.mockReset()
     mockClearAccessToken.mockReset()
-    mockApiGet.mockRejectedValue(new Error('unauthenticated'))
+    mockApiGet.mockRejectedValue(unauthenticatedError())
     delete (window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN
   })
 
   test('auth state updates immediately after login - no redirect loop', async () => {
     mockApiGet
-      .mockRejectedValueOnce(new Error('unauthenticated'))
+      .mockRejectedValueOnce(unauthenticatedError())
       .mockResolvedValue({ username: 'testuser', email: 'test@test.com' })
 
     renderWithAuth('/login')
@@ -288,7 +293,7 @@ describe('auth state race condition regression', () => {
 
   test('auth state updates immediately after register - no redirect loop', async () => {
     mockApiGet
-      .mockRejectedValueOnce(new Error('unauthenticated'))
+      .mockRejectedValueOnce(unauthenticatedError())
       .mockResolvedValue({ username: 'testuser', email: 'test@test.com' })
 
     renderWithAuth('/register')
@@ -334,10 +339,11 @@ describe('anonymous no-token probe suppression', () => {
     await waitFor(() => {
       expect(screen.getByTestId('login-page')).toBeInTheDocument()
     })
-    expect(mockApiGet).not.toHaveBeenCalledWith('/auth/me')
+    expect(mockApiGet).not.toHaveBeenCalledWith('/v1/auth/me', expect.anything())
   })
 
   test('anonymous user falls through correctly to login page from protected route', async () => {
+    mockApiGet.mockRejectedValue(unauthenticatedError())
     renderWithAuth('/')
 
     await waitFor(() => {
@@ -354,7 +360,10 @@ describe('anonymous no-token probe suppression', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('login-page')).not.toBeInTheDocument()
     })
-    expect(mockApiGet).toHaveBeenCalledWith('/auth/me')
+    expect(mockApiGet).toHaveBeenCalledWith('/v1/auth/me', {
+      timeout: 15000,
+      skipAuthRedirect: true,
+    })
     expect(mockSetAccessToken).toHaveBeenCalledWith('ssr-token')
   })
 })

--- a/frontend/src/unit/AuthHardRefresh.test.tsx
+++ b/frontend/src/unit/AuthHardRefresh.test.tsx
@@ -61,7 +61,10 @@ describe('hard refresh session bootstrap', () => {
     await waitFor(() => {
       expect(authState?.isAuthenticated).toBe(true)
     })
-    expect(mockApiGet).toHaveBeenCalledWith('/auth/me')
+    expect(mockApiGet).toHaveBeenCalledWith('/v1/auth/me', {
+      timeout: 15000,
+      skipAuthRedirect: true,
+    })
     expect(mockClearAccessToken).not.toHaveBeenCalled()
   })
 

--- a/frontend/src/unit/api-auth-recovery.test.ts
+++ b/frontend/src/unit/api-auth-recovery.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, expect, it, vi } from 'vitest'
+
+const apiMock = vi.hoisted(() => ({
+  request: vi.fn(),
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+  patch: vi.fn(),
+  interceptors: {
+    request: { use: vi.fn() },
+    response: { use: vi.fn() },
+  },
+}))
+
+vi.mock('axios', () => ({
+  default: {
+    create: vi.fn(() => apiMock),
+  },
+}))
+
+import { getAccessToken, setAccessToken } from '../services/api'
+
+const responseInterceptor = apiMock.interceptors.response.use.mock.calls[0][1] as (
+  error: {
+    config: { url: string; headers?: Record<string, string>; skipAuthRedirect?: boolean }
+    response: { status: number }
+  },
+) => Promise<unknown>
+
+beforeEach(() => {
+  apiMock.post.mockReset()
+  apiMock.request.mockReset()
+  setAccessToken(null)
+})
+
+it('propagates recovery redirect suppression into an internal token refresh', async () => {
+  const refreshError = Object.assign(new Error('refresh unauthorized'), {
+    response: { status: 401 },
+  })
+  apiMock.post.mockRejectedValueOnce(refreshError)
+
+  await expect(responseInterceptor({
+    config: { url: '/v1/auth/me', skipAuthRedirect: true },
+    response: { status: 401 },
+  })).rejects.toBe(refreshError)
+
+  expect(apiMock.post).toHaveBeenCalledWith('/v1/auth/refresh', undefined, {
+    skipAuthRedirect: true,
+  })
+})
+
+it('does not clear the access token when a suppressed refresh endpoint returns 401', async () => {
+  setAccessToken('keep-me')
+  const refreshError = {
+    config: { url: '/v1/auth/refresh', skipAuthRedirect: true },
+    response: { status: 401 },
+  }
+
+  await expect(responseInterceptor(refreshError)).rejects.toBe(refreshError)
+  expect(getAccessToken()).toBe('keep-me')
+})

--- a/frontend/src/unit/auth-failure.test.ts
+++ b/frontend/src/unit/auth-failure.test.ts
@@ -1,23 +1,11 @@
-import axios from 'axios'
 import { describe, expect, it } from 'vitest'
 import { isDefinitiveAuthenticationFailure } from '../services/authFailure'
 
-function axiosError(status?: number) {
-  return new axios.AxiosError(
-    'request failed',
-    undefined,
-    undefined,
-    undefined,
-    status === undefined
-      ? undefined
-      : {
-          status,
-          statusText: 'Error',
-          headers: {},
-          config: { headers: new axios.AxiosHeaders() },
-          data: { detail: 'temporary failure' },
-        },
-  )
+function axiosError(status?: number): unknown {
+  return {
+    isAxiosError: true,
+    response: status === undefined ? undefined : { status },
+  }
 }
 
 describe('isDefinitiveAuthenticationFailure', () => {

--- a/frontend/src/unit/auth-failure.test.ts
+++ b/frontend/src/unit/auth-failure.test.ts
@@ -1,0 +1,39 @@
+import axios from 'axios'
+import { describe, expect, it } from 'vitest'
+import { isDefinitiveAuthenticationFailure } from '../services/authFailure'
+
+function axiosError(status?: number) {
+  return new axios.AxiosError(
+    'request failed',
+    undefined,
+    undefined,
+    undefined,
+    status === undefined
+      ? undefined
+      : {
+          status,
+          statusText: 'Error',
+          headers: {},
+          config: { headers: new axios.AxiosHeaders() },
+          data: { detail: 'temporary failure' },
+        },
+  )
+}
+
+describe('isDefinitiveAuthenticationFailure', () => {
+  it('treats a 401 as definitive authentication loss', () => {
+    expect(isDefinitiveAuthenticationFailure(axiosError(401))).toBe(true)
+  })
+
+  it.each([403, 408, 429, 500, 502, 503, 504])(
+    'keeps status %s recoverable until persistent credentials are rejected',
+    (status) => {
+      expect(isDefinitiveAuthenticationFailure(axiosError(status))).toBe(false)
+    },
+  )
+
+  it('keeps network and timeout failures recoverable', () => {
+    expect(isDefinitiveAuthenticationFailure(axiosError())).toBe(false)
+    expect(isDefinitiveAuthenticationFailure(new Error('network timeout'))).toBe(false)
+  })
+})

--- a/frontend/src/unit/auth-provider-recovery.test.tsx
+++ b/frontend/src/unit/auth-provider-recovery.test.tsx
@@ -1,0 +1,118 @@
+import { act, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AuthContextValue } from '../App'
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  clearAccessToken: vi.fn(),
+  setAccessToken: vi.fn(),
+  getAccessToken: vi.fn<() => string | null>(),
+}))
+
+vi.mock('../services/api', () => ({
+  default: {
+    get: mocks.get,
+    post: mocks.post,
+  },
+  clearAccessToken: mocks.clearAccessToken,
+  setAccessToken: mocks.setAccessToken,
+  getAccessToken: mocks.getAccessToken,
+}))
+
+import { AuthProvider, useAuth } from '../App'
+
+let auth: AuthContextValue | null = null
+
+function Consumer() {
+  auth = useAuth()
+  return null
+}
+
+function renderProvider() {
+  return render(
+    <AuthProvider>
+      <Consumer />
+    </AuthProvider>,
+  )
+}
+
+function axiosError(status: number): Error & { isAxiosError: true; response: { status: number } } {
+  return Object.assign(new Error(`HTTP ${status}`), {
+    isAxiosError: true as const,
+    response: { status },
+  })
+}
+
+describe('AuthProvider transient recovery', () => {
+  beforeEach(() => {
+    auth = null
+    mocks.get.mockReset()
+    mocks.post.mockReset()
+    mocks.clearAccessToken.mockReset()
+    mocks.setAccessToken.mockReset()
+    mocks.getAccessToken.mockReset()
+    mocks.getAccessToken.mockReturnValue('test-token')
+    delete window.__COMIC_PILE_ACCESS_TOKEN
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('keeps bootstrap in recovery after a transient failure and authenticates on retry', async () => {
+    vi.useFakeTimers()
+    mocks.get
+      .mockRejectedValueOnce(new Error('network timeout'))
+      .mockResolvedValueOnce({ username: 'reader', email: 'reader@example.com' })
+
+    renderProvider()
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(auth?.isLoading).toBe(true)
+    expect(auth?.isAuthenticated).toBe(false)
+    expect(mocks.clearAccessToken).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000)
+    })
+
+    expect(auth?.isLoading).toBe(false)
+    expect(auth?.isAuthenticated).toBe(true)
+    expect(mocks.clearAccessToken).not.toHaveBeenCalled()
+    expect(mocks.get).toHaveBeenLastCalledWith('/v1/auth/me', {
+      timeout: 15000,
+      skipAuthRedirect: true,
+    })
+  })
+
+  it('logs out when explicit recovery proves the persistent session is invalid', async () => {
+    mocks.get.mockResolvedValue({ username: 'reader', email: 'reader@example.com' })
+    renderProvider()
+    await waitFor(() => expect(auth?.isAuthenticated).toBe(true))
+
+    mocks.post.mockRejectedValueOnce(axiosError(401))
+    await act(async () => {
+      await expect(auth!.recoverSession(15000)).rejects.toMatchObject({ response: { status: 401 } })
+    })
+
+    expect(auth?.isAuthenticated).toBe(false)
+    expect(mocks.clearAccessToken).toHaveBeenCalledOnce()
+  })
+
+  it('preserves authenticated state when explicit recovery hits a transient server failure', async () => {
+    mocks.get.mockResolvedValue({ username: 'reader', email: 'reader@example.com' })
+    renderProvider()
+    await waitFor(() => expect(auth?.isAuthenticated).toBe(true))
+
+    mocks.post.mockRejectedValueOnce(axiosError(503))
+    await act(async () => {
+      await expect(auth!.recoverSession(15000)).rejects.toMatchObject({ response: { status: 503 } })
+    })
+
+    expect(auth?.isAuthenticated).toBe(true)
+    expect(mocks.clearAccessToken).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/unit/resume-recovery.test.tsx
+++ b/frontend/src/unit/resume-recovery.test.tsx
@@ -55,7 +55,7 @@ describe('ResumeRecovery', () => {
 
     expect(screen.getByText('Last usable screen')).toBeInTheDocument()
     expect(screen.getByRole('status')).toHaveTextContent('Reconnecting ComicPile')
-    await waitFor(() => expect(revalidateSession).toHaveBeenCalledWith(8000))
+    await waitFor(() => expect(revalidateSession).toHaveBeenCalledWith(15000))
     await waitFor(() => expect(invalidateQueries).toHaveBeenCalledOnce())
     await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument())
     expect(recoverSession).not.toHaveBeenCalled()
@@ -98,7 +98,7 @@ describe('ResumeRecovery', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
 
     expect(screen.getByRole('status')).toHaveTextContent('Reconnecting ComicPile')
-    expect(recoverSession).toHaveBeenCalledWith(8000)
+    expect(recoverSession).toHaveBeenCalledWith(15000)
     expect(revalidateSession).toHaveBeenCalledTimes(2)
 
     await act(async () => {


### PR DESCRIPTION
Closes #1013

## Summary
- distinguish definitive 401 authentication loss from network, timeout, rate-limit, and transient server failures
- keep bootstrap in recovery instead of clearing credentials or redirecting to login on transient failures
- retry bootstrap validation while the backend is unavailable and use the canonical `/api/v1/auth/me` surface
- give resume validation 15 seconds of cold-start headroom instead of timing out at 8 seconds
- preserve the existing screen during resume failures while still transitioning to login for definitive persistent-session rejection
- add deterministic classification coverage for 401 versus recoverable failure classes

## Validation
This scheduled connector runtime has no local checkout or package execution environment, so configured PR CI is the validation boundary. Focused frontend regression tests are included in the branch.
