### PR TITLE
Align canonical auth routes with CSRF contract

### DIFF
--- a/app/csrf.py
+++ b/app/csrf.py
@@ -13,6 +13,10 @@ _CSRF_EXEMPT_PATHS = frozenset(
         "/api/auth/login",
         "/api/auth/refresh",
         "/api/auth/register",
+        "/api/v1/auth/csrf",
+        "/api/v1/auth/login",
+        "/api/v1/auth/refresh",
+        "/api/v1/auth/register",
     }
 )
 

--- a/docs/changelog.d/2026-08-09-1028.md
+++ b/docs/changelog.d/2026-08-09-1028.md
@@ -1,0 +1,5 @@
+## 2026-08-09
+
+### Authentication
+
+- [#1028](https://github.com/JoshCLWren/comic-pile/pull/1028) fixes the canonical browser refresh route so CSRF middleware no longer rejects a valid persistent session before authentication recovery can run, and adds regression coverage for independent clients using the same ComicPile account.

--- a/docs/changelog.d/2026-08-09-1028.md
+++ b/docs/changelog.d/2026-08-09-1028.md
@@ -2,4 +2,4 @@
 
 ### Authentication
 
-- [#1028](https://github.com/JoshCLWren/comic-pile/pull/1028) fixes the canonical browser refresh route so CSRF middleware no longer rejects a valid persistent session before authentication recovery can run, and adds regression coverage for independent clients using the same ComicPile account.
+- [#1028](https://github.com/JoshCLWren/comic-pile/pull/1028) fixes the canonical browser refresh route so CSRF middleware no longer rejects a valid persistent session before authentication recovery can run, moves the remaining maintained browser auth calls onto the same versioned API family, and adds regression coverage for independent clients using the same ComicPile account.

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -53,7 +53,7 @@ export default function Navigation({ onBugReportSubmit }: NavigationProps) {
     if (isAuthenticated) {
       setIsLoading(true)
       setHasError(false)
-      api.get<AuthUser>('/auth/me', { skipAuthRedirect: true })
+      api.get<AuthUser>('/v1/auth/me', { skipAuthRedirect: true })
         .then(user => {
           setUsername(user.username || '')
           setHasError(false)
@@ -74,7 +74,7 @@ export default function Navigation({ onBugReportSubmit }: NavigationProps) {
 
   const handleLogout = async () => {
     try {
-      await api.post('/auth/logout', null, { skipAuthRedirect: true })
+      await api.post('/v1/auth/logout', null, { skipAuthRedirect: true })
     } catch (err: unknown) {
       console.error('Logout API failed:', err)
     }

--- a/tests/test_auth_contract.py
+++ b/tests/test_auth_contract.py
@@ -1,0 +1,58 @@
+"""Regression coverage for the canonical browser authentication contract."""
+
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+@pytest.mark.asyncio
+async def test_two_clients_for_one_user_refresh_independently(client: AsyncClient) -> None:
+    """Independent browser sessions for one user must not invalidate each other."""
+    credentials = {
+        "username": "multi-client-user",
+        "email": "multi-client@example.com",
+        "password": "password123",
+    }
+    register_response = await client.post("/api/v1/auth/register", json=credentials)
+    assert register_response.status_code == 200
+
+    login_payload = {"username": credentials["username"], "password": credentials["password"]}
+    first_login = await client.post("/api/v1/auth/login", json=login_payload)
+    assert first_login.status_code == 200
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as second_client:
+        second_login = await second_client.post("/api/v1/auth/login", json=login_payload)
+        assert second_login.status_code == 200
+
+        first_refresh = await client.post("/api/v1/auth/refresh")
+        second_refresh = await second_client.post("/api/v1/auth/refresh")
+        assert first_refresh.status_code == 200
+        assert second_refresh.status_code == 200
+
+        first_access = first_refresh.json()["access_token"]
+        first_logout = await client.post(
+            "/api/v1/auth/logout",
+            headers={"Authorization": f"Bearer {first_access}"},
+        )
+        assert first_logout.status_code == 200
+
+        second_refresh_after_first_logout = await second_client.post("/api/v1/auth/refresh")
+        assert second_refresh_after_first_logout.status_code == 200
+
+
+def test_frontend_does_not_use_legacy_auth_surface() -> None:
+    """Maintained frontend code must use only the canonical /v1/auth family."""
+    frontend_root = Path("frontend/src")
+    offenders: list[str] = []
+    for path in frontend_root.rglob("*"):
+        if path.suffix not in {".ts", ".tsx"}:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if "'/auth/" in text or '"/auth/' in text:
+            offenders.append(str(path))
+
+    assert offenders == [], f"Legacy auth routes found in maintained frontend: {offenders}"

--- a/tests/test_auth_contract.py
+++ b/tests/test_auth_contract.py
@@ -9,8 +9,17 @@ from app.main import app
 
 
 @pytest.mark.asyncio
-async def test_two_clients_for_one_user_refresh_independently(client: AsyncClient) -> None:
-    """Independent browser sessions for one user must not invalidate each other."""
+async def test_two_clients_for_one_user_refresh_independently(
+    client: AsyncClient,
+) -> None:
+    """Independent browser sessions for one user must not invalidate each other.
+
+    Args:
+        client: Authenticated HTTP client representing the first browser session.
+
+    Returns:
+        None: Assertions verify independent refresh and logout isolation.
+    """
     credentials = {
         "username": "multi-client-user",
         "email": "multi-client@example.com",
@@ -45,14 +54,18 @@ async def test_two_clients_for_one_user_refresh_independently(client: AsyncClien
 
 
 def test_frontend_does_not_use_legacy_auth_surface() -> None:
-    """Maintained frontend code must use only the canonical /v1/auth family."""
+    """Maintained frontend code must use only the canonical /v1/auth family.
+
+    Returns:
+        None: Assertion fails if legacy /auth/ routes are found in maintained code.
+    """
     frontend_root = Path("frontend/src")
     offenders: list[str] = []
     for path in frontend_root.rglob("*"):
-        if path.suffix not in {".ts", ".tsx"}:
+        if path.suffix not in {".js", ".jsx", ".ts", ".tsx"}:
             continue
         text = path.read_text(encoding="utf-8")
-        if "'/auth/" in text or '"/auth/' in text:
+        if any(f"{quote}/auth/" in text for quote in ("'", '"', "`")):
             offenders.append(str(path))
 
     assert offenders == [], f"Legacy auth routes found in maintained frontend: {offenders}"

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -65,8 +65,18 @@ async def test_safe_methods_do_not_require_csrf_token(auth_client: AsyncClient) 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("prefix", ["/api/auth", "/api/v1/auth"])
-async def test_csrf_bootstrap_endpoint_sets_cookie(client: AsyncClient, prefix: str) -> None:
-    """Both auth aliases bootstrap the same readable CSRF cookie."""
+async def test_csrf_bootstrap_endpoint_sets_cookie(
+    client: AsyncClient, prefix: str
+) -> None:
+    """Both auth aliases bootstrap the same readable CSRF cookie.
+
+    Args:
+        client: Unauthenticated HTTP client for making requests.
+        prefix: Auth route prefix to test ("/api/auth" or "/api/v1/auth").
+
+    Returns:
+        None: Assertions verify CSRF bootstrap behavior.
+    """
     client.headers.pop(CSRF_HEADER_NAME, None)
     client.cookies.delete(CSRF_COOKIE_NAME)
 
@@ -84,7 +94,15 @@ async def test_login_register_and_refresh_are_exempt_from_csrf(
     client: AsyncClient,
     prefix: str,
 ) -> None:
-    """Canonical and legacy first-time auth flows share the same CSRF contract."""
+    """Canonical and legacy first-time auth flows share the same CSRF contract.
+
+    Args:
+        client: Unauthenticated HTTP client for making requests.
+        prefix: Auth route prefix to test ("/api/auth" or "/api/v1/auth").
+
+    Returns:
+        None: Assertions verify login/register/refresh are CSRF-exempt.
+    """
     username = "csrf-user-v1" if "/v1/" in prefix else "csrf-user-legacy"
     email = f"{username}@example.com"
 
@@ -122,8 +140,18 @@ async def test_login_register_and_refresh_are_exempt_from_csrf(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("prefix", ["/api/auth", "/api/v1/auth"])
-async def test_logout_remains_protected_by_csrf(auth_client: AsyncClient, prefix: str) -> None:
-    """Both logout aliases require CSRF because they mutate server-side auth state."""
+async def test_logout_remains_protected_by_csrf(
+    auth_client: AsyncClient, prefix: str
+) -> None:
+    """Both logout aliases require CSRF because they mutate server-side auth state.
+
+    Args:
+        auth_client: Authenticated HTTP client for making requests.
+        prefix: Auth route prefix to test ("/api/auth" or "/api/v1/auth").
+
+    Returns:
+        None: Assertions verify logout requires CSRF token.
+    """
     auth_client.headers.pop(CSRF_HEADER_NAME, None)
     auth_client.cookies.delete(CSRF_COOKIE_NAME)
 

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -58,18 +58,19 @@ async def test_safe_methods_do_not_require_csrf_token(auth_client: AsyncClient) 
     auth_client.headers.pop(CSRF_HEADER_NAME, None)
     auth_client.cookies.delete(CSRF_COOKIE_NAME)
 
-    response = await auth_client.get("/api/auth/me")
+    response = await auth_client.get("/api/v1/auth/me")
 
     assert response.status_code == 200
 
 
 @pytest.mark.asyncio
-async def test_csrf_bootstrap_endpoint_sets_cookie(client: AsyncClient) -> None:
-    """The CSRF bootstrap endpoint returns a token and refreshes the cookie."""
+@pytest.mark.parametrize("prefix", ["/api/auth", "/api/v1/auth"])
+async def test_csrf_bootstrap_endpoint_sets_cookie(client: AsyncClient, prefix: str) -> None:
+    """Both auth aliases bootstrap the same readable CSRF cookie."""
     client.headers.pop(CSRF_HEADER_NAME, None)
     client.cookies.delete(CSRF_COOKIE_NAME)
 
-    response = await client.get("/api/auth/csrf")
+    response = await client.get(f"{prefix}/csrf")
 
     assert response.status_code == 200
     token = response.json()["csrf_token"]
@@ -78,16 +79,23 @@ async def test_csrf_bootstrap_endpoint_sets_cookie(client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_login_and_refresh_are_exempt_from_csrf(client: AsyncClient) -> None:
-    """First-time auth flows stay usable without a CSRF token."""
+@pytest.mark.parametrize("prefix", ["/api/auth", "/api/v1/auth"])
+async def test_login_register_and_refresh_are_exempt_from_csrf(
+    client: AsyncClient,
+    prefix: str,
+) -> None:
+    """Canonical and legacy first-time auth flows share the same CSRF contract."""
+    username = "csrf-user-v1" if "/v1/" in prefix else "csrf-user-legacy"
+    email = f"{username}@example.com"
+
     client.headers.pop(CSRF_HEADER_NAME, None)
     client.cookies.delete(CSRF_COOKIE_NAME)
 
     register_response = await client.post(
-        "/api/auth/register",
+        f"{prefix}/register",
         json={
-            "username": "csrf-user",
-            "email": "csrf@example.com",
+            "username": username,
+            "email": email,
             "password": "password123",
         },
     )
@@ -98,8 +106,8 @@ async def test_login_and_refresh_are_exempt_from_csrf(client: AsyncClient) -> No
     client.cookies.delete(CSRF_COOKIE_NAME)
 
     login_response = await client.post(
-        "/api/auth/login",
-        json={"username": "csrf-user", "password": "password123"},
+        f"{prefix}/login",
+        json={"username": username, "password": "password123"},
     )
     assert login_response.status_code == 200
     assert client.cookies.get(CSRF_COOKIE_NAME) is not None
@@ -107,18 +115,19 @@ async def test_login_and_refresh_are_exempt_from_csrf(client: AsyncClient) -> No
     client.headers.pop(CSRF_HEADER_NAME, None)
     client.cookies.delete(CSRF_COOKIE_NAME)
 
-    refresh_response = await client.post("/api/auth/refresh")
+    refresh_response = await client.post(f"{prefix}/refresh")
     assert refresh_response.status_code == 200
     assert client.cookies.get(CSRF_COOKIE_NAME) is not None
 
 
 @pytest.mark.asyncio
-async def test_logout_remains_protected_by_csrf(auth_client: AsyncClient) -> None:
-    """Logout still requires CSRF because it mutates server-side auth state."""
+@pytest.mark.parametrize("prefix", ["/api/auth", "/api/v1/auth"])
+async def test_logout_remains_protected_by_csrf(auth_client: AsyncClient, prefix: str) -> None:
+    """Both logout aliases require CSRF because they mutate server-side auth state."""
     auth_client.headers.pop(CSRF_HEADER_NAME, None)
     auth_client.cookies.delete(CSRF_COOKIE_NAME)
 
-    response = await auth_client.post("/api/auth/logout")
+    response = await auth_client.post(f"{prefix}/logout")
 
     assert response.status_code == 403
     assert response.json() == {"detail": "CSRF token missing or invalid"}


### PR DESCRIPTION
Part of #986.

## Summary
- make `/api/v1/auth/register`, `/login`, and `/refresh` share the intended CSRF-exempt bootstrap contract with their retained legacy aliases
- reproduce the production-shaped canonical refresh path under active CSRF middleware so `/api/v1/auth/refresh` cannot regress to a middleware-generated 403
- verify both route families preserve logout CSRF protection and CSRF bootstrap semantics
- add regression coverage proving two independently authenticated clients for one user can refresh separately and one client's logout does not invalidate the other
- add a static frontend contract test that rejects maintained `/auth/*` callers outside the canonical `/v1/auth/*` family

## Validation
This scheduled connector runtime has no local checkout or package execution environment, so configured PR CI is the validation boundary. The branch adds focused backend regression coverage.

## Remaining #986 scope
Production auth diagnostics still need explicit safe reason codes for CSRF rejection, missing refresh cookie, expired/invalid/revoked token, and successful refresh before #986 can close.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed browser refresh authentication so valid persistent sessions are recovered without CSRF errors.
  * Logging out from one device or browser no longer invalidates sessions on other devices.
  * Improved CSRF handling for login, registration, refresh, and logout across supported authentication routes.
* **Improvements**
  * Updated frontend authentication requests to use the current versioned API routes.
  * Added regression coverage for multi-client sessions and authentication security behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->