### PR TITLE
Add structured session resolution diagnostics

### DIFF
--- a/app/middleware/request_logging.py
+++ b/app/middleware/request_logging.py
@@ -233,7 +233,10 @@ def add_request_logging_middleware(app: FastAPI, environment: str) -> None:
         started_at = time.perf_counter()
         request_id = uuid.uuid4().hex
         startup = next_request_snapshot()
-        diagnostics_token = begin_request_diagnostics()
+        diagnostics_token = begin_request_diagnostics(
+            request_id=request_id,
+            route=request.url.path,
+        )
         request.state.request_id = request_id
 
         try:

--- a/app/performance_diagnostics.py
+++ b/app/performance_diagnostics.py
@@ -69,7 +69,15 @@ def begin_request_diagnostics(
     request_id: str | None = None,
     route: str | None = None,
 ) -> Token[RequestDiagnostics | None]:
-    """Start a fresh diagnostics context for the current request."""
+    """Start a fresh diagnostics context for the current request.
+
+    Args:
+        request_id: Correlation identifier for the current HTTP request, when available.
+        route: Request route associated with the diagnostics context, when available.
+
+    Returns:
+        ContextVar token used to restore the previous diagnostics context.
+    """
     return _request_diagnostics.set(RequestDiagnostics(request_id=request_id, route=route))
 
 

--- a/app/performance_diagnostics.py
+++ b/app/performance_diagnostics.py
@@ -21,8 +21,10 @@ _DEFAULT_CACHE_OPERATION_TIMEOUT_SECONDS = 2.0
 
 @dataclass
 class RequestDiagnostics:
-    """Mutable counters collected during one HTTP request."""
+    """Mutable counters and context collected during one HTTP request."""
 
+    request_id: str | None = None
+    route: str | None = None
     cache_calls: int = 0
     cache_hits: int = 0
     cache_misses: int = 0
@@ -62,9 +64,13 @@ _request_diagnostics: ContextVar[RequestDiagnostics | None] = ContextVar(
 )
 
 
-def begin_request_diagnostics() -> Token[RequestDiagnostics | None]:
+def begin_request_diagnostics(
+    *,
+    request_id: str | None = None,
+    route: str | None = None,
+) -> Token[RequestDiagnostics | None]:
     """Start a fresh diagnostics context for the current request."""
-    return _request_diagnostics.set(RequestDiagnostics())
+    return _request_diagnostics.set(RequestDiagnostics(request_id=request_id, route=route))
 
 
 def end_request_diagnostics(token: Token[RequestDiagnostics | None]) -> None:

--- a/comic_pile/session.py
+++ b/comic_pile/session.py
@@ -103,7 +103,15 @@ async def _resolve_current_session_with_candidate_count(
 
 
 async def resolve_current_session(db: AsyncSession, user_id: int) -> Session | None:
-    """Resolve the authoritative unended session from durable recent activity."""
+    """Resolve the authoritative unended session from durable recent activity.
+
+    Args:
+        db: Async database session used to inspect current-session candidates.
+        user_id: User whose authoritative current reading session should be resolved.
+
+    Returns:
+        The authoritative current Session when one exists, otherwise None.
+    """
     session, _ = await _resolve_current_session_with_candidate_count(db, user_id)
     return session
 

--- a/comic_pile/session.py
+++ b/comic_pile/session.py
@@ -63,8 +63,11 @@ def _last_activity_at(session: Session, last_event_at: datetime | None) -> datet
     return max(candidates)
 
 
-async def resolve_current_session(db: AsyncSession, user_id: int) -> Session | None:
-    """Resolve the authoritative unended session from durable recent activity."""
+async def _resolve_current_session_with_candidate_count(
+    db: AsyncSession,
+    user_id: int,
+) -> tuple[Session | None, int]:
+    """Resolve current session and report how many unended rows were considered."""
     cutoff_time = datetime.now(UTC) - timedelta(hours=_session_gap_hours())
     result = await db.execute(
         select(Session, func.max(Event.timestamp).label("last_event_at"))
@@ -73,9 +76,10 @@ async def resolve_current_session(db: AsyncSession, user_id: int) -> Session | N
         .where(Session.ended_at.is_(None))
         .group_by(Session.id)
     )
+    rows = result.all()
 
     candidates: list[tuple[bool, datetime, datetime, int, Session]] = []
-    for session, last_event_at in result.all():
+    for session, last_event_at in rows:
         activity_at = _last_activity_at(session, last_event_at)
         if activity_at < cutoff_time:
             continue
@@ -93,8 +97,38 @@ async def resolve_current_session(db: AsyncSession, user_id: int) -> Session | N
         )
 
     if not candidates:
-        return None
-    return max(candidates, key=lambda candidate: candidate[:4])[4]
+        return None, len(rows)
+    return max(candidates, key=lambda candidate: candidate[:4])[4], len(rows)
+
+
+async def resolve_current_session(db: AsyncSession, user_id: int) -> Session | None:
+    """Resolve the authoritative unended session from durable recent activity."""
+    session, _ = await _resolve_current_session_with_candidate_count(db, user_id)
+    return session
+
+
+def _log_session_resolution(
+    *,
+    user_id: int,
+    session: Session,
+    resolution: str,
+    candidate_unended_sessions: int,
+    creation_reason: str | None = None,
+) -> None:
+    """Emit one structured record describing current-session resolution."""
+    logger.info(
+        "Resolved current reading session",
+        extra={
+            "event": "reading_session_resolution",
+            "user_id": user_id,
+            "session_id": session.id,
+            "session_resolution": resolution,
+            "session_creation_reason": creation_reason,
+            "candidate_unended_sessions": candidate_unended_sessions,
+            "has_pending_thread": session.pending_thread_id is not None,
+            "has_pending_issue": session.pending_issue_id is not None,
+        },
+    )
 
 
 async def is_active(
@@ -240,8 +274,17 @@ async def get_or_create(db: AsyncSession, user_id: int) -> Session:
                 db.add(user)
                 await db.commit()
 
-            active_session = await resolve_current_session(db, user_id)
+            active_session, candidate_count = await _resolve_current_session_with_candidate_count(
+                db,
+                user_id,
+            )
             if active_session:
+                _log_session_resolution(
+                    user_id=user_id,
+                    session=active_session,
+                    resolution="reused",
+                    candidate_unended_sessions=candidate_count,
+                )
                 return active_session
 
             async with _session_creation_lock:
@@ -257,8 +300,16 @@ async def get_or_create(db: AsyncSession, user_id: int) -> Session:
                         error,
                     )
 
-                active_session = await resolve_current_session(db, user_id)
+                active_session, candidate_count = (
+                    await _resolve_current_session_with_candidate_count(db, user_id)
+                )
                 if active_session:
+                    _log_session_resolution(
+                        user_id=user_id,
+                        session=active_session,
+                        resolution="reused",
+                        candidate_unended_sessions=candidate_count,
+                    )
                     return active_session
 
                 new_session = Session(start_die=start_die, user_id=user_id)
@@ -266,14 +317,12 @@ async def get_or_create(db: AsyncSession, user_id: int) -> Session:
                 await create_session_start_snapshot(db, new_session)
                 await db.commit()
                 await db.refresh(new_session)
-                logger.info(
-                    "Resolved current reading session",
-                    extra={
-                        "user_id": user_id,
-                        "session_id": new_session.id,
-                        "session_resolution": "created",
-                        "session_creation_reason": "no_recent_unended_session",
-                    },
+                _log_session_resolution(
+                    user_id=user_id,
+                    session=new_session,
+                    resolution="created",
+                    creation_reason="no_recent_unended_session",
+                    candidate_unended_sessions=candidate_count,
                 )
                 return new_session
         except OperationalError as error:

--- a/comic_pile/session.py
+++ b/comic_pile/session.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_session_settings
 from app.models import Event, Issue, Session, Snapshot, Thread
+from app.performance_diagnostics import get_request_diagnostics
 from app.services.snapshot_contract import USES_ISSUE_TRACKING_KEY
 
 logger = logging.getLogger(__name__)
@@ -116,6 +117,7 @@ def _log_session_resolution(
     creation_reason: str | None = None,
 ) -> None:
     """Emit one structured record describing current-session resolution."""
+    request_diagnostics = get_request_diagnostics()
     logger.info(
         "Resolved current reading session",
         extra={
@@ -127,6 +129,8 @@ def _log_session_resolution(
             "candidate_unended_sessions": candidate_unended_sessions,
             "has_pending_thread": session.pending_thread_id is not None,
             "has_pending_issue": session.pending_issue_id is not None,
+            "request_id": request_diagnostics.request_id,
+            "route": request_diagnostics.route,
         },
     )
 
@@ -160,9 +164,6 @@ async def is_active(
         cutoff_time = datetime.now(UTC) - timedelta(hours=_session_gap_hours())
         return _as_utc(started_at) >= cutoff_time
     if len(sessions) != 1:
-        # started_at is not a unique identity. Refuse ambiguous authority so the caller
-        # falls back to the user-scoped canonical resolver instead of selecting another
-        # user's session that happens to share the same timestamp.
         return False
 
     session = sessions[0]

--- a/docs/changelog.d/2026-08-10-1044.md
+++ b/docs/changelog.d/2026-08-10-1044.md
@@ -1,0 +1,5 @@
+## 2026-08-10
+
+### Session reliability
+
+- [#1044](https://github.com/JoshCLWren/comic-pile/pull/1044) adds structured current-session resolution diagnostics so authentication and Roll recovery incidents can show whether ComicPile reused or created a session, how many open candidates existed, whether reading state was pending, and which request triggered the decision.

--- a/tests/test_session_resolution_observability.py
+++ b/tests/test_session_resolution_observability.py
@@ -19,6 +19,11 @@ def _resolution_record(caplog: pytest.LogCaptureFixture) -> logging.LogRecord:
     )
 
 
+def _field(record: logging.LogRecord, name: str) -> object:
+    """Read a structured logging field without inventing LogRecord attributes for typing."""
+    return record.__dict__[name]
+
+
 @pytest.mark.asyncio
 async def test_reused_session_logs_resolution_and_request_context(
     async_db: AsyncSession,
@@ -51,14 +56,14 @@ async def test_reused_session_logs_resolution_and_request_context(
 
     assert resolved.id == current.id
     record = _resolution_record(caplog)
-    assert record.session_id == current.id
-    assert record.session_resolution == "reused"
-    assert record.session_creation_reason is None
-    assert record.candidate_unended_sessions == 2
-    assert record.has_pending_thread is False
-    assert record.has_pending_issue is False
-    assert record.request_id == "request-987-reuse"
-    assert record.route == "/api/v1/roll/bootstrap"
+    assert _field(record, "session_id") == current.id
+    assert _field(record, "session_resolution") == "reused"
+    assert _field(record, "session_creation_reason") is None
+    assert _field(record, "candidate_unended_sessions") == 2
+    assert _field(record, "has_pending_thread") is False
+    assert _field(record, "has_pending_issue") is False
+    assert _field(record, "request_id") == "request-987-reuse"
+    assert _field(record, "route") == "/api/v1/roll/bootstrap"
 
 
 @pytest.mark.asyncio
@@ -87,11 +92,11 @@ async def test_created_session_logs_reason_and_candidate_count(
         end_request_diagnostics(token)
 
     record = _resolution_record(caplog)
-    assert record.session_id == created.id
-    assert record.session_resolution == "created"
-    assert record.session_creation_reason == "no_recent_unended_session"
-    assert record.candidate_unended_sessions == 1
-    assert record.has_pending_thread is False
-    assert record.has_pending_issue is False
-    assert record.request_id == "request-987-create"
-    assert record.route == "/api/v1/roll/bootstrap"
+    assert _field(record, "session_id") == created.id
+    assert _field(record, "session_resolution") == "created"
+    assert _field(record, "session_creation_reason") == "no_recent_unended_session"
+    assert _field(record, "candidate_unended_sessions") == 1
+    assert _field(record, "has_pending_thread") is False
+    assert _field(record, "has_pending_issue") is False
+    assert _field(record, "request_id") == "request-987-create"
+    assert _field(record, "route") == "/api/v1/roll/bootstrap"

--- a/tests/test_session_resolution_observability.py
+++ b/tests/test_session_resolution_observability.py
@@ -1,0 +1,97 @@
+"""Regression coverage for structured current-session resolution diagnostics."""
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Session, User
+from app.performance_diagnostics import begin_request_diagnostics, end_request_diagnostics
+from comic_pile.session import get_or_create
+
+
+def _resolution_record(caplog: pytest.LogCaptureFixture) -> logging.LogRecord:
+    return next(
+        record
+        for record in caplog.records
+        if getattr(record, "event", None) == "reading_session_resolution"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reused_session_logs_resolution_and_request_context(
+    async_db: AsyncSession,
+    default_user: User,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Reusing a current session emits enough context to trace the decision."""
+    current = Session(
+        started_at=datetime.now(UTC) - timedelta(minutes=5),
+        start_die=12,
+        user_id=default_user.id,
+    )
+    stale = Session(
+        started_at=datetime.now(UTC) - timedelta(hours=9),
+        start_die=6,
+        user_id=default_user.id,
+    )
+    async_db.add_all([current, stale])
+    await async_db.commit()
+
+    token = begin_request_diagnostics(
+        request_id="request-987-reuse",
+        route="/api/v1/roll/bootstrap",
+    )
+    try:
+        with caplog.at_level(logging.INFO, logger="comic_pile.session"):
+            resolved = await get_or_create(async_db, default_user.id)
+    finally:
+        end_request_diagnostics(token)
+
+    assert resolved.id == current.id
+    record = _resolution_record(caplog)
+    assert record.session_id == current.id
+    assert record.session_resolution == "reused"
+    assert record.session_creation_reason is None
+    assert record.candidate_unended_sessions == 2
+    assert record.has_pending_thread is False
+    assert record.has_pending_issue is False
+    assert record.request_id == "request-987-reuse"
+    assert record.route == "/api/v1/roll/bootstrap"
+
+
+@pytest.mark.asyncio
+async def test_created_session_logs_reason_and_candidate_count(
+    async_db: AsyncSession,
+    default_user: User,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Creating a session explains why no prior row was reused."""
+    stale = Session(
+        started_at=datetime.now(UTC) - timedelta(hours=9),
+        start_die=10,
+        user_id=default_user.id,
+    )
+    async_db.add(stale)
+    await async_db.commit()
+
+    token = begin_request_diagnostics(
+        request_id="request-987-create",
+        route="/api/v1/roll/bootstrap",
+    )
+    try:
+        with caplog.at_level(logging.INFO, logger="comic_pile.session"):
+            created = await get_or_create(async_db, default_user.id)
+    finally:
+        end_request_diagnostics(token)
+
+    record = _resolution_record(caplog)
+    assert record.session_id == created.id
+    assert record.session_resolution == "created"
+    assert record.session_creation_reason == "no_recent_unended_session"
+    assert record.candidate_unended_sessions == 1
+    assert record.has_pending_thread is False
+    assert record.has_pending_issue is False
+    assert record.request_id == "request-987-create"
+    assert record.route == "/api/v1/roll/bootstrap"


### PR DESCRIPTION
Completes the remaining observability contract for #987 by logging every current-session reuse/create decision with candidate-session count, pending-state flags, creation reason, request ID, and route. Request context now flows through the existing per-request diagnostics ContextVar, and focused regressions cover both reuse and creation decisions.

Closes #987

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured diagnostics for session reuse and creation.
  * Diagnostic records now include request IDs, routes, pending reading state, candidate counts, and session details.

* **Bug Fixes**
  * Improved visibility into current-session resolution and related request activity.

* **Documentation**
  * Added a changelog entry describing the new session-resolution diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->