### PR TITLE
Add resumable live ComicVine refresh for hydrator misses

### DIFF
--- a/comic_pile/comicvine_live_refresh.py
+++ b/comic_pile/comicvine_live_refresh.py
@@ -1,0 +1,115 @@
+"""Budgeted live ComicVine refresh for read-only hydration reports."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from comic_pile.comicvine_provider import ComicVineClient, ComicVineError, ComicVineRateLimitError
+
+
+@dataclass(frozen=True)
+class LiveRefreshSummary:
+    """Summary of one live-refresh pass over a hydration report."""
+
+    attempted: int
+    matched: int
+    failed: int
+    budget_exhausted: bool
+
+
+def _provider_issue_id(payload: Mapping[str, object]) -> int | None:
+    """Extract the provider issue ID from a singular ComicVine response."""
+    result = payload.get("results")
+    if not isinstance(result, dict):
+        return None
+    value = result.get("id")
+    return value if isinstance(value, int) else None
+
+
+def _recount(report: dict[str, object]) -> None:
+    """Recompute report status counts after live reconciliation."""
+    issues = report.get("issues")
+    if not isinstance(issues, list):
+        return
+    counts: dict[str, int] = {}
+    for row in issues:
+        if not isinstance(row, dict):
+            continue
+        status = row.get("status")
+        if isinstance(status, str):
+            counts[status] = counts.get(status, 0) + 1
+    report["summary"] = {"total": len(issues), **counts}
+
+
+async def refresh_confirmed_local_misses(
+    report: dict[str, object],
+    client: ComicVineClient,
+    *,
+    refresh: bool = False,
+) -> LiveRefreshSummary:
+    """Resolve confirmed local misses through the cached, endpoint-budgeted provider client.
+
+    Only rows that already have an exact confirmed ComicVine issue identity are eligible. This
+    deliberately avoids search or fuzzy matching. Cached successful responses are reused on reruns,
+    and the provider client's persistent endpoint ledger survives process restarts.
+
+    Args:
+        report: Hydration report produced by ``build_report``.
+        client: Configured ComicVine provider client.
+        refresh: Force a live provider request instead of reusing a cached response.
+
+    Returns:
+        Counts describing the reconciliation pass. When the rolling endpoint budget is exhausted,
+        processing stops cleanly and untouched rows remain resumable local misses.
+    """
+    issues = report.get("issues")
+    if not isinstance(issues, list):
+        raise ValueError("hydration report must contain an issues list")
+
+    attempted = 0
+    matched = 0
+    failed = 0
+    budget_exhausted = False
+
+    for row in issues:
+        if not isinstance(row, dict) or row.get("status") != "local-miss":
+            continue
+        issue_id = row.get("comicvine_issue_id")
+        if not isinstance(issue_id, int):
+            continue
+
+        attempted += 1
+        try:
+            response = await client.fetch_issue(issue_id, refresh=refresh)
+        except ComicVineRateLimitError:
+            budget_exhausted = True
+            break
+        except ComicVineError as exc:
+            row["status"] = "failed"
+            row["provenance"] = "comicvine-live"
+            row["detail"] = f"Confirmed identity live refresh failed: {exc}"
+            failed += 1
+            continue
+
+        returned_id = _provider_issue_id(response.payload)
+        if returned_id != issue_id:
+            row["status"] = "failed"
+            row["provenance"] = "comicvine-cache" if response.from_cache else "comicvine-live"
+            row["detail"] = "Provider response did not match the confirmed ComicVine issue identity."
+            failed += 1
+            continue
+
+        row["status"] = "matched"
+        row["provenance"] = "comicvine-cache" if response.from_cache else "comicvine-live"
+        row["detail"] = "Confirmed identity resolved through the budgeted ComicVine issue endpoint."
+        matched += 1
+
+    _recount(report)
+    report["live_refresh"] = {
+        "attempted": attempted,
+        "matched": matched,
+        "failed": failed,
+        "budget_exhausted": budget_exhausted,
+    }
+    return LiveRefreshSummary(attempted, matched, failed, budget_exhausted)

--- a/docs/changelog.d/2026-08-10-1052.md
+++ b/docs/changelog.d/2026-08-10-1052.md
@@ -1,0 +1,5 @@
+## 2026-08-10
+
+### ComicVine hydration
+
+- [PR #1052](https://github.com/JoshCLWren/comic-pile/pull/1052) adds an opt-in, restart-safe live refresh for confirmed ComicVine issue identities that are missing from the local snapshot. Cached responses and the persistent per-endpoint request ledger are reused across runs, and hitting the configured budget leaves remaining misses untouched for a later resume instead of guessing or overrunning the provider limit.

--- a/docs/changelog.d/2026-08-10-1052.md
+++ b/docs/changelog.d/2026-08-10-1052.md
@@ -2,4 +2,4 @@
 
 ### ComicVine hydration
 
-- [PR #1052](https://github.com/JoshCLWren/comic-pile/pull/1052) adds an opt-in, restart-safe live refresh for confirmed ComicVine issue identities that are missing from the local snapshot. Cached responses and the persistent per-endpoint request ledger are reused across runs, and hitting the configured budget leaves remaining misses untouched for a later resume instead of guessing or overrunning the provider limit.
+- [#1052](https://github.com/JoshCLWren/comic-pile/pull/1052) adds an opt-in, restart-safe live refresh for confirmed ComicVine issue identities that are missing from the local snapshot. Cached responses and the persistent per-endpoint request ledger are reused across runs, and hitting the configured budget leaves remaining misses untouched for a later resume instead of guessing or overrunning the provider limit.

--- a/scripts/hydrate_comicvine_issues.py
+++ b/scripts/hydrate_comicvine_issues.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import os
 from pathlib import Path
 
 from app.database import AsyncSessionLocal
 from comic_pile.comicvine_hydrator import build_report, enumerate_user_issues, write_report
+from comic_pile.comicvine_live_refresh import refresh_confirmed_local_misses
+from comic_pile.comicvine_provider import ComicVineClient, DEFAULT_REQUESTS_PER_HOUR
 from comic_pile.local_comicvine import LocalComicVineSnapshot
 
 
@@ -26,6 +29,23 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--user-id", type=int, required=True)
     parser.add_argument("--comicvine-db", type=Path)
     parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--cache-dir", type=Path, default=Path(".cache/comicvine-hydrator"))
+    parser.add_argument(
+        "--requests-per-hour",
+        type=int,
+        default=DEFAULT_REQUESTS_PER_HOUR,
+        help="Per-endpoint rolling request ceiling; defaults to the conservative provider budget.",
+    )
+    parser.add_argument(
+        "--live-refresh",
+        action="store_true",
+        help="Use cached/live ComicVine issue requests for confirmed identities missing locally.",
+    )
+    parser.add_argument(
+        "--force-refresh",
+        action="store_true",
+        help="Bypass successful response cache entries during --live-refresh.",
+    )
     parser.add_argument("--include-test-threads", action="store_true")
     return parser.parse_args()
 
@@ -44,6 +64,18 @@ async def run(args: argparse.Namespace) -> None:
             include_test_threads=args.include_test_threads,
         )
     report = await build_report(targets, snapshot)
+
+    if args.live_refresh:
+        api_key = os.environ.get("COMICVINE_API_KEY", "")
+        if not api_key.strip():
+            raise RuntimeError("COMICVINE_API_KEY is required when --live-refresh is enabled")
+        client = ComicVineClient(
+            api_key,
+            args.cache_dir,
+            requests_per_hour=args.requests_per_hour,
+        )
+        await refresh_confirmed_local_misses(report, client, refresh=args.force_refresh)
+
     write_report(report, args.output)
 
 

--- a/tests/test_comicvine_live_refresh.py
+++ b/tests/test_comicvine_live_refresh.py
@@ -13,8 +13,7 @@ from comic_pile.comicvine_provider import (
 )
 
 
-def report_with_misses() -> dict[str, object]:
-    """Build a compact hydration report fixture."""
+def _report_with_misses() -> dict[str, object]:
     return {
         "summary": {"total": 3, "matched": 1, "local-miss": 2},
         "issues": [
@@ -25,8 +24,7 @@ def report_with_misses() -> dict[str, object]:
     }
 
 
-def issue_rows(report: dict[str, object]) -> list[dict[str, object]]:
-    """Return typed issue rows from a report fixture."""
+def _issue_rows(report: dict[str, object]) -> list[dict[str, object]]:
     value = report["issues"]
     assert isinstance(value, list)
     assert all(isinstance(row, dict) for row in value)
@@ -43,14 +41,14 @@ async def test_refresh_reconciles_confirmed_miss_from_cache() -> None:
             cache_key="issue-cached",
         )
     )
-    report = report_with_misses()
-    report["issues"] = issue_rows(report)[:2]
+    report = _report_with_misses()
+    report["issues"] = _issue_rows(report)[:2]
 
     summary = await refresh_confirmed_local_misses(report, client)
 
     assert summary.matched == 1
     assert report["summary"] == {"total": 2, "matched": 2}
-    refreshed = issue_rows(report)[1]
+    refreshed = _issue_rows(report)[1]
     assert refreshed["provenance"] == "comicvine-cache"
     client.fetch_issue.assert_awaited_once_with(202, refresh=False)
 
@@ -65,14 +63,14 @@ async def test_refresh_rejects_provider_identity_mismatch() -> None:
             cache_key="issue-live",
         )
     )
-    report = report_with_misses()
-    report["issues"] = issue_rows(report)[:2]
+    report = _report_with_misses()
+    report["issues"] = _issue_rows(report)[:2]
 
     summary = await refresh_confirmed_local_misses(report, client)
 
     assert summary.failed == 1
     assert report["summary"] == {"total": 2, "matched": 1, "failed": 1}
-    assert issue_rows(report)[1]["status"] == "failed"
+    assert _issue_rows(report)[1]["status"] == "failed"
 
 
 async def test_refresh_rejects_malformed_provider_payload() -> None:
@@ -85,13 +83,13 @@ async def test_refresh_rejects_malformed_provider_payload() -> None:
             cache_key="issue-live",
         )
     )
-    report = report_with_misses()
-    report["issues"] = issue_rows(report)[:2]
+    report = _report_with_misses()
+    report["issues"] = _issue_rows(report)[:2]
 
     summary = await refresh_confirmed_local_misses(report, client)
 
     assert summary.failed == 1
-    assert issue_rows(report)[1]["status"] == "failed"
+    assert _issue_rows(report)[1]["status"] == "failed"
 
 
 async def test_refresh_records_provider_failure_and_continues() -> None:
@@ -107,14 +105,14 @@ async def test_refresh_records_provider_failure_and_continues() -> None:
             ),
         ]
     )
-    report = report_with_misses()
+    report = _report_with_misses()
 
     summary = await refresh_confirmed_local_misses(report, client)
 
     assert summary.attempted == 2
     assert summary.failed == 1
     assert summary.matched == 1
-    rows = issue_rows(report)
+    rows = _issue_rows(report)
     assert rows[1]["status"] == "failed"
     assert rows[1]["provenance"] == "comicvine-live"
     assert rows[2]["status"] == "matched"
@@ -163,14 +161,14 @@ async def test_budget_exhaustion_stops_cleanly_and_preserves_remaining_misses() 
     """The rolling provider ceiling leaves untouched rows resumable on the next run."""
     client = Mock()
     client.fetch_issue = AsyncMock(side_effect=ComicVineRateLimitError("budget exhausted"))
-    report = report_with_misses()
+    report = _report_with_misses()
 
     summary = await refresh_confirmed_local_misses(report, client)
 
     assert summary.budget_exhausted is True
     assert summary.attempted == 1
     assert report["summary"] == {"total": 3, "matched": 1, "local-miss": 2}
-    rows = issue_rows(report)
+    rows = _issue_rows(report)
     assert rows[1]["status"] == "local-miss"
     assert rows[2]["status"] == "local-miss"
     live_refresh = report["live_refresh"]
@@ -188,8 +186,8 @@ async def test_force_refresh_is_forwarded_to_provider_client() -> None:
             cache_key="issue-live",
         )
     )
-    report = report_with_misses()
-    report["issues"] = issue_rows(report)[:2]
+    report = _report_with_misses()
+    report["issues"] = _issue_rows(report)[:2]
 
     await refresh_confirmed_local_misses(report, client, refresh=True)
 

--- a/tests/test_comicvine_live_refresh.py
+++ b/tests/test_comicvine_live_refresh.py
@@ -1,0 +1,94 @@
+"""Tests for budgeted live refresh of ComicVine hydration misses."""
+
+from unittest.mock import AsyncMock, Mock
+
+from comic_pile.comicvine_live_refresh import refresh_confirmed_local_misses
+from comic_pile.comicvine_provider import ComicVineRateLimitError, ComicVineResponse
+
+
+def report_with_misses() -> dict[str, object]:
+    """Build a compact hydration report fixture."""
+    return {
+        "summary": {"total": 3, "matched": 1, "local-miss": 2},
+        "issues": [
+            {"issue_id": 1, "status": "matched", "comicvine_issue_id": 101},
+            {"issue_id": 2, "status": "local-miss", "comicvine_issue_id": 202},
+            {"issue_id": 3, "status": "local-miss", "comicvine_issue_id": 303},
+        ],
+    }
+
+
+async def test_refresh_reconciles_confirmed_miss_from_cache() -> None:
+    """Cached exact issue responses satisfy a local miss without spending new quota."""
+    client = Mock()
+    client.fetch_issue = AsyncMock(
+        return_value=ComicVineResponse(
+            payload={"results": {"id": 202, "issue_number": "12"}},
+            from_cache=True,
+            cache_key="issue-cached",
+        )
+    )
+    report = report_with_misses()
+    report["issues"] = report["issues"][:2]
+
+    summary = await refresh_confirmed_local_misses(report, client)
+
+    assert summary.matched == 1
+    assert report["summary"] == {"total": 2, "matched": 2}
+    refreshed = report["issues"][1]
+    assert refreshed["provenance"] == "comicvine-cache"
+    client.fetch_issue.assert_awaited_once_with(202, refresh=False)
+
+
+async def test_refresh_rejects_provider_identity_mismatch() -> None:
+    """A provider response may never replace the already-confirmed issue identity."""
+    client = Mock()
+    client.fetch_issue = AsyncMock(
+        return_value=ComicVineResponse(
+            payload={"results": {"id": 999}},
+            from_cache=False,
+            cache_key="issue-live",
+        )
+    )
+    report = report_with_misses()
+    report["issues"] = report["issues"][:2]
+
+    summary = await refresh_confirmed_local_misses(report, client)
+
+    assert summary.failed == 1
+    assert report["summary"] == {"total": 2, "matched": 1, "failed": 1}
+    assert report["issues"][1]["status"] == "failed"
+
+
+async def test_budget_exhaustion_stops_cleanly_and_preserves_remaining_misses() -> None:
+    """The rolling provider ceiling leaves untouched rows resumable on the next run."""
+    client = Mock()
+    client.fetch_issue = AsyncMock(side_effect=ComicVineRateLimitError("budget exhausted"))
+    report = report_with_misses()
+
+    summary = await refresh_confirmed_local_misses(report, client)
+
+    assert summary.budget_exhausted is True
+    assert summary.attempted == 1
+    assert report["summary"] == {"total": 3, "matched": 1, "local-miss": 2}
+    assert report["issues"][1]["status"] == "local-miss"
+    assert report["issues"][2]["status"] == "local-miss"
+    assert report["live_refresh"]["budget_exhausted"] is True
+
+
+async def test_force_refresh_is_forwarded_to_provider_client() -> None:
+    """Explicit refresh bypasses cached responses while preserving exact identity checks."""
+    client = Mock()
+    client.fetch_issue = AsyncMock(
+        return_value=ComicVineResponse(
+            payload={"results": {"id": 202}},
+            from_cache=False,
+            cache_key="issue-live",
+        )
+    )
+    report = report_with_misses()
+    report["issues"] = report["issues"][:2]
+
+    await refresh_confirmed_local_misses(report, client, refresh=True)
+
+    client.fetch_issue.assert_awaited_once_with(202, refresh=True)

--- a/tests/test_comicvine_live_refresh.py
+++ b/tests/test_comicvine_live_refresh.py
@@ -1,9 +1,16 @@
 """Tests for budgeted live refresh of ComicVine hydration misses."""
 
+from typing import cast
 from unittest.mock import AsyncMock, Mock
 
-from comic_pile.comicvine_live_refresh import refresh_confirmed_local_misses
-from comic_pile.comicvine_provider import ComicVineRateLimitError, ComicVineResponse
+import pytest
+
+from comic_pile.comicvine_live_refresh import _recount, refresh_confirmed_local_misses
+from comic_pile.comicvine_provider import (
+    ComicVineError,
+    ComicVineRateLimitError,
+    ComicVineResponse,
+)
 
 
 def report_with_misses() -> dict[str, object]:
@@ -23,7 +30,7 @@ def issue_rows(report: dict[str, object]) -> list[dict[str, object]]:
     value = report["issues"]
     assert isinstance(value, list)
     assert all(isinstance(row, dict) for row in value)
-    return value
+    return cast(list[dict[str, object]], value)
 
 
 async def test_refresh_reconciles_confirmed_miss_from_cache() -> None:
@@ -66,6 +73,90 @@ async def test_refresh_rejects_provider_identity_mismatch() -> None:
     assert summary.failed == 1
     assert report["summary"] == {"total": 2, "matched": 1, "failed": 1}
     assert issue_rows(report)[1]["status"] == "failed"
+
+
+async def test_refresh_rejects_malformed_provider_payload() -> None:
+    """A singular response without an integer ID cannot satisfy a confirmed identity."""
+    client = Mock()
+    client.fetch_issue = AsyncMock(
+        return_value=ComicVineResponse(
+            payload={"results": "unexpected"},
+            from_cache=False,
+            cache_key="issue-live",
+        )
+    )
+    report = report_with_misses()
+    report["issues"] = issue_rows(report)[:2]
+
+    summary = await refresh_confirmed_local_misses(report, client)
+
+    assert summary.failed == 1
+    assert issue_rows(report)[1]["status"] == "failed"
+
+
+async def test_refresh_records_provider_failure_and_continues() -> None:
+    """Provider failures become report rows while later confirmed misses remain resumable."""
+    client = Mock()
+    client.fetch_issue = AsyncMock(
+        side_effect=[
+            ComicVineError("provider unavailable"),
+            ComicVineResponse(
+                payload={"results": {"id": 303}},
+                from_cache=False,
+                cache_key="issue-live",
+            ),
+        ]
+    )
+    report = report_with_misses()
+
+    summary = await refresh_confirmed_local_misses(report, client)
+
+    assert summary.attempted == 2
+    assert summary.failed == 1
+    assert summary.matched == 1
+    rows = issue_rows(report)
+    assert rows[1]["status"] == "failed"
+    assert rows[1]["provenance"] == "comicvine-live"
+    assert rows[2]["status"] == "matched"
+
+
+async def test_refresh_skips_ineligible_rows() -> None:
+    """Only local misses with integer confirmed identities can spend provider budget."""
+    client = Mock()
+    client.fetch_issue = AsyncMock()
+    report: dict[str, object] = {
+        "issues": [
+            "not-a-row",
+            {"status": "matched", "comicvine_issue_id": 101},
+            {"status": "local-miss", "comicvine_issue_id": "202"},
+        ]
+    }
+
+    summary = await refresh_confirmed_local_misses(report, client)
+
+    assert summary.attempted == 0
+    assert report["summary"] == {"total": 3, "matched": 1, "local-miss": 1}
+    client.fetch_issue.assert_not_awaited()
+
+
+async def test_refresh_requires_issue_list() -> None:
+    """Malformed hydration reports fail before any provider request is attempted."""
+    client = Mock()
+    client.fetch_issue = AsyncMock()
+
+    with pytest.raises(ValueError, match="issues list"):
+        await refresh_confirmed_local_misses({"issues": "invalid"}, client)
+
+    client.fetch_issue.assert_not_awaited()
+
+
+def test_recount_ignores_non_list_issue_payload() -> None:
+    """Recount is a no-op when called on an unrelated report shape."""
+    report: dict[str, object] = {"issues": "invalid", "summary": {"total": 1}}
+
+    _recount(report)
+
+    assert report["summary"] == {"total": 1}
 
 
 async def test_budget_exhaustion_stops_cleanly_and_preserves_remaining_misses() -> None:

--- a/tests/test_comicvine_live_refresh.py
+++ b/tests/test_comicvine_live_refresh.py
@@ -71,6 +71,7 @@ async def test_refresh_rejects_provider_identity_mismatch() -> None:
     assert summary.failed == 1
     assert report["summary"] == {"total": 2, "matched": 1, "failed": 1}
     assert _issue_rows(report)[1]["status"] == "failed"
+    assert _issue_rows(report)[1]["comicvine_issue_id"] == 202
 
 
 async def test_refresh_rejects_malformed_provider_payload() -> None:
@@ -90,6 +91,7 @@ async def test_refresh_rejects_malformed_provider_payload() -> None:
 
     assert summary.failed == 1
     assert _issue_rows(report)[1]["status"] == "failed"
+    assert _issue_rows(report)[1]["comicvine_issue_id"] == 202
 
 
 async def test_refresh_records_provider_failure_and_continues() -> None:

--- a/tests/test_comicvine_live_refresh.py
+++ b/tests/test_comicvine_live_refresh.py
@@ -18,6 +18,14 @@ def report_with_misses() -> dict[str, object]:
     }
 
 
+def issue_rows(report: dict[str, object]) -> list[dict[str, object]]:
+    """Return typed issue rows from a report fixture."""
+    value = report["issues"]
+    assert isinstance(value, list)
+    assert all(isinstance(row, dict) for row in value)
+    return value
+
+
 async def test_refresh_reconciles_confirmed_miss_from_cache() -> None:
     """Cached exact issue responses satisfy a local miss without spending new quota."""
     client = Mock()
@@ -29,13 +37,13 @@ async def test_refresh_reconciles_confirmed_miss_from_cache() -> None:
         )
     )
     report = report_with_misses()
-    report["issues"] = report["issues"][:2]
+    report["issues"] = issue_rows(report)[:2]
 
     summary = await refresh_confirmed_local_misses(report, client)
 
     assert summary.matched == 1
     assert report["summary"] == {"total": 2, "matched": 2}
-    refreshed = report["issues"][1]
+    refreshed = issue_rows(report)[1]
     assert refreshed["provenance"] == "comicvine-cache"
     client.fetch_issue.assert_awaited_once_with(202, refresh=False)
 
@@ -51,13 +59,13 @@ async def test_refresh_rejects_provider_identity_mismatch() -> None:
         )
     )
     report = report_with_misses()
-    report["issues"] = report["issues"][:2]
+    report["issues"] = issue_rows(report)[:2]
 
     summary = await refresh_confirmed_local_misses(report, client)
 
     assert summary.failed == 1
     assert report["summary"] == {"total": 2, "matched": 1, "failed": 1}
-    assert report["issues"][1]["status"] == "failed"
+    assert issue_rows(report)[1]["status"] == "failed"
 
 
 async def test_budget_exhaustion_stops_cleanly_and_preserves_remaining_misses() -> None:
@@ -71,9 +79,12 @@ async def test_budget_exhaustion_stops_cleanly_and_preserves_remaining_misses() 
     assert summary.budget_exhausted is True
     assert summary.attempted == 1
     assert report["summary"] == {"total": 3, "matched": 1, "local-miss": 2}
-    assert report["issues"][1]["status"] == "local-miss"
-    assert report["issues"][2]["status"] == "local-miss"
-    assert report["live_refresh"]["budget_exhausted"] is True
+    rows = issue_rows(report)
+    assert rows[1]["status"] == "local-miss"
+    assert rows[2]["status"] == "local-miss"
+    live_refresh = report["live_refresh"]
+    assert isinstance(live_refresh, dict)
+    assert live_refresh["budget_exhausted"] is True
 
 
 async def test_force_refresh_is_forwarded_to_provider_client() -> None:
@@ -87,7 +98,7 @@ async def test_force_refresh_is_forwarded_to_provider_client() -> None:
         )
     )
     report = report_with_misses()
-    report["issues"] = report["issues"][:2]
+    report["issues"] = issue_rows(report)[:2]
 
     await refresh_confirmed_local_misses(report, client, refresh=True)
 


### PR DESCRIPTION
Continues #1025.

Adds an opt-in live-refresh pass for exact confirmed ComicVine issue identities that miss the local snapshot. The pass reuses the existing persistent response cache and endpoint request ledger from #1019, stops cleanly when the rolling budget is exhausted, preserves untouched misses for a later rerun, and rejects provider responses whose returned issue ID does not match the confirmed identity.

The CLI now exposes cache directory, per-endpoint request ceiling, live refresh, and explicit force-refresh controls. Focused tests cover cached reuse, exact-identity validation, clean budget exhaustion, and forced refresh.

This is a coherent continuation of the larger hydrator issue, not full closure of #1025.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional live refresh for confirmed issues missing from local ComicVine data.
  - Supports configurable caching, request limits, and forced refreshes.
  - Refreshes can resume later when the request budget is exhausted.
  - Automatically updates matched records and refresh statistics.

- **Bug Fixes**
  - Handles provider failures, malformed responses, and identity mismatches without stopping remaining refreshes.

- **Documentation**
  - Documented opt-in live refresh behavior, cache reuse, request tracking, and deferred requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->