### PR TITLE
Add production auth refresh reason diagnostics

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -1,9 +1,11 @@
 """Authentication API endpoints."""
 
+import logging
 import secrets
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from jose.exceptions import ExpiredSignatureError
 from sqlalchemy import exc as sqlalchemy_exc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -36,9 +38,33 @@ from app.security import (
 )
 
 router = APIRouter(tags=["auth"])
+logger = logging.getLogger(__name__)
 
 REFRESH_COOKIE_NAME = "refresh_token"
 REFRESH_COOKIE_PATH = "/api"
+
+
+def _log_refresh_outcome(request: Request, *, outcome: str, reason: str) -> None:
+    """Emit one secret-free structured refresh diagnostic.
+
+    Args:
+        request: Incoming refresh request.
+        outcome: Stable high-level result, either ``success`` or ``rejected``.
+        reason: Stable reason code suitable for production log filtering.
+    """
+    logger.warning(
+        "Auth refresh %s: %s",
+        outcome,
+        reason,
+        extra={
+            "event": "auth_refresh",
+            "auth_outcome": outcome,
+            "auth_reason": reason,
+            "path": request.url.path,
+            "request_id": getattr(request.state, "request_id", None),
+            "level": "WARNING",
+        },
+    )
 
 
 def _set_refresh_cookie(response: Response, request: Request, refresh_token: str) -> None:
@@ -75,7 +101,6 @@ async def register_user(
     Raises:
         HTTPException: If username or email already exists.
     """
-    # Check if username or email already exists (single query)
     conditions = [User.username == user_data.username]
     if user_data.email:
         conditions.append(User.email == user_data.email)
@@ -96,7 +121,6 @@ async def register_user(
                 detail="Email already registered",
             )
 
-    # Create new user
     hashed_password = hash_password(user_data.password)
     username = user_data.username
     user = User(
@@ -114,7 +138,6 @@ async def register_user(
             detail="Username or email already registered",
         ) from None
 
-    # Create tokens
     jti = secrets.token_urlsafe(32)
     ensure_csrf_cookie(request, response)
     access_token = create_access_token(data={"sub": username, "jti": jti})
@@ -207,22 +230,32 @@ async def refresh_access_token(
     Raises:
         HTTPException: If refresh token is invalid or revoked.
     """
-    try:
-        refresh_token = (
-            refresh_data.refresh_token if refresh_data else request.cookies.get(REFRESH_COOKIE_NAME)
+    refresh_token = (
+        refresh_data.refresh_token if refresh_data else request.cookies.get(REFRESH_COOKIE_NAME)
+    )
+    if not refresh_token:
+        _log_refresh_outcome(request, outcome="rejected", reason="missing_cookie")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing refresh token",
         )
-        if not refresh_token:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Missing refresh token",
-            )
+
+    try:
         payload = verify_token(refresh_token)
+    except ExpiredSignatureError as e:
+        _log_refresh_outcome(request, outcome="rejected", reason="expired_token")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid refresh token",
+        ) from e
     except JWTError as e:
+        _log_refresh_outcome(request, outcome="rejected", reason="invalid_token")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid refresh token",
         ) from e
     except (AttributeError, TypeError) as e:
+        _log_refresh_outcome(request, outcome="rejected", reason="invalid_token")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid token format",
@@ -239,17 +272,18 @@ async def refresh_access_token(
         or not isinstance(jti, str)
         or token_type != "refresh"
     ):
+        _log_refresh_outcome(request, outcome="rejected", reason="invalid_token")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid refresh token",
         )
 
-    # Check if refresh token is revoked
     from app.models.revoked_token import RevokedToken
 
     result = await db.execute(select(RevokedToken).where(RevokedToken.jti == jti).limit(1))
     revoked = result.scalar_one_or_none()
     if revoked:
+        _log_refresh_outcome(request, outcome="rejected", reason="revoked_token")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Refresh token has been revoked",
@@ -258,17 +292,18 @@ async def refresh_access_token(
     result = await db.execute(select(User).where(User.username == username).limit(1))
     user = result.scalar_one_or_none()
     if not user:
+        _log_refresh_outcome(request, outcome="rejected", reason="invalid_token")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="User not found",
         )
 
-    # Create new tokens
     new_jti = secrets.token_urlsafe(32)
     ensure_csrf_cookie(request, response)
     access_token = create_access_token(data={"sub": user.username, "jti": new_jti})
     refresh_token = create_refresh_token(data={"sub": user.username, "jti": new_jti})
     _set_refresh_cookie(response, request, refresh_token)
+    _log_refresh_outcome(request, outcome="success", reason="refreshed")
 
     return TokenResponse(
         access_token=access_token,
@@ -296,22 +331,18 @@ async def logout_user(
         This endpoint allows logout even with invalid/expired tokens to enable
         clients to clear local storage and redirect to login.
     """
-    # Try to get and revoke token, but don't fail if token is invalid
     auth_header = request.headers.get("authorization")
     if auth_header and auth_header.startswith("Bearer "):
         token = auth_header.split(" ")[1]
         try:
-            # Verify token to get user ID
             payload = verify_token(token)
             username = payload.get("sub")
             if username:
-                # Get user from database
                 result = await db.execute(select(User).where(User.username == username).limit(1))
                 user = result.scalar_one_or_none()
                 if user:
                     await revoke_token(db, token, user.id)
         except (JWTError, AttributeError, TypeError):
-            # Token is invalid/expired - that's ok, just return success
             pass
 
     response.delete_cookie(

--- a/app/csrf.py
+++ b/app/csrf.py
@@ -1,8 +1,11 @@
 """CSRF token helpers for API requests."""
 
+import logging
 import secrets
 
 from fastapi import Request, Response
+
+logger = logging.getLogger(__name__)
 
 CSRF_COOKIE_NAME = "csrf_token"
 CSRF_HEADER_NAME = "X-CSRF-Token"
@@ -41,6 +44,25 @@ def is_csrf_protected_request(method: str, path: str) -> bool:
     """Return whether a request should pass CSRF validation."""
     normalized_path = path.rstrip("/") or "/"
     return method.upper() in CSRF_PROTECTED_METHODS and normalized_path not in _CSRF_EXEMPT_PATHS
+
+
+def log_csrf_rejection(request: Request) -> None:
+    """Emit a secret-free structured diagnostic for a CSRF rejection.
+
+    Args:
+        request: Request rejected by double-submit CSRF validation.
+    """
+    logger.warning(
+        "CSRF request rejected",
+        extra={
+            "event": "auth_csrf" if "/auth/" in request.url.path else "csrf",
+            "auth_outcome": "rejected",
+            "auth_reason": "csrf_rejected",
+            "path": request.url.path,
+            "request_id": getattr(request.state, "request_id", None),
+            "level": "WARNING",
+        },
+    )
 
 
 def set_csrf_cookie(response: Response, request: Request, token: str) -> None:

--- a/app/csrf.py
+++ b/app/csrf.py
@@ -51,6 +51,9 @@ def log_csrf_rejection(request: Request) -> None:
 
     Args:
         request: Request rejected by double-submit CSRF validation.
+
+    Returns:
+        None.
     """
     logger.warning(
         "CSRF request rejected",

--- a/app/main.py
+++ b/app/main.py
@@ -39,7 +39,12 @@ from app.api import (
 )
 from app.cache import cache
 from app.config import get_app_settings, get_database_settings, get_redis_settings
-from app.csrf import CSRF_COOKIE_NAME, CSRF_HEADER_NAME, is_csrf_protected_request
+from app.csrf import (
+    CSRF_COOKIE_NAME,
+    CSRF_HEADER_NAME,
+    is_csrf_protected_request,
+    log_csrf_rejection,
+)
 from app.database import get_db
 from app.exception_handlers import register_exception_handlers
 from app.lifecycle import init_database
@@ -178,6 +183,7 @@ def create_app(*, serve_frontend: bool = True) -> FastAPI:
             or not csrf_header
             or not secrets.compare_digest(csrf_cookie, csrf_header)
         ):
+            log_csrf_rejection(request)
             return JSONResponse(
                 status_code=status.HTTP_403_FORBIDDEN,
                 content={"detail": "CSRF token missing or invalid"},

--- a/docs/changelog.d/2026-08-09-1032.md
+++ b/docs/changelog.d/2026-08-09-1032.md
@@ -1,0 +1,5 @@
+## 2026-08-09
+
+### Authentication
+
+- [PR #1032](https://github.com/JoshCLWren/comic-pile/pull/1032) adds safe production reason codes for refresh success and failures, including missing cookies, expired, invalid, revoked, and CSRF-rejected requests, so login problems can be diagnosed without exposing credentials.

--- a/docs/changelog.d/2026-08-09-1032.md
+++ b/docs/changelog.d/2026-08-09-1032.md
@@ -2,4 +2,4 @@
 
 ### Authentication
 
-- [PR #1032](https://github.com/JoshCLWren/comic-pile/pull/1032) adds safe production reason codes for refresh success and failures, including missing cookies, expired, invalid, revoked, and CSRF-rejected requests, so login problems can be diagnosed without exposing credentials.
+- [#1032](https://github.com/JoshCLWren/comic-pile/pull/1032) adds safe production reason codes for refresh success and failures, including missing cookies, expired, invalid, revoked, and CSRF-rejected requests, so login problems can be diagnosed without exposing credentials.

--- a/tests/test_auth_refresh_logging.py
+++ b/tests/test_auth_refresh_logging.py
@@ -15,9 +15,9 @@ from app.csrf import log_csrf_rejection
 def _auth_reasons(caplog: pytest.LogCaptureFixture) -> list[str]:
     """Return structured authentication reason codes captured by the test logger."""
     return [
-        record.auth_reason
+        str(record.__dict__["auth_reason"])
         for record in caplog.records
-        if hasattr(record, "auth_reason")
+        if "auth_reason" in record.__dict__
     ]
 
 
@@ -146,6 +146,6 @@ def test_csrf_rejection_logs_reason_without_credentials(
 
     assert "csrf_rejected" in _auth_reasons(caplog)
     assert "secret-value" not in caplog.text
-    record = next(record for record in caplog.records if hasattr(record, "auth_reason"))
-    assert record.request_id == "request-123"
-    assert record.path == "/api/v1/auth/logout"
+    record = next(record for record in caplog.records if "auth_reason" in record.__dict__)
+    assert record.__dict__["request_id"] == "request-123"
+    assert record.__dict__["path"] == "/api/v1/auth/logout"

--- a/tests/test_auth_refresh_logging.py
+++ b/tests/test_auth_refresh_logging.py
@@ -1,0 +1,151 @@
+"""Regression coverage for secret-free authentication reason diagnostics."""
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi import Request
+from httpx import AsyncClient
+from jose import jwt
+
+from app.auth import ALGORITHM, SECRET_KEY
+from app.csrf import log_csrf_rejection
+
+
+def _auth_reasons(caplog: pytest.LogCaptureFixture) -> list[str]:
+    """Return structured authentication reason codes captured by the test logger."""
+    return [
+        record.auth_reason
+        for record in caplog.records
+        if hasattr(record, "auth_reason")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_refresh_logs_missing_cookie_without_secrets(
+    client: AsyncClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A browser refresh without its HttpOnly cookie has an explicit reason code."""
+    caplog.set_level(logging.WARNING)
+    client.cookies.clear()
+
+    response = await client.post("/api/v1/auth/refresh")
+
+    assert response.status_code == 401
+    assert "missing_cookie" in _auth_reasons(caplog)
+    assert "refresh_token" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_refresh_logs_expired_token_without_secrets(
+    client: AsyncClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Expired refresh credentials are distinguishable from generic invalid tokens."""
+    caplog.set_level(logging.WARNING)
+    expired_token = jwt.encode(
+        {
+            "sub": "expired-user",
+            "jti": "expired-jti",
+            "type": "refresh",
+            "exp": datetime.now(UTC) - timedelta(minutes=1),
+        },
+        SECRET_KEY,
+        algorithm=ALGORITHM,
+    )
+
+    response = await client.post(
+        "/api/v1/auth/refresh",
+        json={"refresh_token": expired_token},
+    )
+
+    assert response.status_code == 401
+    assert "expired_token" in _auth_reasons(caplog)
+    assert expired_token not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_refresh_logs_invalid_token_without_secrets(
+    client: AsyncClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Malformed refresh credentials emit the stable invalid-token reason code."""
+    caplog.set_level(logging.WARNING)
+    invalid_token = "not-a-valid-jwt"
+
+    response = await client.post(
+        "/api/v1/auth/refresh",
+        json={"refresh_token": invalid_token},
+    )
+
+    assert response.status_code == 401
+    assert "invalid_token" in _auth_reasons(caplog)
+    assert invalid_token not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_refresh_logs_revoked_token_and_success(
+    client: AsyncClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Successful and independently revoked browser refreshes remain distinguishable."""
+    caplog.set_level(logging.WARNING)
+    register_response = await client.post(
+        "/api/v1/auth/register",
+        json={
+            "username": "auth-log-user",
+            "email": "auth-log-user@example.com",
+            "password": "password123",
+        },
+    )
+    assert register_response.status_code == 200
+
+    refresh_response = await client.post("/api/v1/auth/refresh")
+    assert refresh_response.status_code == 200
+    assert "refreshed" in _auth_reasons(caplog)
+
+    access_token = refresh_response.json()["access_token"]
+    refresh_token = refresh_response.json()["refresh_token"]
+    logout_response = await client.post(
+        "/api/v1/auth/logout",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert logout_response.status_code == 200
+
+    revoked_response = await client.post(
+        "/api/v1/auth/refresh",
+        json={"refresh_token": refresh_token},
+    )
+    assert revoked_response.status_code == 401
+    assert "revoked_token" in _auth_reasons(caplog)
+    assert refresh_token not in caplog.text
+
+
+def test_csrf_rejection_logs_reason_without_credentials(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """CSRF middleware diagnostics identify the rejection without logging credentials."""
+    caplog.set_level(logging.WARNING)
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "scheme": "https",
+            "path": "/api/v1/auth/logout",
+            "raw_path": b"/api/v1/auth/logout",
+            "query_string": b"",
+            "headers": [(b"authorization", b"Bearer secret-value")],
+            "client": ("127.0.0.1", 1234),
+            "server": ("test", 443),
+        }
+    )
+    request.state.request_id = "request-123"
+
+    log_csrf_rejection(request)
+
+    assert "csrf_rejected" in _auth_reasons(caplog)
+    assert "secret-value" not in caplog.text
+    record = next(record for record in caplog.records if hasattr(record, "auth_reason"))
+    assert record.request_id == "request-123"
+    assert record.path == "/api/v1/auth/logout"

--- a/tests/test_auth_refresh_logging.py
+++ b/tests/test_auth_refresh_logging.py
@@ -162,17 +162,20 @@ async def test_refresh_logs_revoked_token_and_success(
 async def test_csrf_middleware_logs_rejection_without_credentials(
     client: AsyncClient,
     caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The middleware logs rejected auth mutations before returning 403.
 
     Args:
         client: Async application client backed by the PostgreSQL test database.
         caplog: Pytest log-capture fixture.
+        monkeypatch: Environment patch helper used to exercise production CSRF behavior.
 
     Returns:
         None.
     """
     caplog.set_level(logging.WARNING)
+    monkeypatch.delenv("TEST_ENVIRONMENT", raising=False)
     secret_value = "Bearer secret-value"
 
     response = await client.post(

--- a/tests/test_auth_refresh_logging.py
+++ b/tests/test_auth_refresh_logging.py
@@ -8,6 +8,7 @@ from httpx import AsyncClient
 from jose import jwt
 
 from app.auth import ALGORITHM, SECRET_KEY
+from app.csrf import CSRF_COOKIE_NAME, CSRF_HEADER_NAME
 
 
 def _auth_reasons(caplog: pytest.LogCaptureFixture) -> list[str]:
@@ -176,6 +177,8 @@ async def test_csrf_middleware_logs_rejection_without_credentials(
     """
     caplog.set_level(logging.WARNING)
     monkeypatch.delenv("TEST_ENVIRONMENT", raising=False)
+    client.cookies.delete(CSRF_COOKIE_NAME)
+    client.headers.pop(CSRF_HEADER_NAME, None)
     secret_value = "Bearer secret-value"
 
     response = await client.post(
@@ -196,17 +199,20 @@ async def test_csrf_middleware_logs_rejection_without_credentials(
 async def test_csrf_middleware_allows_matching_token(
     client: AsyncClient,
     caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A protected auth mutation succeeds when cookie and header CSRF tokens match.
 
     Args:
         client: Async application client backed by the PostgreSQL test database.
         caplog: Pytest log-capture fixture.
+        monkeypatch: Environment patch helper used to exercise production CSRF behavior.
 
     Returns:
         None.
     """
     caplog.set_level(logging.WARNING)
+    monkeypatch.delenv("TEST_ENVIRONMENT", raising=False)
     csrf_response = await client.get("/api/v1/auth/csrf")
     assert csrf_response.status_code == 200
     csrf_token = csrf_response.json()["csrf_token"]

--- a/tests/test_auth_refresh_logging.py
+++ b/tests/test_auth_refresh_logging.py
@@ -4,12 +4,10 @@ import logging
 from datetime import UTC, datetime, timedelta
 
 import pytest
-from fastapi import Request
 from httpx import AsyncClient
 from jose import jwt
 
 from app.auth import ALGORITHM, SECRET_KEY
-from app.csrf import log_csrf_rejection
 
 
 def _auth_reasons(caplog: pytest.LogCaptureFixture) -> list[str]:
@@ -26,7 +24,15 @@ async def test_refresh_logs_missing_cookie_without_secrets(
     client: AsyncClient,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A browser refresh without its HttpOnly cookie has an explicit reason code."""
+    """A browser refresh without its HttpOnly cookie has an explicit reason code.
+
+    Args:
+        client: Async application client backed by the PostgreSQL test database.
+        caplog: Pytest log-capture fixture.
+
+    Returns:
+        None.
+    """
     caplog.set_level(logging.WARNING)
     client.cookies.clear()
 
@@ -42,7 +48,15 @@ async def test_refresh_logs_expired_token_without_secrets(
     client: AsyncClient,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Expired refresh credentials are distinguishable from generic invalid tokens."""
+    """Expired refresh credentials are distinguishable from generic invalid tokens.
+
+    Args:
+        client: Async application client backed by the PostgreSQL test database.
+        caplog: Pytest log-capture fixture.
+
+    Returns:
+        None.
+    """
     caplog.set_level(logging.WARNING)
     expired_token = jwt.encode(
         {
@@ -70,7 +84,15 @@ async def test_refresh_logs_invalid_token_without_secrets(
     client: AsyncClient,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Malformed refresh credentials emit the stable invalid-token reason code."""
+    """Malformed refresh credentials emit the stable invalid-token reason code.
+
+    Args:
+        client: Async application client backed by the PostgreSQL test database.
+        caplog: Pytest log-capture fixture.
+
+    Returns:
+        None.
+    """
     caplog.set_level(logging.WARNING)
     invalid_token = "not-a-valid-jwt"
 
@@ -89,7 +111,15 @@ async def test_refresh_logs_revoked_token_and_success(
     client: AsyncClient,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Successful and independently revoked browser refreshes remain distinguishable."""
+    """Successful and independently revoked browser refreshes remain distinguishable.
+
+    Args:
+        client: Async application client backed by the PostgreSQL test database.
+        caplog: Pytest log-capture fixture.
+
+    Returns:
+        None.
+    """
     caplog.set_level(logging.WARNING)
     register_response = await client.post(
         "/api/v1/auth/register",
@@ -107,9 +137,15 @@ async def test_refresh_logs_revoked_token_and_success(
 
     access_token = refresh_response.json()["access_token"]
     refresh_token = refresh_response.json()["refresh_token"]
+    csrf_response = await client.get("/api/v1/auth/csrf")
+    assert csrf_response.status_code == 200
+    csrf_token = csrf_response.json()["csrf_token"]
     logout_response = await client.post(
         "/api/v1/auth/logout",
-        headers={"Authorization": f"Bearer {access_token}"},
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "X-CSRF-Token": csrf_token,
+        },
     )
     assert logout_response.status_code == 200
 
@@ -122,30 +158,61 @@ async def test_refresh_logs_revoked_token_and_success(
     assert refresh_token not in caplog.text
 
 
-def test_csrf_rejection_logs_reason_without_credentials(
+@pytest.mark.asyncio
+async def test_csrf_middleware_logs_rejection_without_credentials(
+    client: AsyncClient,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """CSRF middleware diagnostics identify the rejection without logging credentials."""
+    """The middleware logs rejected auth mutations before returning 403.
+
+    Args:
+        client: Async application client backed by the PostgreSQL test database.
+        caplog: Pytest log-capture fixture.
+
+    Returns:
+        None.
+    """
     caplog.set_level(logging.WARNING)
-    request = Request(
-        {
-            "type": "http",
-            "method": "POST",
-            "scheme": "https",
-            "path": "/api/v1/auth/logout",
-            "raw_path": b"/api/v1/auth/logout",
-            "query_string": b"",
-            "headers": [(b"authorization", b"Bearer secret-value")],
-            "client": ("127.0.0.1", 1234),
-            "server": ("test", 443),
-        }
+    secret_value = "Bearer secret-value"
+
+    response = await client.post(
+        "/api/v1/auth/logout",
+        headers={"Authorization": secret_value},
     )
-    request.state.request_id = "request-123"
 
-    log_csrf_rejection(request)
-
+    assert response.status_code == 403
     assert "csrf_rejected" in _auth_reasons(caplog)
     assert "secret-value" not in caplog.text
     record = next(record for record in caplog.records if "auth_reason" in record.__dict__)
-    assert record.__dict__["request_id"] == "request-123"
     assert record.__dict__["path"] == "/api/v1/auth/logout"
+    assert record.__dict__["auth_outcome"] == "rejected"
+    assert record.__dict__["event"] == "auth_csrf"
+
+
+@pytest.mark.asyncio
+async def test_csrf_middleware_allows_matching_token(
+    client: AsyncClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A protected auth mutation succeeds when cookie and header CSRF tokens match.
+
+    Args:
+        client: Async application client backed by the PostgreSQL test database.
+        caplog: Pytest log-capture fixture.
+
+    Returns:
+        None.
+    """
+    caplog.set_level(logging.WARNING)
+    csrf_response = await client.get("/api/v1/auth/csrf")
+    assert csrf_response.status_code == 200
+    csrf_token = csrf_response.json()["csrf_token"]
+
+    response = await client.post(
+        "/api/v1/auth/logout",
+        headers={"X-CSRF-Token": csrf_token},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"message": "Successfully logged out"}
+    assert "csrf_rejected" not in _auth_reasons(caplog)


### PR DESCRIPTION
Completes the remaining observability scope of #986.

## What changed
- emit structured, secret-free reason codes for missing, expired, invalid, revoked, and successful refresh outcomes
- emit a structured CSRF rejection reason at the actual middleware decision point
- carry request ID and route context without logging auth credentials
- add focused regression coverage for each required reason category

## Validation
This scheduled runtime has no local checkout, so focused execution is delegated to configured PR CI. The branch includes deterministic backend regression tests.

Changelog: `docs/changelog.d/2026-08-09-1032.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved diagnostics for refresh-token and CSRF request outcomes without exposing credentials or secrets.
  * Authentication failures now distinguish missing, expired, invalid, and revoked tokens.
  * CSRF rejection records include useful request context while preserving the existing 403 response.

* **Bug Fixes**
  * Refresh-token validation now handles missing and expired tokens explicitly.

* **Tests**
  * Added coverage for authentication and CSRF logging scenarios, including safeguards against sensitive data exposure.

* **Documentation**
  * Documented authentication and CSRF diagnostic reason codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->