### PR TITLE
Batch ComicVine stale-miss refresh by volume

### DIFF
--- a/comic_pile/comicvine_live_refresh.py
+++ b/comic_pile/comicvine_live_refresh.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from collections.abc import Mapping
 from dataclasses import dataclass
 
@@ -16,6 +17,8 @@ class LiveRefreshSummary:
     matched: int
     failed: int
     budget_exhausted: bool
+    volume_batches: int
+    issue_requests: int
 
 
 def _provider_issue_id(payload: Mapping[str, object]) -> int | None:
@@ -25,6 +28,11 @@ def _provider_issue_id(payload: Mapping[str, object]) -> int | None:
         return None
     value = result.get("id")
     return value if isinstance(value, int) else None
+
+
+def _volume_issue_ids(rows: list[dict[str, object]]) -> set[int]:
+    """Return integer issue IDs from one validated ComicVine volume roster."""
+    return {value for row in rows if isinstance((value := row.get("id")), int)}
 
 
 def _recount(report: dict[str, object]) -> None:
@@ -42,68 +50,130 @@ def _recount(report: dict[str, object]) -> None:
     report["summary"] = {"total": len(issues), **counts}
 
 
+def _mark_matched(row: dict[str, object], *, from_cache: bool, detail: str) -> None:
+    """Mark one hydration row as safely reconciled without replacing its identity."""
+    row["status"] = "matched"
+    row["provenance"] = "comicvine-cache" if from_cache else "comicvine-live"
+    row["detail"] = detail
+
+
+def _mark_failed(row: dict[str, object], *, from_cache: bool, detail: str) -> None:
+    """Mark one hydration row failed while preserving its confirmed identity."""
+    row["status"] = "failed"
+    row["provenance"] = "comicvine-cache" if from_cache else "comicvine-live"
+    row["detail"] = detail
+
+
 async def refresh_confirmed_local_misses(
     report: dict[str, object],
     client: ComicVineClient,
     *,
     refresh: bool = False,
 ) -> LiveRefreshSummary:
-    """Resolve confirmed local misses through the cached, endpoint-budgeted provider client.
+    """Resolve confirmed local misses through cached, endpoint-budgeted provider calls.
 
-    Only rows that already have an exact confirmed ComicVine issue identity are eligible. This
-    deliberately avoids search or fuzzy matching. Cached successful responses are reused on reruns,
-    and the provider client's persistent endpoint ledger survives process restarts.
+    Rows that carry a known ComicVine volume ID are grouped first so one paginated ``/issues``
+    request sequence can reconcile many confirmed issue IDs. Any rows not satisfied by their volume
+    roster then fall back to the narrow singular issue endpoint. Exact confirmed issue identities
+    remain authoritative throughout; volume membership is only a batching optimization and never
+    replaces or guesses an issue identity.
 
     Args:
-        report: Hydration report produced by ``build_report``.
+        report: Hydration report produced by ``build_report`` or an enriched assessment report.
         client: Configured ComicVine provider client.
-        refresh: Force a live provider request instead of reusing a cached response.
+        refresh: Force live provider requests instead of reusing cached responses.
 
     Returns:
-        Counts describing the reconciliation pass. When the rolling endpoint budget is exhausted,
-        processing stops cleanly and untouched rows remain resumable local misses.
+        Counts describing the reconciliation pass. When a rolling endpoint budget is exhausted,
+        untouched rows remain local misses so a later rerun can resume safely.
     """
     issues = report.get("issues")
     if not isinstance(issues, list):
         raise ValueError("hydration report must contain an issues list")
 
-    attempted = 0
+    eligible = [
+        row
+        for row in issues
+        if isinstance(row, dict)
+        and row.get("status") == "local-miss"
+        and isinstance(row.get("comicvine_issue_id"), int)
+    ]
+    attempted = len(eligible)
     matched = 0
     failed = 0
     budget_exhausted = False
+    volume_batches = 0
+    issue_requests = 0
 
-    for row in issues:
-        if not isinstance(row, dict) or row.get("status") != "local-miss":
-            continue
-        issue_id = row.get("comicvine_issue_id")
-        if not isinstance(issue_id, int):
-            continue
+    volume_groups: dict[int, list[dict[str, object]]] = defaultdict(list)
+    for row in eligible:
+        volume_id = row.get("comicvine_volume_id")
+        if isinstance(volume_id, int):
+            volume_groups[volume_id].append(row)
 
-        attempted += 1
+    for volume_id, rows in volume_groups.items():
         try:
-            response = await client.fetch_issue(issue_id, refresh=refresh)
+            roster = await client.fetch_volume_issues(volume_id, refresh=refresh)
         except ComicVineRateLimitError:
             budget_exhausted = True
             break
-        except ComicVineError as exc:
-            row["status"] = "failed"
-            row["provenance"] = "comicvine-live"
-            row["detail"] = f"Confirmed identity live refresh failed: {exc}"
-            failed += 1
+        except ComicVineError:
             continue
 
-        returned_id = _provider_issue_id(response.payload)
-        if returned_id != issue_id:
-            row["status"] = "failed"
-            row["provenance"] = "comicvine-cache" if response.from_cache else "comicvine-live"
-            row["detail"] = "Provider response did not match the confirmed ComicVine issue identity."
-            failed += 1
-            continue
+        volume_batches += 1
+        roster_ids = _volume_issue_ids(roster)
+        for row in rows:
+            issue_id = row.get("comicvine_issue_id")
+            if isinstance(issue_id, int) and issue_id in roster_ids:
+                _mark_matched(
+                    row,
+                    from_cache=False,
+                    detail=(
+                        "Confirmed identity resolved through a volume-batched ComicVine issue "
+                        "roster."
+                    ),
+                )
+                matched += 1
 
-        row["status"] = "matched"
-        row["provenance"] = "comicvine-cache" if response.from_cache else "comicvine-live"
-        row["detail"] = "Confirmed identity resolved through the budgeted ComicVine issue endpoint."
-        matched += 1
+    if not budget_exhausted:
+        for row in eligible:
+            if row.get("status") != "local-miss":
+                continue
+            issue_id = row.get("comicvine_issue_id")
+            if not isinstance(issue_id, int):
+                continue
+
+            issue_requests += 1
+            try:
+                response = await client.fetch_issue(issue_id, refresh=refresh)
+            except ComicVineRateLimitError:
+                budget_exhausted = True
+                break
+            except ComicVineError as exc:
+                row["status"] = "failed"
+                row["provenance"] = "comicvine-live"
+                row["detail"] = f"Confirmed identity live refresh failed: {exc}"
+                failed += 1
+                continue
+
+            returned_id = _provider_issue_id(response.payload)
+            if returned_id != issue_id:
+                _mark_failed(
+                    row,
+                    from_cache=response.from_cache,
+                    detail=(
+                        "Provider response did not match the confirmed ComicVine issue identity."
+                    ),
+                )
+                failed += 1
+                continue
+
+            _mark_matched(
+                row,
+                from_cache=response.from_cache,
+                detail="Confirmed identity resolved through the budgeted ComicVine issue endpoint.",
+            )
+            matched += 1
 
     _recount(report)
     report["live_refresh"] = {
@@ -111,5 +181,14 @@ async def refresh_confirmed_local_misses(
         "matched": matched,
         "failed": failed,
         "budget_exhausted": budget_exhausted,
+        "volume_batches": volume_batches,
+        "issue_requests": issue_requests,
     }
-    return LiveRefreshSummary(attempted, matched, failed, budget_exhausted)
+    return LiveRefreshSummary(
+        attempted,
+        matched,
+        failed,
+        budget_exhausted,
+        volume_batches,
+        issue_requests,
+    )

--- a/comic_pile/comicvine_live_refresh.py
+++ b/comic_pile/comicvine_live_refresh.py
@@ -32,7 +32,12 @@ def _provider_issue_id(payload: Mapping[str, object]) -> int | None:
 
 def _volume_issue_ids(rows: list[dict[str, object]]) -> set[int]:
     """Return integer issue IDs from one validated ComicVine volume roster."""
-    return {value for row in rows if isinstance((value := row.get("id")), int)}
+    issue_ids: set[int] = set()
+    for row in rows:
+        value = row.get("id")
+        if isinstance(value, int):
+            issue_ids.add(value)
+    return issue_ids
 
 
 def _recount(report: dict[str, object]) -> None:
@@ -50,17 +55,17 @@ def _recount(report: dict[str, object]) -> None:
     report["summary"] = {"total": len(issues), **counts}
 
 
-def _mark_matched(row: dict[str, object], *, from_cache: bool, detail: str) -> None:
+def _mark_matched(row: dict[str, object], *, provenance: str, detail: str) -> None:
     """Mark one hydration row as safely reconciled without replacing its identity."""
     row["status"] = "matched"
-    row["provenance"] = "comicvine-cache" if from_cache else "comicvine-live"
+    row["provenance"] = provenance
     row["detail"] = detail
 
 
-def _mark_failed(row: dict[str, object], *, from_cache: bool, detail: str) -> None:
+def _mark_failed(row: dict[str, object], *, provenance: str, detail: str) -> None:
     """Mark one hydration row failed while preserving its confirmed identity."""
     row["status"] = "failed"
-    row["provenance"] = "comicvine-cache" if from_cache else "comicvine-live"
+    row["provenance"] = provenance
     row["detail"] = detail
 
 
@@ -98,7 +103,7 @@ async def refresh_confirmed_local_misses(
         and row.get("status") == "local-miss"
         and isinstance(row.get("comicvine_issue_id"), int)
     ]
-    attempted = len(eligible)
+    attempted_rows: set[int] = set()
     matched = 0
     failed = 0
     budget_exhausted = False
@@ -112,6 +117,7 @@ async def refresh_confirmed_local_misses(
             volume_groups[volume_id].append(row)
 
     for volume_id, rows in volume_groups.items():
+        attempted_rows.update(id(row) for row in rows)
         try:
             roster = await client.fetch_volume_issues(volume_id, refresh=refresh)
         except ComicVineRateLimitError:
@@ -127,7 +133,7 @@ async def refresh_confirmed_local_misses(
             if isinstance(issue_id, int) and issue_id in roster_ids:
                 _mark_matched(
                     row,
-                    from_cache=False,
+                    provenance="comicvine-volume-roster",
                     detail=(
                         "Confirmed identity resolved through a volume-batched ComicVine issue "
                         "roster."
@@ -143,6 +149,7 @@ async def refresh_confirmed_local_misses(
             if not isinstance(issue_id, int):
                 continue
 
+            attempted_rows.add(id(row))
             issue_requests += 1
             try:
                 response = await client.fetch_issue(issue_id, refresh=refresh)
@@ -156,11 +163,12 @@ async def refresh_confirmed_local_misses(
                 failed += 1
                 continue
 
+            provenance = "comicvine-cache" if response.from_cache else "comicvine-live"
             returned_id = _provider_issue_id(response.payload)
             if returned_id != issue_id:
                 _mark_failed(
                     row,
-                    from_cache=response.from_cache,
+                    provenance=provenance,
                     detail=(
                         "Provider response did not match the confirmed ComicVine issue identity."
                     ),
@@ -170,11 +178,12 @@ async def refresh_confirmed_local_misses(
 
             _mark_matched(
                 row,
-                from_cache=response.from_cache,
+                provenance=provenance,
                 detail="Confirmed identity resolved through the budgeted ComicVine issue endpoint.",
             )
             matched += 1
 
+    attempted = len(attempted_rows)
     _recount(report)
     report["live_refresh"] = {
         "attempted": attempted,

--- a/docs/changelog.d/2026-08-10-1053.md
+++ b/docs/changelog.d/2026-08-10-1053.md
@@ -2,4 +2,4 @@
 
 ### ComicVine hydration
 
-- [PR #1053](https://github.com/JoshCLWren/comic-pile/pull/1053) batches stale ComicVine snapshot misses by known provider volume before falling back to one-off issue requests, preserving API quota while keeping confirmed issue identities authoritative.
+- [#1053](https://github.com/JoshCLWren/comic-pile/pull/1053) batches stale ComicVine snapshot misses by known provider volume before falling back to one-off issue requests, preserving API quota while keeping confirmed issue identities authoritative.

--- a/docs/changelog.d/2026-08-10-1053.md
+++ b/docs/changelog.d/2026-08-10-1053.md
@@ -1,0 +1,5 @@
+## 2026-08-10
+
+### ComicVine hydration
+
+- [PR #1053](https://github.com/JoshCLWren/comic-pile/pull/1053) batches stale ComicVine snapshot misses by known provider volume before falling back to one-off issue requests, preserving API quota while keeping confirmed issue identities authoritative.

--- a/frontend/src/unit/apiError.test.ts
+++ b/frontend/src/unit/apiError.test.ts
@@ -26,6 +26,17 @@ describe('getApiErrorDetail', () => {
     expect(getApiErrorDetail(error)).toBe('Internal server error')
   })
 
+  it('returns Unknown error for Axios errors without detail or a message', () => {
+    const error = {
+      isAxiosError: true,
+      response: {
+        status: 500,
+        data: {},
+      },
+    }
+    expect(getApiErrorDetail(error)).toBe('Unknown error')
+  })
+
   it('handles network errors with Axios', () => {
     const error = {
       isAxiosError: true,
@@ -61,6 +72,16 @@ describe('getApiErrorDetail', () => {
       },
     }
     expect(getApiErrorDetail(error)).toBe('Not found')
+  })
+
+  it('returns Unknown error for generic response objects without detail', () => {
+    const error = {
+      response: {
+        status: 500,
+        data: {},
+      },
+    }
+    expect(getApiErrorDetail(error)).toBe('Unknown error')
   })
 
   it('returns Unknown error for objects without response', () => {

--- a/tests/test_comicvine_live_refresh.py
+++ b/tests/test_comicvine_live_refresh.py
@@ -31,6 +31,112 @@ def _issue_rows(report: dict[str, object]) -> list[dict[str, object]]:
     return cast(list[dict[str, object]], value)
 
 
+async def test_refresh_batches_confirmed_misses_by_volume() -> None:
+    """One volume roster can satisfy many confirmed misses without singular requests."""
+    client = Mock()
+    client.fetch_volume_issues = AsyncMock(
+        return_value=[
+            {"id": 202, "issue_number": "12", "volume": {"id": 500}},
+            {"id": 303, "issue_number": "13", "volume": {"id": 500}},
+        ]
+    )
+    client.fetch_issue = AsyncMock()
+    report = _report_with_misses()
+    rows = _issue_rows(report)
+    rows[1]["comicvine_volume_id"] = 500
+    rows[2]["comicvine_volume_id"] = 500
+
+    summary = await refresh_confirmed_local_misses(report, client)
+
+    assert summary.attempted == 2
+    assert summary.matched == 2
+    assert summary.volume_batches == 1
+    assert summary.issue_requests == 0
+    assert report["summary"] == {"total": 3, "matched": 3}
+    client.fetch_volume_issues.assert_awaited_once_with(500, refresh=False)
+    client.fetch_issue.assert_not_awaited()
+
+
+async def test_volume_batch_preserves_identity_and_falls_back_narrowly() -> None:
+    """A missing confirmed ID in a volume roster falls back to its singular issue lookup."""
+    client = Mock()
+    client.fetch_volume_issues = AsyncMock(
+        return_value=[{"id": 202, "issue_number": "12", "volume": {"id": 500}}]
+    )
+    client.fetch_issue = AsyncMock(
+        return_value=ComicVineResponse(
+            payload={"results": {"id": 303}},
+            from_cache=False,
+            cache_key="issue-live",
+        )
+    )
+    report = _report_with_misses()
+    rows = _issue_rows(report)
+    rows[1]["comicvine_volume_id"] = 500
+    rows[2]["comicvine_volume_id"] = 500
+
+    summary = await refresh_confirmed_local_misses(report, client)
+
+    assert summary.matched == 2
+    assert summary.volume_batches == 1
+    assert summary.issue_requests == 1
+    assert rows[2]["comicvine_issue_id"] == 303
+    client.fetch_issue.assert_awaited_once_with(303, refresh=False)
+
+
+async def test_volume_batch_failure_uses_singular_fallback() -> None:
+    """A failed volume request does not strand confirmed identities that can use /issue."""
+    client = Mock()
+    client.fetch_volume_issues = AsyncMock(side_effect=ComicVineError("volume unavailable"))
+    client.fetch_issue = AsyncMock(
+        side_effect=[
+            ComicVineResponse(
+                payload={"results": {"id": 202}},
+                from_cache=False,
+                cache_key="issue-202",
+            ),
+            ComicVineResponse(
+                payload={"results": {"id": 303}},
+                from_cache=False,
+                cache_key="issue-303",
+            ),
+        ]
+    )
+    report = _report_with_misses()
+    rows = _issue_rows(report)
+    rows[1]["comicvine_volume_id"] = 500
+    rows[2]["comicvine_volume_id"] = 500
+
+    summary = await refresh_confirmed_local_misses(report, client)
+
+    assert summary.matched == 2
+    assert summary.volume_batches == 0
+    assert summary.issue_requests == 2
+    assert client.fetch_issue.await_count == 2
+
+
+async def test_volume_budget_exhaustion_preserves_resumable_rows() -> None:
+    """Provider throttling during volume batching stops before spending another endpoint budget."""
+    client = Mock()
+    client.fetch_volume_issues = AsyncMock(
+        side_effect=ComicVineRateLimitError("volume budget exhausted")
+    )
+    client.fetch_issue = AsyncMock()
+    report = _report_with_misses()
+    rows = _issue_rows(report)
+    rows[1]["comicvine_volume_id"] = 500
+    rows[2]["comicvine_volume_id"] = 500
+
+    summary = await refresh_confirmed_local_misses(report, client)
+
+    assert summary.budget_exhausted is True
+    assert summary.matched == 0
+    assert summary.issue_requests == 0
+    assert rows[1]["status"] == "local-miss"
+    assert rows[2]["status"] == "local-miss"
+    client.fetch_issue.assert_not_awaited()
+
+
 async def test_refresh_reconciles_confirmed_miss_from_cache() -> None:
     """Cached exact issue responses satisfy a local miss without spending new quota."""
     client = Mock()
@@ -168,7 +274,8 @@ async def test_budget_exhaustion_stops_cleanly_and_preserves_remaining_misses() 
     summary = await refresh_confirmed_local_misses(report, client)
 
     assert summary.budget_exhausted is True
-    assert summary.attempted == 1
+    assert summary.attempted == 2
+    assert summary.issue_requests == 1
     assert report["summary"] == {"total": 3, "matched": 1, "local-miss": 2}
     rows = _issue_rows(report)
     assert rows[1]["status"] == "local-miss"

--- a/tests/test_comicvine_live_refresh.py
+++ b/tests/test_comicvine_live_refresh.py
@@ -53,6 +53,8 @@ async def test_refresh_batches_confirmed_misses_by_volume() -> None:
     assert summary.volume_batches == 1
     assert summary.issue_requests == 0
     assert report["summary"] == {"total": 3, "matched": 3}
+    assert rows[1]["provenance"] == "comicvine-volume-roster"
+    assert rows[2]["provenance"] == "comicvine-volume-roster"
     client.fetch_volume_issues.assert_awaited_once_with(500, refresh=False)
     client.fetch_issue.assert_not_awaited()
 
@@ -130,6 +132,7 @@ async def test_volume_budget_exhaustion_preserves_resumable_rows() -> None:
     summary = await refresh_confirmed_local_misses(report, client)
 
     assert summary.budget_exhausted is True
+    assert summary.attempted == 2
     assert summary.matched == 0
     assert summary.issue_requests == 0
     assert rows[1]["status"] == "local-miss"
@@ -274,7 +277,7 @@ async def test_budget_exhaustion_stops_cleanly_and_preserves_remaining_misses() 
     summary = await refresh_confirmed_local_misses(report, client)
 
     assert summary.budget_exhausted is True
-    assert summary.attempted == 2
+    assert summary.attempted == 1
     assert summary.issue_requests == 1
     assert report["summary"] == {"total": 3, "matched": 1, "local-miss": 2}
     rows = _issue_rows(report)


### PR DESCRIPTION
Implements the next #1025 hydrator slice: rows with confirmed ComicVine issue identities and a known ComicVine volume are grouped so one paginated `/issues?filter=volume:X` roster can satisfy many local-snapshot misses before falling back to singular `/issue` requests.

Safety rules stay strict: the confirmed issue ID remains authoritative, volume membership is only a batching optimization, mismatched identities are never adopted, provider throttling leaves untouched rows resumable, and volume failures fall back narrowly instead of guessing.

This does not close #1025; composite-thread issue segmentation remains.

Validation: focused tests added; this runtime has no local checkout, so exact-head CI is the configured validation boundary.