### PR TITLE
Add read-only ComicVine hydration report foundation

### DIFF
--- a/comic_pile/comicvine_hydrator.py
+++ b/comic_pile/comicvine_hydrator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Protocol
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -12,9 +12,28 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.external_identity import ExternalIdentity, IssueExternalIdentityMapping
 from app.models.issue import Issue
 from app.models.thread import Thread
-from comic_pile.local_comicvine import LocalComicVineSnapshot
+from comic_pile.local_comicvine import LocalComicVineResult
 
 HydrationStatus = Literal["matched", "local-miss", "unresolved"]
+
+
+class ComicVineSnapshotReader(Protocol):
+    """Read-only ComicVine snapshot contract used by the hydrator."""
+
+    path: Path | None
+
+    @property
+    def available(self) -> bool:
+        """Return whether snapshot data can be read."""
+        ...
+
+    def get_issue(self, issue_id: int) -> LocalComicVineResult | None:
+        """Return one local ComicVine issue by provider ID."""
+        ...
+
+    def sync_metadata(self) -> dict[str, object]:
+        """Return snapshot freshness metadata."""
+        ...
 
 
 @dataclass(frozen=True)
@@ -118,7 +137,7 @@ async def enumerate_user_issues(
 
 def inspect_local_snapshot(
     target: HydrationTarget,
-    snapshot: LocalComicVineSnapshot,
+    snapshot: ComicVineSnapshotReader,
 ) -> HydrationResult:
     """Resolve one target from confirmed identity plus the local snapshot only.
 
@@ -183,7 +202,7 @@ def inspect_local_snapshot(
 
 def build_report(
     targets: list[HydrationTarget],
-    snapshot: LocalComicVineSnapshot,
+    snapshot: ComicVineSnapshotReader,
 ) -> dict[str, object]:
     """Build a deterministic report suitable for resumable hydrator handoff.
 

--- a/comic_pile/comicvine_hydrator.py
+++ b/comic_pile/comicvine_hydrator.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
+import tempfile
+from collections import defaultdict
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Literal, Protocol
@@ -28,11 +32,22 @@ class ComicVineSnapshotReader(Protocol):
         ...
 
     def get_issue(self, issue_id: int) -> LocalComicVineResult | None:
-        """Return one local ComicVine issue by provider ID."""
+        """Return one local ComicVine issue by provider ID.
+
+        Args:
+            issue_id: ComicVine provider issue ID.
+
+        Returns:
+            The normalized local snapshot row when present, otherwise None.
+        """
         ...
 
     def sync_metadata(self) -> dict[str, object]:
-        """Return snapshot freshness metadata."""
+        """Return snapshot freshness metadata.
+
+        Returns:
+            JSON-compatible snapshot synchronization metadata.
+        """
         ...
 
 
@@ -101,7 +116,7 @@ async def enumerate_user_issues(
 
     rows = (await db.execute(issue_query)).all()
     issue_ids = [issue.id for issue, _thread in rows]
-    confirmed_by_issue: dict[int, int] = {}
+    confirmed_ids_by_issue: dict[int, set[int]] = defaultdict(set)
     if issue_ids:
         mapping_query = (
             select(IssueExternalIdentityMapping.issue_id, ExternalIdentity.external_id)
@@ -118,10 +133,15 @@ async def enumerate_user_issues(
         )
         for issue_id, external_id in (await db.execute(mapping_query)).all():
             try:
-                confirmed_by_issue[issue_id] = int(external_id)
+                confirmed_ids_by_issue[issue_id].add(int(external_id))
             except (TypeError, ValueError):
                 continue
 
+    confirmed_by_issue = {
+        issue_id: next(iter(external_ids))
+        for issue_id, external_ids in confirmed_ids_by_issue.items()
+        if len(external_ids) == 1
+    }
     return [
         HydrationTarget(
             issue_id=issue.id,
@@ -135,7 +155,7 @@ async def enumerate_user_issues(
     ]
 
 
-def inspect_local_snapshot(
+async def inspect_local_snapshot(
     target: HydrationTarget,
     snapshot: ComicVineSnapshotReader,
 ) -> HydrationResult:
@@ -145,6 +165,9 @@ def inspect_local_snapshot(
     snapshot miss is reported rather than converted into a guessed mapping. Live
     provider fallback is deliberately left to the endpoint-budgeted client from
     #1019 so this foundation remains safe and restart-friendly.
+
+    SQLite snapshot reads are moved to a worker thread so the asynchronous CLI
+    does not block its event loop while reading the developer-local snapshot.
 
     Args:
         target: ComicPile issue to inspect.
@@ -166,7 +189,7 @@ def inspect_local_snapshot(
             detail="No confirmed ComicVine issue identity is available yet.",
         )
 
-    local = snapshot.get_issue(target.comicvine_issue_id)
+    local = await asyncio.to_thread(snapshot.get_issue, target.comicvine_issue_id)
     if local is None:
         return HydrationResult(
             issue_id=target.issue_id,
@@ -178,6 +201,18 @@ def inspect_local_snapshot(
             comicvine_issue_id=target.comicvine_issue_id,
             provenance="comicvine-local-sqlite",
             detail="Confirmed identity is absent from the configured local snapshot.",
+        )
+    if not local.complete:
+        return HydrationResult(
+            issue_id=target.issue_id,
+            thread_id=target.thread_id,
+            thread_title=target.thread_title,
+            issue_number=target.issue_number,
+            position=target.position,
+            status="local-miss",
+            comicvine_issue_id=target.comicvine_issue_id,
+            provenance=local.provenance,
+            detail="Confirmed identity exists locally, but required hydration data is missing.",
         )
 
     provider_issue_number = str(local.data.get("issue_number", "")).strip()
@@ -200,7 +235,7 @@ def inspect_local_snapshot(
     )
 
 
-def build_report(
+async def build_report(
     targets: list[HydrationTarget],
     snapshot: ComicVineSnapshotReader,
 ) -> dict[str, object]:
@@ -213,16 +248,17 @@ def build_report(
     Returns:
         Summary counts, snapshot metadata, and per-issue results.
     """
-    results = [inspect_local_snapshot(target, snapshot) for target in targets]
+    results = [await inspect_local_snapshot(target, snapshot) for target in targets]
     counts: dict[str, int] = {"matched": 0, "local-miss": 0, "unresolved": 0}
     for result in results:
         counts[result.status] += 1
+    sync_metadata = await asyncio.to_thread(snapshot.sync_metadata)
     return {
         "summary": {"total": len(results), **counts},
         "snapshot": {
             "path": str(snapshot.path) if snapshot.path is not None else None,
             "available": snapshot.available,
-            "sync_metadata": snapshot.sync_metadata(),
+            "sync_metadata": sync_metadata,
         },
         "issues": [result.to_dict() for result in results],
     }
@@ -235,10 +271,22 @@ def write_report(report: dict[str, object], output_path: str | Path) -> None:
         report: JSON-compatible hydration report.
         output_path: Destination file path.
     """
-    import json
-
     destination = Path(output_path)
     destination.parent.mkdir(parents=True, exist_ok=True)
-    temporary = destination.with_suffix(destination.suffix + ".tmp")
-    temporary.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    temporary.replace(destination)
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=destination.parent,
+            prefix=f".{destination.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            json.dump(report, temporary, indent=2, sort_keys=True)
+            temporary.write("\n")
+            temporary_path = Path(temporary.name)
+        temporary_path.replace(destination)
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)

--- a/comic_pile/comicvine_hydrator.py
+++ b/comic_pile/comicvine_hydrator.py
@@ -1,0 +1,225 @@
+"""Read-only ComicVine hydration planning for existing ComicPile issues."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Literal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.external_identity import ExternalIdentity, IssueExternalIdentityMapping
+from app.models.issue import Issue
+from app.models.thread import Thread
+from comic_pile.local_comicvine import LocalComicVineSnapshot
+
+HydrationStatus = Literal["matched", "local-miss", "unresolved"]
+
+
+@dataclass(frozen=True)
+class HydrationTarget:
+    """One user-owned ComicPile issue considered for ComicVine hydration."""
+
+    issue_id: int
+    thread_id: int
+    thread_title: str
+    issue_number: str
+    position: int
+    comicvine_issue_id: int | None = None
+
+
+@dataclass(frozen=True)
+class HydrationResult:
+    """Machine-readable report row for one hydration target."""
+
+    issue_id: int
+    thread_id: int
+    thread_title: str
+    issue_number: str
+    position: int
+    status: HydrationStatus
+    comicvine_issue_id: int | None
+    provenance: str | None
+    detail: str
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize the result without leaking provider credentials.
+
+        Returns:
+            JSON-compatible report data.
+        """
+        return asdict(self)
+
+
+async def enumerate_user_issues(
+    db: AsyncSession,
+    *,
+    user_id: int,
+    include_test_threads: bool = False,
+) -> list[HydrationTarget]:
+    """Enumerate user-owned issues and reuse confirmed ComicVine identities.
+
+    This query is intentionally read-only. It does not modify reading progress,
+    continuity, ratings, threads, issues, or external identity mappings.
+
+    Args:
+        db: Async database session.
+        user_id: ComicPile user whose issues should be inspected.
+        include_test_threads: Include threads marked as test data when true.
+
+    Returns:
+        Deterministically ordered hydration targets.
+    """
+    issue_query = (
+        select(Issue, Thread)
+        .join(Thread, Thread.id == Issue.thread_id)
+        .where(Thread.user_id == user_id)
+        .order_by(Thread.queue_position, Thread.id, Issue.position, Issue.id)
+    )
+    if not include_test_threads:
+        issue_query = issue_query.where(Thread.is_test.is_(False))
+
+    rows = (await db.execute(issue_query)).all()
+    issue_ids = [issue.id for issue, _thread in rows]
+    confirmed_by_issue: dict[int, int] = {}
+    if issue_ids:
+        mapping_query = (
+            select(IssueExternalIdentityMapping.issue_id, ExternalIdentity.external_id)
+            .join(
+                ExternalIdentity,
+                ExternalIdentity.id == IssueExternalIdentityMapping.external_identity_id,
+            )
+            .where(
+                IssueExternalIdentityMapping.issue_id.in_(issue_ids),
+                IssueExternalIdentityMapping.status == "confirmed",
+                ExternalIdentity.provider == "comicvine",
+                ExternalIdentity.entity_type == "issue",
+            )
+        )
+        for issue_id, external_id in (await db.execute(mapping_query)).all():
+            try:
+                confirmed_by_issue[issue_id] = int(external_id)
+            except (TypeError, ValueError):
+                continue
+
+    return [
+        HydrationTarget(
+            issue_id=issue.id,
+            thread_id=thread.id,
+            thread_title=thread.title,
+            issue_number=issue.issue_number,
+            position=issue.position,
+            comicvine_issue_id=confirmed_by_issue.get(issue.id),
+        )
+        for issue, thread in rows
+    ]
+
+
+def inspect_local_snapshot(
+    target: HydrationTarget,
+    snapshot: LocalComicVineSnapshot,
+) -> HydrationResult:
+    """Resolve one target from confirmed identity plus the local snapshot only.
+
+    A confirmed ComicVine issue ID is authoritative identity evidence. A local
+    snapshot miss is reported rather than converted into a guessed mapping. Live
+    provider fallback is deliberately left to the endpoint-budgeted client from
+    #1019 so this foundation remains safe and restart-friendly.
+
+    Args:
+        target: ComicPile issue to inspect.
+        snapshot: Read-only local ComicVine snapshot.
+
+    Returns:
+        A report row describing the local resolution state.
+    """
+    if target.comicvine_issue_id is None:
+        return HydrationResult(
+            issue_id=target.issue_id,
+            thread_id=target.thread_id,
+            thread_title=target.thread_title,
+            issue_number=target.issue_number,
+            position=target.position,
+            status="unresolved",
+            comicvine_issue_id=None,
+            provenance=None,
+            detail="No confirmed ComicVine issue identity is available yet.",
+        )
+
+    local = snapshot.get_issue(target.comicvine_issue_id)
+    if local is None:
+        return HydrationResult(
+            issue_id=target.issue_id,
+            thread_id=target.thread_id,
+            thread_title=target.thread_title,
+            issue_number=target.issue_number,
+            position=target.position,
+            status="local-miss",
+            comicvine_issue_id=target.comicvine_issue_id,
+            provenance="comicvine-local-sqlite",
+            detail="Confirmed identity is absent from the configured local snapshot.",
+        )
+
+    provider_issue_number = str(local.data.get("issue_number", "")).strip()
+    detail = "Confirmed identity resolved from the local ComicVine snapshot."
+    if provider_issue_number and provider_issue_number != target.issue_number:
+        detail = (
+            "Confirmed identity resolved; provider issue number differs from the "
+            "ComicPile label, so the mapping is preserved instead of guessed by number."
+        )
+    return HydrationResult(
+        issue_id=target.issue_id,
+        thread_id=target.thread_id,
+        thread_title=target.thread_title,
+        issue_number=target.issue_number,
+        position=target.position,
+        status="matched",
+        comicvine_issue_id=target.comicvine_issue_id,
+        provenance=local.provenance,
+        detail=detail,
+    )
+
+
+def build_report(
+    targets: list[HydrationTarget],
+    snapshot: LocalComicVineSnapshot,
+) -> dict[str, object]:
+    """Build a deterministic report suitable for resumable hydrator handoff.
+
+    Args:
+        targets: Ordered ComicPile issues to inspect.
+        snapshot: Read-only local ComicVine snapshot.
+
+    Returns:
+        Summary counts, snapshot metadata, and per-issue results.
+    """
+    results = [inspect_local_snapshot(target, snapshot) for target in targets]
+    counts: dict[str, int] = {"matched": 0, "local-miss": 0, "unresolved": 0}
+    for result in results:
+        counts[result.status] += 1
+    return {
+        "summary": {"total": len(results), **counts},
+        "snapshot": {
+            "path": str(snapshot.path) if snapshot.path is not None else None,
+            "available": snapshot.available,
+            "sync_metadata": snapshot.sync_metadata(),
+        },
+        "issues": [result.to_dict() for result in results],
+    }
+
+
+def write_report(report: dict[str, object], output_path: str | Path) -> None:
+    """Write a hydration report atomically enough for restart-safe CLI use.
+
+    Args:
+        report: JSON-compatible hydration report.
+        output_path: Destination file path.
+    """
+    import json
+
+    destination = Path(output_path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_suffix(destination.suffix + ".tmp")
+    temporary.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(destination)

--- a/docs/changelog.d/2026-08-10-1047.md
+++ b/docs/changelog.d/2026-08-10-1047.md
@@ -1,0 +1,5 @@
+## 2026-08-10
+
+### Comic metadata
+
+- [#1047](https://github.com/JoshCLWren/comic-pile/pull/1047) adds a safe read-only ComicVine hydration report for existing ComicPile issues, reusing confirmed identities and the local snapshot so large libraries can be inspected incrementally without changing reading progress or guessing provider matches.

--- a/scripts/hydrate_comicvine_issues.py
+++ b/scripts/hydrate_comicvine_issues.py
@@ -43,7 +43,8 @@ async def run(args: argparse.Namespace) -> None:
             user_id=args.user_id,
             include_test_threads=args.include_test_threads,
         )
-    write_report(build_report(targets, snapshot), args.output)
+    report = await build_report(targets, snapshot)
+    write_report(report, args.output)
 
 
 def main() -> None:

--- a/scripts/hydrate_comicvine_issues.py
+++ b/scripts/hydrate_comicvine_issues.py
@@ -1,0 +1,55 @@
+"""Generate a read-only ComicVine hydration report for one ComicPile user."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from pathlib import Path
+
+from app.database import AsyncSessionLocal
+from comic_pile.comicvine_hydrator import build_report, enumerate_user_issues, write_report
+from comic_pile.local_comicvine import LocalComicVineSnapshot
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Returns:
+        Parsed CLI arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description=(
+            "Inspect existing ComicPile issues against confirmed ComicVine identities "
+            "and a read-only local ComicVine snapshot."
+        )
+    )
+    parser.add_argument("--user-id", type=int, required=True)
+    parser.add_argument("--comicvine-db", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--include-test-threads", action="store_true")
+    return parser.parse_args()
+
+
+async def run(args: argparse.Namespace) -> None:
+    """Build and persist one read-only hydration report.
+
+    Args:
+        args: Parsed CLI arguments.
+    """
+    snapshot = LocalComicVineSnapshot(args.comicvine_db)
+    async with AsyncSessionLocal() as db:
+        targets = await enumerate_user_issues(
+            db,
+            user_id=args.user_id,
+            include_test_threads=args.include_test_threads,
+        )
+    write_report(build_report(targets, snapshot), args.output)
+
+
+def main() -> None:
+    """Run the hydration report command."""
+    asyncio.run(run(parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_comicvine_hydrator.py
+++ b/tests/test_comicvine_hydrator.py
@@ -1,8 +1,17 @@
 """Tests for read-only ComicVine hydration planning."""
 
+import json
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
 
-from comic_pile.comicvine_hydrator import HydrationTarget, build_report, inspect_local_snapshot
+from comic_pile.comicvine_hydrator import (
+    HydrationTarget,
+    build_report,
+    enumerate_user_issues,
+    inspect_local_snapshot,
+    write_report,
+)
 from comic_pile.local_comicvine import LocalComicVineResult
 
 
@@ -87,3 +96,58 @@ def test_report_counts_are_deterministic() -> None:
         "local-miss": 1,
         "unresolved": 1,
     }
+
+
+async def test_enumerate_user_issues_reuses_confirmed_identity() -> None:
+    """Confirmed provider IDs are attached while enumerating user-owned issues."""
+    issue = SimpleNamespace(id=10, issue_number="Revival", position=7)
+    thread = SimpleNamespace(id=4, title="B.P.R.D.: War on Frogs")
+    issue_rows = Mock()
+    issue_rows.all.return_value = [(issue, thread)]
+    mapping_rows = Mock()
+    mapping_rows.all.return_value = [(10, "55")]
+    db = AsyncMock()
+    db.execute.side_effect = [issue_rows, mapping_rows]
+
+    targets = await enumerate_user_issues(db, user_id=1)
+
+    assert targets == [
+        HydrationTarget(
+            issue_id=10,
+            thread_id=4,
+            thread_title="B.P.R.D.: War on Frogs",
+            issue_number="Revival",
+            position=7,
+            comicvine_issue_id=55,
+        )
+    ]
+    assert db.execute.await_count == 2
+
+
+async def test_enumerate_user_issues_ignores_invalid_confirmed_identity() -> None:
+    """Malformed external IDs do not become guessed ComicVine mappings."""
+    issue = SimpleNamespace(id=10, issue_number="12", position=12)
+    thread = SimpleNamespace(id=4, title="X-Men")
+    issue_rows = Mock()
+    issue_rows.all.return_value = [(issue, thread)]
+    mapping_rows = Mock()
+    mapping_rows.all.return_value = [(10, "not-an-integer")]
+    db = AsyncMock()
+    db.execute.side_effect = [issue_rows, mapping_rows]
+
+    targets = await enumerate_user_issues(db, user_id=1, include_test_threads=True)
+
+    assert targets[0].comicvine_issue_id is None
+    assert db.execute.await_count == 2
+
+
+def test_write_report_creates_parent_and_replaces_temporary_file(tmp_path: Path) -> None:
+    """Report writes create parent directories and leave no temporary artifact behind."""
+    destination = tmp_path / "nested" / "hydration.json"
+    report: dict[str, object] = {"summary": {"total": 1}, "issues": [{"issue_id": 10}]}
+
+    write_report(report, destination)
+
+    assert json.loads(destination.read_text(encoding="utf-8")) == report
+    assert destination.read_text(encoding="utf-8").endswith("\n")
+    assert not destination.with_suffix(".json.tmp").exists()

--- a/tests/test_comicvine_hydrator.py
+++ b/tests/test_comicvine_hydrator.py
@@ -45,23 +45,41 @@ def target(*, external_id: int | None, issue_number: str = "12") -> HydrationTar
     )
 
 
-def test_unmapped_issue_remains_unresolved() -> None:
+async def test_unmapped_issue_remains_unresolved() -> None:
     """Never guess provider identity when no confirmed mapping exists."""
-    result = inspect_local_snapshot(target(external_id=None), FakeSnapshot())
+    result = await inspect_local_snapshot(target(external_id=None), FakeSnapshot())
 
     assert result.status == "unresolved"
     assert result.comicvine_issue_id is None
 
 
-def test_confirmed_identity_local_miss_is_not_reinterpreted() -> None:
+async def test_confirmed_identity_local_miss_is_not_reinterpreted() -> None:
     """A stale/local miss stays attached to its confirmed provider identity."""
-    result = inspect_local_snapshot(target(external_id=123), FakeSnapshot())
+    result = await inspect_local_snapshot(target(external_id=123), FakeSnapshot())
 
     assert result.status == "local-miss"
     assert result.comicvine_issue_id == 123
 
 
-def test_human_label_preserves_confirmed_mapping() -> None:
+async def test_incomplete_local_row_remains_a_local_miss() -> None:
+    """Incomplete snapshot rows never masquerade as hydrated matches."""
+    snapshot = FakeSnapshot(
+        {
+            55: LocalComicVineResult(
+                data={"issue_number": "5"},
+                complete=False,
+            )
+        }
+    )
+
+    result = await inspect_local_snapshot(target(external_id=55), snapshot)
+
+    assert result.status == "local-miss"
+    assert result.comicvine_issue_id == 55
+    assert "required hydration data is missing" in result.detail
+
+
+async def test_human_label_preserves_confirmed_mapping() -> None:
     """Human issue labels need not equal ComicVine numeric issue text."""
     snapshot = FakeSnapshot(
         {
@@ -71,13 +89,16 @@ def test_human_label_preserves_confirmed_mapping() -> None:
         }
     )
 
-    result = inspect_local_snapshot(target(external_id=55, issue_number="Revival"), snapshot)
+    result = await inspect_local_snapshot(
+        target(external_id=55, issue_number="Revival"),
+        snapshot,
+    )
 
     assert result.status == "matched"
     assert "differs" in result.detail
 
 
-def test_report_counts_are_deterministic() -> None:
+async def test_report_counts_are_deterministic() -> None:
     """Summary categories match per-issue report states."""
     snapshot = FakeSnapshot(
         {1: LocalComicVineResult(data={"issue_number": "1", "volume_id": 10})}
@@ -88,7 +109,7 @@ def test_report_counts_are_deterministic() -> None:
         HydrationTarget(12, 4, "X-Men", "3", 14, None),
     ]
 
-    report = build_report(targets, snapshot)
+    report = await build_report(targets, snapshot)
 
     assert report["summary"] == {
         "total": 3,
@@ -141,6 +162,27 @@ async def test_enumerate_user_issues_ignores_invalid_confirmed_identity() -> Non
     assert db.execute.await_count == 2
 
 
+async def test_conflicting_confirmed_identities_are_order_independent() -> None:
+    """Conflicting confirmed IDs stay unresolved regardless of database row order."""
+    issue = SimpleNamespace(id=10, issue_number="12", position=12)
+    thread = SimpleNamespace(id=4, title="X-Men")
+
+    async def enumerate_with_rows(rows: list[tuple[int, str]]) -> HydrationTarget:
+        issue_rows = Mock()
+        issue_rows.all.return_value = [(issue, thread)]
+        mapping_rows = Mock()
+        mapping_rows.all.return_value = rows
+        db = AsyncMock()
+        db.execute.side_effect = [issue_rows, mapping_rows]
+        return (await enumerate_user_issues(db, user_id=1))[0]
+
+    first = await enumerate_with_rows([(10, "55"), (10, "56")])
+    reversed_order = await enumerate_with_rows([(10, "56"), (10, "55")])
+
+    assert first.comicvine_issue_id is None
+    assert reversed_order.comicvine_issue_id is None
+
+
 def test_write_report_creates_parent_and_replaces_temporary_file(tmp_path: Path) -> None:
     """Report writes create parent directories and leave no temporary artifact behind."""
     destination = tmp_path / "nested" / "hydration.json"
@@ -150,4 +192,4 @@ def test_write_report_creates_parent_and_replaces_temporary_file(tmp_path: Path)
 
     assert json.loads(destination.read_text(encoding="utf-8")) == report
     assert destination.read_text(encoding="utf-8").endswith("\n")
-    assert not destination.with_suffix(".json.tmp").exists()
+    assert list(destination.parent.glob(".hydration.json.*.tmp")) == []

--- a/tests/test_comicvine_hydrator.py
+++ b/tests/test_comicvine_hydrator.py
@@ -38,7 +38,7 @@ def target(*, external_id: int | None, issue_number: str = "12") -> HydrationTar
 
 def test_unmapped_issue_remains_unresolved() -> None:
     """Never guess provider identity when no confirmed mapping exists."""
-    result = inspect_local_snapshot(target(external_id=None), FakeSnapshot())  # type: ignore[arg-type]
+    result = inspect_local_snapshot(target(external_id=None), FakeSnapshot())
 
     assert result.status == "unresolved"
     assert result.comicvine_issue_id is None
@@ -46,7 +46,7 @@ def test_unmapped_issue_remains_unresolved() -> None:
 
 def test_confirmed_identity_local_miss_is_not_reinterpreted() -> None:
     """A stale/local miss stays attached to its confirmed provider identity."""
-    result = inspect_local_snapshot(target(external_id=123), FakeSnapshot())  # type: ignore[arg-type]
+    result = inspect_local_snapshot(target(external_id=123), FakeSnapshot())
 
     assert result.status == "local-miss"
     assert result.comicvine_issue_id == 123
@@ -62,9 +62,7 @@ def test_human_label_preserves_confirmed_mapping() -> None:
         }
     )
 
-    result = inspect_local_snapshot(
-        target(external_id=55, issue_number="Revival"), snapshot  # type: ignore[arg-type]
-    )
+    result = inspect_local_snapshot(target(external_id=55, issue_number="Revival"), snapshot)
 
     assert result.status == "matched"
     assert "differs" in result.detail
@@ -81,7 +79,7 @@ def test_report_counts_are_deterministic() -> None:
         HydrationTarget(12, 4, "X-Men", "3", 14, None),
     ]
 
-    report = build_report(targets, snapshot)  # type: ignore[arg-type]
+    report = build_report(targets, snapshot)
 
     assert report["summary"] == {
         "total": 3,

--- a/tests/test_comicvine_hydrator.py
+++ b/tests/test_comicvine_hydrator.py
@@ -1,0 +1,91 @@
+"""Tests for read-only ComicVine hydration planning."""
+
+from pathlib import Path
+
+from comic_pile.comicvine_hydrator import HydrationTarget, build_report, inspect_local_snapshot
+from comic_pile.local_comicvine import LocalComicVineResult
+
+
+class FakeSnapshot:
+    """Minimal local snapshot fake for deterministic hydrator tests."""
+
+    def __init__(self, rows: dict[int, LocalComicVineResult] | None = None) -> None:
+        """Initialize fake rows."""
+        self.rows = rows or {}
+        self.path = Path("/tmp/comicvine.db")
+        self.available = True
+
+    def get_issue(self, issue_id: int) -> LocalComicVineResult | None:
+        """Return one fake issue row."""
+        return self.rows.get(issue_id)
+
+    def sync_metadata(self) -> dict[str, object]:
+        """Return deterministic freshness metadata."""
+        return {"0": {"synced_at": "2026-01-09T00:00:00Z"}}
+
+
+def target(*, external_id: int | None, issue_number: str = "12") -> HydrationTarget:
+    """Build one compact hydration target fixture."""
+    return HydrationTarget(
+        issue_id=10,
+        thread_id=4,
+        thread_title="X-Men",
+        issue_number=issue_number,
+        position=12,
+        comicvine_issue_id=external_id,
+    )
+
+
+def test_unmapped_issue_remains_unresolved() -> None:
+    """Never guess provider identity when no confirmed mapping exists."""
+    result = inspect_local_snapshot(target(external_id=None), FakeSnapshot())  # type: ignore[arg-type]
+
+    assert result.status == "unresolved"
+    assert result.comicvine_issue_id is None
+
+
+def test_confirmed_identity_local_miss_is_not_reinterpreted() -> None:
+    """A stale/local miss stays attached to its confirmed provider identity."""
+    result = inspect_local_snapshot(target(external_id=123), FakeSnapshot())  # type: ignore[arg-type]
+
+    assert result.status == "local-miss"
+    assert result.comicvine_issue_id == 123
+
+
+def test_human_label_preserves_confirmed_mapping() -> None:
+    """Human issue labels need not equal ComicVine numeric issue text."""
+    snapshot = FakeSnapshot(
+        {
+            55: LocalComicVineResult(
+                data={"issue_number": "5", "volume_id": 99, "name": "Revival"}
+            )
+        }
+    )
+
+    result = inspect_local_snapshot(
+        target(external_id=55, issue_number="Revival"), snapshot  # type: ignore[arg-type]
+    )
+
+    assert result.status == "matched"
+    assert "differs" in result.detail
+
+
+def test_report_counts_are_deterministic() -> None:
+    """Summary categories match per-issue report states."""
+    snapshot = FakeSnapshot(
+        {1: LocalComicVineResult(data={"issue_number": "1", "volume_id": 10})}
+    )
+    targets = [
+        target(external_id=1, issue_number="1"),
+        HydrationTarget(11, 4, "X-Men", "2", 13, 2),
+        HydrationTarget(12, 4, "X-Men", "3", 14, None),
+    ]
+
+    report = build_report(targets, snapshot)  # type: ignore[arg-type]
+
+    assert report["summary"] == {
+        "total": 3,
+        "matched": 1,
+        "local-miss": 1,
+        "unresolved": 1,
+    }


### PR DESCRIPTION
Begins #1025 at the dependency-safe boundary available on current main. This adds a read-only user-issue enumerator, confirmed ComicVine identity reuse, local-snapshot resolution, deterministic machine-readable reporting, and a CLI that never mutates reading progress or continuity data.

The live endpoint-budgeted hydration and durable provider metadata write path remain blocked on #1019 landing; this PR deliberately does not guess identities or duplicate that in-flight provider client.

Focused tests cover unresolved identities, local snapshot misses, human labels such as `Revival`, and deterministic report counts.

#1025 remains open for CBL-first identity ingestion, volume-segment bulk matching, live provider fallback, deep hydration/story arcs, full fixtures, and persistence integration after #1019.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only ComicVine hydration report for existing issues.
  * Reports matched issues, local snapshot misses, and unresolved identities.
  * Preserves existing mappings when provider issue numbers differ.
  * Added a command-line tool to generate and save reports for a selected user.
  * Report generation does not modify reading progress or guess matches.

* **Documentation**
  * Added a changelog entry describing the ComicVine hydration report.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->