### PR TITLE
Automatically rebase open PRs when main advances

### DIFF
--- a/.github/workflows/auto-rebase-open-prs.yml
+++ b/.github/workflows/auto-rebase-open-prs.yml
@@ -36,7 +36,7 @@ jobs:
           mapfile -t prs < <(
             gh api --paginate \
               "repos/${GITHUB_REPOSITORY}/pulls?state=open&base=main&per_page=100" \
-              --jq '.[] | select(.draft == false and .head.repo.full_name == env.GITHUB_REPOSITORY) | .number'
+              --jq ".[] | select(.draft == false and .head.repo.full_name == \"${GITHUB_REPOSITORY}\") | .number"
           )
 
           if (( ${#prs[@]} == 0 )); then

--- a/.github/workflows/auto-rebase-open-prs.yml
+++ b/.github/workflows/auto-rebase-open-prs.yml
@@ -1,0 +1,62 @@
+name: Auto Rebase Open PRs
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: auto-rebase-open-prs-main
+  cancel-in-progress: false
+
+jobs:
+  rebase-open-prs:
+    name: Rebase open PRs onto main
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ secrets.PR_REBASE_TOKEN }}
+    steps:
+      - name: Require dedicated rebase credential
+        run: |
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::error::PR_REBASE_TOKEN is required. Use a GitHub App token or fine-grained PAT so rebases trigger normal PR CI instead of approval-required runs."
+            exit 1
+          fi
+
+      - name: Rebase eligible open pull requests
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mapfile -t prs < <(
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/pulls?state=open&base=main&per_page=100" \
+              --jq '.[] | select(.draft == false and .head.repo.full_name == env.GITHUB_REPOSITORY) | .number'
+          )
+
+          if (( ${#prs[@]} == 0 )); then
+            echo "No eligible open pull requests target main."
+            exit 0
+          fi
+
+          failures=()
+          for pr in "${prs[@]}"; do
+            echo "Rebasing PR #${pr} onto current main"
+            if ! gh pr update-branch "${pr}" --repo "${GITHUB_REPOSITORY}" --rebase; then
+              echo "::warning::PR #${pr} could not be rebased automatically and needs conflict repair."
+              failures+=("${pr}")
+            fi
+          done
+
+          if (( ${#failures[@]} > 0 )); then
+            joined="$(IFS=,; echo "${failures[*]}")"
+            echo "::error::Automatic rebase failed for PR(s): ${joined}"
+            exit 1
+          fi
+
+          echo "All eligible open pull requests are rebased onto current main."

--- a/docs/changelog.d/2026-08-09-1033.md
+++ b/docs/changelog.d/2026-08-09-1033.md
@@ -1,6 +1,7 @@
-## 2026-08-09 — Automatically rebase open PRs when main advances
+## 2026-08-09
 
-- Added [PR #1033](https://github.com/JoshCLWren/comic-pile/pull/1033) to automatically rebase eligible open pull requests onto the latest `main` whenever `main` advances.
-- This keeps active factory work from drifting dozens of commits behind during high-throughput merge periods while preserving each PR's review history, labels, issue linkage, and discussion.
+### Factory delivery
+
+- [PR #1033](https://github.com/JoshCLWren/comic-pile/pull/1033) automatically rebases eligible open pull requests onto the latest `main` whenever `main` advances, keeping active factory work current while preserving review history, labels, issue linkage, and discussion.
 - Conflicted branches remain open and are surfaced for repair instead of being discarded or replaced automatically.
-- The workflow uses a dedicated `PR_REBASE_TOKEN` credential so rebases trigger normal pull-request CI rather than approval-required runs caused by updates made with the workflow `GITHUB_TOKEN`.
+- The workflow requires a dedicated `PR_REBASE_TOKEN` credential so rebases trigger normal pull-request CI rather than approval-required runs caused by updates made with the workflow `GITHUB_TOKEN`.

--- a/docs/changelog.d/2026-08-09-1033.md
+++ b/docs/changelog.d/2026-08-09-1033.md
@@ -1,4 +1,4 @@
-# 2026-08-09 — Automatically rebase open PRs when main advances
+## 2026-08-09 — Automatically rebase open PRs when main advances
 
 - Added [PR #1033](https://github.com/JoshCLWren/comic-pile/pull/1033) to automatically rebase eligible open pull requests onto the latest `main` whenever `main` advances.
 - This keeps active factory work from drifting dozens of commits behind during high-throughput merge periods while preserving each PR's review history, labels, issue linkage, and discussion.

--- a/docs/changelog.d/2026-08-09-1033.md
+++ b/docs/changelog.d/2026-08-09-1033.md
@@ -2,6 +2,6 @@
 
 ### Factory delivery
 
-- [PR #1033](https://github.com/JoshCLWren/comic-pile/pull/1033) automatically rebases eligible open pull requests onto the latest `main` whenever `main` advances, keeping active factory work current while preserving review history, labels, issue linkage, and discussion.
+- [#1033](https://github.com/JoshCLWren/comic-pile/pull/1033) automatically rebases eligible open pull requests onto the latest `main` whenever `main` advances, keeping active factory work current while preserving review history, labels, issue linkage, and discussion.
 - Conflicted branches remain open and are surfaced for repair instead of being discarded or replaced automatically.
 - The workflow requires a dedicated `PR_REBASE_TOKEN` credential so rebases trigger normal pull-request CI rather than approval-required runs caused by updates made with the workflow `GITHUB_TOKEN`.

--- a/docs/changelog.d/2026-08-09-1033.md
+++ b/docs/changelog.d/2026-08-09-1033.md
@@ -1,0 +1,6 @@
+# 2026-08-09 — Automatically rebase open PRs when main advances
+
+- Added [PR #1033](https://github.com/JoshCLWren/comic-pile/pull/1033) to automatically rebase eligible open pull requests onto the latest `main` whenever `main` advances.
+- This keeps active factory work from drifting dozens of commits behind during high-throughput merge periods while preserving each PR's review history, labels, issue linkage, and discussion.
+- Conflicted branches remain open and are surfaced for repair instead of being discarded or replaced automatically.
+- The workflow uses a dedicated `PR_REBASE_TOKEN` credential so rebases trigger normal pull-request CI rather than approval-required runs caused by updates made with the workflow `GITHUB_TOKEN`.


### PR DESCRIPTION
## Summary
- add a repository workflow that runs whenever `main` advances and on manual dispatch
- rebase every eligible same-repository, non-draft PR targeting `main`
- serialize rebase sweeps so concurrent merges do not race each other
- leave conflicted PRs open and fail the sweep with a clear warning instead of closing or replacing them
- require a dedicated `PR_REBASE_TOKEN` so rebases trigger normal PR CI rather than approval-required runs caused by `GITHUB_TOKEN`

## Rationale
ComicPile merges frequently enough that active factory PRs can fall dozens of commits behind `main` in a short time. Being behind is maintenance, not grounds for disposing of a PR. This keeps surviving PRs current automatically and preserves their review history, issue linkage, labels, and discussion.

## Credential required
Add repository Actions secret `PR_REBASE_TOKEN` using a GitHub App token or fine-grained PAT with access to this repository and sufficient pull-request/contents write permission to update PR branches.

GitHub documents that PRs updated with the workflow `GITHUB_TOKEN` produce `opened`/`synchronize`/`reopened` workflow runs in an approval-required state, while a GitHub App installation token or PAT avoids that behavior. This workflow intentionally refuses to fall back to `GITHUB_TOKEN`.

## Validation
- workflow follows the repository's existing Actions/concurrency conventions
- eligible PR discovery is restricted to open, non-draft PRs targeting `main` whose head repository is this repository
- `gh pr update-branch --rebase` is GitHub CLI's documented rebase operation
- conflict failures are collected so one bad PR does not prevent attempts on later PRs
- runtime mutation validation requires `PR_REBASE_TOKEN`

Changelog: `docs/changelog.d/2026-08-09-1033.md`