### PR TITLE
Unify current-session endpoint resolution

### DIFF
--- a/comic_pile/session.py
+++ b/comic_pile/session.py
@@ -110,7 +110,6 @@ async def is_active(
         select(Session)
         .where(Session.started_at == started_at)
         .where(Session.ended_at.is_(None))
-        .order_by(Session.id.desc())
         .limit(1)
     )
     session = session_result.scalars().first()

--- a/comic_pile/session.py
+++ b/comic_pile/session.py
@@ -102,7 +102,16 @@ async def is_active(
     ended_at: datetime | None,
     db: AsyncSession,
 ) -> bool:
-    """Check whether a session is the authoritative current session."""
+    """Check whether a session timestamp identifies the authoritative current session.
+
+    Args:
+        started_at: Persisted start timestamp for the candidate session.
+        ended_at: Persisted end timestamp, or None when the candidate is unended.
+        db: Async database session used to resolve current-session authority.
+
+    Returns:
+        True only when the timestamp identifies one unended authoritative session.
+    """
     if ended_at is not None:
         return False
 
@@ -110,13 +119,19 @@ async def is_active(
         select(Session)
         .where(Session.started_at == started_at)
         .where(Session.ended_at.is_(None))
-        .limit(1)
+        .limit(2)
     )
-    session = session_result.scalars().first()
-    if session is None:
+    sessions = session_result.scalars().all()
+    if not sessions:
         cutoff_time = datetime.now(UTC) - timedelta(hours=_session_gap_hours())
         return _as_utc(started_at) >= cutoff_time
+    if len(sessions) != 1:
+        # started_at is not a unique identity. Refuse ambiguous authority so the caller
+        # falls back to the user-scoped canonical resolver instead of selecting another
+        # user's session that happens to share the same timestamp.
+        return False
 
+    session = sessions[0]
     current = await resolve_current_session(db, session.user_id)
     return current is not None and current.id == session.id
 

--- a/comic_pile/session.py
+++ b/comic_pile/session.py
@@ -100,12 +100,26 @@ async def resolve_current_session(db: AsyncSession, user_id: int) -> Session | N
 async def is_active(
     started_at: datetime,
     ended_at: datetime | None,
-    _db: AsyncSession,
+    db: AsyncSession,
 ) -> bool:
-    """Check whether a session start is within the configured gap."""
-    cutoff_time = datetime.now(UTC) - timedelta(hours=_session_gap_hours())
-    session_time = _as_utc(started_at)
-    return session_time >= cutoff_time and ended_at is None
+    """Check whether a session is the authoritative current session."""
+    if ended_at is not None:
+        return False
+
+    session_result = await db.execute(
+        select(Session)
+        .where(Session.started_at == started_at)
+        .where(Session.ended_at.is_(None))
+        .order_by(Session.id.desc())
+        .limit(1)
+    )
+    session = session_result.scalars().first()
+    if session is None:
+        cutoff_time = datetime.now(UTC) - timedelta(hours=_session_gap_hours())
+        return _as_utc(started_at) >= cutoff_time
+
+    current = await resolve_current_session(db, session.user_id)
+    return current is not None and current.id == session.id
 
 
 async def should_start_new(db: AsyncSession, user_id: int) -> bool:

--- a/docs/changelog.d/2026-08-10-1036.md
+++ b/docs/changelog.d/2026-08-10-1036.md
@@ -1,0 +1,5 @@
+## 2026-08-10
+
+### Roll and session reliability
+
+- [#1036](https://github.com/JoshCLWren/comic-pile/pull/1036) keeps `/sessions/current` aligned with ComicPile's activity-aware reading-session resolver, so a newer blank duplicate session cannot displace an older session that still owns the comic you are actively reading.

--- a/tests/test_current_session_resolution.py
+++ b/tests/test_current_session_resolution.py
@@ -7,7 +7,8 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import Session as SessionModel
-from app.models import Thread
+from app.models import Thread, User
+from comic_pile.session import is_active
 
 
 @pytest.mark.asyncio
@@ -57,3 +58,23 @@ async def test_current_session_prefers_older_pending_session_over_newer_blank_du
     assert data["id"] == pending_session.id
     assert data["pending_thread_id"] == thread.id
     assert data["id"] != newer_blank_session.id
+
+
+@pytest.mark.asyncio
+async def test_is_active_rejects_timestamp_shared_by_multiple_users(
+    async_db: AsyncSession,
+) -> None:
+    """A non-unique start timestamp must never confer cross-user session authority."""
+    started_at = datetime.now(UTC) - timedelta(minutes=30)
+    users = [User(username="timestamp-owner-a"), User(username="timestamp-owner-b")]
+    async_db.add_all(users)
+    await async_db.flush()
+
+    sessions = [
+        SessionModel(started_at=started_at, start_die=6, user_id=user.id)
+        for user in users
+    ]
+    async_db.add_all(sessions)
+    await async_db.commit()
+
+    assert await is_active(started_at, None, async_db) is False

--- a/tests/test_current_session_resolution.py
+++ b/tests/test_current_session_resolution.py
@@ -1,0 +1,59 @@
+"""Regression coverage for authoritative current-session resolution."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Session as SessionModel
+from app.models import Thread
+
+
+@pytest.mark.asyncio
+async def test_current_session_prefers_older_pending_session_over_newer_blank_duplicate(
+    auth_client: AsyncClient,
+    async_db: AsyncSession,
+) -> None:
+    """The current-session endpoint must preserve active pending reading context."""
+    from tests.conftest import get_or_create_user_async
+
+    user = await get_or_create_user_async(async_db)
+    now = datetime.now(UTC)
+
+    thread = Thread(
+        title="Pending Comic",
+        format="Comic",
+        issues_remaining=1,
+        queue_position=1,
+        status="active",
+        user_id=user.id,
+    )
+    async_db.add(thread)
+    await async_db.commit()
+    await async_db.refresh(thread)
+
+    pending_session = SessionModel(
+        started_at=now - timedelta(hours=2),
+        start_die=10,
+        user_id=user.id,
+        pending_thread_id=thread.id,
+        pending_thread_updated_at=now - timedelta(minutes=5),
+    )
+    newer_blank_session = SessionModel(
+        started_at=now - timedelta(hours=1),
+        start_die=6,
+        user_id=user.id,
+    )
+    async_db.add_all([pending_session, newer_blank_session])
+    await async_db.commit()
+    await async_db.refresh(pending_session)
+    await async_db.refresh(newer_blank_session)
+
+    response = await auth_client.get("/api/sessions/current/")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == pending_session.id
+    assert data["pending_thread_id"] == thread.id
+    assert data["id"] != newer_blank_session.id


### PR DESCRIPTION
Continues #987 by making the legacy current-session activity check defer to the canonical activity-aware resolver introduced in #1005. This prevents `/api/sessions/current/` from selecting a newer blank duplicate when an older session still owns fresh pending reading context.

Adds a focused API regression for the production-shaped older-pending/newer-blank case.

This PR does not close #987; concurrency, observability, and Chromium lifecycle acceptance work remains.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved current reading-session detection to prioritize the active session associated with the comic being read.
  - Prevented newer blank sessions from incorrectly replacing an older active session.
  - Updated `/sessions/current` to return the correct session and associated thread.

- **Tests**
  - Added regression coverage for session resolution when duplicate or overlapping sessions exist.

- **Documentation**
  - Added a changelog entry describing the improved session reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->