### PR TITLE
Instrument cache command counts safely

### DIFF
--- a/app/cache_metrics.py
+++ b/app/cache_metrics.py
@@ -1,8 +1,9 @@
-"""Privacy-safe cache command-count instrumentation.
+"""Privacy-safe cache command-count instrumentation and flow budgets.
 
-The recorder intentionally stores only command names and aggregate counts. Cache
-keys, user ids, values, and provider credentials are never accepted by the API,
-which keeps operational command-budget metrics free of user data.
+The recorder stores only normalized command-family names and aggregate counts. Cache
+keys, user IDs, values, and provider credentials are never accepted by this API.
+Production generation-cache operations share the same counter so tests and operators
+observe the commands the application actually issues.
 """
 
 from __future__ import annotations
@@ -10,12 +11,38 @@ from __future__ import annotations
 from collections import Counter
 from threading import Lock
 
+from app.cache_generation import command_budget
+
+UPSTASH_FREE_MONTHLY_COMMANDS = 500_000
+CONSERVATIVE_MONTHLY_COMMAND_BUDGET = 350_000
+MONTHLY_HEADROOM_COMMANDS = UPSTASH_FREE_MONTHLY_COMMANDS - CONSERVATIVE_MONTHLY_COMMAND_BUDGET
+
+# Upper bounds for the cache-command composition of representative product flows.
+# These are deliberately conservative cold-cache ceilings. A generation-scoped
+# cached read costs at most two commands (atomic EVAL + SET) and a mutation
+# invalidation costs one INCR.
+CACHE_FLOW_COMMAND_CEILINGS: dict[str, int] = {
+    "bootstrap": 4,
+    "queue_load": 2,
+    "roll": 5,
+    "snooze": 1,
+    "rating": 1,
+    "thread_mutation": 1,
+    "issue_mutation": 1,
+    "continuity_mutation": 1,
+}
+
 
 class CacheCommandMetrics:
     """Track aggregate cache command counts without recording command payloads."""
 
-    def __init__(self) -> None:
-        self._counts: Counter[str] = Counter()
+    def __init__(self, counts: Counter[str] | None = None) -> None:
+        """Initialize a recorder, optionally sharing an existing aggregate counter.
+
+        Args:
+            counts: Existing command counter to expose through this privacy-safe API.
+        """
+        self._counts = counts if counts is not None else Counter()
         self._lock = Lock()
 
     def record(self, command: str, *, count: int = 1) -> None:
@@ -52,5 +79,23 @@ class CacheCommandMetrics:
         with self._lock:
             self._counts.clear()
 
+    def assert_within_flow_ceiling(self, flow: str) -> None:
+        """Raise when the current aggregate count exceeds a named flow ceiling.
 
-cache_command_metrics = CacheCommandMetrics()
+        Args:
+            flow: Key from :data:`CACHE_FLOW_COMMAND_CEILINGS`.
+
+        Raises:
+            KeyError: If ``flow`` has no documented ceiling.
+            AssertionError: If recorded commands exceed the ceiling.
+        """
+        ceiling = CACHE_FLOW_COMMAND_CEILINGS[flow]
+        total = self.total()
+        if total > ceiling:
+            raise AssertionError(f"{flow} used {total} cache commands; ceiling is {ceiling}")
+
+
+# ``command_budget`` is the production generation-cache instrumentation introduced
+# with bounded invalidation. Sharing its Counter makes this the stable public metrics
+# surface without adding keys, values, or user identifiers to instrumentation.
+cache_command_metrics = CacheCommandMetrics(command_budget.counts)

--- a/app/cache_metrics.py
+++ b/app/cache_metrics.py
@@ -1,0 +1,56 @@
+"""Privacy-safe cache command-count instrumentation.
+
+The recorder intentionally stores only command names and aggregate counts. Cache
+keys, user ids, values, and provider credentials are never accepted by the API,
+which keeps operational command-budget metrics free of user data.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from threading import Lock
+
+
+class CacheCommandMetrics:
+    """Track aggregate cache command counts without recording command payloads."""
+
+    def __init__(self) -> None:
+        self._counts: Counter[str] = Counter()
+        self._lock = Lock()
+
+    def record(self, command: str, *, count: int = 1) -> None:
+        """Record one or more provider-billed cache commands.
+
+        Args:
+            command: Stable command family such as ``get``, ``set``, or ``delete``.
+            count: Number of provider commands represented by this operation.
+
+        Raises:
+            ValueError: If the command is empty or count is not positive.
+        """
+        normalized = command.strip().lower()
+        if not normalized:
+            raise ValueError("cache metric command must not be empty")
+        if count <= 0:
+            raise ValueError("cache metric count must be positive")
+
+        with self._lock:
+            self._counts[normalized] += count
+
+    def snapshot(self) -> dict[str, int]:
+        """Return a detached command-count snapshot suitable for metrics/tests."""
+        with self._lock:
+            return dict(self._counts)
+
+    def total(self) -> int:
+        """Return the total recorded provider command count."""
+        with self._lock:
+            return sum(self._counts.values())
+
+    def reset(self) -> None:
+        """Clear counters, primarily for deterministic tests."""
+        with self._lock:
+            self._counts.clear()
+
+
+cache_command_metrics = CacheCommandMetrics()

--- a/app/cache_metrics.py
+++ b/app/cache_metrics.py
@@ -17,6 +17,26 @@ UPSTASH_FREE_MONTHLY_COMMANDS = 500_000
 CONSERVATIVE_MONTHLY_COMMAND_BUDGET = 350_000
 MONTHLY_HEADROOM_COMMANDS = UPSTASH_FREE_MONTHLY_COMMANDS - CONSERVATIVE_MONTHLY_COMMAND_BUDGET
 
+# Explicitly bounded labels prevent cache keys, user data, values, or credentials from
+# being smuggled into metric dimensions. Add a family only when application code issues
+# that provider command and the corresponding budget test is updated.
+_ALLOWED_COMMAND_FAMILIES = frozenset(
+    {
+        "delete",
+        "eval",
+        "generation_get",
+        "generation_incr",
+        "generation_value_get",
+        "get",
+        "incr",
+        "mget",
+        "mset",
+        "scan",
+        "set",
+        "value_set",
+    }
+)
+
 # Upper bounds for the cache-command composition of representative product flows.
 # These are deliberately conservative cold-cache ceilings. A generation-scoped
 # cached read costs at most two commands (atomic EVAL + SET) and a mutation
@@ -49,15 +69,17 @@ class CacheCommandMetrics:
         """Record one or more provider-billed cache commands.
 
         Args:
-            command: Stable command family such as ``get``, ``set``, or ``delete``.
+            command: Stable command family from the explicit privacy-safe allowlist.
             count: Number of provider commands represented by this operation.
 
         Raises:
-            ValueError: If the command is empty or count is not positive.
+            ValueError: If the command family is unknown or count is not positive.
         """
         normalized = command.strip().lower()
         if not normalized:
             raise ValueError("cache metric command must not be empty")
+        if normalized not in _ALLOWED_COMMAND_FAMILIES:
+            raise ValueError("cache metric command must be an approved command family")
         if count <= 0:
             raise ValueError("cache metric count must be positive")
 

--- a/app/cache_metrics.py
+++ b/app/cache_metrics.py
@@ -87,12 +87,20 @@ class CacheCommandMetrics:
             self._counts[normalized] += count
 
     def snapshot(self) -> dict[str, int]:
-        """Return a detached command-count snapshot suitable for metrics/tests."""
+        """Return a detached command-count snapshot suitable for metrics/tests.
+
+        Returns:
+            Detached mapping from approved command family to aggregate count.
+        """
         with self._lock:
             return dict(self._counts)
 
     def total(self) -> int:
-        """Return the total recorded provider command count."""
+        """Return the total recorded provider command count.
+
+        Returns:
+            Aggregate count across all approved command families.
+        """
         with self._lock:
             return sum(self._counts.values())
 

--- a/docs/CACHE_COMMAND_BUDGET.md
+++ b/docs/CACHE_COMMAND_BUDGET.md
@@ -1,0 +1,43 @@
+# Cache command budget
+
+Updated: 2026-08-11
+
+ComicPile treats Redis as an optional performance layer, not a correctness dependency. The command budget below exists to keep cache usage measurable and comfortably inside the configured Upstash free-tier allowance while preserving enough headroom for retries, diagnostics, console traffic, and future growth.
+
+## Provider accounting assumptions
+
+The configured production provider is Upstash Redis. As of 2026-08-11, Upstash documents a Free plan allowance of **500,000 commands per month** and prices usage by command. Operational commands such as `PING`, `AUTH`, `HELLO`, `SELECT`, `COMMAND`, `CONFIG`, `INFO`, `RESET`, and `QUIT` are not billed. See:
+
+- https://upstash.com/pricing/redis
+- https://upstash.com/docs/redis/features/restapi
+
+Upstash REST pipelining combines multiple Redis commands into one HTTP request, but each logical Redis command remains a command for budgeting purposes. Pipeline batching therefore reduces network round trips, not this command envelope. Native multi-key commands such as `MGET` and `MSET` are each documented as one Redis command regardless of key count, so budget accounting follows the logical command issued rather than the number of keys inside it. A multi-key `DEL` is likewise one Redis command.
+
+The application-side metrics intentionally count only aggregate command families. They never accept or retain cache keys, user IDs, values, tokens, or provider credentials. Provider console activity can add commands that the application cannot observe, so the application budget deliberately leaves substantial headroom.
+
+## Monthly budget
+
+| Item | Commands/month |
+| --- | ---: |
+| Upstash Free allowance | 500,000 |
+| ComicPile application budget | **350,000** |
+| Reserved headroom | **150,000 (30%)** |
+
+The 350,000-command application ceiling is intentionally conservative. Reaching it should trigger investigation before the provider limit becomes a user-facing cache outage. The remaining 150,000 commands absorb provider-console activity, retries, unusual burst traffic, and measurement differences.
+
+## Representative flow ceilings
+
+These are cold-cache upper bounds for the production generation-cache command composition. Warm reads are cheaper.
+
+| Flow | Ceiling | Command model |
+| --- | ---: | --- |
+| Roll bootstrap | 4 | two generation-scoped reads, each at most `EVAL + SET` |
+| Queue load | 2 | one generation-scoped read, at most `EVAL + SET` |
+| Roll | 5 | two cold generation-scoped reads plus one `INCR` invalidation |
+| Snooze | 1 | one user-generation `INCR` invalidation |
+| Rating | 1 | one deduplicated user-generation `INCR` invalidation |
+| Thread mutation | 1 | one user-generation `INCR` invalidation |
+| Issue mutation | 1 | one user-generation `INCR` invalidation |
+| Continuity mutation | 1 | one user-generation `INCR` invalidation |
+
+The source-of-truth ceilings live in `app/cache_metrics.py` and are exercised by `tests/test_cache_command_budget.py`. If a flow legitimately needs more cache commands, update the implementation, ceiling test, and this document together so budget growth is explicit rather than accidental.

--- a/docs/changelog.d/2026-08-11-1072.md
+++ b/docs/changelog.d/2026-08-11-1072.md
@@ -1,0 +1,5 @@
+## 2026-08-11
+
+### Performance & reliability
+
+- [PR #1072](https://github.com/JoshCLWren/comic-pile/pull/1072) adds privacy-safe cache command counting so ComicPile can measure Redis usage and enforce a conservative command budget without recording cache keys, user data, or values.

--- a/docs/changelog.d/2026-08-11-1072.md
+++ b/docs/changelog.d/2026-08-11-1072.md
@@ -2,4 +2,4 @@
 
 ### Performance & reliability
 
-- [PR #1072](https://github.com/JoshCLWren/comic-pile/pull/1072) adds privacy-safe cache command counting so ComicPile can measure Redis usage and enforce a conservative command budget without recording cache keys, user data, or values.
+- [PR #1072](https://github.com/JoshCLWren/comic-pile/pull/1072) adds privacy-safe aggregate counting for ComicPile's bounded generation-cache commands, tested command ceilings for representative reading flows, and a conservative monthly Redis budget without recording cache keys, user data, or values.

--- a/docs/changelog.d/2026-08-11-1072.md
+++ b/docs/changelog.d/2026-08-11-1072.md
@@ -2,4 +2,4 @@
 
 ### Performance & reliability
 
-- [PR #1072](https://github.com/JoshCLWren/comic-pile/pull/1072) adds privacy-safe aggregate counting for ComicPile's bounded generation-cache commands, tested command ceilings for representative reading flows, and a conservative monthly Redis budget without recording cache keys, user data, or values.
+- [#1072](https://github.com/JoshCLWren/comic-pile/pull/1072) adds privacy-safe aggregate counting for ComicPile's bounded generation-cache commands, tested command ceilings for representative reading flows, and a conservative monthly Redis budget without recording cache keys, user data, or values.

--- a/tests/test_cache_command_budget.py
+++ b/tests/test_cache_command_budget.py
@@ -1,0 +1,175 @@
+"""Upper-bound tests for privacy-safe production cache command budgets."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.cache import cache
+from app.cache_generation import bump_user_generation, generation_cached, generation_key
+from app.cache_metrics import (
+    CACHE_FLOW_COMMAND_CEILINGS,
+    CONSERVATIVE_MONTHLY_COMMAND_BUDGET,
+    MONTHLY_HEADROOM_COMMANDS,
+    UPSTASH_FREE_MONTHLY_COMMANDS,
+    cache_command_metrics,
+)
+
+
+class BudgetRedisClient:
+    """Minimal in-memory Upstash-shaped client for command-envelope tests."""
+
+    def __init__(self) -> None:
+        """Initialize generation-zero state and an empty value store."""
+        self.generation = 0
+        self.values: dict[str, str] = {}
+
+    async def eval(
+        self,
+        script: str,
+        keys: list[str],
+        args: list[str],
+    ) -> list[object | None]:
+        """Return one atomic generation/value snapshot."""
+        assert "redis.call('GET', KEYS[1])" in script
+        assert keys == [generation_key(7)]
+        value_key = f"{args[0]}{self.generation}:{args[1]}"
+        return [str(self.generation), self.values.get(value_key)]
+
+    async def set(self, key: str, value: str, ex: int | None = None) -> None:
+        """Store one serialized generation-scoped value."""
+        _ = ex
+        self.values[key] = value
+
+    async def incr(self, key: str) -> int:
+        """Advance the single test user's generation."""
+        assert key == generation_key(7)
+        self.generation += 1
+        return self.generation
+
+
+@pytest.fixture(autouse=True)
+def reset_cache_metrics() -> None:
+    """Reset shared production command instrumentation before each test."""
+    cache_command_metrics.reset()
+
+
+@pytest.fixture
+def budget_cache(monkeypatch: pytest.MonkeyPatch) -> BudgetRedisClient:
+    """Install an Upstash-shaped client behind the production cache singleton."""
+    client = BudgetRedisClient()
+    monkeypatch.setattr(cache, "_client", client)
+    monkeypatch.setattr(cache, "_initialized", True)
+    monkeypatch.setattr(cache, "_is_upstash", True)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_cold_cache_stays_within_four_commands(
+    budget_cache: BudgetRedisClient,
+) -> None:
+    """Bootstrap's two generation-scoped reads cost at most EVAL+SET each."""
+
+    @generation_cached(ttl=60)
+    async def load_session(user_id: int) -> dict[str, int]:
+        return {"user_id": user_id}
+
+    @generation_cached(ttl=60)
+    async def load_die(user_id: int) -> dict[str, int]:
+        return {"die": 8, "user_id": user_id}
+
+    await load_session(7)
+    await load_die(7)
+
+    assert cache_command_metrics.snapshot() == {"generation_value_get": 2, "value_set": 2}
+    assert cache_command_metrics.total() == CACHE_FLOW_COMMAND_CEILINGS["bootstrap"]
+    cache_command_metrics.assert_within_flow_ceiling("bootstrap")
+
+
+@pytest.mark.asyncio
+async def test_queue_load_cold_cache_stays_within_two_commands(
+    budget_cache: BudgetRedisClient,
+) -> None:
+    """A cold queue read costs one atomic lookup and one value write."""
+
+    @generation_cached(ttl=60)
+    async def load_queue(user_id: int) -> list[int]:
+        return [user_id]
+
+    await load_queue(7)
+
+    assert cache_command_metrics.snapshot() == {"generation_value_get": 1, "value_set": 1}
+    assert cache_command_metrics.total() == CACHE_FLOW_COMMAND_CEILINGS["queue_load"]
+    cache_command_metrics.assert_within_flow_ceiling("queue_load")
+
+
+@pytest.mark.asyncio
+async def test_roll_cold_cache_and_invalidation_stay_within_five_commands(
+    budget_cache: BudgetRedisClient,
+) -> None:
+    """Roll allows two cold reads plus one bounded generation invalidation."""
+
+    @generation_cached(ttl=60)
+    async def load_die(user_id: int) -> int:
+        return user_id + 1
+
+    @generation_cached(ttl=60)
+    async def load_pool(user_id: int) -> list[int]:
+        return [user_id]
+
+    await load_die(7)
+    await load_pool(7)
+    await bump_user_generation(budget_cache, 7)
+
+    assert cache_command_metrics.snapshot() == {
+        "generation_value_get": 2,
+        "value_set": 2,
+        "generation_incr": 1,
+    }
+    assert cache_command_metrics.total() == CACHE_FLOW_COMMAND_CEILINGS["roll"]
+    cache_command_metrics.assert_within_flow_ceiling("roll")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "flow",
+    [
+        "snooze",
+        "rating",
+        "thread_mutation",
+        "issue_mutation",
+        "continuity_mutation",
+    ],
+)
+async def test_mutation_flows_use_one_bounded_generation_invalidation(flow: str) -> None:
+    """Mutation families stay at one remote INCR after SCAN removal."""
+    client = BudgetRedisClient()
+
+    await bump_user_generation(client, 7)
+
+    assert cache_command_metrics.snapshot() == {"generation_incr": 1}
+    assert cache_command_metrics.total() == CACHE_FLOW_COMMAND_CEILINGS[flow]
+    cache_command_metrics.assert_within_flow_ceiling(flow)
+
+
+def test_metrics_never_expose_cache_payloads() -> None:
+    """Snapshots contain command families and aggregate counts only."""
+    cache_command_metrics.record("GET")
+    cache_command_metrics.record("SET", count=2)
+
+    snapshot = cache_command_metrics.snapshot()
+
+    assert snapshot == {"get": 1, "set": 2}
+    serialized = json.dumps(snapshot)
+    assert "cache:user" not in serialized
+    assert "token" not in serialized
+    assert "credential" not in serialized
+
+
+def test_monthly_budget_reserves_thirty_percent_provider_headroom() -> None:
+    """The application budget remains conservatively below Upstash Free capacity."""
+    assert UPSTASH_FREE_MONTHLY_COMMANDS == 500_000
+    assert CONSERVATIVE_MONTHLY_COMMAND_BUDGET == 350_000
+    assert MONTHLY_HEADROOM_COMMANDS == 150_000
+    assert MONTHLY_HEADROOM_COMMANDS / UPSTASH_FREE_MONTHLY_COMMANDS == pytest.approx(0.30)

--- a/tests/test_cache_metrics.py
+++ b/tests/test_cache_metrics.py
@@ -1,0 +1,45 @@
+"""Tests for privacy-safe cache command-count instrumentation."""
+
+import pytest
+
+from app.cache_metrics import CacheCommandMetrics
+
+
+def test_records_aggregate_command_counts() -> None:
+    metrics = CacheCommandMetrics()
+
+    metrics.record("GET")
+    metrics.record("get", count=2)
+    metrics.record("delete")
+
+    assert metrics.snapshot() == {"get": 3, "delete": 1}
+    assert metrics.total() == 4
+
+
+def test_snapshot_is_detached_from_internal_state() -> None:
+    metrics = CacheCommandMetrics()
+    metrics.record("set")
+
+    snapshot = metrics.snapshot()
+    snapshot["set"] = 99
+
+    assert metrics.snapshot() == {"set": 1}
+
+
+@pytest.mark.parametrize(("command", "count"), [("", 1), ("   ", 1), ("get", 0), ("get", -1)])
+def test_rejects_invalid_metric_records(command: str, count: int) -> None:
+    metrics = CacheCommandMetrics()
+
+    with pytest.raises(ValueError):
+        metrics.record(command, count=count)
+
+
+def test_reset_clears_all_counts() -> None:
+    metrics = CacheCommandMetrics()
+    metrics.record("get")
+    metrics.record("set")
+
+    metrics.reset()
+
+    assert metrics.snapshot() == {}
+    assert metrics.total() == 0

--- a/tests/test_cache_metrics.py
+++ b/tests/test_cache_metrics.py
@@ -26,12 +26,23 @@ def test_snapshot_is_detached_from_internal_state() -> None:
     assert metrics.snapshot() == {"set": 1}
 
 
-@pytest.mark.parametrize(("command", "count"), [("", 1), ("   ", 1), ("get", 0), ("get", -1)])
+@pytest.mark.parametrize(
+    ("command", "count"),
+    [
+        ("", 1),
+        ("   ", 1),
+        ("get", 0),
+        ("get", -1),
+        ("get cache:user:7:g3:private-key", 1),
+    ],
+)
 def test_rejects_invalid_metric_records(command: str, count: int) -> None:
     metrics = CacheCommandMetrics()
 
     with pytest.raises(ValueError):
         metrics.record(command, count=count)
+
+    assert metrics.snapshot() == {}
 
 
 def test_reset_clears_all_counts() -> None:

--- a/tests/test_cache_metrics.py
+++ b/tests/test_cache_metrics.py
@@ -6,6 +6,7 @@ from app.cache_metrics import CacheCommandMetrics
 
 
 def test_records_aggregate_command_counts() -> None:
+    """Aggregate normalized command families without retaining payload data."""
     metrics = CacheCommandMetrics()
 
     metrics.record("GET")
@@ -17,6 +18,7 @@ def test_records_aggregate_command_counts() -> None:
 
 
 def test_snapshot_is_detached_from_internal_state() -> None:
+    """Return snapshots that callers cannot use to mutate recorder state."""
     metrics = CacheCommandMetrics()
     metrics.record("set")
 
@@ -37,6 +39,7 @@ def test_snapshot_is_detached_from_internal_state() -> None:
     ],
 )
 def test_rejects_invalid_metric_records(command: str, count: int) -> None:
+    """Reject invalid counts and payload-bearing command labels before recording."""
     metrics = CacheCommandMetrics()
 
     with pytest.raises(ValueError):
@@ -46,6 +49,7 @@ def test_rejects_invalid_metric_records(command: str, count: int) -> None:
 
 
 def test_reset_clears_all_counts() -> None:
+    """Reset aggregate counts without leaving stale command families behind."""
     metrics = CacheCommandMetrics()
     metrics.record("get")
     metrics.record("set")


### PR DESCRIPTION
Completes #960 by exposing the production bounded generation-cache command counter through a privacy-safe allowlisted metrics surface, adding conservative cold-cache command ceilings for bootstrap, Queue load, Roll, snooze, rating, thread mutations, issue mutations, and continuity mutations, and documenting provider pipeline/batch accounting plus a 350,000-command monthly application budget with 30% free-tier headroom.

The instrumentation records only approved aggregate command families, never cache keys, values, user IDs, tokens, or credentials. Focused regression coverage exercises the same generation-cache primitives used by production paths.

Closes #960