### PR TITLE
Prove current-session creation is race-safe

### DIFF
--- a/tests/test_session_creation_concurrency.py
+++ b/tests/test_session_creation_concurrency.py
@@ -1,0 +1,44 @@
+"""Concurrency regression coverage for current-session creation."""
+
+import asyncio
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+from app.models import Session
+from comic_pile.session import get_or_create
+from tests.conftest import get_or_create_user_async
+
+
+@pytest.mark.asyncio
+async def test_concurrent_get_or_create_reuses_one_authoritative_session(
+    async_db_committed: AsyncSession,
+    db_engine: AsyncEngine,
+) -> None:
+    """Concurrent bootstrap-style calls must not manufacture duplicate sessions."""
+    user = await get_or_create_user_async(async_db_committed, username="session_race_user")
+    user_id = user.id
+
+    session_maker = async_sessionmaker(
+        bind=db_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+
+    async def resolve_session_id() -> int:
+        async with session_maker() as db:
+            session = await get_or_create(db, user_id=user_id)
+            return session.id
+
+    session_ids = await asyncio.gather(*(resolve_session_id() for _ in range(8)))
+
+    assert len(set(session_ids)) == 1
+
+    count_result = await async_db_committed.execute(
+        select(func.count())
+        .select_from(Session)
+        .where(Session.user_id == user_id)
+        .where(Session.ended_at.is_(None))
+    )
+    assert count_result.scalar_one() == 1


### PR DESCRIPTION
Adds focused backend concurrency coverage for #987. Eight concurrent bootstrap-style `get_or_create` calls use independent database sessions and must all resolve to the same authoritative unended session, with exactly one session row remaining for the user.

This verifies the existing application/advisory-lock creation contract against the race described in the production incident without changing product behavior.

Changelog: not user-facing