### PR TITLE
Use exact CBL identities before ComicVine discovery

### DIFF
--- a/comic_pile/comicvine_hydrator.py
+++ b/comic_pile/comicvine_hydrator.py
@@ -13,6 +13,7 @@ from typing import Literal, Protocol
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.cbl_ingest import parse_cbl_mirror
 from app.models.external_identity import ExternalIdentity, IssueExternalIdentityMapping
 from app.models.issue import Issue
 from app.models.thread import Thread
@@ -190,6 +191,65 @@ async def enumerate_user_issues(
         )
         for issue, thread in rows
     ]
+
+
+def _normalized_cbl_key(value: str) -> str:
+    """Normalize exact CBL matching text without introducing fuzzy equivalence."""
+    return " ".join(value.strip().casefold().split()).removeprefix("#").strip()
+
+
+async def apply_cbl_issue_identities(
+    targets: list[HydrationTarget],
+    mirror_path: str | Path,
+) -> list[HydrationTarget]:
+    """Fill unresolved targets from unique exact CBL embedded ComicVine issue IDs.
+
+    Existing confirmed database mappings remain authoritative. CBL evidence is only applied
+    when the normalized CBL series title and issue label exactly match the ComicPile target
+    and every matching CBL occurrence with an embedded ComicVine issue ID agrees on one ID.
+    Conflicting or malformed CBL evidence stays unresolved.
+
+    Args:
+        targets: Ordered ComicPile hydration targets.
+        mirror_path: Root directory containing CBL reading-list files.
+
+    Returns:
+        Targets with safe exact CBL issue identities filled where uniquely supported.
+    """
+    root = Path(mirror_path)
+    parsed_lists, _failures = await asyncio.to_thread(parse_cbl_mirror, root)
+    ids_by_key: dict[tuple[str, str], set[int]] = defaultdict(set)
+    for reading_list in parsed_lists:
+        for book in reading_list.books:
+            if book.comicvine_issue_id is None:
+                continue
+            try:
+                issue_id = int(book.comicvine_issue_id)
+            except ValueError:
+                continue
+            if issue_id <= 0:
+                continue
+            key = (
+                _normalized_cbl_key(book.series),
+                _normalized_cbl_key(book.issue_number),
+            )
+            ids_by_key[key].add(issue_id)
+
+    resolved: list[HydrationTarget] = []
+    for target in targets:
+        if target.comicvine_issue_id is not None:
+            resolved.append(target)
+            continue
+        key = (
+            _normalized_cbl_key(target.thread_title),
+            _normalized_cbl_key(target.issue_number),
+        )
+        matches = ids_by_key.get(key, set())
+        if len(matches) == 1:
+            resolved.append(replace(target, comicvine_issue_id=next(iter(matches))))
+        else:
+            resolved.append(target)
+    return resolved
 
 
 def load_volume_segments(path: str | Path) -> list[VolumeSegment]:

--- a/comic_pile/comicvine_hydrator.py
+++ b/comic_pile/comicvine_hydrator.py
@@ -229,10 +229,11 @@ async def apply_cbl_issue_identities(
                 continue
             if issue_id <= 0:
                 continue
-            key = (
-                _normalized_cbl_key(book.series),
-                _normalized_cbl_key(book.issue_number),
-            )
+            series_key = _normalized_cbl_key(book.series)
+            issue_key = _normalized_cbl_key(book.issue_number)
+            if not series_key or not issue_key:
+                continue
+            key = (series_key, issue_key)
             ids_by_key[key].add(issue_id)
 
     resolved: list[HydrationTarget] = []

--- a/docs/changelog.d/2026-08-10-1060.md
+++ b/docs/changelog.d/2026-08-10-1060.md
@@ -1,0 +1,5 @@
+## 2026-08-10
+
+### Comic metadata
+
+- [#1060](https://github.com/JoshCLWren/comic-pile/pull/1060) lets the ComicVine hydrator use exact ComicVine issue IDs already embedded in CBL reading lists before falling back to broader provider discovery, reducing unnecessary API work while leaving conflicting evidence unresolved instead of guessing.

--- a/scripts/hydrate_comicvine_issues.py
+++ b/scripts/hydrate_comicvine_issues.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from app.database import AsyncSessionLocal
 from comic_pile.comicvine_hydrator import (
+    apply_cbl_issue_identities,
     apply_local_volume_segments,
     build_report,
     enumerate_user_issues,
@@ -28,11 +29,19 @@ def parse_args() -> argparse.Namespace:
     """
     parser = argparse.ArgumentParser(
         description=(
-            "Inspect existing ComicPile issues against confirmed ComicVine identities "
+            "Inspect existing ComicPile issues against confirmed/CBL ComicVine identities "
             "and a read-only local ComicVine snapshot."
         )
     )
     parser.add_argument("--user-id", type=int, required=True)
+    parser.add_argument(
+        "--cbl-mirror",
+        type=Path,
+        help=(
+            "Optional CBL mirror root. Exact embedded ComicVine issue IDs are applied before "
+            "local volume-segment or live provider discovery."
+        ),
+    )
     parser.add_argument("--comicvine-db", type=Path)
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument(
@@ -77,6 +86,9 @@ async def run(args: argparse.Namespace) -> None:
             user_id=args.user_id,
             include_test_threads=args.include_test_threads,
         )
+
+    if args.cbl_mirror is not None:
+        targets = await apply_cbl_issue_identities(targets, args.cbl_mirror)
 
     if args.segment_map is not None:
         segments = load_volume_segments(args.segment_map)

--- a/scripts/ingest_local_comicvine_corpus.py
+++ b/scripts/ingest_local_comicvine_corpus.py
@@ -152,7 +152,7 @@ def open_localcv(path: Path) -> sqlite3.Connection:
     return connection
 
 
-def parse_json_value(value: Any) -> Any:
+def parse_json_value(value: object) -> object:
     """Decode JSON text from the local ComicVine snapshot when needed."""
     if value is None or isinstance(value, (dict, list, int, float, bool)):
         return value
@@ -212,7 +212,7 @@ def issues_for_volumes(db: sqlite3.Connection, volume_ids: set[int]) -> Iterator
         )
 
 
-def story_arc_ids(value: Any) -> set[int]:
+def story_arc_ids(value: object) -> set[int]:
     """Extract stable ComicVine story-arc IDs from one relationship payload."""
     credits = parse_json_value(value)
     if not isinstance(credits, list):

--- a/tests/test_comicvine_hydrator_cbl.py
+++ b/tests/test_comicvine_hydrator_cbl.py
@@ -5,12 +5,18 @@ from pathlib import Path
 from comic_pile.comicvine_hydrator import HydrationTarget, apply_cbl_issue_identities
 
 
-def _write_cbl(path: Path, *, issue_id: str) -> None:
+def _write_cbl(
+    path: Path,
+    *,
+    issue_id: str,
+    series: str = "X-Men",
+    issue_number: str = "12",
+) -> None:
     """Write one minimal CBL fixture with an embedded ComicVine issue ID."""
     path.write_text(
         (
             "<ReadingList><Name>Fixture</Name><Books>"
-            f'<Book Series="X-Men" Number="12" IssueID="{issue_id}" />'
+            f'<Book Series="{series}" Number="{issue_number}" IssueID="{issue_id}" />'
             "</Books></ReadingList>"
         ),
         encoding="utf-8",
@@ -18,7 +24,14 @@ def _write_cbl(path: Path, *, issue_id: str) -> None:
 
 
 async def test_unique_exact_cbl_issue_id_resolves_unmapped_target(tmp_path: Path) -> None:
-    """A unique exact title/issue CBL identity fills an otherwise unresolved target."""
+    """Resolve an unmapped target from one exact CBL identity.
+
+    Args:
+        tmp_path: Temporary directory for the CBL fixture.
+
+    Returns:
+        None.
+    """
     _write_cbl(tmp_path / "x-men.cbl", issue_id="12345")
     targets = [HydrationTarget(10, 4, " X-MEN ", "#12", 12)]
 
@@ -28,7 +41,14 @@ async def test_unique_exact_cbl_issue_id_resolves_unmapped_target(tmp_path: Path
 
 
 async def test_conflicting_exact_cbl_issue_ids_remain_unresolved(tmp_path: Path) -> None:
-    """Disagreeing CBL embedded IDs never become an arbitrary provider mapping."""
+    """Leave conflicting exact CBL identities unresolved.
+
+    Args:
+        tmp_path: Temporary directory for the CBL fixtures.
+
+    Returns:
+        None.
+    """
     _write_cbl(tmp_path / "first.cbl", issue_id="12345")
     _write_cbl(tmp_path / "second.cbl", issue_id="67890")
     targets = [HydrationTarget(10, 4, "X-Men", "12", 12)]
@@ -39,10 +59,39 @@ async def test_conflicting_exact_cbl_issue_ids_remain_unresolved(tmp_path: Path)
 
 
 async def test_confirmed_identity_wins_over_cbl_evidence(tmp_path: Path) -> None:
-    """CBL evidence cannot replace an existing confirmed ComicVine issue identity."""
+    """Preserve a confirmed identity over conflicting CBL evidence.
+
+    Args:
+        tmp_path: Temporary directory for the CBL fixture.
+
+    Returns:
+        None.
+    """
     _write_cbl(tmp_path / "x-men.cbl", issue_id="12345")
     targets = [HydrationTarget(10, 4, "X-Men", "12", 12, 99999)]
 
     resolved = await apply_cbl_issue_identities(targets, tmp_path)
 
     assert resolved[0].comicvine_issue_id == 99999
+
+
+async def test_empty_normalized_cbl_key_cannot_resolve_blank_target(tmp_path: Path) -> None:
+    """Reject malformed CBL evidence whose normalized identity key is empty.
+
+    Args:
+        tmp_path: Temporary directory for the CBL fixture.
+
+    Returns:
+        None.
+    """
+    _write_cbl(
+        tmp_path / "malformed.cbl",
+        issue_id="12345",
+        series="#",
+        issue_number="#",
+    )
+    targets = [HydrationTarget(10, 4, "", "", 12)]
+
+    resolved = await apply_cbl_issue_identities(targets, tmp_path)
+
+    assert resolved[0].comicvine_issue_id is None

--- a/tests/test_comicvine_hydrator_cbl.py
+++ b/tests/test_comicvine_hydrator_cbl.py
@@ -1,0 +1,48 @@
+"""CBL-first identity tests for the ComicVine hydrator."""
+
+from pathlib import Path
+
+from comic_pile.comicvine_hydrator import HydrationTarget, apply_cbl_issue_identities
+
+
+def _write_cbl(path: Path, *, issue_id: str) -> None:
+    """Write one minimal CBL fixture with an embedded ComicVine issue ID."""
+    path.write_text(
+        (
+            "<ReadingList><Name>Fixture</Name><Books>"
+            f'<Book Series="X-Men" Number="12" IssueID="{issue_id}" />'
+            "</Books></ReadingList>"
+        ),
+        encoding="utf-8",
+    )
+
+
+async def test_unique_exact_cbl_issue_id_resolves_unmapped_target(tmp_path: Path) -> None:
+    """A unique exact title/issue CBL identity fills an otherwise unresolved target."""
+    _write_cbl(tmp_path / "x-men.cbl", issue_id="12345")
+    targets = [HydrationTarget(10, 4, " X-MEN ", "#12", 12)]
+
+    resolved = await apply_cbl_issue_identities(targets, tmp_path)
+
+    assert resolved[0].comicvine_issue_id == 12345
+
+
+async def test_conflicting_exact_cbl_issue_ids_remain_unresolved(tmp_path: Path) -> None:
+    """Disagreeing CBL embedded IDs never become an arbitrary provider mapping."""
+    _write_cbl(tmp_path / "first.cbl", issue_id="12345")
+    _write_cbl(tmp_path / "second.cbl", issue_id="67890")
+    targets = [HydrationTarget(10, 4, "X-Men", "12", 12)]
+
+    resolved = await apply_cbl_issue_identities(targets, tmp_path)
+
+    assert resolved[0].comicvine_issue_id is None
+
+
+async def test_confirmed_identity_wins_over_cbl_evidence(tmp_path: Path) -> None:
+    """CBL evidence cannot replace an existing confirmed ComicVine issue identity."""
+    _write_cbl(tmp_path / "x-men.cbl", issue_id="12345")
+    targets = [HydrationTarget(10, 4, "X-Men", "12", 12, 99999)]
+
+    resolved = await apply_cbl_issue_identities(targets, tmp_path)
+
+    assert resolved[0].comicvine_issue_id == 99999


### PR DESCRIPTION
Advances #1025 by adding CBL-first automatic issue identity discovery to the read-only ComicVine hydrator.

- Adds `--cbl-mirror` to the hydrator CLI.
- Reuses embedded ComicVine issue IDs only when normalized CBL series title + issue label agree uniquely.
- Preserves existing confirmed mappings ahead of CBL evidence.
- Leaves conflicting, malformed, or ambiguous CBL evidence unresolved instead of guessing.
- Adds focused regression coverage for unique, conflicting, and confirmed-identity cases.

This is a coherent next slice of #1025; the issue remains open for deep issue/story-arc hydration and the remaining reporting/anomaly acceptance criteria.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using CBL reading-list data to identify ComicVine issues.
  * Added an optional CBL mirror setting to the issue hydration tool.
  * Exact, unique issue matches are applied automatically before broader discovery.

* **Bug Fixes**
  * Existing confirmed identities are preserved.
  * Conflicting, invalid, or ambiguous CBL matches remain unresolved instead of being assigned incorrectly.

* **Documentation**
  * Updated the changelog to describe CBL-based identification, reduced lookup work, and conflict handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->