### PR TITLE
Harden pending-session lifecycle browser coverage

### DIFF
--- a/frontend/src/test/issue-984-auth-session-continuity.spec.ts
+++ b/frontend/src/test/issue-984-auth-session-continuity.spec.ts
@@ -1,7 +1,34 @@
 import { expect, test } from './fixtures';
 import { SELECTORS } from './helpers';
 
-test('issue #984: auth recovery keeps the same pending comic and reading session', async ({
+type CurrentSession = {
+  id: number;
+  pending_thread_id: number | null;
+  pending_issue_id?: number | null;
+  current_die?: number;
+  active_thread?: { title?: string; issue_number?: string | null } | null;
+};
+
+async function readCurrentSession(
+  page: import('@playwright/test').Page,
+  token: string,
+): Promise<CurrentSession> {
+  const response = await page.request.get('/api/sessions/current/', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  expect(response.ok()).toBeTruthy();
+  return await response.json() as CurrentSession;
+}
+
+async function readAccessToken(page: import('@playwright/test').Page): Promise<string> {
+  return await page.evaluate(() =>
+    localStorage.getItem('auth_token')
+    ?? (window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN
+    ?? '',
+  );
+}
+
+test('issue #984/#987: reload and auth recovery preserve one authoritative pending session', async ({
   authenticatedWithThreadsPage,
 }) => {
   const page = authenticatedWithThreadsPage;
@@ -17,27 +44,28 @@ test('issue #984: auth recovery keeps the same pending comic and reading session
   await page.getByRole('button', { name: 'Read Now' }).click();
   await expect(page.locator(SELECTORS.rate.ratingInput)).toBeVisible({ timeout: 10000 });
 
-  const tokenBeforeRecovery = await page.evaluate(() =>
-    localStorage.getItem('auth_token')
-    ?? (window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN
-    ?? '',
-  );
+  const tokenBeforeRecovery = await readAccessToken(page);
   expect(tokenBeforeRecovery).toBeTruthy();
 
-  const initialSessionResponse = await page.request.get('/api/sessions/current/', {
-    headers: { Authorization: `Bearer ${tokenBeforeRecovery}` },
-  });
-  expect(initialSessionResponse.ok()).toBeTruthy();
-
-  const initialSession = await initialSessionResponse.json() as {
-    id: number;
-    pending_thread_id: number | null;
-    pending_issue_id?: number | null;
-    current_die?: number;
-    active_thread?: { title?: string; issue_number?: string | null } | null;
-  };
+  const initialSession = await readCurrentSession(page, tokenBeforeRecovery);
   expect(initialSession.pending_thread_id).not.toBeNull();
   expect(initialSession.active_thread?.title).toBeTruthy();
+
+  for (let reload = 0; reload < 3; reload += 1) {
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await expect(page.locator(SELECTORS.rate.ratingInput)).toBeVisible({ timeout: 15000 });
+
+    const token = await readAccessToken(page);
+    expect(token).toBeTruthy();
+    const reloadedSession = await readCurrentSession(page, token);
+
+    expect(reloadedSession.id).toBe(initialSession.id);
+    expect(reloadedSession.pending_thread_id).toBe(initialSession.pending_thread_id);
+    expect(reloadedSession.pending_issue_id ?? null).toBe(initialSession.pending_issue_id ?? null);
+    expect(reloadedSession.current_die).toBe(initialSession.current_die);
+    expect(reloadedSession.active_thread?.title).toBe(initialSession.active_thread?.title);
+    expect(reloadedSession.active_thread?.issue_number).toBe(initialSession.active_thread?.issue_number);
+  }
 
   await page.evaluate(() => {
     const expiredToken = 'expired.access.token';
@@ -49,30 +77,13 @@ test('issue #984: auth recovery keeps the same pending comic and reading session
 
   await expect(page).toHaveURL('/');
   await expect(page.locator(SELECTORS.rate.ratingInput)).toBeVisible({ timeout: 15000 });
-  await expect(
-    page.locator('#thread-info h2'),
-  ).toContainText(initialSession.active_thread!.title!);
+  await expect(page.locator('#thread-info h2')).toContainText(initialSession.active_thread!.title!);
 
-  const tokenAfterRecovery = await page.evaluate(() =>
-    localStorage.getItem('auth_token')
-    ?? (window as Window & { __COMIC_PILE_ACCESS_TOKEN?: string }).__COMIC_PILE_ACCESS_TOKEN
-    ?? '',
-  );
+  const tokenAfterRecovery = await readAccessToken(page);
   expect(tokenAfterRecovery).toBeTruthy();
   expect(tokenAfterRecovery).not.toBe('expired.access.token');
 
-  const recoveredSessionResponse = await page.request.get('/api/sessions/current/', {
-    headers: { Authorization: `Bearer ${tokenAfterRecovery}` },
-  });
-  expect(recoveredSessionResponse.ok()).toBeTruthy();
-
-  const recoveredSession = await recoveredSessionResponse.json() as {
-    id: number;
-    pending_thread_id: number | null;
-    pending_issue_id?: number | null;
-    current_die?: number;
-    active_thread?: { title?: string; issue_number?: string | null } | null;
-  };
+  const recoveredSession = await readCurrentSession(page, tokenAfterRecovery);
 
   expect(recoveredSession.id).toBe(initialSession.id);
   expect(recoveredSession.pending_thread_id).toBe(initialSession.pending_thread_id);


### PR DESCRIPTION
Part of #987.

Adds maintained Chromium lifecycle coverage that repeatedly reloads an authenticated Roll page with a pending comic, then exercises expired-token auth recovery. Every checkpoint must preserve the same authoritative session, pending thread/issue, die, and visible comic.

This closes the remaining browser lifecycle acceptance gap for #987 without changing product behavior. Structured reused/created session-resolution diagnostics remain as the final issue slice.

Changelog: not user-facing