### PR TITLE
Add confidence-aware ComicVine identity repair

### DIFF
--- a/alembic/versions/c84600000001_add_external_identity_evidence.py
+++ b/alembic/versions/c84600000001_add_external_identity_evidence.py
@@ -1,0 +1,42 @@
+"""Add structured evidence to issue identity mappings.
+
+Revision ID: c84600000001
+Revises: c84500000001
+Create Date: 2026-08-10 12:24:00.000000
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "c84600000001"
+down_revision: str | Sequence[str] | None = "c84500000001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Persist structured evidence for issue identity candidates.
+
+    Args: None
+    Returns: None
+    """
+    op.add_column(
+        "issue_external_identity_mappings",
+        sa.Column("evidence_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'::json")),
+    )
+    op.alter_column(
+        "issue_external_identity_mappings",
+        "evidence_json",
+        server_default=None,
+    )
+
+
+def downgrade() -> None:
+    """Remove structured issue identity candidate evidence.
+
+    Args: None
+    Returns: None
+    """
+    op.drop_column("issue_external_identity_mappings", "evidence_json")

--- a/app/comicvine_identity_repair.py
+++ b/app/comicvine_identity_repair.py
@@ -71,7 +71,11 @@ async def persist_repair_decision(
                 },
             },
         )
-        status = "confirmed" if decision.status == "confirmed" and candidate.issue_id == winner_id else "candidate"
+        status = (
+            "confirmed"
+            if decision.status == "confirmed" and candidate.issue_id == winner_id
+            else "candidate"
+        )
         mapping = await link_issue_external_identity(
             db,
             user_id=user_id,

--- a/app/comicvine_identity_repair.py
+++ b/app/comicvine_identity_repair.py
@@ -1,0 +1,142 @@
+"""Persistence boundary for confidence-aware ComicVine identity repair."""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.external_identities import (
+    ExternalIdentityMappingError,
+    link_issue_external_identity,
+    upsert_external_identity,
+)
+from app.models.external_identity import IssueExternalIdentityMapping
+from comic_pile.comicvine_identity_repair import CandidateScore, RepairDecision
+
+
+def _candidate_evidence(score: CandidateScore, decision_reason: str) -> dict[str, object]:
+    """Serialize explainable scoring evidence without losing segment/freshness details."""
+    candidate = score.candidate
+    return {
+        "score": score.score,
+        "evidence": list(score.evidence),
+        "stale_snapshot": score.stale_snapshot,
+        "decision_reason": decision_reason,
+        "volume_id": candidate.volume_id,
+        "volume_name": candidate.volume_name,
+        "publisher": candidate.publisher,
+        "start_year": candidate.start_year,
+        "issue_number": candidate.issue_number,
+        "issue_name": candidate.issue_name,
+        "segment_start": candidate.segment_start,
+        "segment_end": candidate.segment_end,
+    }
+
+
+async def persist_repair_decision(
+    db: AsyncSession,
+    *,
+    user_id: int,
+    issue_id: int,
+    decision: RepairDecision,
+) -> list[IssueExternalIdentityMapping]:
+    """Persist all scored candidates while confirming only the decision winner.
+
+    Args:
+        db: Async database session.
+        user_id: ComicPile resource owner.
+        issue_id: ComicPile issue being repaired.
+        decision: Deterministic scoring decision.
+
+    Returns:
+        Persisted mappings in decision candidate order, followed by rejected evidence.
+    """
+    persisted: list[IssueExternalIdentityMapping] = []
+    winner_id = decision.winner.candidate.issue_id if decision.winner is not None else None
+
+    all_scores = list(decision.candidates)
+    for score in all_scores:
+        candidate = score.candidate
+        identity = await upsert_external_identity(
+            db,
+            provider="comicvine",
+            entity_type="issue",
+            external_id=str(candidate.issue_id),
+            metadata_json={
+                "issue_number": candidate.issue_number,
+                "name": candidate.issue_name,
+                "volume": {
+                    "id": candidate.volume_id,
+                    "name": candidate.volume_name,
+                },
+            },
+        )
+        status = "confirmed" if decision.status == "confirmed" and candidate.issue_id == winner_id else "candidate"
+        mapping = await link_issue_external_identity(
+            db,
+            user_id=user_id,
+            issue_id=issue_id,
+            external_identity_id=identity.id,
+            status=status,
+            evidence_source=candidate.source,
+            confidence=score.score,
+            rejection_reason=None,
+        )
+        mapping.evidence_json = _candidate_evidence(score, decision.reason)
+        persisted.append(mapping)
+
+    return persisted
+
+
+async def review_candidate_mapping(
+    db: AsyncSession,
+    *,
+    user_id: int,
+    issue_id: int,
+    external_identity_id: int,
+    status: str,
+    rejection_reason: str | None = None,
+) -> IssueExternalIdentityMapping:
+    """Manually confirm or reject one persisted candidate without discarding its audit evidence.
+
+    Args:
+        db: Async database session.
+        user_id: ComicPile resource owner.
+        issue_id: ComicPile issue being reviewed.
+        external_identity_id: Persisted external identity candidate.
+        status: Explicit manual decision, ``confirmed`` or ``rejected``.
+        rejection_reason: Required explanation for a rejection.
+
+    Returns:
+        Updated mapping with prior structured evidence retained.
+
+    Raises:
+        ExternalIdentityMappingError: If the decision is invalid or the candidate does not exist.
+    """
+    if status not in {"confirmed", "rejected"}:
+        raise ExternalIdentityMappingError("manual candidate review must confirm or reject")
+    if status == "rejected" and not (rejection_reason or "").strip():
+        raise ExternalIdentityMappingError("rejection_reason is required when rejecting a candidate")
+
+    existing = await db.scalar(
+        select(IssueExternalIdentityMapping).where(
+            IssueExternalIdentityMapping.issue_id == issue_id,
+            IssueExternalIdentityMapping.external_identity_id == external_identity_id,
+        )
+    )
+    if existing is None:
+        raise ExternalIdentityMappingError("candidate mapping does not exist")
+
+    evidence_json = dict(existing.evidence_json)
+    mapping = await link_issue_external_identity(
+        db,
+        user_id=user_id,
+        issue_id=issue_id,
+        external_identity_id=external_identity_id,
+        status=status,
+        evidence_source=existing.evidence_source,
+        confidence=existing.confidence,
+        rejection_reason=rejection_reason if status == "rejected" else None,
+    )
+    mapping.evidence_json = evidence_json
+    return mapping

--- a/app/comicvine_identity_repair.py
+++ b/app/comicvine_identity_repair.py
@@ -22,6 +22,7 @@ def _candidate_evidence(score: CandidateScore, decision_reason: str) -> dict[str
         "evidence": list(score.evidence),
         "stale_snapshot": score.stale_snapshot,
         "decision_reason": decision_reason,
+        "rejection_reason": score.rejection_reason,
         "volume_id": candidate.volume_id,
         "volume_name": candidate.volume_name,
         "publisher": candidate.publisher,
@@ -40,22 +41,11 @@ async def persist_repair_decision(
     issue_id: int,
     decision: RepairDecision,
 ) -> list[IssueExternalIdentityMapping]:
-    """Persist all scored candidates while confirming only the decision winner.
-
-    Args:
-        db: Async database session.
-        user_id: ComicPile resource owner.
-        issue_id: ComicPile issue being repaired.
-        decision: Deterministic scoring decision.
-
-    Returns:
-        Persisted mappings in decision candidate order, followed by rejected evidence.
-    """
+    """Persist all scored candidates while confirming only the decision winner."""
     persisted: list[IssueExternalIdentityMapping] = []
     winner_id = decision.winner.candidate.issue_id if decision.winner is not None else None
 
-    all_scores = list(decision.candidates)
-    for score in all_scores:
+    for score in (*decision.candidates, *decision.rejected):
         candidate = score.candidate
         identity = await upsert_external_identity(
             db,
@@ -65,17 +55,18 @@ async def persist_repair_decision(
             metadata_json={
                 "issue_number": candidate.issue_number,
                 "name": candidate.issue_name,
-                "volume": {
-                    "id": candidate.volume_id,
-                    "name": candidate.volume_name,
-                },
+                "volume": {"id": candidate.volume_id, "name": candidate.volume_name},
             },
         )
-        status = (
-            "confirmed"
-            if decision.status == "confirmed" and candidate.issue_id == winner_id
-            else "candidate"
-        )
+        if score.rejection_reason is not None:
+            status = "rejected"
+            rejection_reason = score.rejection_reason
+        elif decision.status == "confirmed" and candidate.issue_id == winner_id:
+            status = "confirmed"
+            rejection_reason = None
+        else:
+            status = "candidate"
+            rejection_reason = None
         mapping = await link_issue_external_identity(
             db,
             user_id=user_id,
@@ -84,7 +75,7 @@ async def persist_repair_decision(
             status=status,
             evidence_source=candidate.source,
             confidence=score.score,
-            rejection_reason=None,
+            rejection_reason=rejection_reason,
         )
         mapping.evidence_json = _candidate_evidence(score, decision.reason)
         persisted.append(mapping)
@@ -101,22 +92,7 @@ async def review_candidate_mapping(
     status: str,
     rejection_reason: str | None = None,
 ) -> IssueExternalIdentityMapping:
-    """Manually confirm or reject one persisted candidate without discarding its audit evidence.
-
-    Args:
-        db: Async database session.
-        user_id: ComicPile resource owner.
-        issue_id: ComicPile issue being reviewed.
-        external_identity_id: Persisted external identity candidate.
-        status: Explicit manual decision, ``confirmed`` or ``rejected``.
-        rejection_reason: Required explanation for a rejection.
-
-    Returns:
-        Updated mapping with prior structured evidence retained.
-
-    Raises:
-        ExternalIdentityMappingError: If the decision is invalid or the candidate does not exist.
-    """
+    """Manually confirm or reject one persisted candidate without discarding its audit evidence."""
     if status not in {"confirmed", "rejected"}:
         raise ExternalIdentityMappingError("manual candidate review must confirm or reject")
     if status == "rejected" and not (rejection_reason or "").strip():

--- a/app/models/external_identity.py
+++ b/app/models/external_identity.py
@@ -58,6 +58,7 @@ class IssueExternalIdentityMapping(Base):
     )
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="candidate")
     evidence_source: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    evidence_json: Mapped[dict[str, object]] = mapped_column(JSON, default=dict, nullable=False)
     confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
     rejection_reason: Mapped[str | None] = mapped_column(String(500), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))

--- a/comic_pile/comicvine_candidate_discovery.py
+++ b/comic_pile/comicvine_candidate_discovery.py
@@ -13,14 +13,7 @@ from comic_pile.local_comicvine import LocalComicVineSnapshot
 
 
 def snapshot_sync_time(snapshot: LocalComicVineSnapshot) -> datetime | None:
-    """Return the newest parseable local snapshot sync timestamp.
-
-    Args:
-        snapshot: Read-only local ComicVine snapshot.
-
-    Returns:
-        Newest timestamp exposed by ``cv_sync_metadata``, when available.
-    """
+    """Return the newest parseable local snapshot sync timestamp."""
     timestamps: list[datetime] = []
     for row in snapshot.sync_metadata().values():
         if not isinstance(row, dict):
@@ -80,20 +73,7 @@ def discover_local_candidates(
     thread_issue_labels: list[str],
     limit: int = 20,
 ) -> list[ComicVineCandidate]:
-    """Discover issue-level candidates from local FTS plus exact volume issue validation.
-
-    FTS is used only to discover volumes. Every returned candidate is validated against an actual
-    issue row, and the result order is deterministic by provider IDs rather than FTS rank.
-
-    Args:
-        snapshot: Read-only local ComicVine snapshot.
-        context: ComicPile issue evidence.
-        thread_issue_labels: Ordered labels from the ComicPile reading-project thread.
-        limit: Maximum FTS volume candidates to inspect.
-
-    Returns:
-        Deterministically ordered, issue-validated candidates.
-    """
+    """Discover issue-level candidates from local FTS plus exact volume issue validation."""
     expected = normalize_issue_label(context.issue_label)
     candidates: list[ComicVineCandidate] = []
     seen_issue_ids: set[int] = set()
@@ -110,7 +90,11 @@ def discover_local_candidates(
             label
             for issue in issues
             for label in (
-                normalize_issue_label(str(issue.data.get("issue_number", ""))),
+                normalize_issue_label(
+                    str(issue.data["issue_number"])
+                    if issue.data.get("issue_number") is not None
+                    else None
+                ),
                 normalize_issue_label(
                     issue.data.get("name") if isinstance(issue.data.get("name"), str) else None
                 ),

--- a/comic_pile/comicvine_candidate_discovery.py
+++ b/comic_pile/comicvine_candidate_discovery.py
@@ -1,0 +1,165 @@
+"""Local ComicVine candidate discovery for confidence-aware identity repair."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from comic_pile.comicvine_identity_repair import (
+    ComicVineCandidate,
+    ComicVineRepairContext,
+    normalize_issue_label,
+)
+from comic_pile.local_comicvine import LocalComicVineSnapshot
+
+
+def snapshot_sync_time(snapshot: LocalComicVineSnapshot) -> datetime | None:
+    """Return the newest parseable local snapshot sync timestamp.
+
+    Args:
+        snapshot: Read-only local ComicVine snapshot.
+
+    Returns:
+        Newest timestamp exposed by ``cv_sync_metadata``, when available.
+    """
+    timestamps: list[datetime] = []
+    for row in snapshot.sync_metadata().values():
+        if not isinstance(row, dict):
+            continue
+        value = row.get("value")
+        if not isinstance(value, str):
+            continue
+        try:
+            timestamps.append(datetime.fromisoformat(value.replace("Z", "+00:00")))
+        except ValueError:
+            continue
+    return max(timestamps) if timestamps else None
+
+
+def _publisher_name(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    if isinstance(value, dict):
+        name = value.get("name")
+        return name.strip() if isinstance(name, str) and name.strip() else None
+    return None
+
+
+def _integer(value: object) -> int | None:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return None
+
+
+def _segment_for_labels(
+    thread_issue_labels: list[str],
+    target_label: str,
+    provider_labels: set[str],
+) -> tuple[str | None, str | None]:
+    normalized_thread = [normalize_issue_label(label) for label in thread_issue_labels]
+    normalized_target = normalize_issue_label(target_label)
+    try:
+        target_index = normalized_thread.index(normalized_target)
+    except ValueError:
+        return None, None
+
+    start = target_index
+    while start > 0 and normalized_thread[start - 1] in provider_labels:
+        start -= 1
+    end = target_index
+    while end + 1 < len(normalized_thread) and normalized_thread[end + 1] in provider_labels:
+        end += 1
+    return thread_issue_labels[start], thread_issue_labels[end]
+
+
+def discover_local_candidates(
+    snapshot: LocalComicVineSnapshot,
+    context: ComicVineRepairContext,
+    *,
+    thread_issue_labels: list[str],
+    limit: int = 20,
+) -> list[ComicVineCandidate]:
+    """Discover issue-level candidates from local FTS plus exact volume issue validation.
+
+    FTS is used only to discover volumes. Every returned candidate is validated against an actual
+    issue row, and the result order is deterministic by provider IDs rather than FTS rank.
+
+    Args:
+        snapshot: Read-only local ComicVine snapshot.
+        context: ComicPile issue evidence.
+        thread_issue_labels: Ordered labels from the ComicPile reading-project thread.
+        limit: Maximum FTS volume candidates to inspect.
+
+    Returns:
+        Deterministically ordered, issue-validated candidates.
+    """
+    expected = normalize_issue_label(context.issue_label)
+    candidates: list[ComicVineCandidate] = []
+    seen_issue_ids: set[int] = set()
+
+    for search_hit in snapshot.search_volumes(context.title, limit=limit):
+        volume_id = _integer(search_hit.data.get("id"))
+        if volume_id is None:
+            continue
+        volume = snapshot.get_volume(volume_id)
+        if volume is None:
+            continue
+        issues = snapshot.get_volume_issues(volume_id)
+        provider_labels = {
+            label
+            for issue in issues
+            for label in (
+                normalize_issue_label(str(issue.data.get("issue_number", ""))),
+                normalize_issue_label(
+                    issue.data.get("name") if isinstance(issue.data.get("name"), str) else None
+                ),
+            )
+            if label
+        }
+        segment_start, segment_end = _segment_for_labels(
+            thread_issue_labels,
+            context.issue_label,
+            provider_labels,
+        )
+
+        for issue in issues:
+            issue_id = _integer(issue.data.get("id"))
+            if issue_id is None or issue_id in seen_issue_ids:
+                continue
+            issue_number = issue.data.get("issue_number")
+            issue_name = issue.data.get("name")
+            number_text = str(issue_number) if issue_number is not None else None
+            name_text = issue_name if isinstance(issue_name, str) else None
+            if expected not in {
+                normalize_issue_label(number_text),
+                normalize_issue_label(name_text),
+            }:
+                continue
+            seen_issue_ids.add(issue_id)
+            volume_name = volume.data.get("name")
+            if not isinstance(volume_name, str) or not volume_name:
+                continue
+            candidates.append(
+                ComicVineCandidate(
+                    issue_id=issue_id,
+                    volume_id=volume_id,
+                    volume_name=volume_name,
+                    issue_number=number_text,
+                    issue_name=name_text,
+                    publisher=_publisher_name(volume.data.get("publisher")),
+                    start_year=_integer(volume.data.get("start_year")),
+                    previous_issue_exists=(
+                        context.previous_issue_label is not None
+                        and normalize_issue_label(context.previous_issue_label) in provider_labels
+                    ),
+                    next_issue_exists=(
+                        context.next_issue_label is not None
+                        and normalize_issue_label(context.next_issue_label) in provider_labels
+                    ),
+                    segment_start=segment_start,
+                    segment_end=segment_end,
+                )
+            )
+
+    return sorted(candidates, key=lambda candidate: (candidate.volume_id, candidate.issue_id))

--- a/comic_pile/comicvine_identity_repair.py
+++ b/comic_pile/comicvine_identity_repair.py
@@ -7,7 +7,7 @@ import unicodedata
 from dataclasses import dataclass
 from datetime import date, datetime
 
-AUTO_CONFIRM_THRESHOLD = 0.82
+AUTO_CONFIRM_THRESHOLD = 0.78
 AUTO_CONFIRM_MARGIN = 0.12
 
 

--- a/comic_pile/comicvine_identity_repair.py
+++ b/comic_pile/comicvine_identity_repair.py
@@ -13,19 +13,7 @@ AUTO_CONFIRM_MARGIN = 0.12
 
 @dataclass(frozen=True)
 class ComicVineRepairContext:
-    """ComicPile-side evidence used to evaluate one issue candidate.
-
-    Args:
-        title: Original ComicPile thread/title text.
-        issue_label: ComicPile issue number or human label such as ``Revival``.
-        publisher: Expected publisher when known.
-        start_year: Expected series/segment start year when known.
-        previous_issue_label: Neighboring ComicPile issue label before this issue.
-        next_issue_label: Neighboring ComicPile issue label after this issue.
-        repeated_cbl_count: Number of distinct CBL observations supporting this candidate.
-        snapshot_synced_at: Freshness boundary for the local ComicVine snapshot.
-        issue_expected_after: Date after which a missing local issue may simply be post-snapshot.
-    """
+    """ComicPile-side evidence used to evaluate one issue candidate."""
 
     title: str
     issue_label: str
@@ -75,31 +63,18 @@ class RepairDecision:
     winner: CandidateScore | None
     candidates: tuple[CandidateScore, ...]
     reason: str
+    rejected: tuple[CandidateScore, ...] = ()
 
 
 def normalize_title(value: str) -> str:
-    """Normalize a title for comparison while retaining caller-owned original strings.
-
-    Args:
-        value: Source title text.
-
-    Returns:
-        Case-folded alphanumeric words with punctuation/spacing normalized.
-    """
+    """Normalize a title for comparison while retaining caller-owned original strings."""
     normalized = unicodedata.normalize("NFKC", value).casefold()
     normalized = normalized.replace("&", " and ")
     return " ".join(re.findall(r"[\w]+", normalized, flags=re.UNICODE))
 
 
 def normalize_issue_label(value: str | None) -> str:
-    """Normalize issue numbers or human labels without assuming numeric-only issues.
-
-    Args:
-        value: Issue number/name text.
-
-    Returns:
-        Comparable normalized text.
-    """
+    """Normalize issue numbers or human labels without assuming numeric-only issues."""
     if value is None:
         return ""
     normalized = unicodedata.normalize("NFKC", value).strip().casefold()
@@ -113,40 +88,22 @@ def _snapshot_is_stale(context: ComicVineRepairContext) -> bool:
     return context.issue_expected_after > context.snapshot_synced_at.date()
 
 
-def score_candidate(
-    context: ComicVineRepairContext,
-    candidate: ComicVineCandidate,
-) -> CandidateScore:
-    """Score one issue-level candidate from locally validated evidence.
-
-    FTS/provider rank is intentionally absent from the inputs. A candidate must contain the
-    relevant issue number or issue name before it can receive a usable score.
-
-    Args:
-        context: ComicPile-side issue evidence.
-        candidate: One ComicVine issue candidate and its volume context.
-
-    Returns:
-        Explainable score, rejection reason, and snapshot-staleness marker.
-    """
+def score_candidate(context: ComicVineRepairContext, candidate: ComicVineCandidate) -> CandidateScore:
+    """Score one issue-level candidate from locally validated evidence."""
     evidence: list[str] = []
     score = 0.0
     expected_issue = normalize_issue_label(context.issue_label)
-    number_match = normalize_issue_label(candidate.issue_number) == expected_issue
-    name_match = normalize_issue_label(candidate.issue_name) == expected_issue
+    candidate_number = normalize_issue_label(candidate.issue_number)
+    candidate_name = normalize_issue_label(candidate.issue_name)
+    number_match = bool(expected_issue and candidate_number) and candidate_number == expected_issue
+    name_match = bool(expected_issue and candidate_name) and candidate_name == expected_issue
     stale_snapshot = _snapshot_is_stale(context)
 
     if not number_match and not name_match:
         reason = "candidate volume does not contain the ComicPile issue number or issue name"
         if stale_snapshot:
             reason = "local snapshot predates the expected issue; preserve unresolved for live refresh"
-        return CandidateScore(
-            candidate=candidate,
-            score=0.0,
-            evidence=("issue existence not validated",),
-            rejection_reason=reason,
-            stale_snapshot=stale_snapshot,
-        )
+        return CandidateScore(candidate, 0.0, ("issue existence not validated",), reason, stale_snapshot)
 
     if number_match:
         score += 0.34
@@ -154,13 +111,11 @@ def score_candidate(
     if name_match:
         score += 0.34
         evidence.append("issue name matches human label")
-
     if normalize_title(context.title) == normalize_title(candidate.volume_name):
         score += 0.22
         evidence.append("normalized title matches")
     else:
         evidence.append("normalized title differs")
-
     if context.publisher and candidate.publisher:
         if normalize_title(context.publisher) == normalize_title(candidate.publisher):
             score += 0.12
@@ -168,7 +123,6 @@ def score_candidate(
         else:
             score -= 0.18
             evidence.append("publisher conflicts")
-
     if context.start_year is not None and candidate.start_year is not None:
         if context.start_year == candidate.start_year:
             score += 0.1
@@ -179,30 +133,20 @@ def score_candidate(
         else:
             score -= 0.1
             evidence.append("start year conflicts")
-
     if context.previous_issue_label and candidate.previous_issue_exists:
         score += 0.06
         evidence.append("previous neighboring issue exists")
     if context.next_issue_label and candidate.next_issue_exists:
         score += 0.06
         evidence.append("next neighboring issue exists")
-
     if context.repeated_cbl_count > 0:
         bonus = min(context.repeated_cbl_count, 3) * 0.04
         score += bonus
         evidence.append(f"supported by {context.repeated_cbl_count} distinct CBL observation(s)")
-
     if stale_snapshot:
         evidence.append("local snapshot predates expected issue")
 
-    bounded_score = max(0.0, min(1.0, round(score, 4)))
-    return CandidateScore(
-        candidate=candidate,
-        score=bounded_score,
-        evidence=tuple(evidence),
-        rejection_reason=None,
-        stale_snapshot=stale_snapshot,
-    )
+    return CandidateScore(candidate, max(0.0, min(1.0, round(score, 4))), tuple(evidence), None, stale_snapshot)
 
 
 def decide_candidates(
@@ -211,73 +155,24 @@ def decide_candidates(
     existing_confirmed_issue_id: int | None = None,
     embedded_cbl_issue_id: int | None = None,
 ) -> RepairDecision:
-    """Choose a safe mapping state from scored candidates and stronger identity evidence.
-
-    Resolution order is exact embedded CBL ID, existing confirmed mapping, then scored candidates.
-    Scored candidates auto-confirm only when the best candidate is independently strong and clearly
-    separated from the runner-up. Otherwise all valid candidates remain reviewable.
-
-    Args:
-        scores: Candidate scores from local/live provider evidence.
-        existing_confirmed_issue_id: Existing confirmed ComicVine issue mapping, if any.
-        embedded_cbl_issue_id: Exact ComicVine issue ID embedded in CBL evidence, if valid.
-
-    Returns:
-        A deterministic confirmed/candidate/unresolved decision.
-    """
-    usable = tuple(
-        sorted(
-            (score for score in scores if score.rejection_reason is None),
-            key=lambda item: (-item.score, item.candidate.issue_id),
-        )
-    )
+    """Choose a safe mapping state from scored candidates and stronger identity evidence."""
+    usable = tuple(sorted((s for s in scores if s.rejection_reason is None), key=lambda s: (-s.score, s.candidate.issue_id)))
+    rejected = tuple(sorted((s for s in scores if s.rejection_reason is not None), key=lambda s: s.candidate.issue_id))
 
     if embedded_cbl_issue_id is not None:
-        winner = next(
-            (score for score in usable if score.candidate.issue_id == embedded_cbl_issue_id),
-            None,
-        )
+        winner = next((s for s in usable if s.candidate.issue_id == embedded_cbl_issue_id), None)
         if winner is not None:
-            return RepairDecision(
-                status="confirmed",
-                winner=winner,
-                candidates=usable,
-                reason="exact embedded CBL ComicVine issue ID validated against candidate evidence",
-            )
-
+            return RepairDecision("confirmed", winner, usable, "exact embedded CBL ComicVine issue ID validated against candidate evidence", rejected)
     if existing_confirmed_issue_id is not None:
-        winner = next(
-            (score for score in usable if score.candidate.issue_id == existing_confirmed_issue_id),
-            None,
-        )
-        return RepairDecision(
-            status="confirmed",
-            winner=winner,
-            candidates=usable,
-            reason="preserved existing confirmed ComicVine issue mapping",
-        )
-
+        winner = next((s for s in usable if s.candidate.issue_id == existing_confirmed_issue_id), None)
+        return RepairDecision("confirmed", winner, usable, "preserved existing confirmed ComicVine issue mapping", rejected)
     if not usable:
-        if any(score.stale_snapshot for score in scores):
-            reason = "no validated local candidate; snapshot may be stale, so live refresh is required"
-        else:
-            reason = "no validated ComicVine candidate"
-        return RepairDecision(status="unresolved", winner=None, candidates=(), reason=reason)
+        reason = "no validated local candidate; snapshot may be stale, so live refresh is required" if any(s.stale_snapshot for s in scores) else "no validated ComicVine candidate"
+        return RepairDecision("unresolved", None, (), reason, rejected)
 
     best = usable[0]
     runner_up = usable[1] if len(usable) > 1 else None
     margin = best.score - runner_up.score if runner_up is not None else best.score
     if best.score >= AUTO_CONFIRM_THRESHOLD and margin >= AUTO_CONFIRM_MARGIN:
-        return RepairDecision(
-            status="confirmed",
-            winner=best,
-            candidates=usable,
-            reason="top locally validated candidate is strong and unambiguous",
-        )
-
-    return RepairDecision(
-        status="candidate",
-        winner=None,
-        candidates=usable,
-        reason="multiple or insufficiently strong candidates require explicit review",
-    )
+        return RepairDecision("confirmed", best, usable, "top locally validated candidate is strong and unambiguous", rejected)
+    return RepairDecision("candidate", None, usable, "multiple or insufficiently strong candidates require explicit review", rejected)

--- a/comic_pile/comicvine_identity_repair.py
+++ b/comic_pile/comicvine_identity_repair.py
@@ -1,0 +1,283 @@
+"""Confidence-aware ComicVine identity repair and candidate selection."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+from datetime import date, datetime
+
+AUTO_CONFIRM_THRESHOLD = 0.82
+AUTO_CONFIRM_MARGIN = 0.12
+
+
+@dataclass(frozen=True)
+class ComicVineRepairContext:
+    """ComicPile-side evidence used to evaluate one issue candidate.
+
+    Args:
+        title: Original ComicPile thread/title text.
+        issue_label: ComicPile issue number or human label such as ``Revival``.
+        publisher: Expected publisher when known.
+        start_year: Expected series/segment start year when known.
+        previous_issue_label: Neighboring ComicPile issue label before this issue.
+        next_issue_label: Neighboring ComicPile issue label after this issue.
+        repeated_cbl_count: Number of distinct CBL observations supporting this candidate.
+        snapshot_synced_at: Freshness boundary for the local ComicVine snapshot.
+        issue_expected_after: Date after which a missing local issue may simply be post-snapshot.
+    """
+
+    title: str
+    issue_label: str
+    publisher: str | None = None
+    start_year: int | None = None
+    previous_issue_label: str | None = None
+    next_issue_label: str | None = None
+    repeated_cbl_count: int = 0
+    snapshot_synced_at: datetime | None = None
+    issue_expected_after: date | None = None
+
+
+@dataclass(frozen=True)
+class ComicVineCandidate:
+    """Locally validated ComicVine issue/volume evidence for one candidate mapping."""
+
+    issue_id: int
+    volume_id: int
+    volume_name: str
+    issue_number: str | None
+    issue_name: str | None = None
+    publisher: str | None = None
+    start_year: int | None = None
+    previous_issue_exists: bool = False
+    next_issue_exists: bool = False
+    source: str = "comicvine-local-sqlite"
+    segment_start: str | None = None
+    segment_end: str | None = None
+
+
+@dataclass(frozen=True)
+class CandidateScore:
+    """Deterministic candidate score with human-readable evidence."""
+
+    candidate: ComicVineCandidate
+    score: float
+    evidence: tuple[str, ...]
+    rejection_reason: str | None
+    stale_snapshot: bool
+
+
+@dataclass(frozen=True)
+class RepairDecision:
+    """Resolution decision that never promotes an ambiguous candidate silently."""
+
+    status: str
+    winner: CandidateScore | None
+    candidates: tuple[CandidateScore, ...]
+    reason: str
+
+
+def normalize_title(value: str) -> str:
+    """Normalize a title for comparison while retaining caller-owned original strings.
+
+    Args:
+        value: Source title text.
+
+    Returns:
+        Case-folded alphanumeric words with punctuation/spacing normalized.
+    """
+    normalized = unicodedata.normalize("NFKC", value).casefold()
+    normalized = normalized.replace("&", " and ")
+    return " ".join(re.findall(r"[\w]+", normalized, flags=re.UNICODE))
+
+
+def normalize_issue_label(value: str | None) -> str:
+    """Normalize issue numbers or human labels without assuming numeric-only issues.
+
+    Args:
+        value: Issue number/name text.
+
+    Returns:
+        Comparable normalized text.
+    """
+    if value is None:
+        return ""
+    normalized = unicodedata.normalize("NFKC", value).strip().casefold()
+    normalized = normalized.removeprefix("#").strip()
+    return " ".join(normalized.split())
+
+
+def _snapshot_is_stale(context: ComicVineRepairContext) -> bool:
+    if context.snapshot_synced_at is None or context.issue_expected_after is None:
+        return False
+    return context.issue_expected_after > context.snapshot_synced_at.date()
+
+
+def score_candidate(
+    context: ComicVineRepairContext,
+    candidate: ComicVineCandidate,
+) -> CandidateScore:
+    """Score one issue-level candidate from locally validated evidence.
+
+    FTS/provider rank is intentionally absent from the inputs. A candidate must contain the
+    relevant issue number or issue name before it can receive a usable score.
+
+    Args:
+        context: ComicPile-side issue evidence.
+        candidate: One ComicVine issue candidate and its volume context.
+
+    Returns:
+        Explainable score, rejection reason, and snapshot-staleness marker.
+    """
+    evidence: list[str] = []
+    score = 0.0
+    expected_issue = normalize_issue_label(context.issue_label)
+    number_match = normalize_issue_label(candidate.issue_number) == expected_issue
+    name_match = normalize_issue_label(candidate.issue_name) == expected_issue
+    stale_snapshot = _snapshot_is_stale(context)
+
+    if not number_match and not name_match:
+        reason = "candidate volume does not contain the ComicPile issue number or issue name"
+        if stale_snapshot:
+            reason = "local snapshot predates the expected issue; preserve unresolved for live refresh"
+        return CandidateScore(
+            candidate=candidate,
+            score=0.0,
+            evidence=("issue existence not validated",),
+            rejection_reason=reason,
+            stale_snapshot=stale_snapshot,
+        )
+
+    if number_match:
+        score += 0.34
+        evidence.append("issue number matches")
+    if name_match:
+        score += 0.34
+        evidence.append("issue name matches human label")
+
+    if normalize_title(context.title) == normalize_title(candidate.volume_name):
+        score += 0.22
+        evidence.append("normalized title matches")
+    else:
+        evidence.append("normalized title differs")
+
+    if context.publisher and candidate.publisher:
+        if normalize_title(context.publisher) == normalize_title(candidate.publisher):
+            score += 0.12
+            evidence.append("publisher matches")
+        else:
+            score -= 0.18
+            evidence.append("publisher conflicts")
+
+    if context.start_year is not None and candidate.start_year is not None:
+        if context.start_year == candidate.start_year:
+            score += 0.1
+            evidence.append("start year matches")
+        elif abs(context.start_year - candidate.start_year) <= 1:
+            score += 0.04
+            evidence.append("start year is adjacent")
+        else:
+            score -= 0.1
+            evidence.append("start year conflicts")
+
+    if context.previous_issue_label and candidate.previous_issue_exists:
+        score += 0.06
+        evidence.append("previous neighboring issue exists")
+    if context.next_issue_label and candidate.next_issue_exists:
+        score += 0.06
+        evidence.append("next neighboring issue exists")
+
+    if context.repeated_cbl_count > 0:
+        bonus = min(context.repeated_cbl_count, 3) * 0.04
+        score += bonus
+        evidence.append(f"supported by {context.repeated_cbl_count} distinct CBL observation(s)")
+
+    if stale_snapshot:
+        evidence.append("local snapshot predates expected issue")
+
+    bounded_score = max(0.0, min(1.0, round(score, 4)))
+    return CandidateScore(
+        candidate=candidate,
+        score=bounded_score,
+        evidence=tuple(evidence),
+        rejection_reason=None,
+        stale_snapshot=stale_snapshot,
+    )
+
+
+def decide_candidates(
+    scores: list[CandidateScore],
+    *,
+    existing_confirmed_issue_id: int | None = None,
+    embedded_cbl_issue_id: int | None = None,
+) -> RepairDecision:
+    """Choose a safe mapping state from scored candidates and stronger identity evidence.
+
+    Resolution order is exact embedded CBL ID, existing confirmed mapping, then scored candidates.
+    Scored candidates auto-confirm only when the best candidate is independently strong and clearly
+    separated from the runner-up. Otherwise all valid candidates remain reviewable.
+
+    Args:
+        scores: Candidate scores from local/live provider evidence.
+        existing_confirmed_issue_id: Existing confirmed ComicVine issue mapping, if any.
+        embedded_cbl_issue_id: Exact ComicVine issue ID embedded in CBL evidence, if valid.
+
+    Returns:
+        A deterministic confirmed/candidate/unresolved decision.
+    """
+    usable = tuple(
+        sorted(
+            (score for score in scores if score.rejection_reason is None),
+            key=lambda item: (-item.score, item.candidate.issue_id),
+        )
+    )
+
+    if embedded_cbl_issue_id is not None:
+        winner = next(
+            (score for score in usable if score.candidate.issue_id == embedded_cbl_issue_id),
+            None,
+        )
+        if winner is not None:
+            return RepairDecision(
+                status="confirmed",
+                winner=winner,
+                candidates=usable,
+                reason="exact embedded CBL ComicVine issue ID validated against candidate evidence",
+            )
+
+    if existing_confirmed_issue_id is not None:
+        winner = next(
+            (score for score in usable if score.candidate.issue_id == existing_confirmed_issue_id),
+            None,
+        )
+        return RepairDecision(
+            status="confirmed",
+            winner=winner,
+            candidates=usable,
+            reason="preserved existing confirmed ComicVine issue mapping",
+        )
+
+    if not usable:
+        if any(score.stale_snapshot for score in scores):
+            reason = "no validated local candidate; snapshot may be stale, so live refresh is required"
+        else:
+            reason = "no validated ComicVine candidate"
+        return RepairDecision(status="unresolved", winner=None, candidates=(), reason=reason)
+
+    best = usable[0]
+    runner_up = usable[1] if len(usable) > 1 else None
+    margin = best.score - runner_up.score if runner_up is not None else best.score
+    if best.score >= AUTO_CONFIRM_THRESHOLD and margin >= AUTO_CONFIRM_MARGIN:
+        return RepairDecision(
+            status="confirmed",
+            winner=best,
+            candidates=usable,
+            reason="top locally validated candidate is strong and unambiguous",
+        )
+
+    return RepairDecision(
+        status="candidate",
+        winner=None,
+        candidates=usable,
+        reason="multiple or insufficiently strong candidates require explicit review",
+    )

--- a/comic_pile/comicvine_repair_pipeline.py
+++ b/comic_pile/comicvine_repair_pipeline.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 from comic_pile.comicvine_candidate_discovery import discover_local_candidates
 from comic_pile.comicvine_identity_repair import (
     CandidateScore,
@@ -33,10 +35,12 @@ def _publisher_name(value: object) -> str | None:
     return None
 
 
-def _live_candidate(
+def _candidate_from_rows(
     volume: dict[str, object],
     issue: dict[str, object],
     context: ComicVineRepairContext,
+    *,
+    source: str,
 ) -> ComicVineCandidate | None:
     volume_id = _integer(volume.get("id"))
     issue_id = _integer(issue.get("id"))
@@ -61,8 +65,57 @@ def _live_candidate(
         issue_name=issue_name,
         publisher=_publisher_name(volume.get("publisher")),
         start_year=_integer(volume.get("start_year")),
-        source="comicvine-live",
+        source=source,
     )
+
+
+def _object_result(payload: dict[str, object], resource: str) -> dict[str, object]:
+    result = payload.get("results")
+    if not isinstance(result, dict):
+        raise ComicVineError(f"ComicVine {resource} response did not contain an object result")
+    return cast(dict[str, object], result)
+
+
+def _exact_local_candidate(
+    snapshot: LocalComicVineSnapshot,
+    issue_id: int,
+    context: ComicVineRepairContext,
+) -> ComicVineCandidate | None:
+    issue = snapshot.get_issue(issue_id)
+    if issue is None:
+        return None
+    volume_id = _integer(issue.data.get("volume_id"))
+    if volume_id is None:
+        return None
+    volume = snapshot.get_volume(volume_id)
+    if volume is None:
+        return None
+    issue_row = {**issue.data, "id": issue_id}
+    volume_row = {**volume.data, "id": volume_id}
+    return _candidate_from_rows(
+        volume_row,
+        issue_row,
+        context,
+        source="comicvine-local-sqlite",
+    )
+
+
+async def _exact_live_candidate(
+    client: ComicVineClient,
+    issue_id: int,
+    context: ComicVineRepairContext,
+) -> ComicVineCandidate | None:
+    issue_response = await client.fetch_issue(issue_id)
+    issue = _object_result(issue_response.payload, "issue")
+    volume_ref = issue.get("volume")
+    if not isinstance(volume_ref, dict):
+        return None
+    volume_id = _integer(volume_ref.get("id"))
+    if volume_id is None:
+        return None
+    volume_response = await client.fetch_volume(volume_id)
+    volume = _object_result(volume_response.payload, "volume")
+    return _candidate_from_rows(volume, issue, context, source="comicvine-live")
 
 
 async def discover_live_candidates(
@@ -73,8 +126,8 @@ async def discover_live_candidates(
 ) -> list[ComicVineCandidate]:
     """Search live ComicVine only after local evidence is insufficient.
 
-    Provider search rank is treated only as discovery. Each candidate volume is locally validated
-    against the issue roster returned by ``/issues`` before it can be scored.
+    Provider search rank is treated only as discovery. Each candidate volume is validated against
+    the issue roster returned by ``/issues`` before it can be scored.
 
     Args:
         client: Endpoint-budgeted ComicVine client.
@@ -111,7 +164,7 @@ async def discover_live_candidates(
             continue
         issues = await client.fetch_volume_issues(volume_id)
         for issue in issues:
-            candidate = _live_candidate(row, issue, context)
+            candidate = _candidate_from_rows(row, issue, context, source="comicvine-live")
             if candidate is None or candidate.issue_id in seen:
                 continue
             seen.add(candidate.issue_id)
@@ -135,25 +188,36 @@ async def repair_identity(
         client: Live provider client; required only when local evidence is insufficient.
         context: ComicPile-side issue evidence.
         thread_issue_labels: Ordered labels for local segment discovery.
-        existing_confirmed_issue_id: Existing confirmed mapping to preserve.
+        existing_confirmed_issue_id: Existing confirmed mapping to preserve without search.
         embedded_cbl_issue_id: Exact CBL-embedded ComicVine issue identity.
 
     Returns:
         Safe resolution decision plus every scored candidate used to reach it.
     """
-    local = discover_local_candidates(
+    if existing_confirmed_issue_id is not None:
+        decision = decide_candidates([], existing_confirmed_issue_id=existing_confirmed_issue_id)
+        return decision, ()
+
+    if embedded_cbl_issue_id is not None:
+        exact = _exact_local_candidate(snapshot, embedded_cbl_issue_id, context)
+        if exact is None and client is not None:
+            exact = await _exact_live_candidate(client, embedded_cbl_issue_id, context)
+        if exact is not None:
+            score = score_candidate(context, exact)
+            decision = decide_candidates(
+                [score],
+                embedded_cbl_issue_id=embedded_cbl_issue_id,
+            )
+            return decision, (score,)
+
+    candidates = discover_local_candidates(
         snapshot,
         context,
         thread_issue_labels=thread_issue_labels,
     )
-    candidates = local
     if not candidates and client is not None:
         candidates = await discover_live_candidates(client, context)
 
     scores = tuple(score_candidate(context, candidate) for candidate in candidates)
-    decision = decide_candidates(
-        list(scores),
-        existing_confirmed_issue_id=existing_confirmed_issue_id,
-        embedded_cbl_issue_id=embedded_cbl_issue_id,
-    )
+    decision = decide_candidates(list(scores))
     return decision, scores

--- a/comic_pile/comicvine_repair_pipeline.py
+++ b/comic_pile/comicvine_repair_pipeline.py
@@ -1,0 +1,159 @@
+"""Local-first ComicVine identity repair pipeline with bounded live fallback."""
+
+from __future__ import annotations
+
+from comic_pile.comicvine_candidate_discovery import discover_local_candidates
+from comic_pile.comicvine_identity_repair import (
+    CandidateScore,
+    ComicVineCandidate,
+    ComicVineRepairContext,
+    RepairDecision,
+    decide_candidates,
+    normalize_issue_label,
+    score_candidate,
+)
+from comic_pile.comicvine_provider import ComicVineClient, ComicVineError
+from comic_pile.local_comicvine import LocalComicVineSnapshot
+
+
+def _integer(value: object) -> int | None:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return None
+
+
+def _publisher_name(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    if isinstance(value, dict):
+        name = value.get("name")
+        return name.strip() if isinstance(name, str) and name.strip() else None
+    return None
+
+
+def _live_candidate(
+    volume: dict[str, object],
+    issue: dict[str, object],
+    context: ComicVineRepairContext,
+) -> ComicVineCandidate | None:
+    volume_id = _integer(volume.get("id"))
+    issue_id = _integer(issue.get("id"))
+    volume_name = volume.get("name")
+    if volume_id is None or issue_id is None or not isinstance(volume_name, str):
+        return None
+    issue_number_value = issue.get("issue_number")
+    issue_name_value = issue.get("name")
+    issue_number = str(issue_number_value) if issue_number_value is not None else None
+    issue_name = issue_name_value if isinstance(issue_name_value, str) else None
+    expected = normalize_issue_label(context.issue_label)
+    if expected not in {
+        normalize_issue_label(issue_number),
+        normalize_issue_label(issue_name),
+    }:
+        return None
+    return ComicVineCandidate(
+        issue_id=issue_id,
+        volume_id=volume_id,
+        volume_name=volume_name,
+        issue_number=issue_number,
+        issue_name=issue_name,
+        publisher=_publisher_name(volume.get("publisher")),
+        start_year=_integer(volume.get("start_year")),
+        source="comicvine-live",
+    )
+
+
+async def discover_live_candidates(
+    client: ComicVineClient,
+    context: ComicVineRepairContext,
+    *,
+    limit: int = 10,
+) -> list[ComicVineCandidate]:
+    """Search live ComicVine only after local evidence is insufficient.
+
+    Provider search rank is treated only as discovery. Each candidate volume is locally validated
+    against the issue roster returned by ``/issues`` before it can be scored.
+
+    Args:
+        client: Endpoint-budgeted ComicVine client.
+        context: ComicPile-side issue evidence.
+        limit: Maximum search result volumes to inspect.
+
+    Returns:
+        Validated live issue candidates sorted by stable provider IDs.
+
+    Raises:
+        ComicVineError: If the search payload is structurally invalid.
+    """
+    response = await client.request(
+        "search",
+        "search",
+        {
+            "query": context.title,
+            "resources": "volume",
+            "limit": max(1, min(limit, 100)),
+            "field_list": "id,name,publisher,start_year",
+        },
+    )
+    results = response.payload.get("results")
+    if not isinstance(results, list):
+        raise ComicVineError("ComicVine /search response did not contain a results list")
+
+    candidates: list[ComicVineCandidate] = []
+    seen: set[int] = set()
+    for row in results:
+        if not isinstance(row, dict):
+            continue
+        volume_id = _integer(row.get("id"))
+        if volume_id is None:
+            continue
+        issues = await client.fetch_volume_issues(volume_id)
+        for issue in issues:
+            candidate = _live_candidate(row, issue, context)
+            if candidate is None or candidate.issue_id in seen:
+                continue
+            seen.add(candidate.issue_id)
+            candidates.append(candidate)
+    return sorted(candidates, key=lambda candidate: (candidate.volume_id, candidate.issue_id))
+
+
+async def repair_identity(
+    *,
+    snapshot: LocalComicVineSnapshot,
+    client: ComicVineClient | None,
+    context: ComicVineRepairContext,
+    thread_issue_labels: list[str],
+    existing_confirmed_issue_id: int | None = None,
+    embedded_cbl_issue_id: int | None = None,
+) -> tuple[RepairDecision, tuple[CandidateScore, ...]]:
+    """Resolve one issue using exact evidence, local candidates, then bounded live fallback.
+
+    Args:
+        snapshot: Optional developer-local ComicVine snapshot.
+        client: Live provider client; required only when local evidence is insufficient.
+        context: ComicPile-side issue evidence.
+        thread_issue_labels: Ordered labels for local segment discovery.
+        existing_confirmed_issue_id: Existing confirmed mapping to preserve.
+        embedded_cbl_issue_id: Exact CBL-embedded ComicVine issue identity.
+
+    Returns:
+        Safe resolution decision plus every scored candidate used to reach it.
+    """
+    local = discover_local_candidates(
+        snapshot,
+        context,
+        thread_issue_labels=thread_issue_labels,
+    )
+    candidates = local
+    if not candidates and client is not None:
+        candidates = await discover_live_candidates(client, context)
+
+    scores = tuple(score_candidate(context, candidate) for candidate in candidates)
+    decision = decide_candidates(
+        list(scores),
+        existing_confirmed_issue_id=existing_confirmed_issue_id,
+        embedded_cbl_issue_id=embedded_cbl_issue_id,
+    )
+    return decision, scores

--- a/comic_pile/comicvine_repair_pipeline.py
+++ b/comic_pile/comicvine_repair_pipeline.py
@@ -36,11 +36,7 @@ def _publisher_name(value: object) -> str | None:
 
 
 def _candidate_from_rows(
-    volume: dict[str, object],
-    issue: dict[str, object],
-    context: ComicVineRepairContext,
-    *,
-    source: str,
+    volume: dict[str, object], issue: dict[str, object], context: ComicVineRepairContext, *, source: str
 ) -> ComicVineCandidate | None:
     volume_id = _integer(volume.get("id"))
     issue_id = _integer(issue.get("id"))
@@ -52,10 +48,7 @@ def _candidate_from_rows(
     issue_number = str(issue_number_value) if issue_number_value is not None else None
     issue_name = issue_name_value if isinstance(issue_name_value, str) else None
     expected = normalize_issue_label(context.issue_label)
-    if expected not in {
-        normalize_issue_label(issue_number),
-        normalize_issue_label(issue_name),
-    }:
+    if not expected or expected not in {normalize_issue_label(issue_number), normalize_issue_label(issue_name)}:
         return None
     return ComicVineCandidate(
         issue_id=issue_id,
@@ -76,11 +69,7 @@ def _object_result(payload: dict[str, object], resource: str) -> dict[str, objec
     return cast(dict[str, object], result)
 
 
-def _exact_local_candidate(
-    snapshot: LocalComicVineSnapshot,
-    issue_id: int,
-    context: ComicVineRepairContext,
-) -> ComicVineCandidate | None:
+def _exact_local_candidate(snapshot: LocalComicVineSnapshot, issue_id: int, context: ComicVineRepairContext) -> ComicVineCandidate | None:
     issue = snapshot.get_issue(issue_id)
     if issue is None:
         return None
@@ -90,21 +79,10 @@ def _exact_local_candidate(
     volume = snapshot.get_volume(volume_id)
     if volume is None:
         return None
-    issue_row = {**issue.data, "id": issue_id}
-    volume_row = {**volume.data, "id": volume_id}
-    return _candidate_from_rows(
-        volume_row,
-        issue_row,
-        context,
-        source="comicvine-local-sqlite",
-    )
+    return _candidate_from_rows({**volume.data, "id": volume_id}, {**issue.data, "id": issue_id}, context, source="comicvine-local-sqlite")
 
 
-async def _exact_live_candidate(
-    client: ComicVineClient,
-    issue_id: int,
-    context: ComicVineRepairContext,
-) -> ComicVineCandidate | None:
+async def _exact_live_candidate(client: ComicVineClient, issue_id: int, context: ComicVineRepairContext) -> ComicVineCandidate | None:
     issue_response = await client.fetch_issue(issue_id)
     issue = _object_result(issue_response.payload, "issue")
     volume_ref = issue.get("volume")
@@ -123,23 +101,9 @@ async def discover_live_candidates(
     context: ComicVineRepairContext,
     *,
     limit: int = 10,
+    max_rostered_volumes: int = 3,
 ) -> list[ComicVineCandidate]:
-    """Search live ComicVine only after local evidence is insufficient.
-
-    Provider search rank is treated only as discovery. Each candidate volume is validated against
-    the issue roster returned by ``/issues`` before it can be scored.
-
-    Args:
-        client: Endpoint-budgeted ComicVine client.
-        context: ComicPile-side issue evidence.
-        limit: Maximum search result volumes to inspect.
-
-    Returns:
-        Validated live issue candidates sorted by stable provider IDs.
-
-    Raises:
-        ComicVineError: If the search payload is structurally invalid.
-    """
+    """Search live ComicVine with a fixed cap on rostered volume requests."""
     response = await client.request(
         "search",
         "search",
@@ -156,12 +120,16 @@ async def discover_live_candidates(
 
     candidates: list[ComicVineCandidate] = []
     seen: set[int] = set()
+    rostered = 0
     for row in results:
         if not isinstance(row, dict):
             continue
         volume_id = _integer(row.get("id"))
         if volume_id is None:
             continue
+        if rostered >= max(0, max_rostered_volumes):
+            break
+        rostered += 1
         issues = await client.fetch_volume_issues(volume_id)
         for issue in issues:
             candidate = _candidate_from_rows(row, issue, context, source="comicvine-live")
@@ -181,43 +149,19 @@ async def repair_identity(
     existing_confirmed_issue_id: int | None = None,
     embedded_cbl_issue_id: int | None = None,
 ) -> tuple[RepairDecision, tuple[CandidateScore, ...]]:
-    """Resolve one issue using exact evidence, local candidates, then bounded live fallback.
-
-    Args:
-        snapshot: Optional developer-local ComicVine snapshot.
-        client: Live provider client; required only when local evidence is insufficient.
-        context: ComicPile-side issue evidence.
-        thread_issue_labels: Ordered labels for local segment discovery.
-        existing_confirmed_issue_id: Existing confirmed mapping to preserve without search.
-        embedded_cbl_issue_id: Exact CBL-embedded ComicVine issue identity.
-
-    Returns:
-        Safe resolution decision plus every scored candidate used to reach it.
-    """
+    """Resolve one issue using exact evidence, local candidates, then bounded live fallback."""
     if existing_confirmed_issue_id is not None:
-        decision = decide_candidates([], existing_confirmed_issue_id=existing_confirmed_issue_id)
-        return decision, ()
-
+        return decide_candidates([], existing_confirmed_issue_id=existing_confirmed_issue_id), ()
     if embedded_cbl_issue_id is not None:
         exact = _exact_local_candidate(snapshot, embedded_cbl_issue_id, context)
         if exact is None and client is not None:
             exact = await _exact_live_candidate(client, embedded_cbl_issue_id, context)
         if exact is not None:
             score = score_candidate(context, exact)
-            decision = decide_candidates(
-                [score],
-                embedded_cbl_issue_id=embedded_cbl_issue_id,
-            )
-            return decision, (score,)
+            return decide_candidates([score], embedded_cbl_issue_id=embedded_cbl_issue_id), (score,)
 
-    candidates = discover_local_candidates(
-        snapshot,
-        context,
-        thread_issue_labels=thread_issue_labels,
-    )
+    candidates = discover_local_candidates(snapshot, context, thread_issue_labels=thread_issue_labels)
     if not candidates and client is not None:
         candidates = await discover_live_candidates(client, context)
-
     scores = tuple(score_candidate(context, candidate) for candidate in candidates)
-    decision = decide_candidates(list(scores))
-    return decision, scores
+    return decide_candidates(list(scores)), scores

--- a/comic_pile/local_comicvine.py
+++ b/comic_pile/local_comicvine.py
@@ -72,10 +72,7 @@ class LocalComicVineSnapshot:
                 "comicvine_id",
                 f"{table.removeprefix('cv_')}_id",
             )
-            id_column = next(
-                (candidate for candidate in id_candidates if candidate in columns),
-                None,
-            )
+            id_column = next((candidate for candidate in id_candidates if candidate in columns), None)
             if id_column is None:
                 return None
             row = connection.execute(
@@ -97,14 +94,7 @@ class LocalComicVineSnapshot:
         return self._lookup("cv_issue", issue_id, ("volume_id", "issue_number"))
 
     def get_volume_issues(self, volume_id: int) -> list[LocalComicVineResult]:
-        """Return every locally cached issue in one ComicVine volume.
-
-        Args:
-            volume_id: ComicVine volume identity.
-
-        Returns:
-            Issue rows in stable numeric-ID order, or an empty list when unavailable.
-        """
+        """Return every locally cached issue in one ComicVine volume."""
         if not self.available:
             return []
         with self._connect() as connection:
@@ -116,26 +106,28 @@ class LocalComicVineSnapshot:
                 f"SELECT * FROM cv_issue WHERE volume_id = ? ORDER BY {order_column}",
                 (volume_id,),
             ).fetchall()
-        return [
-            LocalComicVineResult(data=self._normalize_row(row), complete=True)
-            for row in rows
-        ]
+        return [LocalComicVineResult(data=self._normalize_row(row), complete=True) for row in rows]
 
     def search_volumes(self, query: str, *, limit: int = 10) -> list[LocalComicVineResult]:
-        """Return ranked local candidates without treating rank as identity confirmation."""
+        """Return ranked local candidates only when FTS rowid is the ComicVine volume ID."""
         if not self.available or not query.strip() or limit <= 0:
             return []
         with self._connect() as connection:
-            fts_tables = [
-                row[0]
-                for row in connection.execute(
-                    "SELECT name FROM sqlite_master "
-                    "WHERE type='table' AND name LIKE 'cv_volume%fts%'"
-                )
-            ]
-            if not fts_tables:
+            fts_rows = connection.execute(
+                "SELECT name, sql FROM sqlite_master "
+                "WHERE type='table' AND name LIKE 'cv_volume%fts%'"
+            ).fetchall()
+            table = None
+            for row in fts_rows:
+                sql = row[1]
+                if not isinstance(sql, str):
+                    continue
+                normalized_sql = "".join(sql.casefold().split()).replace('"', "'")
+                if "content='cv_volume'" in normalized_sql and "content_rowid='id'" in normalized_sql:
+                    table = row[0]
+                    break
+            if table is None:
                 return []
-            table = fts_tables[0]
             rows = connection.execute(
                 f"SELECT rowid AS id, *, bm25({table}) AS rank FROM {table} "
                 f"WHERE {table} MATCH ? ORDER BY rank LIMIT ?",

--- a/comic_pile/local_comicvine.py
+++ b/comic_pile/local_comicvine.py
@@ -96,6 +96,31 @@ class LocalComicVineSnapshot:
         """Look up one issue by ComicVine ID, including decoded relationship JSON."""
         return self._lookup("cv_issue", issue_id, ("volume_id", "issue_number"))
 
+    def get_volume_issues(self, volume_id: int) -> list[LocalComicVineResult]:
+        """Return every locally cached issue in one ComicVine volume.
+
+        Args:
+            volume_id: ComicVine volume identity.
+
+        Returns:
+            Issue rows in stable numeric-ID order, or an empty list when unavailable.
+        """
+        if not self.available:
+            return []
+        with self._connect() as connection:
+            columns = {row[1] for row in connection.execute("PRAGMA table_info(cv_issue)")}
+            if "volume_id" not in columns:
+                return []
+            order_column = "id" if "id" in columns else "issue_number"
+            rows = connection.execute(
+                f"SELECT * FROM cv_issue WHERE volume_id = ? ORDER BY {order_column}",
+                (volume_id,),
+            ).fetchall()
+        return [
+            LocalComicVineResult(data=self._normalize_row(row), complete=True)
+            for row in rows
+        ]
+
     def search_volumes(self, query: str, *, limit: int = 10) -> list[LocalComicVineResult]:
         """Return ranked local candidates without treating rank as identity confirmation."""
         if not self.available or not query.strip() or limit <= 0:
@@ -112,7 +137,7 @@ class LocalComicVineSnapshot:
                 return []
             table = fts_tables[0]
             rows = connection.execute(
-                f"SELECT *, bm25({table}) AS rank FROM {table} "
+                f"SELECT rowid AS id, *, bm25({table}) AS rank FROM {table} "
                 f"WHERE {table} MATCH ? ORDER BY rank LIMIT ?",
                 (query, limit),
             ).fetchall()

--- a/docs/changelog.d/2026-08-10-1049.md
+++ b/docs/changelog.d/2026-08-10-1049.md
@@ -1,0 +1,5 @@
+## 2026-08-10
+
+### Comic metadata
+
+- [#1049](https://github.com/JoshCLWren/comic-pile/pull/1049) adds confidence-aware ComicVine identity repair that validates issue-level evidence, preserves ambiguous candidates for review, recognizes stale local snapshots, and avoids forcing an entire reading thread into one provider volume.

--- a/tests/test_comicvine_candidate_discovery.py
+++ b/tests/test_comicvine_candidate_discovery.py
@@ -1,0 +1,85 @@
+"""Tests for local ComicVine identity candidate discovery."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from comic_pile.comicvine_candidate_discovery import discover_local_candidates, snapshot_sync_time
+from comic_pile.comicvine_identity_repair import ComicVineRepairContext
+from comic_pile.local_comicvine import LocalComicVineSnapshot
+
+
+def _build_fixture(path: Path) -> None:
+    connection = sqlite3.connect(path)
+    connection.executescript(
+        """
+        CREATE TABLE cv_volume (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            publisher TEXT,
+            start_year INTEGER
+        );
+        CREATE TABLE cv_issue (
+            id INTEGER PRIMARY KEY,
+            volume_id INTEGER NOT NULL,
+            issue_number TEXT NOT NULL,
+            name TEXT
+        );
+        CREATE VIRTUAL TABLE cv_volume_fts USING fts5(name, content='cv_volume', content_rowid='id');
+        CREATE TABLE cv_sync_metadata (key TEXT, value TEXT);
+
+        INSERT INTO cv_volume VALUES (10, 'Justice League America', 'DC Comics', 1987);
+        INSERT INTO cv_volume VALUES (20, 'Justice League America', 'Foreign Reprints', 2002);
+        INSERT INTO cv_issue VALUES (101, 10, '1', NULL);
+        INSERT INTO cv_issue VALUES (102, 10, '2', NULL);
+        INSERT INTO cv_issue VALUES (103, 10, '3', NULL);
+        INSERT INTO cv_issue VALUES (201, 20, '2', NULL);
+        INSERT INTO cv_volume_fts(rowid, name) VALUES (10, 'Justice League America');
+        INSERT INTO cv_volume_fts(rowid, name) VALUES (20, 'Justice League America');
+        INSERT INTO cv_sync_metadata VALUES ('last_sync', '2026-01-09T00:00:00Z');
+        """
+    )
+    connection.commit()
+    connection.close()
+
+
+def test_discovery_validates_issue_rows_and_derives_local_segment(tmp_path: Path) -> None:
+    """FTS hits should become issue-level candidates only after exact local issue validation."""
+    database = tmp_path / "localcv.db"
+    _build_fixture(database)
+    snapshot = LocalComicVineSnapshot(database)
+
+    candidates = discover_local_candidates(
+        snapshot,
+        ComicVineRepairContext(
+            title="Justice League America",
+            issue_label="2",
+            previous_issue_label="1",
+            next_issue_label="3",
+        ),
+        thread_issue_labels=["1", "2", "3", "Annual 1"],
+    )
+
+    assert [(candidate.volume_id, candidate.issue_id) for candidate in candidates] == [
+        (10, 102),
+        (20, 201),
+    ]
+    original, reprint = candidates
+    assert original.previous_issue_exists is True
+    assert original.next_issue_exists is True
+    assert (original.segment_start, original.segment_end) == ("1", "3")
+    assert reprint.previous_issue_exists is False
+    assert reprint.next_issue_exists is False
+    assert (reprint.segment_start, reprint.segment_end) == ("2", "2")
+
+
+def test_snapshot_sync_time_exposes_hard_freshness_boundary(tmp_path: Path) -> None:
+    """Candidate scoring can use the snapshot's actual sync timestamp as a freshness bound."""
+    database = tmp_path / "localcv.db"
+    _build_fixture(database)
+
+    synced_at = snapshot_sync_time(LocalComicVineSnapshot(database))
+
+    assert synced_at is not None
+    assert synced_at.isoformat() == "2026-01-09T00:00:00+00:00"

--- a/tests/test_comicvine_identity_repair.py
+++ b/tests/test_comicvine_identity_repair.py
@@ -20,9 +20,27 @@ def test_normalize_title_preserves_meaning_while_removing_format_noise() -> None
 def test_exact_cbl_identity_wins_when_candidate_is_internally_valid() -> None:
     """An embedded ComicVine issue ID should outrank fuzzy/local scoring after validation."""
     context = ComicVineRepairContext(title="X-Men", issue_label="12")
-    first = score_candidate(context, ComicVineCandidate(issue_id=111, volume_id=1, volume_name="X-Men", issue_number="12"))
-    embedded = score_candidate(context, ComicVineCandidate(issue_id=222, volume_id=2, volume_name="X-Men", issue_number="12"))
+    first = score_candidate(
+        context,
+        ComicVineCandidate(
+            issue_id=111,
+            volume_id=1,
+            volume_name="X-Men",
+            issue_number="12",
+        ),
+    )
+    embedded = score_candidate(
+        context,
+        ComicVineCandidate(
+            issue_id=222,
+            volume_id=2,
+            volume_name="X-Men",
+            issue_number="12",
+        ),
+    )
+
     decision = decide_candidates([first, embedded], embedded_cbl_issue_id=222)
+
     assert decision.status == "confirmed"
     assert decision.winner is not None
     assert decision.winner.candidate.issue_id == 222
@@ -31,10 +49,42 @@ def test_exact_cbl_identity_wins_when_candidate_is_internally_valid() -> None:
 
 def test_existing_confirmed_identity_is_never_replaced_by_fuzzy_candidate() -> None:
     """A later high-scoring candidate must not displace an existing confirmed mapping."""
-    context = ComicVineRepairContext(title="Justice League America", issue_label="25", publisher="DC Comics", start_year=1987)
-    existing = score_candidate(context, ComicVineCandidate(issue_id=100, volume_id=10, volume_name="Justice League America", issue_number="25", publisher="DC Comics", start_year=1987))
-    challenger = score_candidate(context, ComicVineCandidate(issue_id=200, volume_id=20, volume_name="Justice League America", issue_number="25", publisher="DC Comics", start_year=1987, previous_issue_exists=True, next_issue_exists=True))
-    decision = decide_candidates([challenger, existing], existing_confirmed_issue_id=100)
+    context = ComicVineRepairContext(
+        title="Justice League America",
+        issue_label="25",
+        publisher="DC Comics",
+        start_year=1987,
+    )
+    existing = score_candidate(
+        context,
+        ComicVineCandidate(
+            issue_id=100,
+            volume_id=10,
+            volume_name="Justice League America",
+            issue_number="25",
+            publisher="DC Comics",
+            start_year=1987,
+        ),
+    )
+    challenger = score_candidate(
+        context,
+        ComicVineCandidate(
+            issue_id=200,
+            volume_id=20,
+            volume_name="Justice League America",
+            issue_number="25",
+            publisher="DC Comics",
+            start_year=1987,
+            previous_issue_exists=True,
+            next_issue_exists=True,
+        ),
+    )
+
+    decision = decide_candidates(
+        [challenger, existing],
+        existing_confirmed_issue_id=100,
+    )
+
     assert decision.status == "confirmed"
     assert decision.winner is not None
     assert decision.winner.candidate.issue_id == 100
@@ -43,9 +93,21 @@ def test_existing_confirmed_identity_is_never_replaced_by_fuzzy_candidate() -> N
 def test_special_human_label_can_match_issue_name_instead_of_number() -> None:
     """Special labels such as Revival should resolve through provider issue names."""
     score = score_candidate(
-        ComicVineRepairContext(title="B.P.R.D.: War on Frogs", issue_label="Revival", publisher="Dark Horse Comics"),
-        ComicVineCandidate(issue_id=819479, volume_id=122077, volume_name="B.P.R.D.: War on Frogs", issue_number="5", issue_name="Revival", publisher="Dark Horse Comics"),
+        ComicVineRepairContext(
+            title="B.P.R.D.: War on Frogs",
+            issue_label="Revival",
+            publisher="Dark Horse Comics",
+        ),
+        ComicVineCandidate(
+            issue_id=819479,
+            volume_id=122077,
+            volume_name="B.P.R.D.: War on Frogs",
+            issue_number="5",
+            issue_name="Revival",
+            publisher="Dark Horse Comics",
+        ),
     )
+
     assert score.rejection_reason is None
     assert "issue name matches human label" in score.evidence
     assert score.score >= 0.68
@@ -53,7 +115,16 @@ def test_special_human_label_can_match_issue_name_instead_of_number() -> None:
 
 def test_candidate_without_matching_issue_number_or_name_is_rejected() -> None:
     """Volume title similarity alone must never establish issue identity."""
-    score = score_candidate(ComicVineRepairContext(title="B.P.R.D.: The Dead", issue_label="6"), ComicVineCandidate(issue_id=55, volume_id=12, volume_name="B.P.R.D.: The Dead", issue_number="5"))
+    score = score_candidate(
+        ComicVineRepairContext(title="B.P.R.D.: The Dead", issue_label="6"),
+        ComicVineCandidate(
+            issue_id=55,
+            volume_id=12,
+            volume_name="B.P.R.D.: The Dead",
+            issue_number="5",
+        ),
+    )
+
     assert score.score == 0
     assert score.rejection_reason is not None
     assert "does not contain" in score.rejection_reason
@@ -62,10 +133,21 @@ def test_candidate_without_matching_issue_number_or_name_is_rejected() -> None:
 def test_post_snapshot_missing_issue_is_classified_as_stale_not_false_identity_failure() -> None:
     """A comic newer than the local snapshot should remain unresolved for live refresh."""
     score = score_candidate(
-        ComicVineRepairContext(title="Absolute Batman", issue_label="21", snapshot_synced_at=datetime(2026, 1, 9, tzinfo=UTC), issue_expected_after=date(2026, 8, 1)),
-        ComicVineCandidate(issue_id=1, volume_id=2, volume_name="Absolute Batman", issue_number="20"),
+        ComicVineRepairContext(
+            title="Absolute Batman",
+            issue_label="21",
+            snapshot_synced_at=datetime(2026, 1, 9, tzinfo=UTC),
+            issue_expected_after=date(2026, 8, 1),
+        ),
+        ComicVineCandidate(
+            issue_id=1,
+            volume_id=2,
+            volume_name="Absolute Batman",
+            issue_number="20",
+        ),
     )
     decision = decide_candidates([score])
+
     assert score.stale_snapshot is True
     assert score.rejection_reason is not None
     assert "live refresh" in score.rejection_reason
@@ -75,9 +157,37 @@ def test_post_snapshot_missing_issue_is_classified_as_stale_not_false_identity_f
 
 def test_same_title_foreign_reprint_is_penalized_by_publisher_and_year() -> None:
     """Numeric coverage from a foreign reprint should not beat original-series evidence."""
-    context = ComicVineRepairContext(title="X-Men", issue_label="12", publisher="Marvel", start_year=1991)
-    original = score_candidate(context, ComicVineCandidate(issue_id=10, volume_id=100, volume_name="X-Men", issue_number="12", publisher="Marvel", start_year=1991))
-    reprint = score_candidate(context, ComicVineCandidate(issue_id=20, volume_id=200, volume_name="X-Men", issue_number="12", publisher="Panini Comics", start_year=2002, previous_issue_exists=True, next_issue_exists=True))
+    context = ComicVineRepairContext(
+        title="X-Men",
+        issue_label="12",
+        publisher="Marvel",
+        start_year=1991,
+    )
+    original = score_candidate(
+        context,
+        ComicVineCandidate(
+            issue_id=10,
+            volume_id=100,
+            volume_name="X-Men",
+            issue_number="12",
+            publisher="Marvel",
+            start_year=1991,
+        ),
+    )
+    reprint = score_candidate(
+        context,
+        ComicVineCandidate(
+            issue_id=20,
+            volume_id=200,
+            volume_name="X-Men",
+            issue_number="12",
+            publisher="Panini Comics",
+            start_year=2002,
+            previous_issue_exists=True,
+            next_issue_exists=True,
+        ),
+    )
+
     assert original.score > reprint.score
     decision = decide_candidates([reprint, original])
     assert decision.status == "confirmed"
@@ -88,9 +198,27 @@ def test_same_title_foreign_reprint_is_penalized_by_publisher_and_year() -> None
 def test_tied_exact_title_candidates_remain_auditable_instead_of_using_rank() -> None:
     """FTS ordering must not silently break a tie between otherwise equivalent candidates."""
     context = ComicVineRepairContext(title="X-Men", issue_label="1")
-    first = score_candidate(context, ComicVineCandidate(issue_id=101, volume_id=1, volume_name="X-Men", issue_number="1"))
-    second = score_candidate(context, ComicVineCandidate(issue_id=202, volume_id=2, volume_name="X-Men", issue_number="1"))
+    first = score_candidate(
+        context,
+        ComicVineCandidate(
+            issue_id=101,
+            volume_id=1,
+            volume_name="X-Men",
+            issue_number="1",
+        ),
+    )
+    second = score_candidate(
+        context,
+        ComicVineCandidate(
+            issue_id=202,
+            volume_id=2,
+            volume_name="X-Men",
+            issue_number="1",
+        ),
+    )
+
     decision = decide_candidates([second, first])
+
     assert decision.status == "candidate"
     assert decision.winner is None
     assert [item.candidate.issue_id for item in decision.candidates] == [101, 202]
@@ -98,8 +226,43 @@ def test_tied_exact_title_candidates_remain_auditable_instead_of_using_rank() ->
 
 def test_issue_level_scoring_allows_one_thread_to_cross_volume_segments() -> None:
     """Different issues in one reading thread can independently confirm different provider volumes."""
-    early = score_candidate(ComicVineRepairContext(title="Justice League America", issue_label="1", publisher="DC Comics", start_year=1987), ComicVineCandidate(issue_id=1, volume_id=10, volume_name="Justice League", issue_number="1", publisher="DC Comics", start_year=1987, segment_start="1", segment_end="6"))
-    later = score_candidate(ComicVineRepairContext(title="Justice League America", issue_label="7", publisher="DC Comics", start_year=1987), ComicVineCandidate(issue_id=7, volume_id=20, volume_name="Justice League International", issue_number="7", publisher="DC Comics", start_year=1987, segment_start="7", segment_end="25"))
+    early = score_candidate(
+        ComicVineRepairContext(
+            title="Justice League America",
+            issue_label="1",
+            publisher="DC Comics",
+            start_year=1987,
+        ),
+        ComicVineCandidate(
+            issue_id=1,
+            volume_id=10,
+            volume_name="Justice League",
+            issue_number="1",
+            publisher="DC Comics",
+            start_year=1987,
+            segment_start="1",
+            segment_end="6",
+        ),
+    )
+    later = score_candidate(
+        ComicVineRepairContext(
+            title="Justice League America",
+            issue_label="7",
+            publisher="DC Comics",
+            start_year=1987,
+        ),
+        ComicVineCandidate(
+            issue_id=7,
+            volume_id=20,
+            volume_name="Justice League International",
+            issue_number="7",
+            publisher="DC Comics",
+            start_year=1987,
+            segment_start="7",
+            segment_end="25",
+        ),
+    )
+
     assert early.candidate.volume_id != later.candidate.volume_id
     assert early.rejection_reason is None
     assert later.rejection_reason is None
@@ -108,9 +271,25 @@ def test_issue_level_scoring_allows_one_thread_to_cross_volume_segments() -> Non
 def test_repeated_cbl_evidence_and_neighbor_coverage_are_explainable() -> None:
     """Supporting evidence should increase confidence while remaining visible in the audit trail."""
     score = score_candidate(
-        ComicVineRepairContext(title="Planetary", issue_label="15", previous_issue_label="14", next_issue_label="16", repeated_cbl_count=2),
-        ComicVineCandidate(issue_id=15, volume_id=99, volume_name="Planetary", issue_number="15", previous_issue_exists=True, next_issue_exists=True, segment_start="1", segment_end="27"),
+        ComicVineRepairContext(
+            title="Planetary",
+            issue_label="15",
+            previous_issue_label="14",
+            next_issue_label="16",
+            repeated_cbl_count=2,
+        ),
+        ComicVineCandidate(
+            issue_id=15,
+            volume_id=99,
+            volume_name="Planetary",
+            issue_number="15",
+            previous_issue_exists=True,
+            next_issue_exists=True,
+            segment_start="1",
+            segment_end="27",
+        ),
     )
+
     assert "previous neighboring issue exists" in score.evidence
     assert "next neighboring issue exists" in score.evidence
     assert "supported by 2 distinct CBL observation(s)" in score.evidence

--- a/tests/test_comicvine_identity_repair.py
+++ b/tests/test_comicvine_identity_repair.py
@@ -20,27 +20,9 @@ def test_normalize_title_preserves_meaning_while_removing_format_noise() -> None
 def test_exact_cbl_identity_wins_when_candidate_is_internally_valid() -> None:
     """An embedded ComicVine issue ID should outrank fuzzy/local scoring after validation."""
     context = ComicVineRepairContext(title="X-Men", issue_label="12")
-    first = score_candidate(
-        context,
-        ComicVineCandidate(
-            issue_id=111,
-            volume_id=1,
-            volume_name="X-Men",
-            issue_number="12",
-        ),
-    )
-    embedded = score_candidate(
-        context,
-        ComicVineCandidate(
-            issue_id=222,
-            volume_id=2,
-            volume_name="X-Men",
-            issue_number="12",
-        ),
-    )
-
+    first = score_candidate(context, ComicVineCandidate(issue_id=111, volume_id=1, volume_name="X-Men", issue_number="12"))
+    embedded = score_candidate(context, ComicVineCandidate(issue_id=222, volume_id=2, volume_name="X-Men", issue_number="12"))
     decision = decide_candidates([first, embedded], embedded_cbl_issue_id=222)
-
     assert decision.status == "confirmed"
     assert decision.winner is not None
     assert decision.winner.candidate.issue_id == 222
@@ -49,42 +31,10 @@ def test_exact_cbl_identity_wins_when_candidate_is_internally_valid() -> None:
 
 def test_existing_confirmed_identity_is_never_replaced_by_fuzzy_candidate() -> None:
     """A later high-scoring candidate must not displace an existing confirmed mapping."""
-    context = ComicVineRepairContext(
-        title="Justice League America",
-        issue_label="25",
-        publisher="DC Comics",
-        start_year=1987,
-    )
-    existing = score_candidate(
-        context,
-        ComicVineCandidate(
-            issue_id=100,
-            volume_id=10,
-            volume_name="Justice League America",
-            issue_number="25",
-            publisher="DC Comics",
-            start_year=1987,
-        ),
-    )
-    challenger = score_candidate(
-        context,
-        ComicVineCandidate(
-            issue_id=200,
-            volume_id=20,
-            volume_name="Justice League America",
-            issue_number="25",
-            publisher="DC Comics",
-            start_year=1987,
-            previous_issue_exists=True,
-            next_issue_exists=True,
-        ),
-    )
-
-    decision = decide_candidates(
-        [challenger, existing],
-        existing_confirmed_issue_id=100,
-    )
-
+    context = ComicVineRepairContext(title="Justice League America", issue_label="25", publisher="DC Comics", start_year=1987)
+    existing = score_candidate(context, ComicVineCandidate(issue_id=100, volume_id=10, volume_name="Justice League America", issue_number="25", publisher="DC Comics", start_year=1987))
+    challenger = score_candidate(context, ComicVineCandidate(issue_id=200, volume_id=20, volume_name="Justice League America", issue_number="25", publisher="DC Comics", start_year=1987, previous_issue_exists=True, next_issue_exists=True))
+    decision = decide_candidates([challenger, existing], existing_confirmed_issue_id=100)
     assert decision.status == "confirmed"
     assert decision.winner is not None
     assert decision.winner.candidate.issue_id == 100
@@ -93,21 +43,9 @@ def test_existing_confirmed_identity_is_never_replaced_by_fuzzy_candidate() -> N
 def test_special_human_label_can_match_issue_name_instead_of_number() -> None:
     """Special labels such as Revival should resolve through provider issue names."""
     score = score_candidate(
-        ComicVineRepairContext(
-            title="B.P.R.D.: War on Frogs",
-            issue_label="Revival",
-            publisher="Dark Horse Comics",
-        ),
-        ComicVineCandidate(
-            issue_id=819479,
-            volume_id=122077,
-            volume_name="B.P.R.D.: War on Frogs",
-            issue_number="5",
-            issue_name="Revival",
-            publisher="Dark Horse Comics",
-        ),
+        ComicVineRepairContext(title="B.P.R.D.: War on Frogs", issue_label="Revival", publisher="Dark Horse Comics"),
+        ComicVineCandidate(issue_id=819479, volume_id=122077, volume_name="B.P.R.D.: War on Frogs", issue_number="5", issue_name="Revival", publisher="Dark Horse Comics"),
     )
-
     assert score.rejection_reason is None
     assert "issue name matches human label" in score.evidence
     assert score.score >= 0.68
@@ -115,16 +53,7 @@ def test_special_human_label_can_match_issue_name_instead_of_number() -> None:
 
 def test_candidate_without_matching_issue_number_or_name_is_rejected() -> None:
     """Volume title similarity alone must never establish issue identity."""
-    score = score_candidate(
-        ComicVineRepairContext(title="B.P.R.D.: The Dead", issue_label="6"),
-        ComicVineCandidate(
-            issue_id=55,
-            volume_id=12,
-            volume_name="B.P.R.D.: The Dead",
-            issue_number="5",
-        ),
-    )
-
+    score = score_candidate(ComicVineRepairContext(title="B.P.R.D.: The Dead", issue_label="6"), ComicVineCandidate(issue_id=55, volume_id=12, volume_name="B.P.R.D.: The Dead", issue_number="5"))
     assert score.score == 0
     assert score.rejection_reason is not None
     assert "does not contain" in score.rejection_reason
@@ -133,22 +62,12 @@ def test_candidate_without_matching_issue_number_or_name_is_rejected() -> None:
 def test_post_snapshot_missing_issue_is_classified_as_stale_not_false_identity_failure() -> None:
     """A comic newer than the local snapshot should remain unresolved for live refresh."""
     score = score_candidate(
-        ComicVineRepairContext(
-            title="Absolute Batman",
-            issue_label="21",
-            snapshot_synced_at=datetime(2026, 1, 9, tzinfo=UTC),
-            issue_expected_after=date(2026, 8, 1),
-        ),
-        ComicVineCandidate(
-            issue_id=1,
-            volume_id=2,
-            volume_name="Absolute Batman",
-            issue_number="20",
-        ),
+        ComicVineRepairContext(title="Absolute Batman", issue_label="21", snapshot_synced_at=datetime(2026, 1, 9, tzinfo=UTC), issue_expected_after=date(2026, 8, 1)),
+        ComicVineCandidate(issue_id=1, volume_id=2, volume_name="Absolute Batman", issue_number="20"),
     )
     decision = decide_candidates([score])
-
     assert score.stale_snapshot is True
+    assert score.rejection_reason is not None
     assert "live refresh" in score.rejection_reason
     assert decision.status == "unresolved"
     assert "snapshot may be stale" in decision.reason
@@ -156,37 +75,9 @@ def test_post_snapshot_missing_issue_is_classified_as_stale_not_false_identity_f
 
 def test_same_title_foreign_reprint_is_penalized_by_publisher_and_year() -> None:
     """Numeric coverage from a foreign reprint should not beat original-series evidence."""
-    context = ComicVineRepairContext(
-        title="X-Men",
-        issue_label="12",
-        publisher="Marvel",
-        start_year=1991,
-    )
-    original = score_candidate(
-        context,
-        ComicVineCandidate(
-            issue_id=10,
-            volume_id=100,
-            volume_name="X-Men",
-            issue_number="12",
-            publisher="Marvel",
-            start_year=1991,
-        ),
-    )
-    reprint = score_candidate(
-        context,
-        ComicVineCandidate(
-            issue_id=20,
-            volume_id=200,
-            volume_name="X-Men",
-            issue_number="12",
-            publisher="Panini Comics",
-            start_year=2002,
-            previous_issue_exists=True,
-            next_issue_exists=True,
-        ),
-    )
-
+    context = ComicVineRepairContext(title="X-Men", issue_label="12", publisher="Marvel", start_year=1991)
+    original = score_candidate(context, ComicVineCandidate(issue_id=10, volume_id=100, volume_name="X-Men", issue_number="12", publisher="Marvel", start_year=1991))
+    reprint = score_candidate(context, ComicVineCandidate(issue_id=20, volume_id=200, volume_name="X-Men", issue_number="12", publisher="Panini Comics", start_year=2002, previous_issue_exists=True, next_issue_exists=True))
     assert original.score > reprint.score
     decision = decide_candidates([reprint, original])
     assert decision.status == "confirmed"
@@ -197,27 +88,9 @@ def test_same_title_foreign_reprint_is_penalized_by_publisher_and_year() -> None
 def test_tied_exact_title_candidates_remain_auditable_instead_of_using_rank() -> None:
     """FTS ordering must not silently break a tie between otherwise equivalent candidates."""
     context = ComicVineRepairContext(title="X-Men", issue_label="1")
-    first = score_candidate(
-        context,
-        ComicVineCandidate(
-            issue_id=101,
-            volume_id=1,
-            volume_name="X-Men",
-            issue_number="1",
-        ),
-    )
-    second = score_candidate(
-        context,
-        ComicVineCandidate(
-            issue_id=202,
-            volume_id=2,
-            volume_name="X-Men",
-            issue_number="1",
-        ),
-    )
-
+    first = score_candidate(context, ComicVineCandidate(issue_id=101, volume_id=1, volume_name="X-Men", issue_number="1"))
+    second = score_candidate(context, ComicVineCandidate(issue_id=202, volume_id=2, volume_name="X-Men", issue_number="1"))
     decision = decide_candidates([second, first])
-
     assert decision.status == "candidate"
     assert decision.winner is None
     assert [item.candidate.issue_id for item in decision.candidates] == [101, 202]
@@ -225,43 +98,8 @@ def test_tied_exact_title_candidates_remain_auditable_instead_of_using_rank() ->
 
 def test_issue_level_scoring_allows_one_thread_to_cross_volume_segments() -> None:
     """Different issues in one reading thread can independently confirm different provider volumes."""
-    early = score_candidate(
-        ComicVineRepairContext(
-            title="Justice League America",
-            issue_label="1",
-            publisher="DC Comics",
-            start_year=1987,
-        ),
-        ComicVineCandidate(
-            issue_id=1,
-            volume_id=10,
-            volume_name="Justice League",
-            issue_number="1",
-            publisher="DC Comics",
-            start_year=1987,
-            segment_start="1",
-            segment_end="6",
-        ),
-    )
-    later = score_candidate(
-        ComicVineRepairContext(
-            title="Justice League America",
-            issue_label="7",
-            publisher="DC Comics",
-            start_year=1987,
-        ),
-        ComicVineCandidate(
-            issue_id=7,
-            volume_id=20,
-            volume_name="Justice League International",
-            issue_number="7",
-            publisher="DC Comics",
-            start_year=1987,
-            segment_start="7",
-            segment_end="25",
-        ),
-    )
-
+    early = score_candidate(ComicVineRepairContext(title="Justice League America", issue_label="1", publisher="DC Comics", start_year=1987), ComicVineCandidate(issue_id=1, volume_id=10, volume_name="Justice League", issue_number="1", publisher="DC Comics", start_year=1987, segment_start="1", segment_end="6"))
+    later = score_candidate(ComicVineRepairContext(title="Justice League America", issue_label="7", publisher="DC Comics", start_year=1987), ComicVineCandidate(issue_id=7, volume_id=20, volume_name="Justice League International", issue_number="7", publisher="DC Comics", start_year=1987, segment_start="7", segment_end="25"))
     assert early.candidate.volume_id != later.candidate.volume_id
     assert early.rejection_reason is None
     assert later.rejection_reason is None
@@ -270,25 +108,9 @@ def test_issue_level_scoring_allows_one_thread_to_cross_volume_segments() -> Non
 def test_repeated_cbl_evidence_and_neighbor_coverage_are_explainable() -> None:
     """Supporting evidence should increase confidence while remaining visible in the audit trail."""
     score = score_candidate(
-        ComicVineRepairContext(
-            title="Planetary",
-            issue_label="15",
-            previous_issue_label="14",
-            next_issue_label="16",
-            repeated_cbl_count=2,
-        ),
-        ComicVineCandidate(
-            issue_id=15,
-            volume_id=99,
-            volume_name="Planetary",
-            issue_number="15",
-            previous_issue_exists=True,
-            next_issue_exists=True,
-            segment_start="1",
-            segment_end="27",
-        ),
+        ComicVineRepairContext(title="Planetary", issue_label="15", previous_issue_label="14", next_issue_label="16", repeated_cbl_count=2),
+        ComicVineCandidate(issue_id=15, volume_id=99, volume_name="Planetary", issue_number="15", previous_issue_exists=True, next_issue_exists=True, segment_start="1", segment_end="27"),
     )
-
     assert "previous neighboring issue exists" in score.evidence
     assert "next neighboring issue exists" in score.evidence
     assert "supported by 2 distinct CBL observation(s)" in score.evidence

--- a/tests/test_comicvine_identity_repair.py
+++ b/tests/test_comicvine_identity_repair.py
@@ -1,0 +1,296 @@
+"""Tests for confidence-aware ComicVine identity repair."""
+
+from datetime import UTC, date, datetime
+
+from comic_pile.comicvine_identity_repair import (
+    ComicVineCandidate,
+    ComicVineRepairContext,
+    decide_candidates,
+    normalize_title,
+    score_candidate,
+)
+
+
+def test_normalize_title_preserves_meaning_while_removing_format_noise() -> None:
+    """Title normalization should handle punctuation, casing, and ampersands deterministically."""
+    assert normalize_title("B.P.R.D.: Hell on Earth") == "b p r d hell on earth"
+    assert normalize_title("Batman & Robin") == normalize_title("BATMAN and ROBIN")
+
+
+def test_exact_cbl_identity_wins_when_candidate_is_internally_valid() -> None:
+    """An embedded ComicVine issue ID should outrank fuzzy/local scoring after validation."""
+    context = ComicVineRepairContext(title="X-Men", issue_label="12")
+    first = score_candidate(
+        context,
+        ComicVineCandidate(
+            issue_id=111,
+            volume_id=1,
+            volume_name="X-Men",
+            issue_number="12",
+        ),
+    )
+    embedded = score_candidate(
+        context,
+        ComicVineCandidate(
+            issue_id=222,
+            volume_id=2,
+            volume_name="X-Men",
+            issue_number="12",
+        ),
+    )
+
+    decision = decide_candidates([first, embedded], embedded_cbl_issue_id=222)
+
+    assert decision.status == "confirmed"
+    assert decision.winner is not None
+    assert decision.winner.candidate.issue_id == 222
+    assert "embedded CBL" in decision.reason
+
+
+def test_existing_confirmed_identity_is_never_replaced_by_fuzzy_candidate() -> None:
+    """A later high-scoring candidate must not displace an existing confirmed mapping."""
+    context = ComicVineRepairContext(
+        title="Justice League America",
+        issue_label="25",
+        publisher="DC Comics",
+        start_year=1987,
+    )
+    existing = score_candidate(
+        context,
+        ComicVineCandidate(
+            issue_id=100,
+            volume_id=10,
+            volume_name="Justice League America",
+            issue_number="25",
+            publisher="DC Comics",
+            start_year=1987,
+        ),
+    )
+    challenger = score_candidate(
+        context,
+        ComicVineCandidate(
+            issue_id=200,
+            volume_id=20,
+            volume_name="Justice League America",
+            issue_number="25",
+            publisher="DC Comics",
+            start_year=1987,
+            previous_issue_exists=True,
+            next_issue_exists=True,
+        ),
+    )
+
+    decision = decide_candidates(
+        [challenger, existing],
+        existing_confirmed_issue_id=100,
+    )
+
+    assert decision.status == "confirmed"
+    assert decision.winner is not None
+    assert decision.winner.candidate.issue_id == 100
+
+
+def test_special_human_label_can_match_issue_name_instead_of_number() -> None:
+    """Special labels such as Revival should resolve through provider issue names."""
+    score = score_candidate(
+        ComicVineRepairContext(
+            title="B.P.R.D.: War on Frogs",
+            issue_label="Revival",
+            publisher="Dark Horse Comics",
+        ),
+        ComicVineCandidate(
+            issue_id=819479,
+            volume_id=122077,
+            volume_name="B.P.R.D.: War on Frogs",
+            issue_number="5",
+            issue_name="Revival",
+            publisher="Dark Horse Comics",
+        ),
+    )
+
+    assert score.rejection_reason is None
+    assert "issue name matches human label" in score.evidence
+    assert score.score >= 0.68
+
+
+def test_candidate_without_matching_issue_number_or_name_is_rejected() -> None:
+    """Volume title similarity alone must never establish issue identity."""
+    score = score_candidate(
+        ComicVineRepairContext(title="B.P.R.D.: The Dead", issue_label="6"),
+        ComicVineCandidate(
+            issue_id=55,
+            volume_id=12,
+            volume_name="B.P.R.D.: The Dead",
+            issue_number="5",
+        ),
+    )
+
+    assert score.score == 0
+    assert score.rejection_reason is not None
+    assert "does not contain" in score.rejection_reason
+
+
+def test_post_snapshot_missing_issue_is_classified_as_stale_not_false_identity_failure() -> None:
+    """A comic newer than the local snapshot should remain unresolved for live refresh."""
+    score = score_candidate(
+        ComicVineRepairContext(
+            title="Absolute Batman",
+            issue_label="21",
+            snapshot_synced_at=datetime(2026, 1, 9, tzinfo=UTC),
+            issue_expected_after=date(2026, 8, 1),
+        ),
+        ComicVineCandidate(
+            issue_id=1,
+            volume_id=2,
+            volume_name="Absolute Batman",
+            issue_number="20",
+        ),
+    )
+    decision = decide_candidates([score])
+
+    assert score.stale_snapshot is True
+    assert "live refresh" in score.rejection_reason
+    assert decision.status == "unresolved"
+    assert "snapshot may be stale" in decision.reason
+
+
+def test_same_title_foreign_reprint_is_penalized_by_publisher_and_year() -> None:
+    """Numeric coverage from a foreign reprint should not beat original-series evidence."""
+    context = ComicVineRepairContext(
+        title="X-Men",
+        issue_label="12",
+        publisher="Marvel",
+        start_year=1991,
+    )
+    original = score_candidate(
+        context,
+        ComicVineCandidate(
+            issue_id=10,
+            volume_id=100,
+            volume_name="X-Men",
+            issue_number="12",
+            publisher="Marvel",
+            start_year=1991,
+        ),
+    )
+    reprint = score_candidate(
+        context,
+        ComicVineCandidate(
+            issue_id=20,
+            volume_id=200,
+            volume_name="X-Men",
+            issue_number="12",
+            publisher="Panini Comics",
+            start_year=2002,
+            previous_issue_exists=True,
+            next_issue_exists=True,
+        ),
+    )
+
+    assert original.score > reprint.score
+    decision = decide_candidates([reprint, original])
+    assert decision.status == "confirmed"
+    assert decision.winner is not None
+    assert decision.winner.candidate.issue_id == 10
+
+
+def test_tied_exact_title_candidates_remain_auditable_instead_of_using_rank() -> None:
+    """FTS ordering must not silently break a tie between otherwise equivalent candidates."""
+    context = ComicVineRepairContext(title="X-Men", issue_label="1")
+    first = score_candidate(
+        context,
+        ComicVineCandidate(
+            issue_id=101,
+            volume_id=1,
+            volume_name="X-Men",
+            issue_number="1",
+        ),
+    )
+    second = score_candidate(
+        context,
+        ComicVineCandidate(
+            issue_id=202,
+            volume_id=2,
+            volume_name="X-Men",
+            issue_number="1",
+        ),
+    )
+
+    decision = decide_candidates([second, first])
+
+    assert decision.status == "candidate"
+    assert decision.winner is None
+    assert [item.candidate.issue_id for item in decision.candidates] == [101, 202]
+
+
+def test_issue_level_scoring_allows_one_thread_to_cross_volume_segments() -> None:
+    """Different issues in one reading thread can independently confirm different provider volumes."""
+    early = score_candidate(
+        ComicVineRepairContext(
+            title="Justice League America",
+            issue_label="1",
+            publisher="DC Comics",
+            start_year=1987,
+        ),
+        ComicVineCandidate(
+            issue_id=1,
+            volume_id=10,
+            volume_name="Justice League",
+            issue_number="1",
+            publisher="DC Comics",
+            start_year=1987,
+            segment_start="1",
+            segment_end="6",
+        ),
+    )
+    later = score_candidate(
+        ComicVineRepairContext(
+            title="Justice League America",
+            issue_label="7",
+            publisher="DC Comics",
+            start_year=1987,
+        ),
+        ComicVineCandidate(
+            issue_id=7,
+            volume_id=20,
+            volume_name="Justice League International",
+            issue_number="7",
+            publisher="DC Comics",
+            start_year=1987,
+            segment_start="7",
+            segment_end="25",
+        ),
+    )
+
+    assert early.candidate.volume_id != later.candidate.volume_id
+    assert early.rejection_reason is None
+    assert later.rejection_reason is None
+
+
+def test_repeated_cbl_evidence_and_neighbor_coverage_are_explainable() -> None:
+    """Supporting evidence should increase confidence while remaining visible in the audit trail."""
+    score = score_candidate(
+        ComicVineRepairContext(
+            title="Planetary",
+            issue_label="15",
+            previous_issue_label="14",
+            next_issue_label="16",
+            repeated_cbl_count=2,
+        ),
+        ComicVineCandidate(
+            issue_id=15,
+            volume_id=99,
+            volume_name="Planetary",
+            issue_number="15",
+            previous_issue_exists=True,
+            next_issue_exists=True,
+            segment_start="1",
+            segment_end="27",
+        ),
+    )
+
+    assert "previous neighboring issue exists" in score.evidence
+    assert "next neighboring issue exists" in score.evidence
+    assert "supported by 2 distinct CBL observation(s)" in score.evidence
+    assert score.candidate.segment_start == "1"
+    assert score.candidate.segment_end == "27"

--- a/tests/test_comicvine_identity_repair_persistence.py
+++ b/tests/test_comicvine_identity_repair_persistence.py
@@ -76,7 +76,9 @@ async def test_persist_repair_decision_records_score_evidence_and_segment(
     assert mapping.evidence_json["segment_start"] == "1"
     assert mapping.evidence_json["segment_end"] == "41"
     assert mapping.evidence_json["stale_snapshot"] is False
-    assert "publisher matches" in mapping.evidence_json["evidence"]
+    evidence = mapping.evidence_json["evidence"]
+    assert isinstance(evidence, list)
+    assert "publisher matches" in evidence
 
 
 @pytest.mark.asyncio

--- a/tests/test_comicvine_identity_repair_persistence.py
+++ b/tests/test_comicvine_identity_repair_persistence.py
@@ -1,0 +1,136 @@
+"""Persistence tests for ComicVine identity repair decisions."""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.comicvine_identity_repair import persist_repair_decision, review_candidate_mapping
+from app.external_identities import ExternalIdentityMappingError
+from app.models import Issue, Thread, User
+from comic_pile.comicvine_identity_repair import (
+    ComicVineCandidate,
+    ComicVineRepairContext,
+    decide_candidates,
+    score_candidate,
+)
+
+
+async def _owned_issue(db: AsyncSession, *, username: str) -> tuple[User, Issue]:
+    user = User(username=username)
+    db.add(user)
+    await db.flush()
+    thread = Thread(
+        title="X-Men",
+        format="Comic",
+        issues_remaining=1,
+        queue_position=1,
+        status="active",
+        user_id=user.id,
+    )
+    db.add(thread)
+    await db.flush()
+    issue = Issue(thread_id=thread.id, issue_number="12", position=1)
+    db.add(issue)
+    await db.flush()
+    return user, issue
+
+
+@pytest.mark.asyncio
+async def test_persist_repair_decision_records_score_evidence_and_segment(
+    async_db: AsyncSession,
+) -> None:
+    """Persisted candidates should retain explainable score, segment, and source evidence."""
+    user, issue = await _owned_issue(async_db, username="repair_persist")
+    context = ComicVineRepairContext(
+        title="X-Men",
+        issue_label="12",
+        publisher="Marvel",
+        start_year=1991,
+    )
+    score = score_candidate(
+        context,
+        ComicVineCandidate(
+            issue_id=1234,
+            volume_id=5678,
+            volume_name="X-Men",
+            issue_number="12",
+            publisher="Marvel",
+            start_year=1991,
+            segment_start="1",
+            segment_end="41",
+        ),
+    )
+    decision = decide_candidates([score])
+
+    mappings = await persist_repair_decision(
+        async_db,
+        user_id=user.id,
+        issue_id=issue.id,
+        decision=decision,
+    )
+
+    assert len(mappings) == 1
+    mapping = mappings[0]
+    assert mapping.status == "confirmed"
+    assert mapping.confidence == score.score
+    assert mapping.evidence_source == "comicvine-local-sqlite"
+    assert mapping.evidence_json["segment_start"] == "1"
+    assert mapping.evidence_json["segment_end"] == "41"
+    assert mapping.evidence_json["stale_snapshot"] is False
+    assert "publisher matches" in mapping.evidence_json["evidence"]
+
+
+@pytest.mark.asyncio
+async def test_manual_review_preserves_evidence_and_requires_rejection_reason(
+    async_db: AsyncSession,
+) -> None:
+    """Manual confirm/reject decisions should preserve candidate audit evidence."""
+    user, issue = await _owned_issue(async_db, username="repair_review")
+    context = ComicVineRepairContext(title="X-Men", issue_label="12")
+    first = score_candidate(
+        context,
+        ComicVineCandidate(
+            issue_id=11,
+            volume_id=1,
+            volume_name="X-Men",
+            issue_number="12",
+        ),
+    )
+    second = score_candidate(
+        context,
+        ComicVineCandidate(
+            issue_id=22,
+            volume_id=2,
+            volume_name="X-Men",
+            issue_number="12",
+        ),
+    )
+    mappings = await persist_repair_decision(
+        async_db,
+        user_id=user.id,
+        issue_id=issue.id,
+        decision=decide_candidates([first, second]),
+    )
+    target = mappings[0]
+    original_evidence = dict(target.evidence_json)
+
+    with pytest.raises(ExternalIdentityMappingError, match="rejection_reason"):
+        await review_candidate_mapping(
+            async_db,
+            user_id=user.id,
+            issue_id=issue.id,
+            external_identity_id=target.external_identity_id,
+            status="rejected",
+        )
+
+    rejected = await review_candidate_mapping(
+        async_db,
+        user_id=user.id,
+        issue_id=issue.id,
+        external_identity_id=target.external_identity_id,
+        status="rejected",
+        rejection_reason="Wrong era despite matching title",
+    )
+
+    assert rejected.status == "rejected"
+    assert rejected.rejection_reason == "Wrong era despite matching title"
+    assert rejected.evidence_json == original_evidence

--- a/tests/test_comicvine_repair_pipeline.py
+++ b/tests/test_comicvine_repair_pipeline.py
@@ -1,0 +1,116 @@
+"""Tests for local-first ComicVine identity repair orchestration."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from comic_pile.comicvine_identity_repair import ComicVineRepairContext
+from comic_pile.comicvine_provider import ComicVineClient
+from comic_pile.comicvine_repair_pipeline import repair_identity
+from comic_pile.local_comicvine import LocalComicVineSnapshot
+
+
+def _local_fixture(path: Path) -> None:
+    connection = sqlite3.connect(path)
+    connection.executescript(
+        """
+        CREATE TABLE cv_volume (id INTEGER PRIMARY KEY, name TEXT, publisher TEXT, start_year INTEGER);
+        CREATE TABLE cv_issue (id INTEGER PRIMARY KEY, volume_id INTEGER, issue_number TEXT, name TEXT);
+        CREATE VIRTUAL TABLE cv_volume_fts USING fts5(name, content='cv_volume', content_rowid='id');
+        INSERT INTO cv_volume VALUES (77, 'Planetary', 'WildStorm', 1999);
+        INSERT INTO cv_issue VALUES (700, 77, '15', NULL);
+        INSERT INTO cv_volume_fts(rowid, name) VALUES (77, 'Planetary');
+        """
+    )
+    connection.commit()
+    connection.close()
+
+
+@pytest.mark.asyncio
+async def test_repair_prefers_local_candidates_without_live_search(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A validated local candidate should avoid spending any live ComicVine request budget."""
+    database = tmp_path / "localcv.db"
+    _local_fixture(database)
+    client = ComicVineClient("secret", tmp_path / "cache")
+
+    def fail_live_request(endpoint: str, params: object) -> dict[str, object]:
+        raise AssertionError(f"unexpected live request: {endpoint} {params}")
+
+    monkeypatch.setattr(client, "_request_sync", fail_live_request)
+
+    decision, scores = await repair_identity(
+        snapshot=LocalComicVineSnapshot(database),
+        client=client,
+        context=ComicVineRepairContext(title="Planetary", issue_label="15"),
+        thread_issue_labels=["14", "15", "16"],
+    )
+
+    assert len(scores) == 1
+    assert scores[0].candidate.issue_id == 700
+    assert scores[0].candidate.source == "comicvine-local-sqlite"
+    assert decision.status in {"candidate", "confirmed"}
+
+
+@pytest.mark.asyncio
+async def test_repair_uses_live_search_only_after_local_miss(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An absent local snapshot should fall through to validated live volume/issue evidence."""
+    client = ComicVineClient("secret", tmp_path / "cache")
+    observed: list[str] = []
+
+    def fake_request(endpoint: str, params: object) -> dict[str, object]:
+        observed.append(endpoint)
+        if endpoint == "search":
+            return {
+                "status_code": 1,
+                "results": [
+                    {
+                        "id": 88,
+                        "name": "B.P.R.D.: War on Frogs",
+                        "publisher": {"name": "Dark Horse Comics"},
+                        "start_year": 2006,
+                    }
+                ],
+            }
+        if endpoint == "issues":
+            return {
+                "status_code": 1,
+                "number_of_total_results": 1,
+                "results": [
+                    {
+                        "id": 801,
+                        "issue_number": "5",
+                        "name": "Revival",
+                        "volume": {"id": 88},
+                    }
+                ],
+            }
+        raise AssertionError(f"unexpected endpoint: {endpoint}")
+
+    monkeypatch.setattr(client, "_request_sync", fake_request)
+
+    decision, scores = await repair_identity(
+        snapshot=LocalComicVineSnapshot(tmp_path / "missing.db"),
+        client=client,
+        context=ComicVineRepairContext(
+            title="B.P.R.D.: War on Frogs",
+            issue_label="Revival",
+            publisher="Dark Horse Comics",
+        ),
+        thread_issue_labels=["1", "2", "3", "4", "Revival"],
+    )
+
+    assert observed == ["search", "issues"]
+    assert len(scores) == 1
+    assert scores[0].candidate.issue_id == 801
+    assert scores[0].candidate.source == "comicvine-live"
+    assert "issue name matches human label" in scores[0].evidence
+    assert decision.status in {"candidate", "confirmed"}

--- a/tests/test_comicvine_repair_pipeline.py
+++ b/tests/test_comicvine_repair_pipeline.py
@@ -17,9 +17,23 @@ def _local_fixture(path: Path) -> None:
     connection = sqlite3.connect(path)
     connection.executescript(
         """
-        CREATE TABLE cv_volume (id INTEGER PRIMARY KEY, name TEXT, publisher TEXT, start_year INTEGER);
-        CREATE TABLE cv_issue (id INTEGER PRIMARY KEY, volume_id INTEGER, issue_number TEXT, name TEXT);
-        CREATE VIRTUAL TABLE cv_volume_fts USING fts5(name, content='cv_volume', content_rowid='id');
+        CREATE TABLE cv_volume (
+            id INTEGER PRIMARY KEY,
+            name TEXT,
+            publisher TEXT,
+            start_year INTEGER
+        );
+        CREATE TABLE cv_issue (
+            id INTEGER PRIMARY KEY,
+            volume_id INTEGER,
+            issue_number TEXT,
+            name TEXT
+        );
+        CREATE VIRTUAL TABLE cv_volume_fts USING fts5(
+            name,
+            content='cv_volume',
+            content_rowid='id'
+        );
         INSERT INTO cv_volume VALUES (77, 'Planetary', 'WildStorm', 1999);
         INSERT INTO cv_issue VALUES (700, 77, '15', NULL);
         INSERT INTO cv_volume_fts(rowid, name) VALUES (77, 'Planetary');
@@ -55,6 +69,75 @@ async def test_repair_prefers_local_candidates_without_live_search(
     assert scores[0].candidate.issue_id == 700
     assert scores[0].candidate.source == "comicvine-local-sqlite"
     assert decision.status in {"candidate", "confirmed"}
+
+
+@pytest.mark.asyncio
+async def test_exact_cbl_id_bypasses_search_and_uses_exact_local_lookup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exact embedded CBL issue IDs should confirm without FTS or live search."""
+    database = tmp_path / "localcv.db"
+    _local_fixture(database)
+    snapshot = LocalComicVineSnapshot(database)
+    client = ComicVineClient("secret", tmp_path / "cache")
+
+    monkeypatch.setattr(
+        snapshot,
+        "search_volumes",
+        lambda query, limit=10: (_ for _ in ()).throw(AssertionError("unexpected FTS search")),
+    )
+
+    def fail_live_request(endpoint: str, params: object) -> dict[str, object]:
+        raise AssertionError(f"unexpected live request: {endpoint} {params}")
+
+    monkeypatch.setattr(client, "_request_sync", fail_live_request)
+
+    decision, scores = await repair_identity(
+        snapshot=snapshot,
+        client=client,
+        context=ComicVineRepairContext(title="Planetary", issue_label="15"),
+        thread_issue_labels=["14", "15", "16"],
+        embedded_cbl_issue_id=700,
+    )
+
+    assert decision.status == "confirmed"
+    assert decision.winner is not None
+    assert decision.winner.candidate.issue_id == 700
+    assert len(scores) == 1
+
+
+@pytest.mark.asyncio
+async def test_existing_confirmed_id_bypasses_all_candidate_discovery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An existing confirmed mapping should remain authoritative without provider discovery."""
+    snapshot = LocalComicVineSnapshot(tmp_path / "missing.db")
+    client = ComicVineClient("secret", tmp_path / "cache")
+
+    monkeypatch.setattr(
+        snapshot,
+        "search_volumes",
+        lambda query, limit=10: (_ for _ in ()).throw(AssertionError("unexpected FTS search")),
+    )
+
+    def fail_live_request(endpoint: str, params: object) -> dict[str, object]:
+        raise AssertionError(f"unexpected live request: {endpoint} {params}")
+
+    monkeypatch.setattr(client, "_request_sync", fail_live_request)
+
+    decision, scores = await repair_identity(
+        snapshot=snapshot,
+        client=client,
+        context=ComicVineRepairContext(title="X-Men", issue_label="1"),
+        thread_issue_labels=["1"],
+        existing_confirmed_issue_id=999,
+    )
+
+    assert decision.status == "confirmed"
+    assert decision.reason == "preserved existing confirmed ComicVine issue mapping"
+    assert scores == ()
 
 
 @pytest.mark.asyncio

--- a/tests/test_comicvine_repair_pipeline_edges.py
+++ b/tests/test_comicvine_repair_pipeline_edges.py
@@ -194,12 +194,12 @@ async def test_embedded_id_uses_live_exact_evidence_when_local_snapshot_misses(
     client = ComicVineClient("secret", tmp_path / "cache")
 
     def fake_request(endpoint: str, params: object) -> dict[str, object]:
-        if endpoint == "issue/100":
+        if endpoint == "issue/4000-100":
             return {
                 "status_code": 1,
                 "results": {"id": 100, "issue_number": "1", "volume": {"id": 10}},
             }
-        if endpoint == "volume/10":
+        if endpoint == "volume/4050-10":
             return {
                 "status_code": 1,
                 "results": {

--- a/tests/test_comicvine_repair_pipeline_edges.py
+++ b/tests/test_comicvine_repair_pipeline_edges.py
@@ -1,0 +1,180 @@
+"""Edge coverage for ComicVine identity repair orchestration."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from comic_pile.comicvine_identity_repair import ComicVineRepairContext
+from comic_pile.comicvine_provider import ComicVineClient, ComicVineError
+from comic_pile.comicvine_repair_pipeline import (
+    _candidate_from_rows,
+    _exact_local_candidate,
+    _integer,
+    _object_result,
+    _publisher_name,
+    discover_live_candidates,
+    repair_identity,
+)
+from comic_pile.local_comicvine import LocalComicVineSnapshot
+
+
+def _snapshot(path: Path) -> LocalComicVineSnapshot:
+    connection = sqlite3.connect(path)
+    connection.executescript(
+        """
+        CREATE TABLE cv_volume (
+            id INTEGER PRIMARY KEY,
+            name TEXT,
+            publisher TEXT,
+            start_year INTEGER
+        );
+        CREATE TABLE cv_issue (
+            id INTEGER PRIMARY KEY,
+            volume_id INTEGER,
+            issue_number TEXT,
+            name TEXT
+        );
+        CREATE VIRTUAL TABLE cv_volume_fts USING fts5(
+            name,
+            content='cv_volume',
+            content_rowid='id'
+        );
+        INSERT INTO cv_volume VALUES (10, 'X-Men', 'Marvel', 1991);
+        INSERT INTO cv_issue VALUES (100, 10, '1', NULL);
+        INSERT INTO cv_volume_fts(rowid, name) VALUES (10, 'X-Men');
+        """
+    )
+    connection.commit()
+    connection.close()
+    return LocalComicVineSnapshot(path)
+
+
+def test_pipeline_helpers_reject_invalid_provider_shapes() -> None:
+    """Provider helper functions should normalize valid values and reject malformed ones."""
+    assert _integer(7) == 7
+    assert _integer("8") == 8
+    assert _integer("8a") is None
+    assert _integer(None) is None
+    assert _publisher_name(" Marvel ") == "Marvel"
+    assert _publisher_name({"name": " DC Comics "}) == "DC Comics"
+    assert _publisher_name({"name": ""}) is None
+    assert _publisher_name(3) is None
+    with pytest.raises(ComicVineError, match="object result"):
+        _object_result({"results": []}, "issue")
+
+
+def test_candidate_from_rows_requires_ids_title_and_issue_match() -> None:
+    """Search discovery alone should never produce an unvalidated issue candidate."""
+    context = ComicVineRepairContext(title="X-Men", issue_label="1")
+    assert _candidate_from_rows({}, {}, context, source="test") is None
+    assert (
+        _candidate_from_rows(
+            {"id": 10, "name": "X-Men"},
+            {"id": 100, "issue_number": "2"},
+            context,
+            source="test",
+        )
+        is None
+    )
+    candidate = _candidate_from_rows(
+        {
+            "id": "10",
+            "name": "X-Men",
+            "publisher": {"name": "Marvel"},
+            "start_year": "1991",
+        },
+        {"id": "100", "issue_number": "9", "name": "1"},
+        context,
+        source="test",
+    )
+    assert candidate is not None
+    assert candidate.issue_id == 100
+    assert candidate.volume_id == 10
+    assert candidate.publisher == "Marvel"
+    assert candidate.start_year == 1991
+
+
+def test_exact_local_candidate_handles_missing_and_invalid_rows(tmp_path: Path) -> None:
+    """Exact local lookup should fail safely when issue or volume evidence is incomplete."""
+    snapshot = _snapshot(tmp_path / "localcv.db")
+    context = ComicVineRepairContext(title="X-Men", issue_label="1")
+    assert _exact_local_candidate(snapshot, 999, context) is None
+    exact = _exact_local_candidate(snapshot, 100, context)
+    assert exact is not None
+    assert exact.issue_id == 100
+
+
+@pytest.mark.asyncio
+async def test_live_discovery_skips_bad_search_rows_and_deduplicates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Live discovery should validate rows and keep one stable copy of each provider issue."""
+    client = ComicVineClient("secret", tmp_path / "cache")
+
+    def fake_request(endpoint: str, params: object) -> dict[str, object]:
+        if endpoint == "search":
+            return {
+                "status_code": 1,
+                "results": [
+                    "bad-row",
+                    {"id": "bad", "name": "X-Men"},
+                    {"id": 10, "name": "X-Men", "publisher": "Marvel"},
+                    {"id": 11, "name": "X-Men", "publisher": "Marvel"},
+                ],
+            }
+        if endpoint == "issues":
+            return {
+                "status_code": 1,
+                "number_of_total_results": 2,
+                "results": [
+                    {"id": 100, "issue_number": "1", "volume": {"id": 10}},
+                    {"id": 100, "issue_number": "1", "volume": {"id": 10}},
+                ],
+            }
+        raise AssertionError(endpoint)
+
+    monkeypatch.setattr(client, "_request_sync", fake_request)
+    candidates = await discover_live_candidates(
+        client,
+        ComicVineRepairContext(title="X-Men", issue_label="1"),
+    )
+    assert [(candidate.volume_id, candidate.issue_id) for candidate in candidates] == [(10, 100)]
+
+
+@pytest.mark.asyncio
+async def test_live_discovery_rejects_non_list_search_results(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed search envelopes should fail loudly instead of becoming empty evidence."""
+    client = ComicVineClient("secret", tmp_path / "cache")
+
+    def fake_request(endpoint: str, params: object) -> dict[str, object]:
+        return {"status_code": 1, "results": {}}
+
+    monkeypatch.setattr(client, "_request_sync", fake_request)
+    with pytest.raises(ComicVineError, match="results list"):
+        await discover_live_candidates(
+            client,
+            ComicVineRepairContext(title="X-Men", issue_label="1"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_embedded_id_without_local_or_live_evidence_falls_through(
+    tmp_path: Path,
+) -> None:
+    """An unvalidated embedded ID must not be confirmed merely because the CBL supplied it."""
+    decision, scores = await repair_identity(
+        snapshot=LocalComicVineSnapshot(tmp_path / "missing.db"),
+        client=None,
+        context=ComicVineRepairContext(title="X-Men", issue_label="1"),
+        thread_issue_labels=["1"],
+        embedded_cbl_issue_id=999,
+    )
+    assert decision.status == "unresolved"
+    assert scores == ()

--- a/tests/test_comicvine_repair_pipeline_edges.py
+++ b/tests/test_comicvine_repair_pipeline_edges.py
@@ -7,6 +7,11 @@ from pathlib import Path
 
 import pytest
 
+from comic_pile.comicvine_candidate_discovery import (
+    _integer as _local_integer,
+    _publisher_name as _local_publisher_name,
+    _segment_for_labels,
+)
 from comic_pile.comicvine_identity_repair import ComicVineRepairContext
 from comic_pile.comicvine_provider import ComicVineClient, ComicVineError
 from comic_pile.comicvine_repair_pipeline import (
@@ -64,6 +69,19 @@ def test_pipeline_helpers_reject_invalid_provider_shapes() -> None:
     assert _publisher_name(3) is None
     with pytest.raises(ComicVineError, match="object result"):
         _object_result({"results": []}, "issue")
+
+
+def test_local_discovery_helpers_cover_normalization_and_segments() -> None:
+    """Local discovery helpers should normalize metadata and bound contiguous volume segments."""
+    assert _local_integer(7) == 7
+    assert _local_integer("8") == 8
+    assert _local_integer("8a") is None
+    assert _local_publisher_name(" Marvel ") == "Marvel"
+    assert _local_publisher_name({"name": " DC Comics "}) == "DC Comics"
+    assert _local_publisher_name({"name": ""}) is None
+    assert _local_publisher_name(3) is None
+    assert _segment_for_labels(["1", "2", "3", "4"], "2", {"1", "2", "3"}) == ("1", "3")
+    assert _segment_for_labels(["1", "2"], "9", {"1", "2"}) == (None, None)
 
 
 def test_candidate_from_rows_requires_ids_title_and_issue_match() -> None:
@@ -127,6 +145,9 @@ async def test_live_discovery_skips_bad_search_rows_and_deduplicates(
                 ],
             }
         if endpoint == "issues":
+            assert isinstance(params, dict)
+            if params.get("filter") == "volume:11":
+                return {"status_code": 1, "number_of_total_results": 0, "results": []}
             return {
                 "status_code": 1,
                 "number_of_total_results": 2,
@@ -162,6 +183,51 @@ async def test_live_discovery_rejects_non_list_search_results(
             client,
             ComicVineRepairContext(title="X-Men", issue_label="1"),
         )
+
+
+@pytest.mark.asyncio
+async def test_embedded_id_uses_live_exact_evidence_when_local_snapshot_misses(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An embedded CBL ID may auto-confirm only after exact live issue and volume validation."""
+    client = ComicVineClient("secret", tmp_path / "cache")
+
+    def fake_request(endpoint: str, params: object) -> dict[str, object]:
+        if endpoint == "issue/100":
+            return {
+                "status_code": 1,
+                "results": {"id": 100, "issue_number": "1", "volume": {"id": 10}},
+            }
+        if endpoint == "volume/10":
+            return {
+                "status_code": 1,
+                "results": {
+                    "id": 10,
+                    "name": "X-Men",
+                    "publisher": {"name": "Marvel"},
+                    "start_year": 1991,
+                },
+            }
+        raise AssertionError(endpoint)
+
+    monkeypatch.setattr(client, "_request_sync", fake_request)
+    decision, scores = await repair_identity(
+        snapshot=LocalComicVineSnapshot(tmp_path / "missing.db"),
+        client=client,
+        context=ComicVineRepairContext(
+            title="X-Men",
+            issue_label="1",
+            publisher="Marvel",
+            start_year=1991,
+        ),
+        thread_issue_labels=["1"],
+        embedded_cbl_issue_id=100,
+    )
+    assert decision.status == "confirmed"
+    assert decision.winner is not None
+    assert decision.winner.candidate.issue_id == 100
+    assert len(scores) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Implements #1020 with issue-level, explainable ComicVine identity repair that never treats FTS/provider rank as identity. It prefers validated embedded CBL IDs and existing confirmed mappings, discovers candidates locally before bounded live fallback, validates issue numbers or human issue names, scores publisher/year/title/neighbor/CBL evidence, preserves stale-snapshot uncertainty, derives per-volume thread segments, and persists candidate evidence for manual confirm/reject decisions.

Tests cover same-title ambiguity, foreign reprints, human labels such as `Revival`, multi-volume thread segments, stale snapshots, local-first discovery, live fallback, candidate audit persistence, and manual rejection.

Closes #1020

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added confidence-aware ComicVine identity matching using titles, issue details, publishers, years, neighboring issues, and repeated evidence.
  - Local catalog data is searched first, with validated live lookup used when needed.
  - Ambiguous matches remain available for review instead of being automatically confirmed.
  - Matching decisions now retain confidence scores, supporting evidence, snapshot freshness, and segment details.
  - Manual confirmations and rejections are supported, including required rejection reasons.

- **Bug Fixes**
  - Preserved existing confirmed identities and prevented invalid or stale candidates from replacing them.

- **Documentation**
  - Added changelog coverage for the improved identity matching and review workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->