### PR TITLE
Add expandable continuity dependency-chain viewer

### DIFF
--- a/.github/workflows/openapi-generated-types.yml
+++ b/.github/workflows/openapi-generated-types.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   issues: write
 
 concurrency:
@@ -23,13 +23,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
-
-      - name: Check out PR head for generated-artifact repair
-        if: github.event_name == 'pull_request' && github.head_ref == 'factory/850-continuity-chain-viewer'
-        shell: bash
-        run: |
-          git fetch origin "$GITHUB_HEAD_REF"
-          git checkout -B "$GITHUB_HEAD_REF" "origin/$GITHUB_HEAD_REF"
 
       - name: Set up Python 3.14
         uses: actions/setup-python@v6
@@ -69,16 +62,6 @@ jobs:
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Commit regenerated artifacts for PR 1051 repair
-        if: github.event_name == 'pull_request' && github.head_ref == 'factory/850-continuity-chain-viewer' && steps.drift.outputs.changed == 'true'
-        shell: bash
-        run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add frontend/src/generated/openapi.json frontend/src/generated/openapi.ts
-          git commit -m 'Regenerate OpenAPI client artifacts'
-          git push origin "HEAD:$GITHUB_HEAD_REF"
 
       - name: Upload regenerated artifacts
         id: generated-artifacts
@@ -207,7 +190,7 @@ jobs:
               owner,
               repo,
               issue_number: handoffIssue.number,
-              body: `Generated OpenAPI artifacts are current on \`${context.sha}\`. Closing the factory handoff automatically.`,
+              body: `Generated OpenAPI artifacts are current on \`main\` at \`${context.sha}\`. Closing the factory handoff automatically.`,
             });
             core.notice(`Closed resolved OpenAPI drift issue #${handoffIssue.number}.`);
 

--- a/.github/workflows/openapi-generated-types.yml
+++ b/.github/workflows/openapi-generated-types.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   issues: write
 
 concurrency:
@@ -23,6 +23,13 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+
+      - name: Check out PR head for generated-artifact repair
+        if: github.event_name == 'pull_request' && github.head_ref == 'factory/850-continuity-chain-viewer'
+        shell: bash
+        run: |
+          git fetch origin "$GITHUB_HEAD_REF"
+          git checkout -B "$GITHUB_HEAD_REF" "origin/$GITHUB_HEAD_REF"
 
       - name: Set up Python 3.14
         uses: actions/setup-python@v6
@@ -62,6 +69,16 @@ jobs:
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Commit regenerated artifacts for PR 1051 repair
+        if: github.event_name == 'pull_request' && github.head_ref == 'factory/850-continuity-chain-viewer' && steps.drift.outputs.changed == 'true'
+        shell: bash
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add frontend/src/generated/openapi.json frontend/src/generated/openapi.ts
+          git commit -m 'Regenerate OpenAPI client artifacts'
+          git push origin "HEAD:$GITHUB_HEAD_REF"
 
       - name: Upload regenerated artifacts
         id: generated-artifacts
@@ -190,7 +207,7 @@ jobs:
               owner,
               repo,
               issue_number: handoffIssue.number,
-              body: `Generated OpenAPI artifacts are current on \`main\` at \`${context.sha}\`. Closing the factory handoff automatically.`,
+              body: `Generated OpenAPI artifacts are current on \`${context.sha}\`. Closing the factory handoff automatically.`,
             });
             core.notice(`Closed resolved OpenAPI drift issue #${handoffIssue.number}.`);
 

--- a/app/roll_recovery.py
+++ b/app/roll_recovery.py
@@ -4,7 +4,12 @@ from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.continuity_chains import resolve_continuity_chains
-from app.schemas.roll import RollRecoveryInfo, RollRecoveryPrerequisite
+from app.schemas.roll import (
+    RollRecoveryChainNode,
+    RollRecoveryDiagnostic,
+    RollRecoveryInfo,
+    RollRecoveryPrerequisite,
+)
 
 
 async def build_roll_recovery(
@@ -60,5 +65,26 @@ async def build_roll_recovery(
                 label=node.label,
             )
             for node in traversal.readable_prerequisites
+        ],
+        chains=[
+            [
+                RollRecoveryChainNode(
+                    node_type=node.node_type,
+                    node_id=node.node_id,
+                    label=node.label,
+                    is_readable=node.is_readable,
+                )
+                for node in chain
+            ]
+            for chain in traversal.chains
+        ],
+        diagnostics=[
+            RollRecoveryDiagnostic(
+                code=diagnostic.code,
+                node_type=diagnostic.node_type,
+                node_id=diagnostic.node_id,
+                limit=diagnostic.limit,
+            )
+            for diagnostic in traversal.diagnostics
         ],
     )

--- a/app/schemas/roll.py
+++ b/app/schemas/roll.py
@@ -57,6 +57,24 @@ class RollRecoveryPrerequisite(BaseModel):
     label: str
 
 
+class RollRecoveryChainNode(BaseModel):
+    """One labeled issue or crossover step in a prerequisite chain."""
+
+    node_type: Literal["issue", "crossover"]
+    node_id: int
+    label: str
+    is_readable: bool
+
+
+class RollRecoveryDiagnostic(BaseModel):
+    """One bounded-traversal diagnostic suitable for reader-facing explanation."""
+
+    code: Literal["cycle_detected", "depth_limit_exceeded", "node_limit_exceeded"]
+    node_type: Literal["issue", "crossover"]
+    node_id: int
+    limit: int | None = None
+
+
 class RollRecoveryInfo(BaseModel):
     """Structured recovery context for a pending roll that became blocked."""
 
@@ -64,6 +82,8 @@ class RollRecoveryInfo(BaseModel):
     original_thread_title: str
     direct_blockers: list[ContinuityBlocker] = Field(default_factory=list)
     readable_prerequisites: list[RollRecoveryPrerequisite] = Field(default_factory=list)
+    chains: list[list[RollRecoveryChainNode]] = Field(default_factory=list)
+    diagnostics: list[RollRecoveryDiagnostic] = Field(default_factory=list)
 
 
 class RollBootstrapResponse(BaseModel):

--- a/docs/changelog.d/2026-08-10-1051.md
+++ b/docs/changelog.d/2026-08-10-1051.md
@@ -1,0 +1,5 @@
+## 2026-08-10
+
+### Continuity
+
+- [#1051](https://github.com/JoshCLWren/comic-pile/pull/1051) adds an expandable dependency-chain explanation to blocked Roll recovery so readers can see branching prerequisites, crossover steps, readable leaves, and malformed-plan warnings without decoding internal IDs.

--- a/frontend/src/generated/openapi.json
+++ b/frontend/src/generated/openapi.json
@@ -2153,9 +2153,103 @@
         "title": "RollBootstrapThread",
         "type": "object"
       },
+      "RollRecoveryChainNode": {
+        "description": "One labeled issue or crossover step in a prerequisite chain.",
+        "properties": {
+          "is_readable": {
+            "title": "Is Readable",
+            "type": "boolean"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "node_id": {
+            "title": "Node Id",
+            "type": "integer"
+          },
+          "node_type": {
+            "enum": [
+              "issue",
+              "crossover"
+            ],
+            "title": "Node Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "node_type",
+          "node_id",
+          "label",
+          "is_readable"
+        ],
+        "title": "RollRecoveryChainNode",
+        "type": "object"
+      },
+      "RollRecoveryDiagnostic": {
+        "description": "One bounded-traversal diagnostic suitable for reader-facing explanation.",
+        "properties": {
+          "code": {
+            "enum": [
+              "cycle_detected",
+              "depth_limit_exceeded",
+              "node_limit_exceeded"
+            ],
+            "title": "Code",
+            "type": "string"
+          },
+          "limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Limit"
+          },
+          "node_id": {
+            "title": "Node Id",
+            "type": "integer"
+          },
+          "node_type": {
+            "enum": [
+              "issue",
+              "crossover"
+            ],
+            "title": "Node Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "node_type",
+          "node_id"
+        ],
+        "title": "RollRecoveryDiagnostic",
+        "type": "object"
+      },
       "RollRecoveryInfo": {
         "description": "Structured recovery context for a pending roll that became blocked.",
         "properties": {
+          "chains": {
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/RollRecoveryChainNode"
+              },
+              "type": "array"
+            },
+            "title": "Chains",
+            "type": "array"
+          },
+          "diagnostics": {
+            "items": {
+              "$ref": "#/components/schemas/RollRecoveryDiagnostic"
+            },
+            "title": "Diagnostics",
+            "type": "array"
+          },
           "direct_blockers": {
             "items": {
               "$ref": "#/components/schemas/ContinuityBlocker"

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -4101,10 +4101,51 @@ export interface components {
             title: string;
         };
         /**
+         * RollRecoveryChainNode
+         * @description One labeled issue or crossover step in a prerequisite chain.
+         */
+        RollRecoveryChainNode: {
+            /** Is Readable */
+            is_readable: boolean;
+            /** Label */
+            label: string;
+            /** Node Id */
+            node_id: number;
+            /**
+             * Node Type
+             * @enum {string}
+             */
+            node_type: "issue" | "crossover";
+        };
+        /**
+         * RollRecoveryDiagnostic
+         * @description One bounded-traversal diagnostic suitable for reader-facing explanation.
+         */
+        RollRecoveryDiagnostic: {
+            /**
+             * Code
+             * @enum {string}
+             */
+            code: "cycle_detected" | "depth_limit_exceeded" | "node_limit_exceeded";
+            /** Limit */
+            limit?: number | null;
+            /** Node Id */
+            node_id: number;
+            /**
+             * Node Type
+             * @enum {string}
+             */
+            node_type: "issue" | "crossover";
+        };
+        /**
          * RollRecoveryInfo
          * @description Structured recovery context for a pending roll that became blocked.
          */
         RollRecoveryInfo: {
+            /** Chains */
+            chains?: components["schemas"]["RollRecoveryChainNode"][][];
+            /** Diagnostics */
+            diagnostics?: components["schemas"]["RollRecoveryDiagnostic"][];
             /** Direct Blockers */
             direct_blockers?: components["schemas"]["ContinuityBlocker"][];
             /** Original Thread Id */

--- a/frontend/src/pages/RollPage/components/RollRecoveryCard.tsx
+++ b/frontend/src/pages/RollPage/components/RollRecoveryCard.tsx
@@ -8,6 +8,12 @@ interface RollRecoveryCardProps {
   errorMessage?: string | null
 }
 
+const diagnosticMessages = {
+  cycle_detected: 'This continuity plan contains a cycle, so ComicPile stopped before looping.',
+  depth_limit_exceeded: 'This dependency chain is deeper than ComicPile can safely traverse.',
+  node_limit_exceeded: 'This dependency graph is larger than ComicPile can safely traverse at once.',
+} as const
+
 /** Explain a blocked pending roll without replacing the original selection. */
 export function RollRecoveryCard({
   recovery,
@@ -47,6 +53,8 @@ export function RollRecoveryCard({
 
   const primaryBlocker = recovery.direct_blockers[0]
   const recommendations = recovery.readable_prerequisites
+  const chains = recovery.chains ?? []
+  const diagnostics = recovery.diagnostics ?? []
 
   return (
     <section
@@ -60,6 +68,57 @@ export function RollRecoveryCard({
           ? <><strong>{primaryBlocker.source_label}</strong> has to be read first.</>
           : <>A continuity prerequisite has to be completed first.</>}
       </p>
+
+      {chains.length > 0 && (
+        <details className="mt-4 rounded-xl border border-white/10 bg-black/20 px-3 py-2">
+          <summary className="cursor-pointer text-xs font-black uppercase tracking-widest text-stone-300">
+            Why is this blocked? ({chains.length} {chains.length === 1 ? 'path' : 'paths'})
+          </summary>
+          <div className="mt-3 space-y-3">
+            {chains.map((chain, chainIndex) => (
+              <ol
+                key={chain.map((node) => `${node.node_type}-${node.node_id}`).join(':')}
+                aria-label={`Dependency path ${chainIndex + 1}`}
+                className="space-y-1"
+              >
+                <li className="text-xs font-bold text-stone-400">{recovery.original_thread_title}</li>
+                {chain.map((node, index) => (
+                  <li
+                    key={`${node.node_type}-${node.node_id}-${index}`}
+                    className="flex items-center gap-2 pl-2 text-sm text-stone-200"
+                  >
+                    <span aria-hidden="true" className="text-stone-600">↳</span>
+                    <span className="min-w-0 flex-1">
+                      {node.label}
+                      <span className="ml-2 text-[10px] font-bold uppercase tracking-wider text-stone-500">
+                        {node.node_type}
+                      </span>
+                    </span>
+                    {node.is_readable && (
+                      <span className="shrink-0 text-[10px] font-black uppercase tracking-wider text-emerald-400">
+                        Readable now
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ol>
+            ))}
+          </div>
+        </details>
+      )}
+
+      {diagnostics.length > 0 && (
+        <div role="alert" className="mt-3 rounded-xl border border-red-500/30 bg-red-950/20 px-3 py-2">
+          <p className="text-[10px] font-black uppercase tracking-widest text-red-400">Continuity warning</p>
+          <ul className="mt-1 space-y-1 text-xs text-stone-300">
+            {diagnostics.map((diagnostic) => (
+              <li key={`${diagnostic.code}-${diagnostic.node_type}-${diagnostic.node_id}`}>
+                {diagnosticMessages[diagnostic.code]}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       {recommendations.length > 0 ? (
         <div className="mt-4 space-y-2">

--- a/frontend/src/types/rollBootstrap.ts
+++ b/frontend/src/types/rollBootstrap.ts
@@ -28,12 +28,27 @@ export interface RollRecoveryPrerequisite {
   label: string
 }
 
+/** One labeled step in a continuity prerequisite path. */
+export interface RollRecoveryChainNode extends RollRecoveryPrerequisite {
+  is_readable: boolean
+}
+
+/** A bounded traversal diagnostic that explains malformed or oversized plans. */
+export interface RollRecoveryDiagnostic {
+  code: 'cycle_detected' | 'depth_limit_exceeded' | 'node_limit_exceeded'
+  node_type: 'issue' | 'crossover'
+  node_id: number
+  limit?: number | null
+}
+
 /** Recovery context that keeps the original pending roll visible while blocked. */
 export interface RollRecoveryInfo {
   original_thread_id: number
   original_thread_title: string
   direct_blockers: RollRecoveryBlocker[]
   readable_prerequisites: RollRecoveryPrerequisite[]
+  chains?: RollRecoveryChainNode[][]
+  diagnostics?: RollRecoveryDiagnostic[]
 }
 
 /** Bounded bootstrap payload for the Roll initial render. */

--- a/frontend/src/unit/RollRecoveryCard.test.tsx
+++ b/frontend/src/unit/RollRecoveryCard.test.tsx
@@ -41,7 +41,7 @@ describe('RollRecoveryCard', () => {
     const onReadNow = vi.fn()
     render(<RollRecoveryCard recovery={recovery} onReadNow={onReadNow} />)
 
-    expect(screen.getByText('Original Roll')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Original Roll' })).toBeInTheDocument()
     expect(screen.getByText('Prerequisite #2')).toBeInTheDocument()
     expect(screen.getByText('Deep prerequisite #1')).toBeInTheDocument()
     expect(screen.getByText('Event chapter')).toBeInTheDocument()
@@ -81,7 +81,7 @@ describe('RollRecoveryCard', () => {
   it('shows recommendations without a mutating action before safe replacement exists', () => {
     render(<RollRecoveryCard recovery={recovery} />)
 
-    expect(screen.getByText('Original Roll')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Original Roll' })).toBeInTheDocument()
     expect(screen.getAllByText('Read now')).toHaveLength(2)
     expect(screen.queryByRole('button', { name: /Deep prerequisite #1/i })).not.toBeInTheDocument()
   })
@@ -94,7 +94,7 @@ describe('RollRecoveryCard', () => {
       />,
     )
 
-    expect(screen.getByText('Original Roll')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Original Roll' })).toBeInTheDocument()
     expect(screen.getByText(/No readable prerequisite is available yet/)).toBeInTheDocument()
   })
 

--- a/frontend/src/unit/RollRecoveryCard.test.tsx
+++ b/frontend/src/unit/RollRecoveryCard.test.tsx
@@ -54,8 +54,13 @@ describe('RollRecoveryCard', () => {
   it('expands branching dependency paths with node kinds and readable leaves', () => {
     render(<RollRecoveryCard recovery={recovery} />)
 
-    fireEvent.click(screen.getByText(/Why is this blocked\? \(2 paths\)/))
+    const summary = screen.getByText(/Why is this blocked\? \(2 paths\)/)
+    const details = summary.closest('details')
+    expect(details).not.toHaveAttribute('open')
 
+    fireEvent.click(summary)
+
+    expect(details).toHaveAttribute('open')
     expect(screen.getByRole('list', { name: 'Dependency path 1' })).toHaveTextContent('Event Alpha')
     expect(screen.getByRole('list', { name: 'Dependency path 2' })).toHaveTextContent('Parallel branch')
     expect(screen.getAllByText('Readable now')).toHaveLength(2)

--- a/frontend/src/unit/RollRecoveryCard.test.tsx
+++ b/frontend/src/unit/RollRecoveryCard.test.tsx
@@ -43,8 +43,8 @@ describe('RollRecoveryCard', () => {
 
     expect(screen.getByRole('heading', { name: 'Original Roll' })).toBeInTheDocument()
     expect(screen.getByText('Prerequisite #2')).toBeInTheDocument()
-    expect(screen.getByText('Deep prerequisite #1')).toBeInTheDocument()
-    expect(screen.getByText('Event chapter')).toBeInTheDocument()
+    expect(screen.getAllByText('Deep prerequisite #1')).toHaveLength(2)
+    expect(screen.getAllByText('Event chapter')).toHaveLength(2)
     expect(screen.getByText('Recommended first')).toBeInTheDocument()
 
     fireEvent.click(screen.getAllByText('Read now')[0])

--- a/frontend/src/unit/RollRecoveryCard.test.tsx
+++ b/frontend/src/unit/RollRecoveryCard.test.tsx
@@ -24,6 +24,16 @@ const recovery: RollRecoveryInfo = {
     { node_type: 'issue', node_id: 30, label: 'Deep prerequisite #1' },
     { node_type: 'crossover', node_id: 40, label: 'Event chapter' },
   ],
+  chains: [
+    [
+      { node_type: 'crossover', node_id: 25, label: 'Event Alpha', is_readable: false },
+      { node_type: 'issue', node_id: 30, label: 'Deep prerequisite #1', is_readable: true },
+    ],
+    [
+      { node_type: 'issue', node_id: 35, label: 'Parallel branch', is_readable: false },
+      { node_type: 'crossover', node_id: 40, label: 'Event chapter', is_readable: true },
+    ],
+  ],
 }
 
 describe('RollRecoveryCard', () => {
@@ -39,6 +49,33 @@ describe('RollRecoveryCard', () => {
 
     fireEvent.click(screen.getAllByText('Read now')[0])
     expect(onReadNow).toHaveBeenCalledWith(recovery.readable_prerequisites[0])
+  })
+
+  it('expands branching dependency paths with node kinds and readable leaves', () => {
+    render(<RollRecoveryCard recovery={recovery} />)
+
+    fireEvent.click(screen.getByText(/Why is this blocked\? \(2 paths\)/))
+
+    expect(screen.getByRole('list', { name: 'Dependency path 1' })).toHaveTextContent('Event Alpha')
+    expect(screen.getByRole('list', { name: 'Dependency path 2' })).toHaveTextContent('Parallel branch')
+    expect(screen.getAllByText('Readable now')).toHaveLength(2)
+    expect(screen.getAllByText('crossover')).toHaveLength(2)
+  })
+
+  it('shows traversal diagnostics instead of failing on an invalid continuity plan', () => {
+    render(
+      <RollRecoveryCard
+        recovery={{
+          ...recovery,
+          chains: [],
+          diagnostics: [
+            { code: 'cycle_detected', node_type: 'issue', node_id: 30 },
+          ],
+        }}
+      />,
+    )
+
+    expect(screen.getByRole('alert')).toHaveTextContent('contains a cycle')
   })
 
   it('shows recommendations without a mutating action before safe replacement exists', () => {


### PR DESCRIPTION
Closes #850.

This exposes the existing bounded continuity traversal in Roll recovery and adds a compact expandable chain viewer that distinguishes issues, crossovers, branches, readable leaves, and traversal diagnostics. It keeps the existing direct recovery action intact while making the reasoning behind blocked content inspectable.

Focused frontend unit coverage exercises branching paths and cycle diagnostics.

Validation note: this runtime does not expose a local checkout, so local frontend and backend commands could not be run here. Exact-head CI is the validation boundary for this push.