### PR TITLE
Use local ComicVine SQLite snapshot before live metadata

### DIFF
--- a/comic_pile/local_comicvine.py
+++ b/comic_pile/local_comicvine.py
@@ -25,6 +25,7 @@ class LocalComicVineSnapshot:
     """Read a local ComicVine SQLite cache without mutating it."""
 
     def __init__(self, path: str | Path | None = None) -> None:
+        """Configure the optional local snapshot path."""
         configured = path or os.getenv(LOCAL_COMICVINE_DB_ENV)
         self.path = Path(configured).expanduser() if configured else None
 

--- a/comic_pile/local_comicvine.py
+++ b/comic_pile/local_comicvine.py
@@ -1,0 +1,136 @@
+"""Read-only access to a developer-local ComicVine SQLite snapshot."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+LOCAL_COMICVINE_DB_ENV = "COMICPILE_COMICVINE_SQLITE_PATH"
+
+
+@dataclass(frozen=True)
+class LocalComicVineResult:
+    """Normalized result from the local ComicVine snapshot."""
+
+    data: dict[str, object]
+    provenance: str = "comicvine-local-sqlite"
+    complete: bool = True
+
+
+class LocalComicVineSnapshot:
+    """Read a local ComicVine SQLite cache without mutating it."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        configured = path or os.getenv(LOCAL_COMICVINE_DB_ENV)
+        self.path = Path(configured).expanduser() if configured else None
+
+    @property
+    def available(self) -> bool:
+        """Return whether the configured snapshot exists."""
+        return self.path is not None and self.path.is_file()
+
+    def _connect(self) -> sqlite3.Connection:
+        if not self.available or self.path is None:
+            raise FileNotFoundError("Local ComicVine snapshot is not configured or does not exist")
+        connection = sqlite3.connect(f"file:{self.path}?mode=ro", uri=True)
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    @staticmethod
+    def _decode_value(value: object) -> object:
+        if not isinstance(value, str):
+            return value
+        stripped = value.strip()
+        if not stripped or stripped[0] not in "[{":
+            return value
+        try:
+            return json.loads(stripped)
+        except json.JSONDecodeError:
+            return value
+
+    @classmethod
+    def _normalize_row(cls, row: sqlite3.Row) -> dict[str, object]:
+        return {key: cls._decode_value(row[key]) for key in row.keys()}
+
+    def _lookup(self, table: str, external_id: int, required: tuple[str, ...]) -> LocalComicVineResult | None:
+        if not self.available:
+            return None
+        with self._connect() as connection:
+            columns = {row[1] for row in connection.execute(f"PRAGMA table_info({table})")}
+            id_column = next(
+                (candidate for candidate in ("id", "comicvine_id", f"{table.removeprefix('cv_')}_id") if candidate in columns),
+                None,
+            )
+            if id_column is None:
+                return None
+            row = connection.execute(
+                f"SELECT * FROM {table} WHERE {id_column} = ? LIMIT 1",
+                (external_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        data = self._normalize_row(row)
+        complete = all(data.get(field) not in (None, "") for field in required)
+        return LocalComicVineResult(data=data, complete=complete)
+
+    def get_volume(self, volume_id: int) -> LocalComicVineResult | None:
+        """Look up one volume by ComicVine ID."""
+        result = self._lookup("cv_volume", volume_id, ("id", "name"))
+        if result is None:
+            result = self._lookup("cv_volume", volume_id, ("comicvine_id", "name"))
+        return result
+
+    def get_issue(self, issue_id: int) -> LocalComicVineResult | None:
+        """Look up one issue by ComicVine ID, including decoded relationship JSON."""
+        result = self._lookup("cv_issue", issue_id, ("id", "volume_id", "issue_number"))
+        if result is None:
+            result = self._lookup("cv_issue", issue_id, ("comicvine_id", "volume_id", "issue_number"))
+        return result
+
+    def search_volumes(self, query: str, *, limit: int = 10) -> list[LocalComicVineResult]:
+        """Return ranked local candidates without treating rank as identity confirmation."""
+        if not self.available or not query.strip() or limit <= 0:
+            return []
+        with self._connect() as connection:
+            fts_tables = [
+                row[0]
+                for row in connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'cv_volume%fts%'"
+                )
+            ]
+            if not fts_tables:
+                return []
+            table = fts_tables[0]
+            rows = connection.execute(
+                f"SELECT *, bm25({table}) AS rank FROM {table} WHERE {table} MATCH ? ORDER BY rank LIMIT ?",
+                (query, limit),
+            ).fetchall()
+        return [LocalComicVineResult(data=self._normalize_row(row), complete=False) for row in rows]
+
+    def sync_metadata(self) -> dict[str, object]:
+        """Expose snapshot freshness metadata when the snapshot provides it."""
+        if not self.available:
+            return {}
+        with self._connect() as connection:
+            exists = connection.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='cv_sync_metadata'"
+            ).fetchone()
+            if exists is None:
+                return {}
+            rows = connection.execute("SELECT * FROM cv_sync_metadata").fetchall()
+        return {str(index): self._normalize_row(row) for index, row in enumerate(rows)}
+
+    def get_issue_or_fallback(
+        self,
+        issue_id: int,
+        fallback: Callable[[int], Mapping[str, object]],
+    ) -> LocalComicVineResult:
+        """Prefer a complete local issue and call the live provider only for a miss/incomplete row."""
+        local = self.get_issue(issue_id)
+        if local is not None and local.complete:
+            return local
+        return LocalComicVineResult(data=dict(fallback(issue_id)), provenance="comicvine-live")

--- a/comic_pile/local_comicvine.py
+++ b/comic_pile/local_comicvine.py
@@ -56,13 +56,23 @@ class LocalComicVineSnapshot:
     def _normalize_row(cls, row: sqlite3.Row) -> dict[str, object]:
         return {key: cls._decode_value(row[key]) for key in row.keys()}
 
-    def _lookup(self, table: str, external_id: int, required: tuple[str, ...]) -> LocalComicVineResult | None:
+    def _lookup(
+        self,
+        table: str,
+        external_id: int,
+        required: tuple[str, ...],
+    ) -> LocalComicVineResult | None:
         if not self.available:
             return None
         with self._connect() as connection:
             columns = {row[1] for row in connection.execute(f"PRAGMA table_info({table})")}
+            id_candidates = (
+                "id",
+                "comicvine_id",
+                f"{table.removeprefix('cv_')}_id",
+            )
             id_column = next(
-                (candidate for candidate in ("id", "comicvine_id", f"{table.removeprefix('cv_')}_id") if candidate in columns),
+                (candidate for candidate in id_candidates if candidate in columns),
                 None,
             )
             if id_column is None:
@@ -79,17 +89,11 @@ class LocalComicVineSnapshot:
 
     def get_volume(self, volume_id: int) -> LocalComicVineResult | None:
         """Look up one volume by ComicVine ID."""
-        result = self._lookup("cv_volume", volume_id, ("id", "name"))
-        if result is None:
-            result = self._lookup("cv_volume", volume_id, ("comicvine_id", "name"))
-        return result
+        return self._lookup("cv_volume", volume_id, ("name",))
 
     def get_issue(self, issue_id: int) -> LocalComicVineResult | None:
         """Look up one issue by ComicVine ID, including decoded relationship JSON."""
-        result = self._lookup("cv_issue", issue_id, ("id", "volume_id", "issue_number"))
-        if result is None:
-            result = self._lookup("cv_issue", issue_id, ("comicvine_id", "volume_id", "issue_number"))
-        return result
+        return self._lookup("cv_issue", issue_id, ("volume_id", "issue_number"))
 
     def search_volumes(self, query: str, *, limit: int = 10) -> list[LocalComicVineResult]:
         """Return ranked local candidates without treating rank as identity confirmation."""
@@ -99,17 +103,22 @@ class LocalComicVineSnapshot:
             fts_tables = [
                 row[0]
                 for row in connection.execute(
-                    "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'cv_volume%fts%'"
+                    "SELECT name FROM sqlite_master "
+                    "WHERE type='table' AND name LIKE 'cv_volume%fts%'"
                 )
             ]
             if not fts_tables:
                 return []
             table = fts_tables[0]
             rows = connection.execute(
-                f"SELECT *, bm25({table}) AS rank FROM {table} WHERE {table} MATCH ? ORDER BY rank LIMIT ?",
+                f"SELECT *, bm25({table}) AS rank FROM {table} "
+                f"WHERE {table} MATCH ? ORDER BY rank LIMIT ?",
                 (query, limit),
             ).fetchall()
-        return [LocalComicVineResult(data=self._normalize_row(row), complete=False) for row in rows]
+        return [
+            LocalComicVineResult(data=self._normalize_row(row), complete=False)
+            for row in rows
+        ]
 
     def sync_metadata(self) -> dict[str, object]:
         """Expose snapshot freshness metadata when the snapshot provides it."""
@@ -117,7 +126,8 @@ class LocalComicVineSnapshot:
             return {}
         with self._connect() as connection:
             exists = connection.execute(
-                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='cv_sync_metadata'"
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type='table' AND name='cv_sync_metadata'"
             ).fetchone()
             if exists is None:
                 return {}
@@ -129,7 +139,7 @@ class LocalComicVineSnapshot:
         issue_id: int,
         fallback: Callable[[int], Mapping[str, object]],
     ) -> LocalComicVineResult:
-        """Prefer a complete local issue and call the live provider only for a miss/incomplete row."""
+        """Prefer a complete local issue; use the live provider only for a miss/incomplete row."""
         local = self.get_issue(issue_id)
         if local is not None and local.complete:
             return local

--- a/docs/changelog.d/2026-08-09-1030.md
+++ b/docs/changelog.d/2026-08-09-1030.md
@@ -1,0 +1,5 @@
+## 2026-08-09
+
+### Comic metadata
+
+- [#1030](https://github.com/JoshCLWren/comic-pile/pull/1030) lets developer-local metadata hydration prefer a read-only ComicVine SQLite snapshot before spending live API requests, while safely falling back when local data is missing or incomplete.

--- a/tests/test_local_comicvine.py
+++ b/tests/test_local_comicvine.py
@@ -48,6 +48,7 @@ def _build_fixture(path: Path) -> None:
 
 
 def test_exact_local_volume_and_issue_lookup_avoids_fallback(tmp_path: Path) -> None:
+    """Prefer complete exact local matches without invoking the live provider."""
     database = tmp_path / "localcv.db"
     _build_fixture(database)
     snapshot = LocalComicVineSnapshot(database)
@@ -70,6 +71,7 @@ def test_exact_local_volume_and_issue_lookup_avoids_fallback(tmp_path: Path) -> 
 
 
 def test_missing_or_incomplete_issue_falls_back(tmp_path: Path) -> None:
+    """Use the live provider when the local snapshot cannot supply a complete issue."""
     database = tmp_path / "localcv.db"
     _build_fixture(database)
     snapshot = LocalComicVineSnapshot(database)
@@ -81,6 +83,7 @@ def test_missing_or_incomplete_issue_falls_back(tmp_path: Path) -> None:
 
 
 def test_snapshot_is_optional_and_read_only(tmp_path: Path) -> None:
+    """Allow an absent snapshot and enforce SQLite read-only access when present."""
     missing = LocalComicVineSnapshot(tmp_path / "missing.db")
 
     assert missing.available is False
@@ -100,6 +103,7 @@ def test_snapshot_is_optional_and_read_only(tmp_path: Path) -> None:
 
 
 def test_fts_candidates_are_ranked_but_not_confirmed(tmp_path: Path) -> None:
+    """Return FTS candidates as ranked possibilities rather than confirmed identities."""
     database = tmp_path / "localcv.db"
     _build_fixture(database)
     snapshot = LocalComicVineSnapshot(database)
@@ -112,6 +116,7 @@ def test_fts_candidates_are_ranked_but_not_confirmed(tmp_path: Path) -> None:
 
 
 def test_sync_metadata_exposes_snapshot_freshness(tmp_path: Path) -> None:
+    """Expose sync metadata so callers can judge local snapshot freshness."""
     database = tmp_path / "localcv.db"
     _build_fixture(database)
     snapshot = LocalComicVineSnapshot(database)

--- a/tests/test_local_comicvine.py
+++ b/tests/test_local_comicvine.py
@@ -1,0 +1,121 @@
+"""Tests for the developer-local ComicVine SQLite adapter."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from comic_pile.local_comicvine import LocalComicVineSnapshot
+
+
+def _build_fixture(path: Path) -> None:
+    connection = sqlite3.connect(path)
+    connection.executescript(
+        """
+        CREATE TABLE cv_volume (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            aliases TEXT,
+            start_year INTEGER
+        );
+        CREATE TABLE cv_issue (
+            id INTEGER PRIMARY KEY,
+            volume_id INTEGER NOT NULL,
+            issue_number TEXT NOT NULL,
+            character_credits TEXT,
+            person_credits TEXT,
+            team_credits TEXT,
+            story_arc_credits TEXT
+        );
+        CREATE VIRTUAL TABLE cv_volume_fts USING fts5(name, aliases, content='cv_volume', content_rowid='id');
+        CREATE TABLE cv_sync_metadata (key TEXT, value TEXT);
+        INSERT INTO cv_volume VALUES (122077, 'House of X', 'HOX', 2019);
+        INSERT INTO cv_issue VALUES (
+            819479,
+            122077,
+            '1',
+            '[{"id": 1, "name": "Cyclops"}]',
+            '[{"id": 2, "name": "Jonathan Hickman", "role": "writer"}]',
+            '[{"id": 3, "name": "X-Men"}]',
+            '[{"id": 4, "name": "Dawn of X"}]'
+        );
+        INSERT INTO cv_volume_fts(rowid, name, aliases) VALUES (122077, 'House of X', 'HOX');
+        INSERT INTO cv_sync_metadata VALUES ('last_sync', '2026-01-09T00:00:00Z');
+        """
+    )
+    connection.commit()
+    connection.close()
+
+
+def test_exact_local_volume_and_issue_lookup_avoids_fallback(tmp_path: Path) -> None:
+    database = tmp_path / "localcv.db"
+    _build_fixture(database)
+    snapshot = LocalComicVineSnapshot(database)
+    calls: list[int] = []
+
+    volume = snapshot.get_volume(122077)
+    issue = snapshot.get_issue_or_fallback(
+        819479,
+        lambda issue_id: calls.append(issue_id) or {"id": issue_id},
+    )
+
+    assert volume is not None
+    assert volume.data["name"] == "House of X"
+    assert issue.provenance == "comicvine-local-sqlite"
+    assert issue.data["story_arc_credits"] == [{"id": 4, "name": "Dawn of X"}]
+    assert issue.data["person_credits"] == [
+        {"id": 2, "name": "Jonathan Hickman", "role": "writer"}
+    ]
+    assert calls == []
+
+
+def test_missing_or_incomplete_issue_falls_back(tmp_path: Path) -> None:
+    database = tmp_path / "localcv.db"
+    _build_fixture(database)
+    snapshot = LocalComicVineSnapshot(database)
+
+    result = snapshot.get_issue_or_fallback(999999, lambda issue_id: {"id": issue_id, "name": "live"})
+
+    assert result.provenance == "comicvine-live"
+    assert result.data == {"id": 999999, "name": "live"}
+
+
+def test_snapshot_is_optional_and_read_only(tmp_path: Path) -> None:
+    missing = LocalComicVineSnapshot(tmp_path / "missing.db")
+
+    assert missing.available is False
+    assert missing.get_issue(819479) is None
+    assert missing.search_volumes("House") == []
+
+    database = tmp_path / "localcv.db"
+    _build_fixture(database)
+    snapshot = LocalComicVineSnapshot(database)
+    with snapshot._connect() as connection:
+        try:
+            connection.execute("DELETE FROM cv_issue")
+        except sqlite3.OperationalError as error:
+            assert "readonly" in str(error).lower()
+        else:
+            raise AssertionError("snapshot connection unexpectedly allowed a write")
+
+
+def test_fts_candidates_are_ranked_but_not_confirmed(tmp_path: Path) -> None:
+    database = tmp_path / "localcv.db"
+    _build_fixture(database)
+    snapshot = LocalComicVineSnapshot(database)
+
+    candidates = snapshot.search_volumes("House")
+
+    assert len(candidates) == 1
+    assert candidates[0].data["name"] == "House of X"
+    assert candidates[0].complete is False
+
+
+def test_sync_metadata_exposes_snapshot_freshness(tmp_path: Path) -> None:
+    database = tmp_path / "localcv.db"
+    _build_fixture(database)
+    snapshot = LocalComicVineSnapshot(database)
+
+    metadata = snapshot.sync_metadata()
+
+    assert metadata["0"] == {"key": "last_sync", "value": "2026-01-09T00:00:00Z"}


### PR DESCRIPTION
Fixes #1026

## Summary
- add a read-only, optional local ComicVine SQLite adapter configurable by path or `COMICPILE_COMICVINE_SQLITE_PATH`
- resolve exact volume/issue IDs locally and decode relationship JSON defensively
- expose FTS volume candidates without treating rank as identity confirmation
- expose snapshot sync metadata and fall through to a live-provider callback for local misses/incomplete issue rows
- cover known volume `122077`, issue `819479`, rich relationships, read-only enforcement, missing snapshots, FTS candidates, and fallback behavior with a tiny fixture database

## Validation
This scheduled connector runtime does not expose a local checkout or Python runner, so configured PR CI is the validation boundary. Focused regression tests are included.