### PR TITLE
Add bounded cache invalidation boundary

### DIFF
--- a/app/cache_invalidation.py
+++ b/app/cache_invalidation.py
@@ -1,0 +1,42 @@
+"""Bounded cache invalidation helpers for mutation paths.
+
+Production invalidation must never traverse the Redis keyspace. This module gives
+mutation code one user-scoped invalidation boundary backed by the generation
+primitive from :mod:`app.cache_generation`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from app.cache_generation import invalidate_user_cache, invalidate_user_caches
+
+
+async def invalidate_user_view(user_id: int) -> bool:
+    """Invalidate every cached view owned by one user with one generation bump.
+
+    Args:
+        user_id: Authenticated user identifier.
+
+    Returns:
+        ``True`` when the generation was bumped, otherwise ``False`` when caching
+        is disabled or unavailable.
+    """
+    if user_id <= 0:
+        raise ValueError("user_id must be positive")
+    return await invalidate_user_cache(user_id)
+
+
+async def invalidate_user_views(user_ids: Iterable[int]) -> int:
+    """Invalidate each distinct user namespace at most once.
+
+    Args:
+        user_ids: User identifiers affected by one logical mutation batch.
+
+    Returns:
+        Number of user namespaces successfully invalidated.
+    """
+    normalized = tuple(user_ids)
+    if any(user_id <= 0 for user_id in normalized):
+        raise ValueError("user_id must be positive")
+    return await invalidate_user_caches(normalized)

--- a/docs/changelog.d/2026-08-09-1029.md
+++ b/docs/changelog.d/2026-08-09-1029.md
@@ -1,0 +1,5 @@
+## 2026-08-09
+
+### Performance
+
+- [#1029](https://github.com/JoshCLWren/comic-pile/pull/1029) adds the bounded per-user cache invalidation boundary needed to replace Redis keyspace scans, reducing the risk that cache maintenance consumes excessive remote commands as ComicPile grows.

--- a/tests/test_cache_invalidation.py
+++ b/tests/test_cache_invalidation.py
@@ -1,0 +1,44 @@
+"""Tests for bounded mutation cache invalidation."""
+
+from collections.abc import Iterator
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app import cache_invalidation
+
+
+@pytest.mark.asyncio
+async def test_invalidate_user_view_delegates_to_generation_boundary(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One user mutation should issue one generation invalidation request."""
+    invalidator = AsyncMock(return_value=True)
+    monkeypatch.setattr(cache_invalidation, "invalidate_user_cache", invalidator)
+
+    assert await cache_invalidation.invalidate_user_view(7) is True
+
+    invalidator.assert_awaited_once_with(7)
+
+
+@pytest.mark.asyncio
+async def test_invalidate_user_views_deduplicates_inside_generation_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A logical batch should delegate all affected owners in one bounded call."""
+    invalidator = AsyncMock(return_value=2)
+    monkeypatch.setattr(cache_invalidation, "invalidate_user_caches", invalidator)
+
+    user_ids: Iterator[int] = iter((7, 7, 9))
+    assert await cache_invalidation.invalidate_user_views(user_ids) == 2
+
+    invalidator.assert_awaited_once_with((7, 7, 9))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("user_id", [0, -1])
+async def test_invalidation_rejects_non_positive_user_ids(user_id: int) -> None:
+    """Invalid owner identities must never produce shared cache invalidation."""
+    with pytest.raises(ValueError, match="user_id must be positive"):
+        await cache_invalidation.invalidate_user_view(user_id)
+
+    with pytest.raises(ValueError, match="user_id must be positive"):
+        await cache_invalidation.invalidate_user_views((1, user_id))


### PR DESCRIPTION
Part of #959.

## Summary
- add one mutation-facing cache invalidation boundary backed by the existing per-user generation primitive
- validate user ownership before invalidation so callers cannot fall into a shared namespace
- expose one-user and multi-user batch entrypoints, with focused tests proving delegation and invalid-owner rejection

## Validation
This scheduled connector runtime has no local checkout or package runner, so configured PR CI is the validation boundary. Focused regression tests are included.

## Remaining #959 scope
Production mutation call sites still need to be migrated from pattern-based `invalidate_cache()` helpers onto this bounded generation boundary, then `SCAN` invalidation can be removed entirely.