### PR TITLE
Add CBL mirror parser and discovery foundation

### DIFF
--- a/app/cbl_ingest.py
+++ b/app/cbl_ingest.py
@@ -1,0 +1,144 @@
+"""Parse CBL reading-list mirrors into normalized import records."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+
+@dataclass(frozen=True, slots=True)
+class CBLBook:
+    """One ordered comic reference declared by a CBL reading list."""
+
+    position: int
+    series: str
+    issue_number: str
+    volume_year: int | None
+    publication_year: int | None
+    comicvine_series_id: str | None
+    comicvine_issue_id: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class CBLList:
+    """One parsed CBL file plus provenance needed for idempotent syncing."""
+
+    source_path: str
+    content_hash: str
+    name: str
+    declared_issue_count: int | None
+    books: tuple[CBLBook, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class CBLParseFailure:
+    """Path-specific parse failure that does not prevent other files importing."""
+
+    source_path: str
+    message: str
+
+
+def discover_cbl_files(mirror_path: Path) -> tuple[Path, ...]:
+    """Return every CBL file beneath a mirror in deterministic relative-path order."""
+    return tuple(
+        sorted(
+            (path for path in mirror_path.rglob("*") if path.is_file() and path.suffix.lower() == ".cbl"),
+            key=lambda path: path.relative_to(mirror_path).as_posix().casefold(),
+        )
+    )
+
+
+def parse_cbl_file(path: Path, *, mirror_path: Path) -> CBLList:
+    """Parse a CBL file without performing database or network I/O."""
+    raw = path.read_bytes()
+    relative_path = path.relative_to(mirror_path).as_posix()
+    try:
+        root = ET.fromstring(raw)
+    except ET.ParseError as exc:
+        raise ValueError(f"{relative_path}: malformed CBL XML: {exc}") from exc
+
+    name = _text(root.find("Name")) or path.stem
+    declared_issue_count = _optional_int(_text(root.find("NumIssues")))
+    books_node = root.find("Books")
+    book_nodes = [] if books_node is None else books_node.findall("Book")
+    books = tuple(_parse_book(node, index) for index, node in enumerate(book_nodes, start=1))
+    return CBLList(
+        source_path=relative_path,
+        content_hash=sha256(raw).hexdigest(),
+        name=name,
+        declared_issue_count=declared_issue_count,
+        books=books,
+    )
+
+
+def parse_cbl_mirror(mirror_path: Path) -> tuple[tuple[CBLList, ...], tuple[CBLParseFailure, ...]]:
+    """Parse all CBL files while isolating malformed files with path-specific diagnostics."""
+    parsed: list[CBLList] = []
+    failures: list[CBLParseFailure] = []
+    for path in discover_cbl_files(mirror_path):
+        try:
+            parsed.append(parse_cbl_file(path, mirror_path=mirror_path))
+        except (OSError, ValueError) as exc:
+            failures.append(
+                CBLParseFailure(
+                    source_path=path.relative_to(mirror_path).as_posix(),
+                    message=str(exc),
+                )
+            )
+    return tuple(parsed), tuple(failures)
+
+
+def _parse_book(node: ET.Element, position: int) -> CBLBook:
+    series = (node.get("Series") or "").strip()
+    issue_number = (node.get("Number") or "").strip()
+    if not series or not issue_number:
+        raise ValueError(f"book {position} is missing required Series or Number")
+
+    volume_year = _optional_int(node.get("Volume"))
+    publication_year = _optional_int(node.get("Year"))
+    series_id, issue_id = _comicvine_ids(node)
+    return CBLBook(
+        position=position,
+        series=series,
+        issue_number=issue_number,
+        volume_year=volume_year,
+        publication_year=publication_year,
+        comicvine_series_id=series_id,
+        comicvine_issue_id=issue_id,
+    )
+
+
+def _comicvine_ids(node: ET.Element) -> tuple[str | None, str | None]:
+    series_id = _first_attr(node, "SeriesID", "SeriesId", "VolumeID", "VolumeId")
+    issue_id = _first_attr(node, "IssueID", "IssueId")
+    database = node.find("Database")
+    if database is not None and (database.get("Name") or "").casefold() == "comicvine":
+        series_id = series_id or _first_attr(database, "Series", "SeriesID", "Volume", "VolumeID")
+        issue_id = issue_id or _first_attr(database, "Issue", "IssueID")
+    return series_id, issue_id
+
+
+def _first_attr(node: ET.Element, *names: str) -> str | None:
+    for name in names:
+        value = node.get(name)
+        if value is not None and value.strip():
+            return value.strip()
+    return None
+
+
+def _text(node: ET.Element | None) -> str | None:
+    if node is None or node.text is None:
+        return None
+    value = node.text.strip()
+    return value or None
+
+
+def _optional_int(value: str | None) -> int | None:
+    if value is None or not value.strip():
+        return None
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise ValueError(f"expected integer value, got {value!r}") from exc

--- a/app/cbl_ingest.py
+++ b/app/cbl_ingest.py
@@ -41,7 +41,14 @@ class CBLParseFailure:
 
 
 def discover_cbl_files(mirror_path: Path) -> tuple[Path, ...]:
-    """Return every CBL file beneath a mirror in deterministic relative-path order."""
+    """Return every CBL file beneath a mirror in deterministic relative-path order.
+
+    Args:
+        mirror_path: Root directory of the configured local CBL mirror.
+
+    Returns:
+        All discovered CBL file paths sorted by case-insensitive relative path.
+    """
     return tuple(
         sorted(
             (path for path in mirror_path.rglob("*") if path.is_file() and path.suffix.lower() == ".cbl"),
@@ -51,7 +58,15 @@ def discover_cbl_files(mirror_path: Path) -> tuple[Path, ...]:
 
 
 def parse_cbl_file(path: Path, *, mirror_path: Path) -> CBLList:
-    """Parse a CBL file without performing database or network I/O."""
+    """Parse a CBL file without performing database or network I/O.
+
+    Args:
+        path: CBL file to parse.
+        mirror_path: Root directory used to derive stable source-relative provenance.
+
+    Returns:
+        Parsed list metadata, ordered book entries, source path, and content hash.
+    """
     raw = path.read_bytes()
     relative_path = path.relative_to(mirror_path).as_posix()
     try:
@@ -74,7 +89,14 @@ def parse_cbl_file(path: Path, *, mirror_path: Path) -> CBLList:
 
 
 def parse_cbl_mirror(mirror_path: Path) -> tuple[tuple[CBLList, ...], tuple[CBLParseFailure, ...]]:
-    """Parse all CBL files while isolating malformed files with path-specific diagnostics."""
+    """Parse all CBL files while isolating malformed files with path-specific diagnostics.
+
+    Args:
+        mirror_path: Root directory of the configured local CBL mirror.
+
+    Returns:
+        A pair containing successfully parsed lists and path-specific parse failures.
+    """
     parsed: list[CBLList] = []
     failures: list[CBLParseFailure] = []
     for path in discover_cbl_files(mirror_path):

--- a/docs/changelog.d/2026-08-10-1017.md
+++ b/docs/changelog.d/2026-08-10-1017.md
@@ -1,0 +1,3 @@
+# Added
+
+- [#1017](https://github.com/JoshCLWren/comic-pile/issues/1017) begins the CBL mirror ingestion pipeline with recursive `.cbl` discovery, deterministic parsing, content hashes, ordered comic references, ComicVine identity evidence, and path-specific malformed-file diagnostics.

--- a/docs/changelog.d/2026-08-10-1017.md
+++ b/docs/changelog.d/2026-08-10-1017.md
@@ -1,3 +1,0 @@
-# Added
-
-- [#1017](https://github.com/JoshCLWren/comic-pile/issues/1017) begins the CBL mirror ingestion pipeline with recursive `.cbl` discovery, deterministic parsing, content hashes, ordered comic references, ComicVine identity evidence, and path-specific malformed-file diagnostics.

--- a/docs/changelog.d/2026-08-10-1045.md
+++ b/docs/changelog.d/2026-08-10-1045.md
@@ -1,0 +1,5 @@
+## 2026-08-10
+
+### Reading-list ingestion
+
+- [#1045](https://github.com/JoshCLWren/comic-pile/pull/1045) starts ComicPile’s CBL ingestion pipeline with recursive mirror discovery, deterministic parsing, source hashes, exact reading-list order, ComicVine identity evidence, and isolated diagnostics for malformed files.

--- a/tests/test_cbl_ingest.py
+++ b/tests/test_cbl_ingest.py
@@ -89,7 +89,10 @@ def test_invalid_book_reports_path_specific_failure(tmp_path: Path) -> None:
 def test_invalid_numeric_metadata_is_rejected(tmp_path: Path) -> None:
     """Reject malformed numeric metadata instead of silently coercing it."""
     path = tmp_path / "bad-year.cbl"
-    path.write_text("<ReadingList><Books><Book Series='X-Men' Number='1' Year='nope' /></Books></ReadingList>")
+    path.write_text(
+        "<ReadingList><Books><Book Series='X-Men' Number='1' "
+        "Year='nope' /></Books></ReadingList>"
+    )
 
     with pytest.raises(ValueError, match="expected integer value"):
         parse_cbl_file(path, mirror_path=tmp_path)

--- a/tests/test_cbl_ingest.py
+++ b/tests/test_cbl_ingest.py
@@ -22,6 +22,7 @@ CBL = """<?xml version="1.0"?>
 
 
 def test_discovers_all_cbl_files_recursively_and_deterministically(tmp_path: Path) -> None:
+    """Discover CBL files recursively in deterministic relative-path order."""
     (tmp_path / "Marvel" / "Events").mkdir(parents=True)
     (tmp_path / "DC" / "Other").mkdir(parents=True)
     (tmp_path / "Marvel" / "Events" / "z.cbl").write_text(CBL)
@@ -37,6 +38,7 @@ def test_discovers_all_cbl_files_recursively_and_deterministically(tmp_path: Pat
 
 
 def test_parses_order_provenance_and_comicvine_evidence(tmp_path: Path) -> None:
+    """Preserve ordered books, provenance, hashes, and ComicVine evidence."""
     path = tmp_path / "Events" / "x.cbl"
     path.parent.mkdir()
     path.write_text(CBL)
@@ -60,6 +62,7 @@ def test_parses_order_provenance_and_comicvine_evidence(tmp_path: Path) -> None:
 
 
 def test_malformed_file_is_isolated_from_successful_files(tmp_path: Path) -> None:
+    """Isolate malformed CBL files without discarding valid parse results."""
     (tmp_path / "good.cbl").write_text(CBL)
     (tmp_path / "bad.cbl").write_text("<ReadingList><Books>")
 
@@ -72,6 +75,7 @@ def test_malformed_file_is_isolated_from_successful_files(tmp_path: Path) -> Non
 
 
 def test_invalid_book_reports_path_specific_failure(tmp_path: Path) -> None:
+    """Report the source path when a book omits required identity fields."""
     path = tmp_path / "broken.cbl"
     path.write_text("<ReadingList><Books><Book Series='X-Men' /></Books></ReadingList>")
 
@@ -83,6 +87,7 @@ def test_invalid_book_reports_path_specific_failure(tmp_path: Path) -> None:
 
 
 def test_invalid_numeric_metadata_is_rejected(tmp_path: Path) -> None:
+    """Reject malformed numeric metadata instead of silently coercing it."""
     path = tmp_path / "bad-year.cbl"
     path.write_text("<ReadingList><Books><Book Series='X-Men' Number='1' Year='nope' /></Books></ReadingList>")
 

--- a/tests/test_cbl_ingest.py
+++ b/tests/test_cbl_ingest.py
@@ -1,0 +1,90 @@
+"""Focused coverage for CBL mirror discovery and parsing."""
+
+from pathlib import Path
+
+import pytest
+
+from app.cbl_ingest import discover_cbl_files, parse_cbl_file, parse_cbl_mirror
+
+
+CBL = """<?xml version="1.0"?>
+<ReadingList>
+  <Name>X of Swords</Name>
+  <NumIssues>2</NumIssues>
+  <Books>
+    <Book Series="X-Men" Number="12" Volume="2019" Year="2020" SeriesID="123" IssueID="456" />
+    <Book Series="X of Swords: Creation" Number="1" Year="2020">
+      <Database Name="ComicVine" Series="789" Issue="101112" />
+    </Book>
+  </Books>
+</ReadingList>
+"""
+
+
+def test_discovers_all_cbl_files_recursively_and_deterministically(tmp_path: Path) -> None:
+    (tmp_path / "Marvel" / "Events").mkdir(parents=True)
+    (tmp_path / "DC" / "Other").mkdir(parents=True)
+    (tmp_path / "Marvel" / "Events" / "z.cbl").write_text(CBL)
+    (tmp_path / "DC" / "Other" / "A.CBL").write_text(CBL)
+    (tmp_path / "ignored.xml").write_text(CBL)
+
+    discovered = discover_cbl_files(tmp_path)
+
+    assert [path.relative_to(tmp_path).as_posix() for path in discovered] == [
+        "DC/Other/A.CBL",
+        "Marvel/Events/z.cbl",
+    ]
+
+
+def test_parses_order_provenance_and_comicvine_evidence(tmp_path: Path) -> None:
+    path = tmp_path / "Events" / "x.cbl"
+    path.parent.mkdir()
+    path.write_text(CBL)
+
+    parsed = parse_cbl_file(path, mirror_path=tmp_path)
+
+    assert parsed.name == "X of Swords"
+    assert parsed.declared_issue_count == 2
+    assert parsed.source_path == "Events/x.cbl"
+    assert len(parsed.content_hash) == 64
+    assert [(book.position, book.series, book.issue_number) for book in parsed.books] == [
+        (1, "X-Men", "12"),
+        (2, "X of Swords: Creation", "1"),
+    ]
+    assert parsed.books[0].volume_year == 2019
+    assert parsed.books[0].publication_year == 2020
+    assert parsed.books[0].comicvine_series_id == "123"
+    assert parsed.books[0].comicvine_issue_id == "456"
+    assert parsed.books[1].comicvine_series_id == "789"
+    assert parsed.books[1].comicvine_issue_id == "101112"
+
+
+def test_malformed_file_is_isolated_from_successful_files(tmp_path: Path) -> None:
+    (tmp_path / "good.cbl").write_text(CBL)
+    (tmp_path / "bad.cbl").write_text("<ReadingList><Books>")
+
+    parsed, failures = parse_cbl_mirror(tmp_path)
+
+    assert [item.source_path for item in parsed] == ["good.cbl"]
+    assert len(failures) == 1
+    assert failures[0].source_path == "bad.cbl"
+    assert "malformed CBL XML" in failures[0].message
+
+
+def test_invalid_book_reports_path_specific_failure(tmp_path: Path) -> None:
+    path = tmp_path / "broken.cbl"
+    path.write_text("<ReadingList><Books><Book Series='X-Men' /></Books></ReadingList>")
+
+    parsed, failures = parse_cbl_mirror(tmp_path)
+
+    assert parsed == ()
+    assert failures[0].source_path == "broken.cbl"
+    assert "missing required Series or Number" in failures[0].message
+
+
+def test_invalid_numeric_metadata_is_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "bad-year.cbl"
+    path.write_text("<ReadingList><Books><Book Series='X-Men' Number='1' Year='nope' /></Books></ReadingList>")
+
+    with pytest.raises(ValueError, match="expected integer value"):
+        parse_cbl_file(path, mirror_path=tmp_path)


### PR DESCRIPTION
Implements the first executable slice of #1017: recursive mirror-wide `.cbl` discovery, deterministic source-relative parsing, SHA-256 content hashes, exact ordered entries, embedded ComicVine identity evidence, and path-specific malformed-file isolation.

This deliberately performs no provider network I/O and does not infer continuity from adjacency. Focused tests cover recursive discovery outside `Events`, order/provenance, both observed ComicVine ID shapes, malformed XML isolation, missing required book fields, and invalid numeric metadata.

#1017 remains open for normalized Postgres persistence, transactional idempotent reconciliation/deactivation, dry-run summary CLI, and end-to-end sync tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Comic Book List (CBL) mirror ingestion with recursive, deterministic file discovery.
  * Preserves reading-list order, book metadata, source hashes, and ComicVine identifiers.
  * Reports malformed or invalid files individually so valid lists can still be imported.

* **Bug Fixes**
  * Added validation and clear diagnostics for invalid XML, missing book identifiers, and numeric metadata.

* **Tests**
  * Added coverage for discovery, parsing, metadata preservation, error isolation, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->