### PR TITLE
Add endpoint-aware ComicVine metadata hydration

### DIFF
--- a/app/comicvine_hydration.py
+++ b/app/comicvine_hydration.py
@@ -1,0 +1,245 @@
+"""ComicVine hydration services built on provider-independent external identities."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import cast
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.external_identities import upsert_external_identity
+from app.models.external_identity import ExternalIdentity
+from comic_pile.comicvine_provider import ComicVineClient, ComicVineError
+
+COMICVINE_PROVIDER = "comicvine"
+
+
+def _result_object(payload: dict[str, object]) -> dict[str, object]:
+    result = payload.get("results")
+    if not isinstance(result, dict):
+        raise ComicVineError("ComicVine resource response did not contain an object result")
+    return cast(dict[str, object], result)
+
+
+def _external_url(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _provider_timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    normalized = value.replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+
+
+def _compact_reference(value: object) -> dict[str, object] | None:
+    if not isinstance(value, dict):
+        return None
+    allowed = ("id", "name", "api_detail_url", "site_detail_url")
+    return {key: value[key] for key in allowed if key in value}
+
+
+def _compact_references(value: object) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        return []
+    result: list[dict[str, object]] = []
+    for item in value:
+        compact = _compact_reference(item)
+        if compact is not None:
+            if isinstance(item, dict) and "role" in item:
+                compact["role"] = item["role"]
+            result.append(compact)
+    return result
+
+
+def normalize_issue(result: dict[str, object]) -> dict[str, object]:
+    """Normalize useful singular issue metadata while retaining the complete raw provider row.
+
+    Args:
+        result: ComicVine singular issue result.
+
+    Returns:
+        Stable metadata suitable for ``ExternalIdentity.metadata_json``.
+    """
+    volume = _compact_reference(result.get("volume"))
+    image = result.get("image") if isinstance(result.get("image"), dict) else None
+    primary_image = None
+    if isinstance(image, dict):
+        for key in ("original_url", "super_url", "medium_url", "small_url"):
+            candidate = image.get(key)
+            if isinstance(candidate, str) and candidate:
+                primary_image = candidate
+                break
+    return {
+        "name": result.get("name"),
+        "issue_number": result.get("issue_number"),
+        "cover_date": result.get("cover_date"),
+        "store_date": result.get("store_date"),
+        "volume": volume,
+        "primary_image": primary_image,
+        "creator_credits": _compact_references(result.get("person_credits")),
+        "characters": _compact_references(result.get("character_credits")),
+        "teams": _compact_references(result.get("team_credits")),
+        "story_arcs": _compact_references(result.get("story_arc_credits")),
+        "raw_provider_payload": result,
+    }
+
+
+def normalize_volume(result: dict[str, object]) -> dict[str, object]:
+    """Normalize useful volume metadata while retaining the complete raw provider row.
+
+    Args:
+        result: ComicVine singular volume result.
+
+    Returns:
+        Stable metadata suitable for ``ExternalIdentity.metadata_json``.
+    """
+    publisher = _compact_reference(result.get("publisher"))
+    image = result.get("image") if isinstance(result.get("image"), dict) else None
+    primary_image = None
+    if isinstance(image, dict):
+        for key in ("original_url", "super_url", "medium_url", "small_url"):
+            candidate = image.get(key)
+            if isinstance(candidate, str) and candidate:
+                primary_image = candidate
+                break
+    return {
+        "name": result.get("name"),
+        "publisher": publisher,
+        "start_year": result.get("start_year"),
+        "count_of_issues": result.get("count_of_issues"),
+        "primary_image": primary_image,
+        "raw_provider_payload": result,
+    }
+
+
+async def persist_issue_result(
+    db: AsyncSession,
+    result: dict[str, object],
+) -> ExternalIdentity:
+    """Upsert one ComicVine issue result into the provider-independent identity store.
+
+    Args:
+        db: Async database session.
+        result: ComicVine issue result object.
+
+    Returns:
+        Persisted issue identity.
+
+    Raises:
+        ComicVineError: If the provider row has no stable numeric identity.
+    """
+    external_id = result.get("id")
+    if not isinstance(external_id, int):
+        raise ComicVineError("ComicVine issue result is missing an integer id")
+    return await upsert_external_identity(
+        db,
+        provider=COMICVINE_PROVIDER,
+        entity_type="issue",
+        external_id=str(external_id),
+        external_url=_external_url(result.get("site_detail_url")),
+        metadata_json=normalize_issue(result),
+        provider_updated_at=_provider_timestamp(result.get("date_last_updated")),
+    )
+
+
+async def persist_volume_result(
+    db: AsyncSession,
+    result: dict[str, object],
+) -> ExternalIdentity:
+    """Upsert one ComicVine volume result into the provider-independent identity store.
+
+    Args:
+        db: Async database session.
+        result: ComicVine volume result object.
+
+    Returns:
+        Persisted series identity.
+
+    Raises:
+        ComicVineError: If the provider row has no stable numeric identity.
+    """
+    external_id = result.get("id")
+    if not isinstance(external_id, int):
+        raise ComicVineError("ComicVine volume result is missing an integer id")
+    return await upsert_external_identity(
+        db,
+        provider=COMICVINE_PROVIDER,
+        entity_type="series",
+        external_id=str(external_id),
+        external_url=_external_url(result.get("site_detail_url")),
+        metadata_json=normalize_volume(result),
+        provider_updated_at=_provider_timestamp(result.get("date_last_updated")),
+    )
+
+
+async def hydrate_issue(
+    db: AsyncSession,
+    client: ComicVineClient,
+    issue_id: int,
+    *,
+    refresh: bool = False,
+) -> ExternalIdentity:
+    """Deep-hydrate one issue and cache every story arc it explicitly references.
+
+    Each provider resource is fetched independently. Story-arc failures do not discard the
+    successfully persisted issue metadata; callers can commit the returned identity and retry the
+    missing cached resource later.
+
+    Args:
+        db: Async database session.
+        client: Configured ComicVine provider client.
+        issue_id: ComicVine issue ID.
+        refresh: Force live provider fetches instead of cache reuse.
+
+    Returns:
+        Persisted external issue identity.
+    """
+    response = await client.fetch_issue(issue_id, refresh=refresh)
+    result = _result_object(response.payload)
+    identity = await persist_issue_result(db, result)
+    arcs = result.get("story_arc_credits")
+    if isinstance(arcs, list):
+        seen: set[int] = set()
+        for arc in arcs:
+            if not isinstance(arc, dict):
+                continue
+            arc_id = arc.get("id")
+            if not isinstance(arc_id, int) or arc_id in seen:
+                continue
+            seen.add(arc_id)
+            try:
+                await client.fetch_story_arc(arc_id, refresh=refresh)
+            except ComicVineError:
+                continue
+    return identity
+
+
+async def hydrate_volume(
+    db: AsyncSession,
+    client: ComicVineClient,
+    volume_id: int,
+    *,
+    refresh: bool = False,
+) -> tuple[ExternalIdentity, list[ExternalIdentity]]:
+    """Hydrate one volume and its complete basic issue roster idempotently.
+
+    Args:
+        db: Async database session.
+        client: Configured ComicVine provider client.
+        volume_id: ComicVine volume ID.
+        refresh: Force live provider fetches instead of cache reuse.
+
+    Returns:
+        Persisted series identity and persisted basic issue identities.
+    """
+    volume_response = await client.fetch_volume(volume_id, refresh=refresh)
+    volume_identity = await persist_volume_result(db, _result_object(volume_response.payload))
+    issue_rows = await client.fetch_volume_issues(volume_id, refresh=refresh)
+    issue_identities: list[ExternalIdentity] = []
+    for row in issue_rows:
+        issue_identities.append(await persist_issue_result(db, row))
+    return volume_identity, issue_identities

--- a/comic_pile/comicvine_provider.py
+++ b/comic_pile/comicvine_provider.py
@@ -9,7 +9,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -59,7 +59,7 @@ class PersistentEndpointLimiter:
         path: str | Path,
         *,
         requests_per_hour: int = DEFAULT_REQUESTS_PER_HOUR,
-        clock: callable = time.time,
+        clock: Callable[[], float] = time.time,
     ) -> None:
         """Configure a persistent rolling-hour limiter.
 
@@ -87,7 +87,9 @@ class PersistentEndpointLimiter:
         result: dict[str, list[float]] = {}
         for endpoint, timestamps in raw.items():
             if isinstance(endpoint, str) and isinstance(timestamps, list):
-                result[endpoint] = [float(value) for value in timestamps if isinstance(value, int | float)]
+                result[endpoint] = [
+                    float(value) for value in timestamps if isinstance(value, int | float)
+                ]
         return result
 
     def _write(self, ledger: Mapping[str, list[float]]) -> None:

--- a/comic_pile/comicvine_provider.py
+++ b/comic_pile/comicvine_provider.py
@@ -1,0 +1,303 @@
+"""Endpoint-aware ComicVine provider client with persistent cache and rate limiting."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+from filelock import FileLock
+
+COMICVINE_BASE_URL = "https://comicvine.gamespot.com/api"
+DEFAULT_REQUESTS_PER_HOUR = 180
+COLLECTION_PAGE_LIMIT = 100
+DEEP_ISSUE_FIELDS = (
+    "id",
+    "name",
+    "issue_number",
+    "cover_date",
+    "store_date",
+    "image",
+    "volume",
+    "person_credits",
+    "character_credits",
+    "team_credits",
+    "story_arc_credits",
+    "date_last_updated",
+)
+
+
+class ComicVineError(RuntimeError):
+    """Base error raised for provider failures."""
+
+
+class ComicVineRateLimitError(ComicVineError):
+    """Raised when local or provider rate limiting prevents a request."""
+
+
+@dataclass(frozen=True)
+class ComicVineResponse:
+    """One decoded provider response plus cache provenance."""
+
+    payload: dict[str, object]
+    from_cache: bool
+    cache_key: str
+
+
+class PersistentEndpointLimiter:
+    """Persist request timestamps per endpoint so restarts retain the rolling budget."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        requests_per_hour: int = DEFAULT_REQUESTS_PER_HOUR,
+        clock: callable = time.time,
+    ) -> None:
+        """Configure a persistent rolling-hour limiter.
+
+        Args:
+            path: JSON ledger path.
+            requests_per_hour: Maximum requests per endpoint in one rolling hour.
+            clock: Time source used by tests and production.
+        """
+        if requests_per_hour <= 0:
+            raise ValueError("requests_per_hour must be positive")
+        self.path = Path(path)
+        self.requests_per_hour = requests_per_hour
+        self._clock = clock
+        self._lock = FileLock(f"{self.path}.lock")
+
+    def _read(self) -> dict[str, list[float]]:
+        if not self.path.exists():
+            return {}
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return {}
+        if not isinstance(raw, dict):
+            return {}
+        result: dict[str, list[float]] = {}
+        for endpoint, timestamps in raw.items():
+            if isinstance(endpoint, str) and isinstance(timestamps, list):
+                result[endpoint] = [float(value) for value in timestamps if isinstance(value, int | float)]
+        return result
+
+    def _write(self, ledger: Mapping[str, list[float]]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        temp = self.path.with_suffix(f"{self.path.suffix}.tmp")
+        temp.write_text(json.dumps(ledger, sort_keys=True), encoding="utf-8")
+        temp.replace(self.path)
+
+    def acquire(self, endpoint: str) -> None:
+        """Record one request or raise when the rolling endpoint budget is exhausted.
+
+        Args:
+            endpoint: Stable endpoint bucket such as ``issue`` or ``issues``.
+
+        Raises:
+            ComicVineRateLimitError: When the endpoint has exhausted its rolling-hour budget.
+        """
+        now = float(self._clock())
+        cutoff = now - 3600
+        with self._lock:
+            ledger = self._read()
+            recent = [stamp for stamp in ledger.get(endpoint, []) if stamp > cutoff]
+            if len(recent) >= self.requests_per_hour:
+                raise ComicVineRateLimitError(
+                    f"ComicVine local rate budget exhausted for endpoint {endpoint!r}"
+                )
+            recent.append(now)
+            ledger[endpoint] = recent
+            self._write(ledger)
+
+
+class ComicVineClient:
+    """Fetch ComicVine resources with endpoint-specific contracts and resumable caching."""
+
+    def __init__(
+        self,
+        api_key: str,
+        cache_dir: str | Path,
+        *,
+        requests_per_hour: int = DEFAULT_REQUESTS_PER_HOUR,
+        base_url: str = COMICVINE_BASE_URL,
+        timeout_seconds: float = 30.0,
+    ) -> None:
+        """Configure the provider client.
+
+        Args:
+            api_key: ComicVine API key. It is never included in cache keys or persisted payload metadata.
+            cache_dir: Directory for raw successful response cache and request ledger.
+            requests_per_hour: Conservative rolling-hour budget per endpoint path.
+            base_url: Provider API base URL.
+            timeout_seconds: Network timeout per request.
+        """
+        if not api_key.strip():
+            raise ValueError("api_key is required")
+        self.api_key = api_key
+        self.cache_dir = Path(cache_dir)
+        self.base_url = base_url.rstrip("/")
+        self.timeout_seconds = timeout_seconds
+        self.limiter = PersistentEndpointLimiter(
+            self.cache_dir / "request-ledger.json",
+            requests_per_hour=requests_per_hour,
+        )
+
+    @staticmethod
+    def _cache_key(endpoint: str, params: Mapping[str, object]) -> str:
+        safe_params = {key: value for key, value in params.items() if key != "api_key"}
+        encoded = json.dumps([endpoint, safe_params], sort_keys=True, separators=(",", ":"))
+        digest = hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+        return f"{endpoint}-{digest}"
+
+    def _cache_path(self, cache_key: str) -> Path:
+        return self.cache_dir / "responses" / f"{cache_key}.json"
+
+    def _read_cache(self, cache_key: str) -> dict[str, object] | None:
+        path = self._cache_path(cache_key)
+        if not path.exists():
+            return None
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return None
+        return payload if isinstance(payload, dict) else None
+
+    def _write_cache(self, cache_key: str, payload: Mapping[str, object]) -> None:
+        path = self._cache_path(cache_key)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temp = path.with_suffix(".tmp")
+        temp.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+        temp.replace(path)
+
+    def _request_sync(self, endpoint: str, params: Mapping[str, object]) -> dict[str, object]:
+        query = {
+            **params,
+            "api_key": self.api_key,
+            "format": "json",
+        }
+        url = f"{self.base_url}/{endpoint.lstrip('/')}?{urllib.parse.urlencode(query)}"
+        request = urllib.request.Request(url, headers={"User-Agent": "ComicPile/1.0"})
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout_seconds) as response:
+                decoded = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            if exc.code == 429:
+                raise ComicVineRateLimitError("ComicVine returned HTTP 429") from exc
+            raise ComicVineError(f"ComicVine HTTP {exc.code} for {endpoint}") from exc
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+            raise ComicVineError(f"ComicVine request failed for {endpoint}: {exc}") from exc
+        if not isinstance(decoded, dict):
+            raise ComicVineError(f"ComicVine returned a non-object response for {endpoint}")
+        status_code = decoded.get("status_code")
+        if status_code not in (None, 1):
+            raise ComicVineError(
+                f"ComicVine API error for {endpoint}: {decoded.get('error', status_code)!r}"
+            )
+        return decoded
+
+    async def request(
+        self,
+        endpoint_bucket: str,
+        endpoint: str,
+        params: Mapping[str, object],
+        *,
+        refresh: bool = False,
+    ) -> ComicVineResponse:
+        """Fetch one provider resource, reusing a persisted successful response by default.
+
+        Args:
+            endpoint_bucket: Stable rate-limit bucket for the provider path.
+            endpoint: Relative API path.
+            params: Provider request parameters excluding credentials and output format.
+            refresh: Force a live request instead of using a cached successful payload.
+
+        Returns:
+            Decoded provider payload with cache provenance.
+        """
+        cache_key = self._cache_key(endpoint, params)
+        if not refresh:
+            cached = self._read_cache(cache_key)
+            if cached is not None:
+                return ComicVineResponse(cached, True, cache_key)
+        self.limiter.acquire(endpoint_bucket)
+        payload = await asyncio.to_thread(self._request_sync, endpoint, params)
+        self._write_cache(cache_key, payload)
+        return ComicVineResponse(payload, False, cache_key)
+
+    async def fetch_volume(self, volume_id: int, *, refresh: bool = False) -> ComicVineResponse:
+        """Fetch one volume resource by ComicVine ID."""
+        return await self.request("volume", f"volume/4050-{volume_id}", {}, refresh=refresh)
+
+    async def fetch_issue(self, issue_id: int, *, refresh: bool = False) -> ComicVineResponse:
+        """Deep-hydrate one issue using the supported singular relationship fields."""
+        return await self.request(
+            "issue",
+            f"issue/4000-{issue_id}",
+            {"field_list": ",".join(DEEP_ISSUE_FIELDS)},
+            refresh=refresh,
+        )
+
+    async def fetch_story_arc(self, arc_id: int, *, refresh: bool = False) -> ComicVineResponse:
+        """Fetch one story arc without interpreting returned issue-array order as reading order."""
+        return await self.request("story_arc", f"story_arc/4045-{arc_id}", {}, refresh=refresh)
+
+    async def fetch_volume_issues(
+        self,
+        volume_id: int,
+        *,
+        refresh: bool = False,
+    ) -> list[dict[str, object]]:
+        """Fetch a complete volume issue roster using the documented 100-row page maximum.
+
+        Args:
+            volume_id: ComicVine volume ID.
+            refresh: Force live requests for every page.
+
+        Returns:
+            Ordered provider rows across all pages.
+
+        Raises:
+            ComicVineError: When pagination metadata is inconsistent or a returned row belongs to
+                a different volume, which indicates that the provider ignored the collection filter.
+        """
+        rows: list[dict[str, object]] = []
+        offset = 0
+        while True:
+            response = await self.request(
+                "issues",
+                "issues",
+                {
+                    "filter": f"volume:{volume_id}",
+                    "limit": COLLECTION_PAGE_LIMIT,
+                    "offset": offset,
+                },
+                refresh=refresh,
+            )
+            results = response.payload.get("results")
+            if not isinstance(results, list):
+                raise ComicVineError("ComicVine /issues response did not contain a results list")
+            page_rows = [row for row in results if isinstance(row, dict)]
+            for row in page_rows:
+                volume = row.get("volume")
+                if isinstance(volume, dict) and volume.get("id") not in (None, volume_id):
+                    raise ComicVineError(
+                        "ComicVine /issues ignored the requested volume filter; refusing mixed data"
+                    )
+            rows.extend(page_rows)
+            page_count = len(page_rows)
+            total = response.payload.get("number_of_total_results")
+            if isinstance(total, int) and len(rows) >= total:
+                break
+            if page_count < COLLECTION_PAGE_LIMIT:
+                break
+            offset += page_count
+        return rows

--- a/docs/changelog.d/2026-08-10-1046.md
+++ b/docs/changelog.d/2026-08-10-1046.md
@@ -2,4 +2,4 @@
 
 ### Comic metadata
 
-- [PR #1046](https://github.com/JoshCLWren/comic-pile/pull/1046) adds resumable, endpoint-aware ComicVine metadata hydration with persistent rate budgeting and raw-response caching, so provider enrichment can safely resume without wasting API requests or turning external metadata into reading-order rules.
+- [#1046](https://github.com/JoshCLWren/comic-pile/pull/1046) adds resumable, endpoint-aware ComicVine metadata hydration with persistent rate budgeting and raw-response caching, so provider enrichment can safely resume without wasting API requests or turning external metadata into reading-order rules.

--- a/docs/changelog.d/2026-08-10-1046.md
+++ b/docs/changelog.d/2026-08-10-1046.md
@@ -1,0 +1,5 @@
+## 2026-08-10
+
+### Comic metadata
+
+- [PR #1046](https://github.com/JoshCLWren/comic-pile/pull/1046) adds resumable, endpoint-aware ComicVine metadata hydration with persistent rate budgeting and raw-response caching, so provider enrichment can safely resume without wasting API requests or turning external metadata into reading-order rules.

--- a/tests/test_comicvine_hydration.py
+++ b/tests/test_comicvine_hydration.py
@@ -1,0 +1,263 @@
+"""Tests for normalized ComicVine metadata persistence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import cast
+
+import pytest
+
+import app.comicvine_hydration as hydration
+from comic_pile.comicvine_provider import ComicVineError, ComicVineResponse
+
+
+@dataclass
+class FakeIdentity:
+    """Minimal external identity stand-in for service tests."""
+
+    external_id: str
+    metadata_json: dict[str, object]
+
+
+def test_normalize_issue_preserves_raw_and_relationship_roles() -> None:
+    """Issue normalization should retain raw evidence and useful relationship fields."""
+    raw: dict[str, object] = {
+        "id": 11,
+        "name": "The Test",
+        "issue_number": "1",
+        "cover_date": "2026-01-01",
+        "store_date": "2025-12-31",
+        "volume": {"id": 22, "name": "Series", "ignored": "value"},
+        "image": {"medium_url": "https://img/medium", "small_url": "https://img/small"},
+        "person_credits": [{"id": 1, "name": "Writer", "role": "writer", "junk": True}],
+        "character_credits": [{"id": 2, "name": "Hero"}],
+        "team_credits": [{"id": 3, "name": "Team"}],
+        "story_arc_credits": [{"id": 4, "name": "Arc"}],
+    }
+
+    normalized = hydration.normalize_issue(raw)
+
+    assert normalized["name"] == "The Test"
+    assert normalized["primary_image"] == "https://img/medium"
+    assert normalized["volume"] == {"id": 22, "name": "Series"}
+    assert normalized["creator_credits"] == [{"id": 1, "name": "Writer", "role": "writer"}]
+    assert normalized["story_arcs"] == [{"id": 4, "name": "Arc"}]
+    assert normalized["raw_provider_payload"] is raw
+
+
+def test_normalize_volume_preserves_publisher_and_best_image() -> None:
+    """Volume normalization should retain core identity metadata and full raw evidence."""
+    raw: dict[str, object] = {
+        "id": 22,
+        "name": "Series",
+        "publisher": {"id": 7, "name": "Publisher"},
+        "start_year": "2025",
+        "count_of_issues": 12,
+        "image": {"original_url": "https://img/original"},
+    }
+
+    normalized = hydration.normalize_volume(raw)
+
+    assert normalized["publisher"] == {"id": 7, "name": "Publisher"}
+    assert normalized["primary_image"] == "https://img/original"
+    assert normalized["raw_provider_payload"] is raw
+
+
+def test_normalizers_tolerate_provider_shape_oddities() -> None:
+    """Unexpected relationship/image shapes should not corrupt normalized metadata."""
+    issue = hydration.normalize_issue(
+        {
+            "image": "unexpected",
+            "volume": "unexpected",
+            "person_credits": {"id": 1},
+            "character_credits": None,
+            "team_credits": "unexpected",
+            "story_arc_credits": [None, "bad"],
+        }
+    )
+    volume = hydration.normalize_volume({"image": [], "publisher": "unexpected"})
+
+    assert issue["primary_image"] is None
+    assert issue["volume"] is None
+    assert issue["creator_credits"] == []
+    assert issue["story_arcs"] == []
+    assert volume["publisher"] is None
+    assert volume["primary_image"] is None
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("2026-08-10T09:00:00Z", "2026-08-10T09:00:00+00:00"),
+        ("not-a-date", None),
+        (None, None),
+    ],
+)
+def test_provider_timestamp_is_tolerant(value: object, expected: str | None) -> None:
+    """Provider timestamps should parse when valid and degrade safely when malformed."""
+    parsed = hydration._provider_timestamp(value)
+    assert (parsed.isoformat() if parsed else None) == expected
+
+
+@pytest.mark.asyncio
+async def test_persist_issue_result_uses_provider_independent_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue persistence should upsert a ComicVine issue without touching continuity."""
+    observed: dict[str, object] = {}
+
+    async def fake_upsert(db: object, **kwargs: object) -> FakeIdentity:
+        observed.update(kwargs)
+        return FakeIdentity(str(kwargs["external_id"]), cast(dict[str, object], kwargs["metadata_json"]))
+
+    monkeypatch.setattr(hydration, "upsert_external_identity", fake_upsert)
+    raw = {
+        "id": 99,
+        "name": "Issue",
+        "site_detail_url": "https://comicvine/issue/99",
+        "date_last_updated": "2026-08-10T09:00:00Z",
+    }
+
+    identity = await hydration.persist_issue_result(cast(object, None), raw)
+
+    assert identity.external_id == "99"
+    assert observed["provider"] == "comicvine"
+    assert observed["entity_type"] == "issue"
+    assert observed["external_url"] == "https://comicvine/issue/99"
+    assert observed["provider_updated_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_persist_volume_result_requires_stable_integer_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Provider rows without stable IDs must not create guessed identities."""
+    with pytest.raises(ComicVineError, match="missing an integer id"):
+        await hydration.persist_volume_result(cast(object, None), {"id": "bad"})
+
+    async def fake_upsert(db: object, **kwargs: object) -> FakeIdentity:
+        return FakeIdentity(str(kwargs["external_id"]), cast(dict[str, object], kwargs["metadata_json"]))
+
+    monkeypatch.setattr(hydration, "upsert_external_identity", fake_upsert)
+    identity = await hydration.persist_volume_result(
+        cast(object, None),
+        {"id": 5, "name": "Volume", "site_detail_url": "https://comicvine/volume/5"},
+    )
+    assert identity.external_id == "5"
+
+
+class FakeClient:
+    """Provider-client stand-in that records endpoint hydration requests."""
+
+    def __init__(self) -> None:
+        self.story_arcs: list[int] = []
+
+    async def fetch_issue(self, issue_id: int, *, refresh: bool = False) -> ComicVineResponse:
+        """Return one deep issue fixture."""
+        return ComicVineResponse(
+            {
+                "status_code": 1,
+                "results": {
+                    "id": issue_id,
+                    "story_arc_credits": [
+                        {"id": 3, "name": "Arc"},
+                        {"id": 3, "name": "Duplicate"},
+                        {"id": "bad"},
+                    ],
+                },
+            },
+            False,
+            "issue",
+        )
+
+    async def fetch_story_arc(self, arc_id: int, *, refresh: bool = False) -> ComicVineResponse:
+        """Record a story-arc request and return an unordered membership fixture."""
+        self.story_arcs.append(arc_id)
+        return ComicVineResponse(
+            {"status_code": 1, "results": {"id": arc_id, "issues": [{"id": 2}, {"id": 1}]}},
+            False,
+            "arc",
+        )
+
+    async def fetch_volume(self, volume_id: int, *, refresh: bool = False) -> ComicVineResponse:
+        """Return one volume fixture."""
+        return ComicVineResponse(
+            {"status_code": 1, "results": {"id": volume_id, "name": "Volume"}},
+            False,
+            "volume",
+        )
+
+    async def fetch_volume_issues(
+        self, volume_id: int, *, refresh: bool = False
+    ) -> list[dict[str, object]]:
+        """Return basic issue rows for one volume."""
+        return [
+            {"id": 1, "issue_number": "1", "volume": {"id": volume_id}},
+            {"id": 2, "issue_number": "2", "volume": {"id": volume_id}},
+        ]
+
+
+@pytest.mark.asyncio
+async def test_hydrate_issue_deduplicates_story_arc_fetches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deep hydration should cache each discovered story arc once per issue response."""
+    client = FakeClient()
+
+    async def fake_persist(db: object, result: dict[str, object]) -> FakeIdentity:
+        return FakeIdentity(str(result["id"]), result)
+
+    monkeypatch.setattr(hydration, "persist_issue_result", fake_persist)
+    identity = await hydration.hydrate_issue(cast(object, None), cast(object, client), 42)
+
+    assert identity.external_id == "42"
+    assert client.story_arcs == [3]
+
+
+@pytest.mark.asyncio
+async def test_hydrate_issue_keeps_success_when_story_arc_fetch_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A relationship endpoint failure should not erase the successfully hydrated issue."""
+    client = FakeClient()
+
+    async def failing_arc(arc_id: int, *, refresh: bool = False) -> ComicVineResponse:
+        raise ComicVineError("transient")
+
+    async def fake_persist(db: object, result: dict[str, object]) -> FakeIdentity:
+        return FakeIdentity(str(result["id"]), result)
+
+    monkeypatch.setattr(client, "fetch_story_arc", failing_arc)
+    monkeypatch.setattr(hydration, "persist_issue_result", fake_persist)
+
+    identity = await hydration.hydrate_issue(cast(object, None), cast(object, client), 42)
+
+    assert identity.external_id == "42"
+
+
+@pytest.mark.asyncio
+async def test_hydrate_volume_persists_volume_and_complete_roster(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Volume hydration should persist the series and every basic issue row idempotently."""
+    client = FakeClient()
+
+    async def fake_volume(db: object, result: dict[str, object]) -> FakeIdentity:
+        return FakeIdentity(str(result["id"]), result)
+
+    async def fake_issue(db: object, result: dict[str, object]) -> FakeIdentity:
+        return FakeIdentity(str(result["id"]), result)
+
+    monkeypatch.setattr(hydration, "persist_volume_result", fake_volume)
+    monkeypatch.setattr(hydration, "persist_issue_result", fake_issue)
+
+    volume, issues = await hydration.hydrate_volume(cast(object, None), cast(object, client), 7)
+
+    assert volume.external_id == "7"
+    assert [issue.external_id for issue in issues] == ["1", "2"]
+
+
+def test_result_object_rejects_collection_shape() -> None:
+    """Singular hydration must reject collection-shaped responses."""
+    with pytest.raises(ComicVineError, match="object result"):
+        hydration._result_object({"results": []})

--- a/tests/test_comicvine_hydration.py
+++ b/tests/test_comicvine_hydration.py
@@ -150,6 +150,7 @@ class FakeClient:
     """Provider-client stand-in that records endpoint hydration requests."""
 
     def __init__(self) -> None:
+        """Initialize an empty story-arc request ledger."""
         self.story_arcs: list[int] = []
 
     async def fetch_issue(self, issue_id: int, *, refresh: bool = False) -> ComicVineResponse:

--- a/tests/test_comicvine_provider.py
+++ b/tests/test_comicvine_provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import urllib.error
 from pathlib import Path
 
 import pytest
@@ -64,6 +65,72 @@ def test_persistent_limiter_drops_entries_outside_rolling_hour(tmp_path: Path) -
 
     payload = json.loads(ledger.read_text(encoding="utf-8"))
     assert payload == {"issues": [13601.0]}
+
+
+def test_provider_configuration_and_corrupt_cache_fail_safely(tmp_path: Path) -> None:
+    """Reject invalid configuration while treating corrupt persisted cache data as a miss."""
+    with pytest.raises(ValueError, match="requests_per_hour must be positive"):
+        PersistentEndpointLimiter(tmp_path / "ledger.json", requests_per_hour=0)
+    with pytest.raises(ValueError, match="api_key is required"):
+        ComicVineClient(" ", tmp_path)
+
+    client = ComicVineClient("secret", tmp_path)
+    key = client._cache_key("issue/4000-1", {})
+    cache_path = client._cache_path(key)
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text("{not-json", encoding="utf-8")
+    assert client._read_cache(key) is None
+
+    ledger_path = tmp_path / "broken-ledger.json"
+    ledger_path.write_text("[]", encoding="utf-8")
+    limiter = PersistentEndpointLimiter(ledger_path)
+    assert limiter._read() == {}
+
+
+class FakeUrlResponse:
+    """Minimal context-managed urllib response fixture."""
+
+    def __init__(self, payload: bytes) -> None:
+        """Store encoded response bytes."""
+        self.payload = payload
+
+    def __enter__(self) -> FakeUrlResponse:
+        """Return the response fixture for a with block."""
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        """Leave the response fixture without suppressing exceptions."""
+
+    def read(self) -> bytes:
+        """Return encoded response bytes."""
+        return self.payload
+
+
+def test_request_sync_decodes_success_and_maps_provider_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Decode successful provider JSON and convert HTTP/provider failures into typed errors."""
+    client = ComicVineClient("secret", tmp_path)
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda request, timeout: FakeUrlResponse(b'{"status_code": 1, "results": {"id": 7}}'),
+    )
+    assert client._request_sync("issue/4000-7", {})["results"] == {"id": 7}
+
+    def rate_limited(request: object, timeout: float) -> FakeUrlResponse:
+        raise urllib.error.HTTPError("https://example.invalid", 429, "slow down", {}, None)
+
+    monkeypatch.setattr("urllib.request.urlopen", rate_limited)
+    with pytest.raises(ComicVineRateLimitError, match="HTTP 429"):
+        client._request_sync("issue/4000-7", {})
+
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda request, timeout: FakeUrlResponse(b'{"status_code": 100, "error": "bad key"}'),
+    )
+    with pytest.raises(ComicVineError, match="API error"):
+        client._request_sync("issue/4000-7", {})
 
 
 @pytest.mark.asyncio
@@ -144,6 +211,40 @@ async def test_volume_roster_rejects_ignored_provider_filter(
     monkeypatch.setattr(client, "_request_sync", fake_request)
     with pytest.raises(ComicVineError, match="ignored the requested volume filter"):
         await client.fetch_volume_issues(7, refresh=True)
+
+
+@pytest.mark.asyncio
+async def test_volume_roster_rejects_non_list_results(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reject collection responses whose results payload is not a list."""
+    client = ComicVineClient("secret", tmp_path)
+
+    def fake_request(endpoint: str, params: object) -> dict[str, object]:
+        return {"status_code": 1, "results": {"id": 1}}
+
+    monkeypatch.setattr(client, "_request_sync", fake_request)
+    with pytest.raises(ComicVineError, match="results list"):
+        await client.fetch_volume_issues(7, refresh=True)
+
+
+@pytest.mark.asyncio
+async def test_fetch_volume_uses_singular_volume_endpoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fetch a volume by the singular ComicVine volume resource path."""
+    client = ComicVineClient("secret", tmp_path)
+    observed: list[str] = []
+
+    def fake_request(endpoint: str, params: object) -> dict[str, object]:
+        observed.append(endpoint)
+        return {"status_code": 1, "results": {"id": 7}}
+
+    monkeypatch.setattr(client, "_request_sync", fake_request)
+    response = await client.fetch_volume(7)
+
+    assert response.payload["results"] == {"id": 7}
+    assert observed == ["volume/4050-7"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_comicvine_provider.py
+++ b/tests/test_comicvine_provider.py
@@ -1,0 +1,166 @@
+"""Tests for endpoint-aware ComicVine hydration behavior."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from comic_pile.comicvine_provider import (
+    COLLECTION_PAGE_LIMIT,
+    ComicVineClient,
+    ComicVineError,
+    ComicVineRateLimitError,
+    PersistentEndpointLimiter,
+)
+
+
+@pytest.mark.asyncio
+async def test_request_reuses_successful_cache_without_spending_budget(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A rerun should use the successful raw cache rather than repeat provider I/O."""
+    client = ComicVineClient("secret", tmp_path, requests_per_hour=1)
+    calls: list[str] = []
+
+    def fake_request(endpoint: str, params: object) -> dict[str, object]:
+        calls.append(endpoint)
+        return {"status_code": 1, "results": {"id": 99}}
+
+    monkeypatch.setattr(client, "_request_sync", fake_request)
+
+    first = await client.fetch_issue(99)
+    second = await client.fetch_issue(99)
+
+    assert first.from_cache is False
+    assert second.from_cache is True
+    assert calls == ["issue/4000-99"]
+    ledger = json.loads((tmp_path / "request-ledger.json").read_text(encoding="utf-8"))
+    assert len(ledger["issue"]) == 1
+    cached_text = (tmp_path / "responses" / f"{first.cache_key}.json").read_text(encoding="utf-8")
+    assert "secret" not in cached_text
+
+
+def test_persistent_limiter_survives_restart(tmp_path: Path) -> None:
+    """The rate ledger should remain authoritative across new limiter instances."""
+    ledger = tmp_path / "ledger.json"
+    first = PersistentEndpointLimiter(ledger, requests_per_hour=1, clock=lambda: 10000.0)
+    first.acquire("issue")
+
+    second = PersistentEndpointLimiter(ledger, requests_per_hour=1, clock=lambda: 10001.0)
+    with pytest.raises(ComicVineRateLimitError):
+        second.acquire("issue")
+
+
+def test_persistent_limiter_drops_entries_outside_rolling_hour(tmp_path: Path) -> None:
+    """Old requests should stop consuming endpoint capacity after one rolling hour."""
+    ledger = tmp_path / "ledger.json"
+    first = PersistentEndpointLimiter(ledger, requests_per_hour=1, clock=lambda: 10000.0)
+    first.acquire("issues")
+
+    later = PersistentEndpointLimiter(ledger, requests_per_hour=1, clock=lambda: 13601.0)
+    later.acquire("issues")
+
+    payload = json.loads(ledger.read_text(encoding="utf-8"))
+    assert payload == {"issues": [13601.0]}
+
+
+@pytest.mark.asyncio
+async def test_deep_issue_uses_singular_relationship_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Deep hydration should request relationships only from the singular issue endpoint."""
+    client = ComicVineClient("secret", tmp_path)
+    observed: list[tuple[str, object]] = []
+
+    def fake_request(endpoint: str, params: object) -> dict[str, object]:
+        observed.append((endpoint, params))
+        return {
+            "status_code": 1,
+            "results": {
+                "id": 42,
+                "story_arc_credits": [{"id": 7, "name": "Annihilation"}],
+                "person_credits": [{"id": 3, "name": "Writer", "role": "writer"}],
+            },
+        }
+
+    monkeypatch.setattr(client, "_request_sync", fake_request)
+    response = await client.fetch_issue(42)
+
+    assert response.payload["results"]
+    endpoint, params = observed[0]
+    assert endpoint == "issue/4000-42"
+    assert "story_arc_credits" in str(params)
+    assert "person_credits" in str(params)
+
+
+@pytest.mark.asyncio
+async def test_volume_roster_paginates_at_documented_maximum(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Volume hydration should page at 100 and preserve provider ordering."""
+    client = ComicVineClient("secret", tmp_path)
+    offsets: list[int] = []
+
+    def fake_request(endpoint: str, params: object) -> dict[str, object]:
+        assert endpoint == "issues"
+        assert isinstance(params, dict)
+        offset = int(params["offset"])
+        offsets.append(offset)
+        count = COLLECTION_PAGE_LIMIT if offset == 0 else 5
+        return {
+            "status_code": 1,
+            "number_of_total_results": 105,
+            "results": [
+                {"id": offset + index, "issue_number": str(offset + index), "volume": {"id": 7}}
+                for index in range(count)
+            ],
+        }
+
+    monkeypatch.setattr(client, "_request_sync", fake_request)
+    rows = await client.fetch_volume_issues(7, refresh=True)
+
+    assert offsets == [0, 100]
+    assert len(rows) == 105
+    assert rows[0]["id"] == 0
+    assert rows[-1]["id"] == 104
+
+
+@pytest.mark.asyncio
+async def test_volume_roster_rejects_ignored_provider_filter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Successful provider responses must still be validated for filter correctness."""
+    client = ComicVineClient("secret", tmp_path)
+
+    def fake_request(endpoint: str, params: object) -> dict[str, object]:
+        return {
+            "status_code": 1,
+            "number_of_total_results": 1,
+            "results": [{"id": 1, "issue_number": "1", "volume": {"id": 999}}],
+        }
+
+    monkeypatch.setattr(client, "_request_sync", fake_request)
+    with pytest.raises(ComicVineError, match="ignored the requested volume filter"):
+        await client.fetch_volume_issues(7, refresh=True)
+
+
+@pytest.mark.asyncio
+async def test_story_arc_preserves_provider_membership_without_claiming_reading_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Story-arc issue arrays should be retained verbatim rather than sorted as chapters."""
+    client = ComicVineClient("secret", tmp_path)
+    raw_members = [
+        {"id": 2, "issue_number": "2"},
+        {"id": 1, "issue_number": "1"},
+    ]
+
+    def fake_request(endpoint: str, params: object) -> dict[str, object]:
+        return {"status_code": 1, "results": {"id": 8, "issues": raw_members}}
+
+    monkeypatch.setattr(client, "_request_sync", fake_request)
+    response = await client.fetch_story_arc(8)
+
+    assert response.payload["results"] == {"id": 8, "issues": raw_members}


### PR DESCRIPTION
Implements #1019 with an endpoint-aware ComicVine client, persistent per-endpoint rolling-hour budget, resumable raw-response cache, validated volume pagination, narrow singular issue hydration, story-arc caching, and provider-independent metadata persistence. Hydration preserves raw provider rows for audit while normalizing the fields ComicPile needs, and does not touch continuity rules.

Focused provider-contract tests cover restart-safe rate limiting, cache reuse, singular relationship fields, 100-row volume pagination, ignored collection filters, and story-arc order preservation.

Closes #1019