### PR TITLE
Complete ComicVine hydrator report classifications

### DIFF
--- a/comic_pile/comicvine_report_classification.py
+++ b/comic_pile/comicvine_report_classification.py
@@ -1,0 +1,60 @@
+"""Normalize ComicVine hydrator outcomes into stable machine-readable classifications."""
+
+from __future__ import annotations
+
+from typing import Any
+
+REPORT_CLASSIFICATIONS = (
+    "matched",
+    "ambiguous",
+    "stale-source",
+    "anomalous",
+    "unresolved",
+    "failed",
+    "skipped",
+    "completed",
+)
+
+
+def classify_hydration_report(report: dict[str, object]) -> dict[str, object]:
+    """Add stable outcome classifications without discarding the lower-level status.
+
+    The local-first hydrator can prove three states directly: a complete local match, a
+    confirmed identity missing from the snapshot, or an unresolved identity. The first two
+    map to ``completed`` and ``stale-source`` respectively. Later discovery stages may set an
+    explicit ``classification`` (for example ``ambiguous`` or ``anomalous``); this function
+    preserves those values and always emits counters for the complete report vocabulary.
+    """
+    raw_issues = report.get("issues")
+    if not isinstance(raw_issues, list):
+        raise ValueError("hydration report issues must be a list")
+
+    counts = {name: 0 for name in REPORT_CLASSIFICATIONS}
+    classified: list[dict[str, Any]] = []
+    for raw_issue in raw_issues:
+        if not isinstance(raw_issue, dict):
+            raise ValueError("hydration report issue rows must be objects")
+        issue = dict(raw_issue)
+        explicit = issue.get("classification")
+        if explicit is not None:
+            if explicit not in REPORT_CLASSIFICATIONS:
+                raise ValueError(f"unknown hydration classification: {explicit}")
+            classification = str(explicit)
+        else:
+            status = issue.get("status")
+            if status == "matched":
+                classification = "completed"
+            elif status == "local-miss":
+                classification = "stale-source"
+            elif status == "unresolved":
+                classification = "unresolved"
+            else:
+                classification = "failed"
+        issue["classification"] = classification
+        counts[classification] += 1
+        classified.append(issue)
+
+    summary = report.get("summary")
+    normalized_summary = dict(summary) if isinstance(summary, dict) else {}
+    normalized_summary["classifications"] = counts
+    return {**report, "summary": normalized_summary, "issues": classified}

--- a/comic_pile/comicvine_report_classification.py
+++ b/comic_pile/comicvine_report_classification.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, TypedDict
 
 REPORT_CLASSIFICATIONS = (
     "matched",
@@ -16,7 +16,14 @@ REPORT_CLASSIFICATIONS = (
 )
 
 
-def classify_hydration_report(report: dict[str, object]) -> dict[str, object]:
+class HydrationReport(TypedDict):
+    """Normalized hydration report shape used by operators and tests."""
+
+    summary: dict[str, Any]
+    issues: list[dict[str, Any]]
+
+
+def classify_hydration_report(report: dict[str, object]) -> HydrationReport:
     """Add stable outcome classifications without discarding the lower-level status.
 
     The local-first hydrator can prove three states directly: a complete local match, a
@@ -29,7 +36,7 @@ def classify_hydration_report(report: dict[str, object]) -> dict[str, object]:
     if not isinstance(raw_issues, list):
         raise ValueError("hydration report issues must be a list")
 
-    counts = {name: 0 for name in REPORT_CLASSIFICATIONS}
+    counts = dict.fromkeys(REPORT_CLASSIFICATIONS, 0)
     classified: list[dict[str, Any]] = []
     for raw_issue in raw_issues:
         if not isinstance(raw_issue, dict):
@@ -57,4 +64,4 @@ def classify_hydration_report(report: dict[str, object]) -> dict[str, object]:
     summary = report.get("summary")
     normalized_summary = dict(summary) if isinstance(summary, dict) else {}
     normalized_summary["classifications"] = counts
-    return {**report, "summary": normalized_summary, "issues": classified}
+    return {"summary": normalized_summary, "issues": classified}

--- a/docs/changelog.d/2026-08-11-1064.md
+++ b/docs/changelog.d/2026-08-11-1064.md
@@ -1,0 +1,5 @@
+## 2026-08-11
+
+### ComicVine
+
+- [#1064](https://github.com/JoshCLWren/comic-pile/pull/1064) makes hydrator output easier to resume and audit by adding stable machine-readable outcome classifications for completed, stale-source, unresolved, ambiguous, anomalous, failed, and skipped records.

--- a/scripts/hydrate_comicvine_issues.py
+++ b/scripts/hydrate_comicvine_issues.py
@@ -19,6 +19,7 @@ from comic_pile.comicvine_hydrator import (
 )
 from comic_pile.comicvine_live_refresh import refresh_confirmed_local_misses
 from comic_pile.comicvine_provider import ComicVineClient, DEFAULT_REQUESTS_PER_HOUR
+from comic_pile.comicvine_report_classification import classify_hydration_report
 from comic_pile.local_comicvine import LocalComicVineSnapshot
 
 
@@ -146,7 +147,7 @@ async def run(args: argparse.Namespace) -> None:
             refresh=args.force_refresh,
         )
 
-    write_report(report, args.output)
+    write_report(classify_hydration_report(report), args.output)
 
 
 def main() -> None:

--- a/tests/test_comicvine_report_classification.py
+++ b/tests/test_comicvine_report_classification.py
@@ -1,0 +1,65 @@
+"""Tests for stable machine-readable ComicVine hydration classifications."""
+
+import pytest
+
+from comic_pile.comicvine_report_classification import (
+    REPORT_CLASSIFICATIONS,
+    classify_hydration_report,
+)
+
+
+def test_classifies_local_first_outcomes_and_emits_full_vocabulary() -> None:
+    """Base hydrator states become operator-facing completion/freshness outcomes."""
+    report = classify_hydration_report(
+        {
+            "summary": {"total": 3, "matched": 1, "local-miss": 1, "unresolved": 1},
+            "issues": [
+                {"issue_id": 1, "status": "matched"},
+                {"issue_id": 2, "status": "local-miss"},
+                {"issue_id": 3, "status": "unresolved"},
+            ],
+        }
+    )
+
+    assert [row["classification"] for row in report["issues"]] == [
+        "completed",
+        "stale-source",
+        "unresolved",
+    ]
+    counts = report["summary"]["classifications"]
+    assert set(counts) == set(REPORT_CLASSIFICATIONS)
+    assert counts["completed"] == 1
+    assert counts["stale-source"] == 1
+    assert counts["unresolved"] == 1
+    assert counts["ambiguous"] == counts["anomalous"] == counts["failed"] == 0
+
+
+def test_preserves_explicit_discovery_classification() -> None:
+    """Later discovery stages can report ambiguity/anomalies without being overwritten."""
+    report = classify_hydration_report(
+        {
+            "issues": [
+                {"issue_id": 1, "status": "unresolved", "classification": "ambiguous"},
+                {"issue_id": 2, "status": "unresolved", "classification": "anomalous"},
+                {"issue_id": 3, "status": "unresolved", "classification": "skipped"},
+            ]
+        }
+    )
+
+    assert report["summary"]["classifications"]["ambiguous"] == 1
+    assert report["summary"]["classifications"]["anomalous"] == 1
+    assert report["summary"]["classifications"]["skipped"] == 1
+
+
+def test_rejects_unknown_explicit_classification() -> None:
+    """Typos cannot silently create an uncounted report category."""
+    with pytest.raises(ValueError, match="unknown hydration classification"):
+        classify_hydration_report(
+            {"issues": [{"issue_id": 1, "status": "unresolved", "classification": "maybe"}]}
+        )
+
+
+def test_rejects_malformed_issue_rows() -> None:
+    """Machine-readable reports fail clearly instead of emitting a partial shape."""
+    with pytest.raises(ValueError, match="issue rows must be objects"):
+        classify_hydration_report({"issues": ["bad-row"]})


### PR DESCRIPTION
Continues #1025.

Adds a stable machine-readable classification layer to the ComicVine hydrator report. Existing low-level statuses remain intact while operator-facing outcomes distinguish completed, stale-source, unresolved, ambiguous, anomalous, failed, and skipped records. Later discovery stages can supply explicit ambiguity/anomaly classifications without having them overwritten.

Focused regression coverage validates classification mapping, the complete vocabulary, explicit discovery outcomes, and malformed report rejection.

This does not close #1025 until the remaining acceptance criteria are verified after merge.