### PR TITLE
Make automatic OpenCode reviews structurally read-only

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -52,16 +52,22 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          for label in factory:building factory:changes-requested factory:ci factory:ready; do
-            gh api --method DELETE \
-              "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels/${label}" \
-              >/dev/null 2>&1 || true
-          done
+          current_labels="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels?per_page=100" \
+            --jq '[.[].name]')"
+          owner="$(jq -r '
+            map(select(test("^factory:(unowned|local|[1-5])$"))) | first // "factory:unowned"
+          ' <<< "$current_labels")"
+          target_labels="$(jq -c --arg owner "$owner" '
+            map(select(
+              (test("^factory:(building|review|changes-requested|ci|ready|blocked)$") | not) and
+              (test("^factory:(unowned|local|[1-5])$") | not) and
+              . != "factory"
+            )) + ["factory", $owner, "factory:review"] | unique
+          ' <<< "$current_labels")"
           gh api --method POST \
             "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" \
-            --input - <<'JSON' >/dev/null
-          {"labels":["factory","factory:review"]}
-          JSON
+            --input - <<< "{\"labels\":${target_labels}}" >/dev/null
 
       - name: Install pinned FCM discovery CLI
         run: npm install --global --ignore-scripts free-coding-models@0.5.69
@@ -146,13 +152,19 @@ jobs:
           else
             target_stage='factory:ci'
           fi
-          for label in factory:building factory:review factory:changes-requested factory:ci factory:ready; do
-            gh api --method DELETE \
-              "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels/${label}" \
-              >/dev/null 2>&1 || true
-          done
+          current_labels="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels?per_page=100" \
+            --jq '[.[].name]')"
+          owner="$(jq -r '
+            map(select(test("^factory:(unowned|local|[1-5])$"))) | first // "factory:unowned"
+          ' <<< "$current_labels")"
+          target_labels="$(jq -c --arg owner "$owner" --arg stage "$target_stage" '
+            map(select(
+              (test("^factory:(building|review|changes-requested|ci|ready|blocked)$") | not) and
+              (test("^factory:(unowned|local|[1-5])$") | not) and
+              . != "factory"
+            )) + ["factory", $owner, $stage] | unique
+          ' <<< "$current_labels")"
           gh api --method POST \
             "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" \
-            --input - <<JSON >/dev/null
-          {"labels":["factory","${target_stage}"]}
-          JSON
+            --input - <<< "{\"labels\":${target_labels}}" >/dev/null

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -65,7 +65,7 @@ jobs:
               . != "factory"
             )) + ["factory", $owner, "factory:review"] | unique
           ' <<< "$current_labels")"
-          gh api --method POST \
+          gh api --method PUT \
             "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" \
             --input - <<< "{\"labels\":${target_labels}}" >/dev/null
 
@@ -165,6 +165,6 @@ jobs:
               . != "factory"
             )) + ["factory", $owner, $stage] | unique
           ' <<< "$current_labels")"
-          gh api --method POST \
+          gh api --method PUT \
             "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" \
             --input - <<< "{\"labels\":${target_labels}}" >/dev/null

--- a/docs/changelog.d/2026-08-10-1042.md
+++ b/docs/changelog.d/2026-08-10-1042.md
@@ -2,4 +2,4 @@
 
 ### Factory delivery
 
-- [PR #1042](https://github.com/JoshCLWren/comic-pile/pull/1042) makes automatic OpenCode pull-request reviews structurally read-only, preventing reviewer analysis from modifying a branch or attempting to commit review-time edits.
+- [#1042](https://github.com/JoshCLWren/comic-pile/pull/1042) makes automatic OpenCode pull-request reviews structurally read-only, preventing reviewer analysis from modifying a branch or attempting to commit review-time edits.

--- a/docs/changelog.d/2026-08-10-1042.md
+++ b/docs/changelog.d/2026-08-10-1042.md
@@ -1,0 +1,5 @@
+## 2026-08-10
+
+### Factory delivery
+
+- [PR #1042](https://github.com/JoshCLWren/comic-pile/pull/1042) makes automatic OpenCode pull-request reviews structurally read-only, preventing reviewer analysis from modifying a branch or attempting to commit review-time edits.

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "edit": "deny",
+    "question": "deny",
+    "bash": {
+      "*": "deny",
+      "cat *": "allow",
+      "find *": "allow",
+      "git diff*": "allow",
+      "git log*": "allow",
+      "git ls-files*": "allow",
+      "git rev-parse*": "allow",
+      "git show*": "allow",
+      "git status*": "allow",
+      "grep *": "allow",
+      "head *": "allow",
+      "rg *": "allow",
+      "sed *": "allow",
+      "tail *": "allow",
+      "wc *": "allow",
+      "gh api --method POST repos/*/pulls/*/comments*": "allow"
+    }
+  }
+}

--- a/scripts/tests/test_opencode_review_policy.py
+++ b/scripts/tests/test_opencode_review_policy.py
@@ -1,0 +1,49 @@
+"""Regression tests for the automatic OpenCode reviewer safety contract."""
+
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+OPENCODE_CONFIG = ROOT / "opencode.json"
+OPENCODE_WORKFLOW = ROOT / ".github" / "workflows" / "opencode.yml"
+
+
+class OpenCodeReviewPolicyTests(unittest.TestCase):
+    """Protect structural read-only review and atomic factory metadata updates."""
+
+    def test_reviewer_cannot_edit_or_run_arbitrary_shell_commands(self) -> None:
+        """Require structural denial of edits and arbitrary shell execution."""
+        config = json.loads(OPENCODE_CONFIG.read_text(encoding="utf-8"))
+        permission = config["permission"]
+        self.assertEqual(permission["edit"], "deny")
+        self.assertEqual(permission["question"], "deny")
+        self.assertEqual(permission["bash"]["*"], "deny")
+        self.assertEqual(
+            permission["bash"]["gh api --method POST repos/*/pulls/*/comments*"],
+            "allow",
+        )
+
+    def test_workflow_reconciles_labels_atomically_and_preserves_owner(self) -> None:
+        """Reject sequential stage mutation or owner-dropping label replacement."""
+        workflow = OPENCODE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertNotIn("gh api --method DELETE", workflow)
+        self.assertIn('^factory:(unowned|local|[1-5])$', workflow)
+        self.assertIn('first // "factory:unowned"', workflow)
+        self.assertGreaterEqual(workflow.count('gh api --method POST'), 2)
+        self.assertGreaterEqual(workflow.count('"factory", $owner'), 2)
+
+    def test_reviewer_has_no_merge_or_label_mutation_command(self) -> None:
+        """Keep automatic review limited to posting inline findings."""
+        config = json.loads(OPENCODE_CONFIG.read_text(encoding="utf-8"))
+        allowed_bash = {
+            command
+            for command, decision in config["permission"]["bash"].items()
+            if decision == "allow"
+        }
+        self.assertFalse(any("merge" in command for command in allowed_bash))
+        self.assertFalse(any("labels" in command for command in allowed_bash))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_opencode_review_policy.py
+++ b/scripts/tests/test_opencode_review_policy.py
@@ -25,12 +25,16 @@ class OpenCodeReviewPolicyTests(unittest.TestCase):
         )
 
     def test_workflow_reconciles_labels_atomically_and_preserves_owner(self) -> None:
-        """Reject sequential stage mutation or owner-dropping label replacement."""
+        """Reject additive/sequential stage mutation or owner-dropping replacement."""
         workflow = OPENCODE_WORKFLOW.read_text(encoding="utf-8")
         self.assertNotIn("gh api --method DELETE", workflow)
         self.assertIn('^factory:(unowned|local|[1-5])$', workflow)
         self.assertIn('first // "factory:unowned"', workflow)
-        self.assertGreaterEqual(workflow.count('gh api --method POST'), 2)
+        self.assertEqual(workflow.count('gh api --method PUT'), 2)
+        self.assertNotIn(
+            'gh api --method POST \\\n            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels"',
+            workflow,
+        )
         self.assertGreaterEqual(workflow.count('"factory", $owner'), 2)
 
     def test_reviewer_has_no_merge_or_label_mutation_command(self) -> None:


### PR DESCRIPTION
Fixes #1041.

Enforces repository-level OpenCode permissions so automatic PR review cannot edit files or run arbitrary shell commands, while retaining read-only inspection and the narrowly scoped GitHub API call needed to post inline review comments.

This addresses the #1038 reviewer failure where OpenCode edited the checkout and then attempted to commit those changes despite the read-only review prompt.

The remaining Factory Policy V19 label-reconciliation cleanup is being completed on this same PR before readiness.