### PR TITLE
Add optional deep ComicVine hydration

### DIFF
--- a/comic_pile/comicvine_deep_hydration.py
+++ b/comic_pile/comicvine_deep_hydration.py
@@ -1,0 +1,173 @@
+"""Optional deep ComicVine metadata hydration for existing issue reports."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+
+from comic_pile.comicvine_provider import ComicVineClient, ComicVineError, ComicVineRateLimitError
+
+
+@dataclass(frozen=True)
+class DeepHydrationSummary:
+    """Summary of a resumable deep-hydration pass."""
+
+    attempted_issues: int
+    hydrated_issues: int
+    failed_issues: int
+    discovered_story_arcs: int
+    hydrated_story_arcs: int
+    failed_story_arcs: int
+    issue_budget_exhausted: bool
+    story_arc_budget_exhausted: bool
+
+
+def _provider_result(payload: Mapping[str, object]) -> dict[str, object] | None:
+    """Return one singular provider result when the payload shape is valid."""
+    result = payload.get("results")
+    return result if isinstance(result, dict) else None
+
+
+def _story_arc_ids(issue: Mapping[str, object]) -> set[int]:
+    """Extract unique positive story-arc IDs from one deep issue payload."""
+    credits = issue.get("story_arc_credits")
+    if not isinstance(credits, list):
+        return set()
+    ids: set[int] = set()
+    for credit in credits:
+        if not isinstance(credit, dict):
+            continue
+        value = credit.get("id")
+        if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+            ids.add(value)
+    return ids
+
+
+def _eligible_issue_rows(report: Mapping[str, object]) -> list[dict[str, object]]:
+    """Return matched rows with confirmed integer ComicVine issue identities."""
+    issues = report.get("issues")
+    if not isinstance(issues, list):
+        raise ValueError("hydration report must contain an issues list")
+    return [
+        row
+        for row in issues
+        if isinstance(row, dict)
+        and row.get("status") == "matched"
+        and isinstance(row.get("comicvine_issue_id"), int)
+        and not isinstance(row.get("comicvine_issue_id"), bool)
+    ]
+
+
+async def hydrate_deep_metadata(
+    report: dict[str, object],
+    client: ComicVineClient,
+    *,
+    hydrate_story_arcs: bool = False,
+    refresh: bool = False,
+) -> DeepHydrationSummary:
+    """Deep-hydrate matched issues and optionally deduplicated discovered story arcs.
+
+    Core ComicPile state is never mutated. Deep payloads are attached only to the generated report,
+    and an issue response is accepted only when its provider ID matches the already-confirmed
+    identity. Story-arc IDs are collected into a set before any story-arc request is made so an arc
+    credited by many issues consumes at most one cached/live request in a pass.
+
+    Args:
+        report: Machine-readable hydration report produced by the base hydrator.
+        client: Endpoint-budgeted ComicVine provider client.
+        hydrate_story_arcs: Fetch unique story arcs discovered from deep issue responses.
+        refresh: Bypass successful provider cache entries when true.
+
+    Returns:
+        Counts and endpoint-budget state for the pass.
+    """
+    rows = _eligible_issue_rows(report)
+    attempted_issues = 0
+    hydrated_issues = 0
+    failed_issues = 0
+    issue_budget_exhausted = False
+    discovered_arc_ids: set[int] = set()
+
+    for row in rows:
+        issue_id = row.get("comicvine_issue_id")
+        if not isinstance(issue_id, int) or isinstance(issue_id, bool):
+            continue
+        attempted_issues += 1
+        try:
+            response = await client.fetch_issue(issue_id, refresh=refresh)
+        except ComicVineRateLimitError:
+            issue_budget_exhausted = True
+            break
+        except ComicVineError as exc:
+            row["deep_hydration"] = {
+                "status": "failed",
+                "detail": str(exc),
+            }
+            failed_issues += 1
+            continue
+
+        result = _provider_result(response.payload)
+        returned_id = result.get("id") if result is not None else None
+        if returned_id != issue_id:
+            row["deep_hydration"] = {
+                "status": "failed",
+                "detail": "Provider response did not match the confirmed ComicVine issue identity.",
+            }
+            failed_issues += 1
+            continue
+
+        row["deep_hydration"] = {
+            "status": "hydrated",
+            "provenance": "comicvine-cache" if response.from_cache else "comicvine-live",
+            "metadata": result,
+        }
+        discovered_arc_ids.update(_story_arc_ids(result))
+        hydrated_issues += 1
+
+    story_arcs: dict[str, object] = {}
+    hydrated_story_arcs = 0
+    failed_story_arcs = 0
+    story_arc_budget_exhausted = False
+    if hydrate_story_arcs:
+        for arc_id in sorted(discovered_arc_ids):
+            try:
+                response = await client.fetch_story_arc(arc_id, refresh=refresh)
+            except ComicVineRateLimitError:
+                story_arc_budget_exhausted = True
+                break
+            except ComicVineError as exc:
+                story_arcs[str(arc_id)] = {"status": "failed", "detail": str(exc)}
+                failed_story_arcs += 1
+                continue
+
+            result = _provider_result(response.payload)
+            returned_id = result.get("id") if result is not None else None
+            if returned_id != arc_id:
+                story_arcs[str(arc_id)] = {
+                    "status": "failed",
+                    "detail": "Provider response did not match the discovered ComicVine story arc.",
+                }
+                failed_story_arcs += 1
+                continue
+            story_arcs[str(arc_id)] = {
+                "status": "hydrated",
+                "provenance": "comicvine-cache" if response.from_cache else "comicvine-live",
+                "metadata": result,
+            }
+            hydrated_story_arcs += 1
+
+    if hydrate_story_arcs:
+        report["story_arcs"] = story_arcs
+
+    summary = DeepHydrationSummary(
+        attempted_issues=attempted_issues,
+        hydrated_issues=hydrated_issues,
+        failed_issues=failed_issues,
+        discovered_story_arcs=len(discovered_arc_ids),
+        hydrated_story_arcs=hydrated_story_arcs,
+        failed_story_arcs=failed_story_arcs,
+        issue_budget_exhausted=issue_budget_exhausted,
+        story_arc_budget_exhausted=story_arc_budget_exhausted,
+    )
+    report["deep_hydration"] = asdict(summary)
+    return summary

--- a/comic_pile/comicvine_deep_hydration.py
+++ b/comic_pile/comicvine_deep_hydration.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass
+from typing import TypeGuard
 
 from comic_pile.comicvine_provider import ComicVineClient, ComicVineError, ComicVineRateLimitError
 
@@ -22,10 +23,15 @@ class DeepHydrationSummary:
     story_arc_budget_exhausted: bool
 
 
+def _is_object_dict(value: object) -> TypeGuard[dict[str, object]]:
+    """Return whether a JSON-like value is a string-keyed object mapping."""
+    return isinstance(value, dict) and all(isinstance(key, str) for key in value)
+
+
 def _provider_result(payload: Mapping[str, object]) -> dict[str, object] | None:
     """Return one singular provider result when the payload shape is valid."""
     result = payload.get("results")
-    return result if isinstance(result, dict) else None
+    return result if _is_object_dict(result) else None
 
 
 def _story_arc_ids(issue: Mapping[str, object]) -> set[int]:
@@ -35,7 +41,7 @@ def _story_arc_ids(issue: Mapping[str, object]) -> set[int]:
         return set()
     ids: set[int] = set()
     for credit in credits:
-        if not isinstance(credit, dict):
+        if not _is_object_dict(credit):
             continue
         value = credit.get("id")
         if isinstance(value, int) and not isinstance(value, bool) and value > 0:
@@ -51,7 +57,7 @@ def _eligible_issue_rows(report: Mapping[str, object]) -> list[dict[str, object]
     return [
         row
         for row in issues
-        if isinstance(row, dict)
+        if _is_object_dict(row)
         and row.get("status") == "matched"
         and isinstance(row.get("comicvine_issue_id"), int)
         and not isinstance(row.get("comicvine_issue_id"), bool)

--- a/docs/COMICVINE_HYDRATOR.md
+++ b/docs/COMICVINE_HYDRATOR.md
@@ -1,0 +1,67 @@
+# ComicVine hydrator
+
+The ComicVine hydrator inspects comics that already exist in ComicPile and writes a machine-readable JSON report. It does not modify threads, issues, reading progress, ratings, dependencies, continuity rules, or confirmed provider mappings.
+
+## Report-only local run
+
+Use the local ComicVine snapshot and optional CBL mirror first. This mode does not require a ComicVine API key and does not make provider requests.
+
+```bash
+uv run python scripts/hydrate_comicvine_issues.py \
+  --user-id 1 \
+  --cbl-mirror ../CBL-ReadingLists \
+  --comicvine-db ./localcv.db \
+  --output .cache/comicvine-hydrator/user-1-report.json
+```
+
+For composite ComicPile threads that span multiple provider volumes, add an explicit segment map. Segment declarations scope a volume to a position range and never assert that the whole thread belongs to one ComicVine volume.
+
+```bash
+uv run python scripts/hydrate_comicvine_issues.py \
+  --user-id 1 \
+  --comicvine-db ./localcv.db \
+  --segment-map ./comicvine-volume-segments.json \
+  --output .cache/comicvine-hydrator/user-1-segmented.json
+```
+
+## Budgeted live refresh
+
+Set `COMICVINE_API_KEY` in the environment. The default ceiling is 180 requests per hour for each endpoint bucket, with a persistent request ledger in the cache directory so restarting the command does not reset the rolling budget.
+
+```bash
+COMICVINE_API_KEY=... uv run python scripts/hydrate_comicvine_issues.py \
+  --user-id 1 \
+  --comicvine-db ./localcv.db \
+  --cache-dir .cache/comicvine-hydrator \
+  --live-refresh \
+  --output .cache/comicvine-hydrator/user-1-live.json
+```
+
+Successful provider responses are cached. Rerunning the same command reuses those cached responses unless `--force-refresh` is supplied.
+
+## Optional deep issue and story-arc hydration
+
+Deep hydration is separate from basic identity resolution. It requests the singular ComicVine issue resource only for already matched issues, verifies that the returned provider ID still equals the confirmed identity, and stores the metadata only in the report.
+
+```bash
+COMICVINE_API_KEY=... uv run python scripts/hydrate_comicvine_issues.py \
+  --user-id 1 \
+  --comicvine-db ./localcv.db \
+  --cache-dir .cache/comicvine-hydrator \
+  --deep-hydration \
+  --output .cache/comicvine-hydrator/user-1-deep.json
+```
+
+To hydrate story arcs discovered in deep issue responses, add `--hydrate-story-arcs`. Story-arc IDs are deduplicated across all hydrated issues before any story-arc request is made, so a shared arc is fetched at most once per pass and then benefits from the persistent response cache on later runs.
+
+```bash
+COMICVINE_API_KEY=... uv run python scripts/hydrate_comicvine_issues.py \
+  --user-id 1 \
+  --comicvine-db ./localcv.db \
+  --cache-dir .cache/comicvine-hydrator \
+  --deep-hydration \
+  --hydrate-story-arcs \
+  --output .cache/comicvine-hydrator/user-1-deep-arcs.json
+```
+
+`--hydrate-story-arcs` requires `--deep-hydration`. Provider throttling stops the affected endpoint pass cleanly, leaves already collected report data intact, and records budget exhaustion so a later rerun can continue using the same cache and request ledger.

--- a/docs/changelog.d/2026-08-11-1063.md
+++ b/docs/changelog.d/2026-08-11-1063.md
@@ -1,0 +1,5 @@
+## 2026-08-11
+
+### ComicVine metadata
+
+- [#1063](https://github.com/JoshCLWren/comic-pile/pull/1063) adds optional deep issue metadata hydration and deduplicated story-arc hydration to the resumable ComicVine hydrator, so rich provider details can be collected safely without changing reading state or wasting repeated API requests on the same arc.

--- a/scripts/hydrate_comicvine_issues.py
+++ b/scripts/hydrate_comicvine_issues.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 
 from app.database import AsyncSessionLocal
+from comic_pile.comicvine_deep_hydration import hydrate_deep_metadata
 from comic_pile.comicvine_hydrator import (
     apply_cbl_issue_identities,
     apply_local_volume_segments,
@@ -65,12 +66,45 @@ def parse_args() -> argparse.Namespace:
         help="Use cached/live ComicVine issue requests for confirmed identities missing locally.",
     )
     parser.add_argument(
+        "--deep-hydration",
+        action="store_true",
+        help=(
+            "Fetch full singular ComicVine issue metadata for matched confirmed identities and "
+            "store it only in the generated report."
+        ),
+    )
+    parser.add_argument(
+        "--hydrate-story-arcs",
+        action="store_true",
+        help=(
+            "With --deep-hydration, fetch each unique story arc discovered from issue metadata "
+            "at most once per pass."
+        ),
+    )
+    parser.add_argument(
         "--force-refresh",
         action="store_true",
-        help="Bypass successful response cache entries during --live-refresh.",
+        help="Bypass successful response cache entries during live or deep hydration.",
     )
     parser.add_argument("--include-test-threads", action="store_true")
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.hydrate_story_arcs and not args.deep_hydration:
+        parser.error("--hydrate-story-arcs requires --deep-hydration")
+    return args
+
+
+def _provider_client(args: argparse.Namespace) -> ComicVineClient:
+    """Build the shared endpoint-budgeted provider client for network-enabled modes."""
+    api_key = os.environ.get("COMICVINE_API_KEY", "")
+    if not api_key.strip():
+        raise RuntimeError(
+            "COMICVINE_API_KEY is required when live or deep ComicVine hydration is enabled"
+        )
+    return ComicVineClient(
+        api_key,
+        args.cache_dir,
+        requests_per_hour=args.requests_per_hour,
+    )
 
 
 async def run(args: argparse.Namespace) -> None:
@@ -95,17 +129,22 @@ async def run(args: argparse.Namespace) -> None:
         targets = await apply_local_volume_segments(targets, snapshot, segments)
 
     report = await build_report(targets, snapshot)
+    client: ComicVineClient | None = None
+    if args.live_refresh or args.deep_hydration:
+        client = _provider_client(args)
 
     if args.live_refresh:
-        api_key = os.environ.get("COMICVINE_API_KEY", "")
-        if not api_key.strip():
-            raise RuntimeError("COMICVINE_API_KEY is required when --live-refresh is enabled")
-        client = ComicVineClient(
-            api_key,
-            args.cache_dir,
-            requests_per_hour=args.requests_per_hour,
-        )
+        assert client is not None
         await refresh_confirmed_local_misses(report, client, refresh=args.force_refresh)
+
+    if args.deep_hydration:
+        assert client is not None
+        await hydrate_deep_metadata(
+            report,
+            client,
+            hydrate_story_arcs=args.hydrate_story_arcs,
+            refresh=args.force_refresh,
+        )
 
     write_report(report, args.output)
 

--- a/tests/test_comicvine_deep_hydration.py
+++ b/tests/test_comicvine_deep_hydration.py
@@ -1,0 +1,231 @@
+"""Tests for optional deep ComicVine issue and story-arc hydration."""
+
+from typing import cast
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from comic_pile.comicvine_deep_hydration import hydrate_deep_metadata
+from comic_pile.comicvine_provider import (
+    ComicVineError,
+    ComicVineRateLimitError,
+    ComicVineResponse,
+)
+
+
+def _report() -> dict[str, object]:
+    return {
+        "issues": [
+            {"issue_id": 1, "status": "matched", "comicvine_issue_id": 101},
+            {"issue_id": 2, "status": "matched", "comicvine_issue_id": 202},
+            {"issue_id": 3, "status": "unresolved", "comicvine_issue_id": None},
+        ]
+    }
+
+
+def _rows(report: dict[str, object]) -> list[dict[str, object]]:
+    issues = report["issues"]
+    assert isinstance(issues, list)
+    assert all(isinstance(row, dict) for row in issues)
+    return cast(list[dict[str, object]], issues)
+
+
+async def test_deep_hydration_attaches_metadata_without_changing_identity_status() -> None:
+    """Deep metadata remains report-only and preserves the matched identity state."""
+    client = Mock()
+    client.fetch_issue = AsyncMock(
+        side_effect=[
+            ComicVineResponse(
+                payload={"results": {"id": 101, "name": "One", "story_arc_credits": []}},
+                from_cache=True,
+                cache_key="issue-101",
+            ),
+            ComicVineResponse(
+                payload={"results": {"id": 202, "name": "Two", "story_arc_credits": []}},
+                from_cache=False,
+                cache_key="issue-202",
+            ),
+        ]
+    )
+    client.fetch_story_arc = AsyncMock()
+    report = _report()
+
+    summary = await hydrate_deep_metadata(report, client)
+
+    assert summary.hydrated_issues == 2
+    assert summary.attempted_issues == 2
+    rows = _rows(report)
+    assert rows[0]["status"] == "matched"
+    assert rows[0]["comicvine_issue_id"] == 101
+    assert rows[0]["deep_hydration"] == {
+        "status": "hydrated",
+        "provenance": "comicvine-cache",
+        "metadata": {"id": 101, "name": "One", "story_arc_credits": []},
+    }
+    assert rows[1]["deep_hydration"]["provenance"] == "comicvine-live"
+    client.fetch_story_arc.assert_not_awaited()
+
+
+async def test_story_arc_hydration_deduplicates_ids_across_issues() -> None:
+    """An arc credited by multiple issues is fetched only once after issue hydration."""
+    client = Mock()
+    client.fetch_issue = AsyncMock(
+        side_effect=[
+            ComicVineResponse(
+                payload={
+                    "results": {
+                        "id": 101,
+                        "story_arc_credits": [{"id": 9001}, {"id": 9002}],
+                    }
+                },
+                from_cache=False,
+                cache_key="issue-101",
+            ),
+            ComicVineResponse(
+                payload={
+                    "results": {
+                        "id": 202,
+                        "story_arc_credits": [{"id": 9001}, {"id": 9001}],
+                    }
+                },
+                from_cache=False,
+                cache_key="issue-202",
+            ),
+        ]
+    )
+    client.fetch_story_arc = AsyncMock(
+        side_effect=[
+            ComicVineResponse(
+                payload={"results": {"id": 9001, "name": "Arc One"}},
+                from_cache=False,
+                cache_key="arc-9001",
+            ),
+            ComicVineResponse(
+                payload={"results": {"id": 9002, "name": "Arc Two"}},
+                from_cache=True,
+                cache_key="arc-9002",
+            ),
+        ]
+    )
+    report = _report()
+
+    summary = await hydrate_deep_metadata(report, client, hydrate_story_arcs=True)
+
+    assert summary.discovered_story_arcs == 2
+    assert summary.hydrated_story_arcs == 2
+    assert client.fetch_story_arc.await_count == 2
+    client.fetch_story_arc.assert_any_await(9001, refresh=False)
+    client.fetch_story_arc.assert_any_await(9002, refresh=False)
+    assert set(cast(dict[str, object], report["story_arcs"])) == {"9001", "9002"}
+
+
+async def test_deep_hydration_rejects_identity_mismatch() -> None:
+    """Deep hydration never replaces or accepts a mismatched confirmed issue identity."""
+    client = Mock()
+    client.fetch_issue = AsyncMock(
+        side_effect=[
+            ComicVineResponse(
+                payload={"results": {"id": 999}},
+                from_cache=False,
+                cache_key="issue-101",
+            ),
+            ComicVineResponse(
+                payload={"results": {"id": 202}},
+                from_cache=False,
+                cache_key="issue-202",
+            ),
+        ]
+    )
+    client.fetch_story_arc = AsyncMock()
+    report = _report()
+
+    summary = await hydrate_deep_metadata(report, client)
+
+    assert summary.failed_issues == 1
+    first = _rows(report)[0]
+    assert first["status"] == "matched"
+    assert first["comicvine_issue_id"] == 101
+    assert first["deep_hydration"]["status"] == "failed"
+
+
+async def test_issue_budget_exhaustion_preserves_unattempted_rows() -> None:
+    """Issue endpoint throttling stops cleanly so a rerun can resume from cache/report state."""
+    client = Mock()
+    client.fetch_issue = AsyncMock(side_effect=ComicVineRateLimitError("issue budget exhausted"))
+    client.fetch_story_arc = AsyncMock()
+    report = _report()
+
+    summary = await hydrate_deep_metadata(report, client, hydrate_story_arcs=True)
+
+    assert summary.issue_budget_exhausted is True
+    assert summary.attempted_issues == 1
+    assert summary.hydrated_issues == 0
+    assert "deep_hydration" not in _rows(report)[1]
+    client.fetch_story_arc.assert_not_awaited()
+
+
+async def test_story_arc_budget_exhaustion_is_independent_of_issue_budget() -> None:
+    """Story-arc throttling preserves completed issue metadata and stops only arc requests."""
+    client = Mock()
+    client.fetch_issue = AsyncMock(
+        side_effect=[
+            ComicVineResponse(
+                payload={"results": {"id": 101, "story_arc_credits": [{"id": 9001}]}},
+                from_cache=False,
+                cache_key="issue-101",
+            ),
+            ComicVineResponse(
+                payload={"results": {"id": 202, "story_arc_credits": [{"id": 9002}]}},
+                from_cache=False,
+                cache_key="issue-202",
+            ),
+        ]
+    )
+    client.fetch_story_arc = AsyncMock(
+        side_effect=ComicVineRateLimitError("story arc budget exhausted")
+    )
+    report = _report()
+
+    summary = await hydrate_deep_metadata(report, client, hydrate_story_arcs=True)
+
+    assert summary.hydrated_issues == 2
+    assert summary.story_arc_budget_exhausted is True
+    assert summary.hydrated_story_arcs == 0
+    assert client.fetch_story_arc.await_count == 1
+
+
+async def test_provider_failure_is_recorded_without_aborting_later_issues() -> None:
+    """A single provider error is reportable while later issues continue."""
+    client = Mock()
+    client.fetch_issue = AsyncMock(
+        side_effect=[
+            ComicVineError("provider unavailable"),
+            ComicVineResponse(
+                payload={"results": {"id": 202}},
+                from_cache=False,
+                cache_key="issue-202",
+            ),
+        ]
+    )
+    client.fetch_story_arc = AsyncMock()
+    report = _report()
+
+    summary = await hydrate_deep_metadata(report, client)
+
+    assert summary.failed_issues == 1
+    assert summary.hydrated_issues == 1
+    assert _rows(report)[0]["deep_hydration"]["status"] == "failed"
+    assert _rows(report)[1]["deep_hydration"]["status"] == "hydrated"
+
+
+async def test_malformed_report_fails_before_provider_calls() -> None:
+    """Deep hydration rejects malformed report shapes before spending provider budget."""
+    client = Mock()
+    client.fetch_issue = AsyncMock()
+    client.fetch_story_arc = AsyncMock()
+
+    with pytest.raises(ValueError, match="issues list"):
+        await hydrate_deep_metadata({"issues": "invalid"}, client)
+
+    client.fetch_issue.assert_not_awaited()
+    client.fetch_story_arc.assert_not_awaited()

--- a/tests/test_comicvine_deep_hydration.py
+++ b/tests/test_comicvine_deep_hydration.py
@@ -30,6 +30,12 @@ def _rows(report: dict[str, object]) -> list[dict[str, object]]:
     return cast(list[dict[str, object]], issues)
 
 
+def _dict(value: object) -> dict[str, object]:
+    assert isinstance(value, dict)
+    assert all(isinstance(key, str) for key in value)
+    return cast(dict[str, object], value)
+
+
 async def test_deep_hydration_attaches_metadata_without_changing_identity_status() -> None:
     """Deep metadata remains report-only and preserves the matched identity state."""
     client = Mock()
@@ -62,7 +68,7 @@ async def test_deep_hydration_attaches_metadata_without_changing_identity_status
         "provenance": "comicvine-cache",
         "metadata": {"id": 101, "name": "One", "story_arc_credits": []},
     }
-    assert rows[1]["deep_hydration"]["provenance"] == "comicvine-live"
+    assert _dict(rows[1]["deep_hydration"])["provenance"] == "comicvine-live"
     client.fetch_story_arc.assert_not_awaited()
 
 
@@ -116,7 +122,7 @@ async def test_story_arc_hydration_deduplicates_ids_across_issues() -> None:
     assert client.fetch_story_arc.await_count == 2
     client.fetch_story_arc.assert_any_await(9001, refresh=False)
     client.fetch_story_arc.assert_any_await(9002, refresh=False)
-    assert set(cast(dict[str, object], report["story_arcs"])) == {"9001", "9002"}
+    assert set(_dict(report["story_arcs"])) == {"9001", "9002"}
 
 
 async def test_deep_hydration_rejects_identity_mismatch() -> None:
@@ -145,7 +151,7 @@ async def test_deep_hydration_rejects_identity_mismatch() -> None:
     first = _rows(report)[0]
     assert first["status"] == "matched"
     assert first["comicvine_issue_id"] == 101
-    assert first["deep_hydration"]["status"] == "failed"
+    assert _dict(first["deep_hydration"])["status"] == "failed"
 
 
 async def test_issue_budget_exhaustion_preserves_unattempted_rows() -> None:
@@ -214,8 +220,51 @@ async def test_provider_failure_is_recorded_without_aborting_later_issues() -> N
 
     assert summary.failed_issues == 1
     assert summary.hydrated_issues == 1
-    assert _rows(report)[0]["deep_hydration"]["status"] == "failed"
-    assert _rows(report)[1]["deep_hydration"]["status"] == "hydrated"
+    assert _dict(_rows(report)[0]["deep_hydration"])["status"] == "failed"
+    assert _dict(_rows(report)[1]["deep_hydration"])["status"] == "hydrated"
+
+
+async def test_story_arc_failures_are_recorded_and_later_arcs_continue() -> None:
+    """Provider errors and mismatched arc identities are isolated per discovered story arc."""
+    client = Mock()
+    client.fetch_issue = AsyncMock(
+        side_effect=[
+            ComicVineResponse(
+                payload={
+                    "results": {
+                        "id": 101,
+                        "story_arc_credits": [None, {"id": True}, {"id": 9001}, {"id": 9002}],
+                    }
+                },
+                from_cache=False,
+                cache_key="issue-101",
+            ),
+            ComicVineResponse(
+                payload={"results": {"id": 202, "story_arc_credits": "invalid"}},
+                from_cache=False,
+                cache_key="issue-202",
+            ),
+        ]
+    )
+    client.fetch_story_arc = AsyncMock(
+        side_effect=[
+            ComicVineError("arc provider unavailable"),
+            ComicVineResponse(
+                payload={"results": {"id": 9999}},
+                from_cache=False,
+                cache_key="arc-9002",
+            ),
+        ]
+    )
+    report = _report()
+
+    summary = await hydrate_deep_metadata(report, client, hydrate_story_arcs=True)
+
+    assert summary.discovered_story_arcs == 2
+    assert summary.failed_story_arcs == 2
+    arcs = _dict(report["story_arcs"])
+    assert _dict(arcs["9001"])["detail"] == "arc provider unavailable"
+    assert _dict(arcs["9002"])["status"] == "failed"
 
 
 async def test_malformed_report_fails_before_provider_calls() -> None:


### PR DESCRIPTION
Part of #1025.

Adds a separate report-only deep hydration pass for matched ComicVine issue identities. The pass validates each singular issue response against the confirmed provider ID, attaches rich metadata without mutating ComicPile core state, deduplicates discovered story-arc IDs before optional story-arc hydration, and stops cleanly when either endpoint budget is exhausted.

The CLI now exposes `--deep-hydration` and `--hydrate-story-arcs`, reuses the existing persistent cache/rate ledger, and documents representative user 1 report-only, live-refresh, deep-hydration, and story-arc workflows.

Focused tests cover identity mismatch rejection, cross-issue story-arc deduplication, independent endpoint throttling, provider failures, and malformed report input.

#1025 remains open after this PR for the remaining anomaly/report classification work and final closure verification.