### PR TITLE
Add issue-level ComicVine volume segmentation

### DIFF
--- a/comic_pile/comicvine_hydrator.py
+++ b/comic_pile/comicvine_hydrator.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 import tempfile
 from collections import defaultdict
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 from typing import Literal, Protocol
 
@@ -42,6 +42,10 @@ class ComicVineSnapshotReader(Protocol):
         """
         ...
 
+    def get_volume_issues(self, volume_id: int) -> list[LocalComicVineResult]:
+        """Return locally cached issues for one ComicVine volume."""
+        ...
+
     def sync_metadata(self) -> dict[str, object]:
         """Return snapshot freshness metadata.
 
@@ -61,6 +65,39 @@ class HydrationTarget:
     issue_number: str
     position: int
     comicvine_issue_id: int | None = None
+
+
+@dataclass(frozen=True)
+class VolumeSegment:
+    """Explicit provider-volume evidence for one contiguous slice of a ComicPile thread."""
+
+    thread_id: int
+    start_position: int
+    end_position: int
+    comicvine_volume_id: int
+
+    @classmethod
+    def from_dict(cls, value: dict[str, object]) -> VolumeSegment:
+        """Parse and validate one JSON segment declaration.
+
+        Args:
+            value: JSON-compatible mapping describing a thread slice and ComicVine volume.
+
+        Returns:
+            Validated segment declaration.
+
+        Raises:
+            ValueError: If required integer fields are absent or invalid.
+        """
+        fields: dict[str, int] = {}
+        for name in ("thread_id", "start_position", "end_position", "comicvine_volume_id"):
+            raw = value.get(name)
+            if not isinstance(raw, int) or isinstance(raw, bool) or raw <= 0:
+                raise ValueError(f"segment {name} must be a positive integer")
+            fields[name] = raw
+        if fields["end_position"] < fields["start_position"]:
+            raise ValueError("segment end_position must be >= start_position")
+        return cls(**fields)
 
 
 @dataclass(frozen=True)
@@ -153,6 +190,106 @@ async def enumerate_user_issues(
         )
         for issue, thread in rows
     ]
+
+
+def load_volume_segments(path: str | Path) -> list[VolumeSegment]:
+    """Load deterministic issue-level volume segments from JSON.
+
+    The file is intentionally explicit evidence. Segments scope a provider volume to a
+    position range inside one ComicPile reading thread; they never declare that an entire
+    thread is one external volume.
+
+    Args:
+        path: JSON file containing either a segment list or {"segments": [...]}.
+
+    Returns:
+        Validated segments sorted by thread and position.
+
+    Raises:
+        ValueError: If the JSON shape is invalid or segments overlap within a thread.
+    """
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    items = raw.get("segments") if isinstance(raw, dict) else raw
+    if not isinstance(items, list):
+        raise ValueError("segment map must be a JSON list or an object containing 'segments'")
+
+    segments = [VolumeSegment.from_dict(item) for item in items if isinstance(item, dict)]
+    if len(segments) != len(items):
+        raise ValueError("every segment entry must be a JSON object")
+    segments.sort(key=lambda segment: (segment.thread_id, segment.start_position, segment.end_position))
+
+    previous_by_thread: dict[int, VolumeSegment] = {}
+    for segment in segments:
+        previous = previous_by_thread.get(segment.thread_id)
+        if previous is not None and segment.start_position <= previous.end_position:
+            raise ValueError(f"overlapping volume segments for thread {segment.thread_id}")
+        previous_by_thread[segment.thread_id] = segment
+    return segments
+
+
+async def apply_local_volume_segments(
+    targets: list[HydrationTarget],
+    snapshot: ComicVineSnapshotReader,
+    segments: list[VolumeSegment],
+) -> list[HydrationTarget]:
+    """Resolve unresolved issue identities from explicit per-thread volume segments.
+
+    A segment is only an optimization/evidence boundary. Each issue must still match exactly
+    one provider issue by number or provider issue name inside that volume. Existing confirmed
+    issue identities always win, and ambiguous/missing labels remain unresolved.
+
+    Args:
+        targets: Ordered ComicPile hydration targets.
+        snapshot: Read-only local ComicVine snapshot.
+        segments: Explicit issue-level volume segment declarations.
+
+    Returns:
+        Targets with safe local identities filled where uniquely resolved.
+    """
+    segments_by_thread: dict[int, list[VolumeSegment]] = defaultdict(list)
+    for segment in segments:
+        segments_by_thread[segment.thread_id].append(segment)
+
+    roster_cache: dict[int, dict[str, set[int]]] = {}
+    resolved: list[HydrationTarget] = []
+    for target in targets:
+        if target.comicvine_issue_id is not None:
+            resolved.append(target)
+            continue
+        segment = next(
+            (
+                candidate
+                for candidate in segments_by_thread.get(target.thread_id, [])
+                if candidate.start_position <= target.position <= candidate.end_position
+            ),
+            None,
+        )
+        if segment is None:
+            resolved.append(target)
+            continue
+
+        if segment.comicvine_volume_id not in roster_cache:
+            rows = await asyncio.to_thread(snapshot.get_volume_issues, segment.comicvine_volume_id)
+            labels: dict[str, set[int]] = defaultdict(set)
+            for row in rows:
+                issue_id = row.data.get("id")
+                if not isinstance(issue_id, int) or isinstance(issue_id, bool):
+                    continue
+                for raw_label in (row.data.get("issue_number"), row.data.get("name")):
+                    if raw_label is None:
+                        continue
+                    label = str(raw_label).strip().casefold().removeprefix("#").strip()
+                    if label:
+                        labels[label].add(issue_id)
+            roster_cache[segment.comicvine_volume_id] = labels
+
+        expected = target.issue_number.strip().casefold().removeprefix("#").strip()
+        matches = roster_cache[segment.comicvine_volume_id].get(expected, set())
+        if len(matches) == 1:
+            resolved.append(replace(target, comicvine_issue_id=next(iter(matches))))
+        else:
+            resolved.append(target)
+    return resolved
 
 
 async def inspect_local_snapshot(

--- a/docs/changelog.d/2026-08-10-1057.md
+++ b/docs/changelog.d/2026-08-10-1057.md
@@ -1,0 +1,5 @@
+## 2026-08-10
+
+### ComicVine hydration
+
+- [#1057](https://github.com/JoshCLWren/comic-pile/pull/1057) lets the read-only hydrator apply explicit issue-level volume segments to composite reading threads, so title changes, specials, and human labels can resolve against the correct ComicVine volume without treating an entire ComicPile thread as one provider series.

--- a/scripts/hydrate_comicvine_issues.py
+++ b/scripts/hydrate_comicvine_issues.py
@@ -8,7 +8,13 @@ import os
 from pathlib import Path
 
 from app.database import AsyncSessionLocal
-from comic_pile.comicvine_hydrator import build_report, enumerate_user_issues, write_report
+from comic_pile.comicvine_hydrator import (
+    apply_local_volume_segments,
+    build_report,
+    enumerate_user_issues,
+    load_volume_segments,
+    write_report,
+)
 from comic_pile.comicvine_live_refresh import refresh_confirmed_local_misses
 from comic_pile.comicvine_provider import ComicVineClient, DEFAULT_REQUESTS_PER_HOUR
 from comic_pile.local_comicvine import LocalComicVineSnapshot
@@ -29,6 +35,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--user-id", type=int, required=True)
     parser.add_argument("--comicvine-db", type=Path)
     parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--segment-map",
+        type=Path,
+        help=(
+            "Optional JSON file mapping ComicPile thread position ranges to confirmed "
+            "ComicVine volume IDs for issue-level composite-thread hydration."
+        ),
+    )
     parser.add_argument("--cache-dir", type=Path, default=Path(".cache/comicvine-hydrator"))
     parser.add_argument(
         "--requests-per-hour",
@@ -63,6 +77,11 @@ async def run(args: argparse.Namespace) -> None:
             user_id=args.user_id,
             include_test_threads=args.include_test_threads,
         )
+
+    if args.segment_map is not None:
+        segments = load_volume_segments(args.segment_map)
+        targets = await apply_local_volume_segments(targets, snapshot, segments)
+
     report = await build_report(targets, snapshot)
 
     if args.live_refresh:

--- a/tests/test_comicvine_hydrator.py
+++ b/tests/test_comicvine_hydrator.py
@@ -5,11 +5,16 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
+import pytest
+
 from comic_pile.comicvine_hydrator import (
     HydrationTarget,
+    VolumeSegment,
+    apply_local_volume_segments,
     build_report,
     enumerate_user_issues,
     inspect_local_snapshot,
+    load_volume_segments,
     write_report,
 )
 from comic_pile.local_comicvine import LocalComicVineResult
@@ -18,15 +23,24 @@ from comic_pile.local_comicvine import LocalComicVineResult
 class FakeSnapshot:
     """Minimal local snapshot fake for deterministic hydrator tests."""
 
-    def __init__(self, rows: dict[int, LocalComicVineResult] | None = None) -> None:
+    def __init__(
+        self,
+        rows: dict[int, LocalComicVineResult] | None = None,
+        volume_rows: dict[int, list[LocalComicVineResult]] | None = None,
+    ) -> None:
         """Initialize fake rows."""
         self.rows = rows or {}
+        self.volume_rows = volume_rows or {}
         self.path = Path("/tmp/comicvine.db")
         self.available = True
 
     def get_issue(self, issue_id: int) -> LocalComicVineResult | None:
         """Return one fake issue row."""
         return self.rows.get(issue_id)
+
+    def get_volume_issues(self, volume_id: int) -> list[LocalComicVineResult]:
+        """Return fake issues for one provider volume."""
+        return self.volume_rows.get(volume_id, [])
 
     def sync_metadata(self) -> dict[str, object]:
         """Return deterministic freshness metadata."""
@@ -181,6 +195,117 @@ async def test_conflicting_confirmed_identities_are_order_independent() -> None:
 
     assert first.comicvine_issue_id is None
     assert reversed_order.comicvine_issue_id is None
+
+
+async def test_volume_segments_split_one_thread_across_provider_volumes() -> None:
+    """Justice League/JLI/JLA-style title transitions resolve issue-by-issue."""
+    targets = [
+        HydrationTarget(101, 77, "Justice League America", "1", 1),
+        HydrationTarget(107, 77, "Justice League America", "7", 7),
+        HydrationTarget(126, 77, "Justice League America", "26", 26),
+    ]
+    snapshot = FakeSnapshot(
+        volume_rows={
+            10: [LocalComicVineResult(data={"id": 1001, "issue_number": "1"})],
+            20: [LocalComicVineResult(data={"id": 2007, "issue_number": "7"})],
+            30: [LocalComicVineResult(data={"id": 3026, "issue_number": "26"})],
+        }
+    )
+    segments = [
+        VolumeSegment(77, 1, 6, 10),
+        VolumeSegment(77, 7, 25, 20),
+        VolumeSegment(77, 26, 61, 30),
+    ]
+
+    resolved = await apply_local_volume_segments(targets, snapshot, segments)
+
+    assert [item.comicvine_issue_id for item in resolved] == [1001, 2007, 3026]
+
+
+async def test_volume_segment_can_match_human_label_by_provider_issue_name() -> None:
+    """Composite segments support labels such as Revival without forcing numeric equality."""
+    snapshot = FakeSnapshot(
+        volume_rows={
+            99: [
+                LocalComicVineResult(data={"id": 550, "issue_number": "5", "name": "Revival"})
+            ]
+        }
+    )
+    targets = [HydrationTarget(10, 4, "B.P.R.D.: War on Frogs", "Revival", 5)]
+
+    resolved = await apply_local_volume_segments(
+        targets,
+        snapshot,
+        [VolumeSegment(4, 1, 5, 99)],
+    )
+
+    assert resolved[0].comicvine_issue_id == 550
+
+
+async def test_volume_segment_never_replaces_confirmed_issue_identity() -> None:
+    """Segment evidence is subordinate to an existing confirmed issue mapping."""
+    snapshot = FakeSnapshot(
+        volume_rows={10: [LocalComicVineResult(data={"id": 999, "issue_number": "1"})]}
+    )
+    targets = [HydrationTarget(101, 77, "Justice League America", "1", 1, 123)]
+
+    resolved = await apply_local_volume_segments(
+        targets,
+        snapshot,
+        [VolumeSegment(77, 1, 6, 10)],
+    )
+
+    assert resolved[0].comicvine_issue_id == 123
+
+
+async def test_ambiguous_segment_label_remains_unresolved() -> None:
+    """Duplicate provider labels never become an arbitrary issue mapping."""
+    snapshot = FakeSnapshot(
+        volume_rows={
+            10: [
+                LocalComicVineResult(data={"id": 1, "issue_number": "1"}),
+                LocalComicVineResult(data={"id": 2, "issue_number": "1"}),
+            ]
+        }
+    )
+    targets = [HydrationTarget(101, 77, "Composite", "1", 1)]
+
+    resolved = await apply_local_volume_segments(
+        targets,
+        snapshot,
+        [VolumeSegment(77, 1, 6, 10)],
+    )
+
+    assert resolved[0].comicvine_issue_id is None
+
+
+def test_load_volume_segments_rejects_overlaps(tmp_path: Path) -> None:
+    """Overlapping segment evidence is rejected before any hydration work begins."""
+    path = tmp_path / "segments.json"
+    path.write_text(
+        json.dumps(
+            {
+                "segments": [
+                    {
+                        "thread_id": 77,
+                        "start_position": 1,
+                        "end_position": 10,
+                        "comicvine_volume_id": 10,
+                    },
+                    {
+                        "thread_id": 77,
+                        "start_position": 10,
+                        "end_position": 20,
+                        "comicvine_volume_id": 20,
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="overlapping volume segments"):
+        load_volume_segments(path)
 
 
 def test_write_report_creates_parent_and_replaces_temporary_file(tmp_path: Path) -> None:


### PR DESCRIPTION
Continues #1025.

Adds an explicit read-only segment map for composite ComicPile threads so one reading project can safely resolve issues across multiple ComicVine volumes. A segment scopes a provider volume to a ComicPile position range, then each issue must still match exactly one provider issue by number or issue name before the hydrator adopts that identity.

Safety behavior stays strict: existing confirmed issue identities always win, overlapping segment declarations are rejected, ambiguous provider labels remain unresolved, and no core ComicPile tables are modified.

Focused coverage includes the verified Justice League / Justice League International / Justice League America transition pattern, the `Revival` human-label case, ambiguous duplicate labels, and confirmed-identity preservation.

This does not close #1025; CBL-first automatic segment discovery and the remaining deep/story-arc hydration contract still remain.

Validation: this runtime has no local checkout, so exact-head CI is the configured validation boundary.