### PR TITLE
Fix OpenCode reviewer GitHub authentication

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -117,6 +117,7 @@ jobs:
         if: github.event_name != 'workflow_dispatch'
         uses: anomalyco/opencode/github@77fc88c8ade8e5a620ebbe1197f3a572d29ae91a
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
           PROMPT: >-
             ${{ github.event_name == 'pull_request' && 'Perform an exact-head code review of this pull request. Read the complete diff and relevant surrounding code. Report only actionable correctness, security, regression, maintainability, or missing-test findings. For every actionable finding, use the GitHub API or gh CLI to create a pull-request review comment directly on the relevant changed RIGHT-side diff line; include a concise explanation and a valid suggested patch when appropriate. Do not merely list findings in the final summary, do not comment on unchanged lines, and do not modify, push, or change labels. Use the final PR comment only for an overall verdict and a count of inline findings. End that verdict with exactly OPENCODE_REVIEW: PASS when there are zero actionable inline findings, or OPENCODE_REVIEW: CHANGES_REQUIRED when one or more actionable inline findings were posted.' || '' }}
@@ -139,7 +140,7 @@ jobs:
           verdict="$(gh api \
             "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" | \
             jq -r --arg run "/actions/runs/${GITHUB_RUN_ID}" \
-              '.[] | select(.user.login == "opencode-agent[bot]" and (.body | contains($run))) | .body' | \
+              '.[] | select((.user.login == "opencode-agent[bot]" or .user.login == "github-actions[bot]") and (.body | contains($run))) | .body' | \
             tail -n 1)"
           if grep -q 'OPENCODE_REVIEW: CHANGES_REQUIRED' <<< "$verdict"; then
             target_stage='factory:changes-requested'

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -114,13 +114,14 @@ jobs:
         run: echo "FCM_NVIDIA_GITHUB_OK (${{ steps.model.outputs.model }})"
 
       - name: Run OpenCode PR agent
+        id: opencode_review
         if: github.event_name != 'workflow_dispatch'
         uses: anomalyco/opencode/github@77fc88c8ade8e5a620ebbe1197f3a572d29ae91a
         env:
           GITHUB_TOKEN: ${{ github.token }}
           NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
           PROMPT: >-
-            ${{ github.event_name == 'pull_request' && 'Perform an exact-head code review of this pull request. Read the complete diff and relevant surrounding code. Report only actionable correctness, security, regression, maintainability, or missing-test findings. For every actionable finding, use the GitHub API or gh CLI to create a pull-request review comment directly on the relevant changed RIGHT-side diff line; include a concise explanation and a valid suggested patch when appropriate. Do not merely list findings in the final summary, do not comment on unchanged lines, and do not modify, push, or change labels. Use the final PR comment only for an overall verdict and a count of inline findings. End that verdict with exactly OPENCODE_REVIEW: PASS when there are zero actionable inline findings, or OPENCODE_REVIEW: CHANGES_REQUIRED when one or more actionable inline findings were posted.' || '' }}
+            ${{ github.event_name == 'pull_request' && 'Perform an exact-head code review of this pull request. Read the complete diff and relevant surrounding code. Report only actionable correctness, security, regression, maintainability, or missing-test findings. For every actionable finding, use the GitHub API or gh CLI to create a pull-request review comment directly on the relevant changed RIGHT-side diff line; include a concise explanation and a valid suggested patch when appropriate. Do not merely list findings in the final summary, do not comment on unchanged lines, and do not modify, push, merge, or change labels. Use the final response for an overall verdict and a count of inline findings. End that verdict with exactly OPENCODE_REVIEW: PASS when there are zero actionable inline findings, or OPENCODE_REVIEW: CHANGES_REQUIRED when one or more actionable inline findings were posted.' || '' }}
         with:
           model: ${{ steps.model.outputs.model }}
           use_github_token: true
@@ -131,20 +132,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           EXPECTED_HEAD: ${{ github.event.pull_request.head.sha }}
+          VERDICT: ${{ steps.opencode_review.outputs.result }}
         run: |
           current_head="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .head.sha)"
           if [[ "$current_head" != "$EXPECTED_HEAD" ]]; then
             echo "PR moved from ${EXPECTED_HEAD} to ${current_head}; refusing to tag a stale review." >&2
             exit 1
           fi
-          verdict="$(gh api \
-            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" | \
-            jq -r --arg run "/actions/runs/${GITHUB_RUN_ID}" \
-              '.[] | select((.user.login == "opencode-agent[bot]" or .user.login == "github-actions[bot]") and (.body | contains($run))) | .body' | \
-            tail -n 1)"
-          if grep -q 'OPENCODE_REVIEW: CHANGES_REQUIRED' <<< "$verdict"; then
+          if grep -q 'OPENCODE_REVIEW: CHANGES_REQUIRED' <<< "$VERDICT"; then
             target_stage='factory:changes-requested'
-          elif grep -q 'OPENCODE_REVIEW: PASS' <<< "$verdict"; then
+          elif grep -q 'OPENCODE_REVIEW: PASS' <<< "$VERDICT"; then
             target_stage='factory:ci'
           else
             echo 'OpenCode omitted the required exact-head verdict marker; leaving factory:review in place.' >&2

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -114,14 +114,13 @@ jobs:
         run: echo "FCM_NVIDIA_GITHUB_OK (${{ steps.model.outputs.model }})"
 
       - name: Run OpenCode PR agent
-        id: opencode_review
         if: github.event_name != 'workflow_dispatch'
         uses: anomalyco/opencode/github@77fc88c8ade8e5a620ebbe1197f3a572d29ae91a
         env:
           GITHUB_TOKEN: ${{ github.token }}
           NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
           PROMPT: >-
-            ${{ github.event_name == 'pull_request' && 'Perform an exact-head code review of this pull request. Read the complete diff and relevant surrounding code. Report only actionable correctness, security, regression, maintainability, or missing-test findings. For every actionable finding, use the GitHub API or gh CLI to create a pull-request review comment directly on the relevant changed RIGHT-side diff line; include a concise explanation and a valid suggested patch when appropriate. Do not merely list findings in the final summary, do not comment on unchanged lines, and do not modify, push, merge, or change labels. Use the final response for an overall verdict and a count of inline findings. End that verdict with exactly OPENCODE_REVIEW: PASS when there are zero actionable inline findings, or OPENCODE_REVIEW: CHANGES_REQUIRED when one or more actionable inline findings were posted.' || '' }}
+            ${{ github.event_name == 'pull_request' && 'Perform an exact-head code review of this pull request. Read the complete diff and relevant surrounding code. Report only actionable correctness, security, regression, maintainability, or missing-test findings. For every actionable finding, use the GitHub API or gh CLI to create a pull-request review comment directly on the relevant changed RIGHT-side diff line; include a concise explanation and a valid suggested patch when appropriate. Do not merely list findings in the final summary, do not comment on unchanged lines, and do not modify, push, merge, or change labels. Your FINAL response MUST begin with exactly OPENCODE_REVIEW: PASS when there are zero actionable inline findings, or exactly OPENCODE_REVIEW: CHANGES_REQUIRED when one or more actionable inline findings were posted. After that first line, you may include a concise overall verdict and finding count.' || '' }}
         with:
           model: ${{ steps.model.outputs.model }}
           use_github_token: true
@@ -132,16 +131,20 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           EXPECTED_HEAD: ${{ github.event.pull_request.head.sha }}
-          VERDICT: ${{ steps.opencode_review.outputs.result }}
         run: |
           current_head="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .head.sha)"
           if [[ "$current_head" != "$EXPECTED_HEAD" ]]; then
             echo "PR moved from ${EXPECTED_HEAD} to ${current_head}; refusing to tag a stale review." >&2
             exit 1
           fi
-          if grep -q 'OPENCODE_REVIEW: CHANGES_REQUIRED' <<< "$VERDICT"; then
+          verdict="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" | \
+            jq -r --arg run "/actions/runs/${GITHUB_RUN_ID}" \
+              '.[] | select((.user.login == "opencode-agent[bot]" or .user.login == "github-actions[bot]") and (.body | contains($run))) | .body' | \
+            tail -n 1)"
+          if grep -q '^OPENCODE_REVIEW: CHANGES_REQUIRED' <<< "$verdict"; then
             target_stage='factory:changes-requested'
-          elif grep -q 'OPENCODE_REVIEW: PASS' <<< "$VERDICT"; then
+          elif grep -q '^OPENCODE_REVIEW: PASS' <<< "$verdict"; then
             target_stage='factory:ci'
           else
             echo 'OpenCode omitted the required exact-head verdict marker; leaving factory:review in place.' >&2

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -122,6 +122,7 @@ jobs:
             ${{ github.event_name == 'pull_request' && 'Perform an exact-head code review of this pull request. Read the complete diff and relevant surrounding code. Report only actionable correctness, security, regression, maintainability, or missing-test findings. For every actionable finding, use the GitHub API or gh CLI to create a pull-request review comment directly on the relevant changed RIGHT-side diff line; include a concise explanation and a valid suggested patch when appropriate. Do not merely list findings in the final summary, do not comment on unchanged lines, and do not modify, push, or change labels. Use the final PR comment only for an overall verdict and a count of inline findings. End that verdict with exactly OPENCODE_REVIEW: PASS when there are zero actionable inline findings, or OPENCODE_REVIEW: CHANGES_REQUIRED when one or more actionable inline findings were posted.' || '' }}
         with:
           model: ${{ steps.model.outputs.model }}
+          use_github_token: true
 
       - name: Reconcile automatic review stage
         if: github.event_name == 'pull_request'

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -137,18 +137,14 @@ jobs:
             echo "PR moved from ${EXPECTED_HEAD} to ${current_head}; refusing to tag a stale review." >&2
             exit 1
           fi
-          verdict="$(gh api \
-            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" | \
-            jq -r --arg run "/actions/runs/${GITHUB_RUN_ID}" \
-              '.[] | select((.user.login == "opencode-agent[bot]" or .user.login == "github-actions[bot]") and (.body | contains($run))) | .body' | \
-            tail -n 1)"
-          if grep -q '^OPENCODE_REVIEW: CHANGES_REQUIRED' <<< "$verdict"; then
+          finding_count="$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/comments?per_page=100" | \
+            jq -s --arg head "$EXPECTED_HEAD" \
+              '[.[][] | select((.user.login == "opencode-agent[bot]" or .user.login == "github-actions[bot]") and .commit_id == $head)] | length')"
+          if (( finding_count > 0 )); then
             target_stage='factory:changes-requested'
-          elif grep -q '^OPENCODE_REVIEW: PASS' <<< "$verdict"; then
-            target_stage='factory:ci'
           else
-            echo 'OpenCode omitted the required exact-head verdict marker; leaving factory:review in place.' >&2
-            exit 1
+            target_stage='factory:ci'
           fi
           for label in factory:building factory:review factory:changes-requested factory:ci factory:ready; do
             gh api --method DELETE \

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -123,6 +123,7 @@ jobs:
             ${{ github.event_name == 'pull_request' && 'Perform an exact-head code review of this pull request. Read the complete diff and relevant surrounding code. Report only actionable correctness, security, regression, maintainability, or missing-test findings. For every actionable finding, use the GitHub API or gh CLI to create a pull-request review comment directly on the relevant changed RIGHT-side diff line; include a concise explanation and a valid suggested patch when appropriate. Do not merely list findings in the final summary, do not comment on unchanged lines, and do not modify, push, merge, or change labels. Your FINAL response MUST begin with exactly OPENCODE_REVIEW: PASS when there are zero actionable inline findings, or exactly OPENCODE_REVIEW: CHANGES_REQUIRED when one or more actionable inline findings were posted. After that first line, you may include a concise overall verdict and finding count.' || '' }}
         with:
           model: ${{ steps.model.outputs.model }}
+          agent: pr-reviewer
           use_github_token: true
 
       - name: Reconcile automatic review stage

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -37,7 +37,6 @@ jobs:
       cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
       pull-requests: write
       issues: write

--- a/.opencode/agents/pr-reviewer.md
+++ b/.opencode/agents/pr-reviewer.md
@@ -1,0 +1,18 @@
+---
+description: Read-only pull request reviewer that may post GitHub review findings
+mode: primary
+permission:
+  edit: deny
+  task: deny
+  external_directory: deny
+  question: deny
+  bash:
+    "*": deny
+    "gh api *": allow
+    "git diff*": allow
+    "git log*": allow
+    "git show*": allow
+    "git status*": allow
+---
+
+Review the current pull request without modifying the working tree. Use native read, search, and language tools to inspect code. You may use the allowed read-only git commands for history and diffs, and `gh api` only when the review prompt requires posting an inline pull-request review comment. Never edit files, create commits, push branches, merge pull requests, or change labels.

--- a/docs/changelog.d/2026-08-09-1040.md
+++ b/docs/changelog.d/2026-08-09-1040.md
@@ -1,0 +1,5 @@
+## 2026-08-09
+
+### Factory reliability
+
+- [PR #1040](https://github.com/JoshCLWren/comic-pile/pull/1040) lets the automatic OpenCode reviewer use the workflow GitHub token, so factory PR reviews can post their findings instead of failing on an unprivileged bot identity.

--- a/docs/changelog.d/2026-08-09-1040.md
+++ b/docs/changelog.d/2026-08-09-1040.md
@@ -2,4 +2,4 @@
 
 ### Factory reliability
 
-- [PR #1040](https://github.com/JoshCLWren/comic-pile/pull/1040) lets the automatic OpenCode reviewer use the workflow GitHub token, so factory PR reviews can post their findings instead of failing on an unprivileged bot identity.
+- [#1040](https://github.com/JoshCLWren/comic-pile/pull/1040) lets the automatic OpenCode reviewer use the workflow GitHub token, so factory PR reviews can post their findings instead of failing on an unprivileged bot identity.


### PR DESCRIPTION
Fixes #1039.

The automatic OpenCode review action was launching with its default `use_github_token: false`, so the selected NVIDIA reviewer reached GitHub as `opencode-agent[bot]` with no repository permission and failed before it could post a review. This opts the action into the workflow token, whose job permissions already include pull-request and issue writes.

The existing exact-head reconciliation and NVIDIA model selection stay unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated code reviews can now update labels and post review findings using the workflow’s GitHub access.
  * Review verdicts are recognized consistently from supported automated reviewers.

* **Documentation**
  * Added a changelog entry describing the improved automated review behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->