### PR TITLE
Bound OpenCode review runtime

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -36,6 +36,7 @@ jobs:
       group: opencode-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write

--- a/docs/changelog.d/2026-08-10-1048.md
+++ b/docs/changelog.d/2026-08-10-1048.md
@@ -1,0 +1,5 @@
+## 2026-08-10
+
+### Factory reliability
+
+- [#1048](https://github.com/JoshCLWren/comic-pile/pull/1048) bounds automated OpenCode PR reviews to 30 minutes so a stalled external review agent fails visibly instead of leaving ComicPile delivery work stuck indefinitely.


### PR DESCRIPTION
Repairs factory delivery infrastructure by bounding the OpenCode review job so a stalled external review agent cannot hold a factory PR in review indefinitely. The current #1044 review has remained inside the OpenCode agent step for well over an hour while product CI, documentation, OpenAPI generation, and CodeRabbit are otherwise complete.

This keeps the existing review behavior and model selection unchanged; it only gives the job a 30-minute ceiling so GitHub can surface a truthful failure and the factory can repair or retry instead of waiting forever.