### PR TITLE
Add database-backed release ledger API

### DIFF
--- a/.github/workflows/openapi-generated-types.yml
+++ b/.github/workflows/openapi-generated-types.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   issues: write
 
 concurrency:
@@ -23,8 +23,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Python 3.14
         uses: actions/setup-python@v6
@@ -75,17 +73,6 @@ jobs:
             frontend/src/generated/openapi.json
             frontend/src/generated/openapi.ts
           if-no-files-found: error
-
-      - name: Commit regenerated artifacts to the PR branch
-        if: github.event_name == 'pull_request' && steps.drift.outputs.changed == 'true'
-        env:
-          HEAD_REF: ${{ github.head_ref }}
-        run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add frontend/src/generated/openapi.json frontend/src/generated/openapi.ts
-          git commit -m 'Regenerate OpenAPI client artifacts'
-          git push origin "HEAD:${HEAD_REF}"
 
       - name: Reconcile post-merge factory handoff
         if: >-

--- a/.github/workflows/openapi-generated-types.yml
+++ b/.github/workflows/openapi-generated-types.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   issues: write
 
 concurrency:
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Python 3.14
         uses: actions/setup-python@v6
@@ -73,6 +75,17 @@ jobs:
             frontend/src/generated/openapi.json
             frontend/src/generated/openapi.ts
           if-no-files-found: error
+
+      - name: Commit regenerated artifacts to the PR branch
+        if: github.event_name == 'pull_request' && steps.drift.outputs.changed == 'true'
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add frontend/src/generated/openapi.json frontend/src/generated/openapi.ts
+          git commit -m 'Regenerate OpenAPI client artifacts'
+          git push origin "HEAD:${HEAD_REF}"
 
       - name: Reconcile post-merge factory handoff
         if: >-
@@ -190,7 +203,7 @@ jobs:
               owner,
               repo,
               issue_number: handoffIssue.number,
-              body: `Generated OpenAPI artifacts are current on \`main\` at \`${context.sha}\`. Closing the factory handoff automatically.`,
+              body: `Generated OpenAPI artifacts are current on \`${context.sha}\`. Closing the factory handoff automatically.`,
             });
             core.notice(`Closed resolved OpenAPI drift issue #${handoffIssue.number}.`);
 

--- a/.github/workflows/openapi-generated-types.yml
+++ b/.github/workflows/openapi-generated-types.yml
@@ -190,7 +190,7 @@ jobs:
               owner,
               repo,
               issue_number: handoffIssue.number,
-              body: `Generated OpenAPI artifacts are current on \`${context.sha}\`. Closing the factory handoff automatically.`,
+              body: `Generated OpenAPI artifacts are current on \`main\` at \`${context.sha}\`. Closing the factory handoff automatically.`,
             });
             core.notice(`Closed resolved OpenAPI drift issue #${handoffIssue.number}.`);
 

--- a/alembic/versions/c84900000001_add_release_ledger.py
+++ b/alembic/versions/c84900000001_add_release_ledger.py
@@ -1,0 +1,69 @@
+"""Add durable database-backed release ledger.
+
+Revision ID: c84900000001
+Revises: c84800000001
+Create Date: 2026-08-11 09:58:00.000000
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "c84900000001"
+down_revision: str | Sequence[str] | None = "c84800000001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the releases table and deterministic publication index."""
+    op.create_table(
+        "releases",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("source_repository", sa.String(length=255), nullable=False),
+        sa.Column("source_pr_number", sa.Integer(), nullable=True),
+        sa.Column("source_merge_sha", sa.String(length=64), nullable=True),
+        sa.Column("merged_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("released_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("category", sa.String(length=100), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=False),
+        sa.Column("body", sa.Text(), nullable=True),
+        sa.Column("visibility", sa.String(length=20), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("sort_order", sa.Integer(), nullable=False),
+        sa.Column("provenance_json", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "visibility IN ('public', 'internal')",
+            name="ck_release_visibility",
+        ),
+        sa.CheckConstraint(
+            "status IN ('draft', 'published', 'retracted')",
+            name="ck_release_status",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "source_repository",
+            "source_pr_number",
+            name="uq_release_source_pr",
+        ),
+        sa.UniqueConstraint(
+            "source_repository",
+            "source_merge_sha",
+            name="uq_release_source_merge_sha",
+        ),
+    )
+    op.create_index(
+        "ix_release_published_order",
+        "releases",
+        ["status", "visibility", "released_at", "sort_order", "id"],
+    )
+
+
+def downgrade() -> None:
+    """Remove the durable release ledger."""
+    op.drop_index("ix_release_published_order", table_name="releases")
+    op.drop_table("releases")

--- a/alembic/versions/c84900000001_add_release_ledger.py
+++ b/alembic/versions/c84900000001_add_release_ledger.py
@@ -17,7 +17,14 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    """Create the releases table and deterministic publication index."""
+    """Create the releases table and deterministic publication index.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+    """
     op.create_table(
         "releases",
         sa.Column("id", sa.Integer(), nullable=False),
@@ -64,6 +71,13 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Remove the durable release ledger."""
+    """Remove the durable release ledger.
+
+    Args:
+        None.
+
+    Returns:
+        None.
+    """
     op.drop_index("ix_release_published_order", table_name="releases")
     op.drop_table("releases")

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -8,6 +8,7 @@ from app.api import dependency_group as dependency_group
 from app.api import dependency_group_batch as dependency_group_batch
 from app.api import health as health
 from app.api import issue_dependency_batch as issue_dependency_batch
+from app.api import releases as releases
 from app.api import roll_recovery_switch as roll_recovery_switch
 
 analytics.router.include_router(health.router)
@@ -17,6 +18,7 @@ dependency.router.include_router(dependency_group_batch.router)
 dependency.router.include_router(continuity_rule.router)
 dependency.router.include_router(continuity_readiness.router)
 dependency.router.include_router(roll_recovery_switch.router, prefix="/roll")
+dependency.router.include_router(releases.router, prefix="/releases")
 
 __all__ = [
     "analytics",
@@ -27,5 +29,6 @@ __all__ = [
     "dependency_group_batch",
     "health",
     "issue_dependency_batch",
+    "releases",
     "roll_recovery_switch",
 ]

--- a/app/api/releases.py
+++ b/app/api/releases.py
@@ -55,7 +55,11 @@ async def require_release_writer_token(
         )
 
 
-@router.get("/source", response_model=ReleaseSourceResponse)
+@router.get(
+    "/source",
+    response_model=ReleaseSourceResponse,
+    description="Resolve whether trusted automation already published a GitHub source.",
+)
 async def reconcile_release_source(
     _: Annotated[None, Depends(require_release_writer_token)],
     db: AsyncSession = Depends(get_db),
@@ -95,7 +99,11 @@ async def reconcile_release_source(
     return ReleaseSourceResponse(exists=release is not None, release=release)
 
 
-@router.get("/", response_model=ReleaseListResponse)
+@router.get(
+    "/",
+    response_model=ReleaseListResponse,
+    description="List public published releases newest-first.",
+)
 async def list_releases(
     db: AsyncSession = Depends(get_db),
     limit: int = Query(default=20, ge=1, le=100),
@@ -115,7 +123,11 @@ async def list_releases(
     return ReleaseListResponse(releases=releases, total=total, limit=limit, offset=offset)
 
 
-@router.get("/{release_id}", response_model=ReleaseResponse)
+@router.get(
+    "/{release_id}",
+    response_model=ReleaseResponse,
+    description="Fetch one public published release.",
+)
 async def get_release(
     release_id: int,
     db: AsyncSession = Depends(get_db),
@@ -138,7 +150,11 @@ async def get_release(
     return ReleaseResponse.model_validate(release)
 
 
-@router.put("/", response_model=ReleaseResponse)
+@router.put(
+    "/",
+    response_model=ReleaseResponse,
+    description="Idempotently create or update one merged-PR-backed release.",
+)
 async def publish_release(
     payload: ReleaseUpsertRequest,
     _: Annotated[None, Depends(require_release_writer_token)],

--- a/app/api/releases.py
+++ b/app/api/releases.py
@@ -28,7 +28,17 @@ router = APIRouter(tags=["releases"])
 async def require_release_writer_token(
     x_release_writer_token: Annotated[str | None, Header()] = None,
 ) -> None:
-    """Require the server-only release-writer credential for mutation/reconciliation."""
+    """Require the server-only release-writer credential for mutation/reconciliation.
+
+    Args:
+        x_release_writer_token: Release-writer credential supplied by trusted automation.
+
+    Returns:
+        None.
+
+    Raises:
+        HTTPException: If release writing is unconfigured or the credential is invalid.
+    """
     expected = os.getenv("RELEASE_WRITER_TOKEN", "").strip()
     if not expected:
         raise HTTPException(
@@ -53,7 +63,21 @@ async def reconcile_release_source(
     source_pr_number: int | None = Query(default=None, ge=1),
     source_merge_sha: str | None = Query(default=None, min_length=7, max_length=64),
 ) -> ReleaseSourceResponse:
-    """Resolve whether trusted automation already published a GitHub source."""
+    """Resolve whether trusted automation already published a GitHub source.
+
+    Args:
+        _: Successful release-writer authorization dependency.
+        db: Async database session.
+        source_repository: Repository containing the source pull request.
+        source_pr_number: Source pull request number when known.
+        source_merge_sha: Source merge commit SHA when known.
+
+    Returns:
+        Reconciliation result containing any matching durable release.
+
+    Raises:
+        HTTPException: If no source identity is supplied or the identities conflict.
+    """
     if source_pr_number is None and source_merge_sha is None:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -77,7 +101,16 @@ async def list_releases(
     limit: int = Query(default=20, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
 ) -> ReleaseListResponse:
-    """List public published releases newest-first."""
+    """List public published releases newest-first.
+
+    Args:
+        db: Async database session.
+        limit: Maximum releases to return.
+        offset: Number of matching releases to skip.
+
+    Returns:
+        Paginated public release list and total count.
+    """
     releases, total = await list_published_releases(db, limit=limit, offset=offset)
     return ReleaseListResponse(releases=releases, total=total, limit=limit, offset=offset)
 
@@ -87,7 +120,18 @@ async def get_release(
     release_id: int,
     db: AsyncSession = Depends(get_db),
 ) -> ReleaseResponse:
-    """Fetch one public published release."""
+    """Fetch one public published release.
+
+    Args:
+        release_id: Release primary key.
+        db: Async database session.
+
+    Returns:
+        The requested public published release.
+
+    Raises:
+        HTTPException: If the release is unavailable to public readers.
+    """
     release = await get_published_release(db, release_id)
     if release is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Release not found")
@@ -100,7 +144,19 @@ async def publish_release(
     _: Annotated[None, Depends(require_release_writer_token)],
     db: AsyncSession = Depends(get_db),
 ) -> ReleaseResponse:
-    """Idempotently create or update one merged-PR-backed release."""
+    """Idempotently create or update one merged-PR-backed release.
+
+    Args:
+        payload: Validated release publication request.
+        _: Successful release-writer authorization dependency.
+        db: Async database session.
+
+    Returns:
+        The created or updated durable release.
+
+    Raises:
+        HTTPException: If the source identity conflicts with established provenance.
+    """
     try:
         release = await upsert_release(db, payload)
     except ReleaseSourceConflictError as exc:

--- a/app/api/releases.py
+++ b/app/api/releases.py
@@ -1,0 +1,109 @@
+"""Public read and service-authorized write API for What's New releases."""
+
+import os
+import secrets
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.schemas.release import (
+    ReleaseListResponse,
+    ReleaseResponse,
+    ReleaseSourceResponse,
+    ReleaseUpsertRequest,
+)
+from app.services.release_ledger import (
+    ReleaseSourceConflictError,
+    find_release_by_source,
+    get_published_release,
+    list_published_releases,
+    upsert_release,
+)
+
+router = APIRouter(tags=["releases"])
+
+
+async def require_release_writer_token(
+    x_release_writer_token: Annotated[str | None, Header()] = None,
+) -> None:
+    """Require the server-only release-writer credential for mutation/reconciliation."""
+    expected = os.getenv("RELEASE_WRITER_TOKEN", "").strip()
+    if not expected:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Release writer authorization is not configured",
+        )
+    if x_release_writer_token is None or not secrets.compare_digest(
+        x_release_writer_token,
+        expected,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid release writer credential",
+        )
+
+
+@router.get("/source", response_model=ReleaseSourceResponse)
+async def reconcile_release_source(
+    _: Annotated[None, Depends(require_release_writer_token)],
+    db: AsyncSession = Depends(get_db),
+    source_repository: str = Query(min_length=1, max_length=255),
+    source_pr_number: int | None = Query(default=None, ge=1),
+    source_merge_sha: str | None = Query(default=None, min_length=7, max_length=64),
+) -> ReleaseSourceResponse:
+    """Resolve whether trusted automation already published a GitHub source."""
+    if source_pr_number is None and source_merge_sha is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="source_pr_number or source_merge_sha is required",
+        )
+    try:
+        release = await find_release_by_source(
+            db,
+            source_repository=source_repository,
+            source_pr_number=source_pr_number,
+            source_merge_sha=source_merge_sha,
+        )
+    except ReleaseSourceConflictError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    return ReleaseSourceResponse(exists=release is not None, release=release)
+
+
+@router.get("/", response_model=ReleaseListResponse)
+async def list_releases(
+    db: AsyncSession = Depends(get_db),
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+) -> ReleaseListResponse:
+    """List public published releases newest-first."""
+    releases, total = await list_published_releases(db, limit=limit, offset=offset)
+    return ReleaseListResponse(releases=releases, total=total, limit=limit, offset=offset)
+
+
+@router.get("/{release_id}", response_model=ReleaseResponse)
+async def get_release(
+    release_id: int,
+    db: AsyncSession = Depends(get_db),
+) -> ReleaseResponse:
+    """Fetch one public published release."""
+    release = await get_published_release(db, release_id)
+    if release is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Release not found")
+    return ReleaseResponse.model_validate(release)
+
+
+@router.put("/", response_model=ReleaseResponse)
+async def publish_release(
+    payload: ReleaseUpsertRequest,
+    _: Annotated[None, Depends(require_release_writer_token)],
+    db: AsyncSession = Depends(get_db),
+) -> ReleaseResponse:
+    """Idempotently create or update one merged-PR-backed release."""
+    try:
+        release = await upsert_release(db, payload)
+    except ReleaseSourceConflictError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    return ReleaseResponse.model_validate(release)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -13,6 +13,7 @@ from app.models.external_identity import (
 from app.models.failed_login_attempt import FailedLoginAttempt
 from app.models.issue import Issue
 from app.models.reading_order import ReadingOrder, ReadingOrderItem
+from app.models.release import Release
 from app.models.revoked_token import RevokedToken
 from app.models.session import Session
 from app.models.snapshot import Snapshot
@@ -35,6 +36,7 @@ __all__ = [
     "IssueExternalIdentityMapping",
     "ReadingOrder",
     "ReadingOrderItem",
+    "Release",
     "RevokedToken",
     "Session",
     "Snapshot",

--- a/app/models/release.py
+++ b/app/models/release.py
@@ -1,0 +1,45 @@
+"""Database-backed release ledger for user-facing What's New entries."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import CheckConstraint, DateTime, Index, Integer, JSON, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class Release(Base):
+    """One durable release record, optionally backed by a merged GitHub pull request."""
+
+    __tablename__ = "releases"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    source_repository: Mapped[str] = mapped_column(String(255), nullable=False)
+    source_pr_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    source_merge_sha: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    merged_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    released_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    category: Mapped[str] = mapped_column(String(100), nullable=False)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    summary: Mapped[str] = mapped_column(Text, nullable=False)
+    body: Mapped[str | None] = mapped_column(Text, nullable=True)
+    visibility: Mapped[str] = mapped_column(String(20), nullable=False, default="public")
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="published")
+    sort_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    provenance_json: Mapped[dict[str, object]] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+
+    __table_args__ = (
+        CheckConstraint("visibility IN ('public', 'internal')", name="ck_release_visibility"),
+        CheckConstraint("status IN ('draft', 'published', 'retracted')", name="ck_release_status"),
+        UniqueConstraint("source_repository", "source_pr_number", name="uq_release_source_pr"),
+        UniqueConstraint("source_repository", "source_merge_sha", name="uq_release_source_merge_sha"),
+        Index("ix_release_published_order", "status", "visibility", "released_at", "sort_order", "id"),
+    )

--- a/app/schemas/release.py
+++ b/app/schemas/release.py
@@ -60,7 +60,17 @@ class ReleaseUpsertRequest(BaseModel):
 
     @model_validator(mode="after")
     def require_github_identity(self) -> ReleaseUpsertRequest:
-        """Require at least one stable source identity for retry-safe publication."""
+        """Require at least one stable source identity for retry-safe publication.
+
+        Args:
+            self: Validated release publication request.
+
+        Returns:
+            The validated request when a GitHub source identity is present.
+
+        Raises:
+            ValueError: If both source PR number and merge SHA are absent.
+        """
         if self.source_pr_number is None and self.source_merge_sha is None:
             raise ValueError("source_pr_number or source_merge_sha is required")
         return self

--- a/app/schemas/release.py
+++ b/app/schemas/release.py
@@ -1,0 +1,73 @@
+"""Typed API schemas for the durable release ledger."""
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+ReleaseVisibility = Literal["public", "internal"]
+ReleaseStatus = Literal["draft", "published", "retracted"]
+
+
+class ReleaseResponse(BaseModel):
+    """One release ledger record returned by the API."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    source_repository: str
+    source_pr_number: int | None
+    source_merge_sha: str | None
+    merged_at: datetime | None
+    released_at: datetime
+    category: str
+    title: str
+    summary: str
+    body: str | None
+    visibility: ReleaseVisibility
+    status: ReleaseStatus
+    sort_order: int
+    provenance_json: dict[str, object]
+    created_at: datetime
+    updated_at: datetime
+
+
+class ReleaseListResponse(BaseModel):
+    """Paginated published releases for What's New."""
+
+    releases: list[ReleaseResponse]
+    total: int
+    limit: int
+    offset: int
+
+
+class ReleaseUpsertRequest(BaseModel):
+    """Idempotent release publication payload from trusted automation."""
+
+    source_repository: str = Field(min_length=1, max_length=255)
+    source_pr_number: int | None = Field(default=None, ge=1)
+    source_merge_sha: str | None = Field(default=None, min_length=7, max_length=64)
+    merged_at: datetime | None = None
+    released_at: datetime
+    category: str = Field(min_length=1, max_length=100)
+    title: str = Field(min_length=1, max_length=255)
+    summary: str = Field(min_length=1)
+    body: str | None = None
+    visibility: ReleaseVisibility = "public"
+    status: ReleaseStatus = "published"
+    sort_order: int = 0
+    provenance_json: dict[str, object] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def require_github_identity(self) -> "ReleaseUpsertRequest":
+        """Require at least one stable source identity for retry-safe publication."""
+        if self.source_pr_number is None and self.source_merge_sha is None:
+            raise ValueError("source_pr_number or source_merge_sha is required")
+        return self
+
+
+class ReleaseSourceResponse(BaseModel):
+    """Result of reconciling a GitHub source identity with the ledger."""
+
+    exists: bool
+    release: ReleaseResponse | None = None

--- a/app/schemas/release.py
+++ b/app/schemas/release.py
@@ -59,7 +59,7 @@ class ReleaseUpsertRequest(BaseModel):
     provenance_json: dict[str, object] = Field(default_factory=dict)
 
     @model_validator(mode="after")
-    def require_github_identity(self) -> "ReleaseUpsertRequest":
+    def require_github_identity(self) -> ReleaseUpsertRequest:
         """Require at least one stable source identity for retry-safe publication."""
         if self.source_pr_number is None and self.source_merge_sha is None:
             raise ValueError("source_pr_number or source_merge_sha is required")

--- a/app/services/release_ledger.py
+++ b/app/services/release_ledger.py
@@ -18,7 +18,16 @@ async def list_published_releases(
     limit: int,
     offset: int,
 ) -> tuple[list[Release], int]:
-    """List public published releases in deterministic newest-first order."""
+    """List public published releases in deterministic newest-first order.
+
+    Args:
+        db: Async database session.
+        limit: Maximum releases to return.
+        offset: Number of releases to skip.
+
+    Returns:
+        The page of releases and total matching release count.
+    """
     filters = (Release.status == "published", Release.visibility == "public")
     total = await db.scalar(select(func.count(Release.id)).where(*filters))
     result = await db.execute(
@@ -36,7 +45,15 @@ async def list_published_releases(
 
 
 async def get_published_release(db: AsyncSession, release_id: int) -> Release | None:
-    """Fetch one public published release by id."""
+    """Fetch one public published release by id.
+
+    Args:
+        db: Async database session.
+        release_id: Release primary key.
+
+    Returns:
+        The published public release, or None when unavailable.
+    """
     result = await db.execute(
         select(Release).where(
             Release.id == release_id,
@@ -55,6 +72,15 @@ async def find_release_by_source(
     source_merge_sha: str | None,
 ) -> Release | None:
     """Resolve a release by stable GitHub source identity.
+
+    Args:
+        db: Async database session.
+        source_repository: Repository containing the source pull request.
+        source_pr_number: Source pull request number when known.
+        source_merge_sha: Source merge commit SHA when known.
+
+    Returns:
+        The matching release, or None when no source identity matches.
 
     Raises:
         ReleaseSourceConflictError: If the PR and merge SHA point to different rows.
@@ -96,11 +122,25 @@ def _apply_payload(release: Release, payload: ReleaseUpsertRequest) -> None:
     ):
         raise ReleaseSourceConflictError("source PR is already attached to another merge SHA")
     for field, value in payload.model_dump().items():
+        if field in {"source_pr_number", "source_merge_sha"} and value is None:
+            continue
         setattr(release, field, value)
 
 
 async def upsert_release(db: AsyncSession, payload: ReleaseUpsertRequest) -> Release:
-    """Create or update one GitHub-backed release idempotently, including concurrent retries."""
+    """Create or update one GitHub-backed release idempotently, including concurrent retries.
+
+    Args:
+        db: Async database session.
+        payload: Validated release publication payload.
+
+    Returns:
+        The created or updated durable release.
+
+    Raises:
+        ReleaseSourceConflictError: If source identities conflict with established provenance.
+        IntegrityError: If persistence fails for a reason other than a concurrent duplicate retry.
+    """
     existing = await find_release_by_source(
         db,
         source_repository=payload.source_repository,

--- a/app/services/release_ledger.py
+++ b/app/services/release_ledger.py
@@ -1,0 +1,114 @@
+"""Service layer for the durable What's New release ledger."""
+
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.release import Release
+from app.schemas.release import ReleaseUpsertRequest
+
+
+class ReleaseSourceConflictError(ValueError):
+    """Raised when PR and merge-SHA provenance identify different releases."""
+
+
+async def list_published_releases(
+    db: AsyncSession,
+    *,
+    limit: int,
+    offset: int,
+) -> tuple[list[Release], int]:
+    """List public published releases in deterministic newest-first order."""
+    filters = (Release.status == "published", Release.visibility == "public")
+    total = await db.scalar(select(func.count(Release.id)).where(*filters))
+    result = await db.execute(
+        select(Release)
+        .where(*filters)
+        .order_by(
+            Release.released_at.desc(),
+            Release.sort_order.desc(),
+            Release.id.desc(),
+        )
+        .offset(offset)
+        .limit(limit)
+    )
+    return list(result.scalars().all()), int(total or 0)
+
+
+async def get_published_release(db: AsyncSession, release_id: int) -> Release | None:
+    """Fetch one public published release by id."""
+    result = await db.execute(
+        select(Release).where(
+            Release.id == release_id,
+            Release.status == "published",
+            Release.visibility == "public",
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def find_release_by_source(
+    db: AsyncSession,
+    *,
+    source_repository: str,
+    source_pr_number: int | None,
+    source_merge_sha: str | None,
+) -> Release | None:
+    """Resolve a release by stable GitHub source identity.
+
+    Raises:
+        ReleaseSourceConflictError: If the PR and merge SHA point to different rows.
+    """
+    predicates = []
+    if source_pr_number is not None:
+        predicates.append(Release.source_pr_number == source_pr_number)
+    if source_merge_sha is not None:
+        predicates.append(Release.source_merge_sha == source_merge_sha)
+    if not predicates:
+        return None
+
+    result = await db.execute(
+        select(Release).where(
+            Release.source_repository == source_repository,
+            or_(*predicates),
+        )
+    )
+    matches = list(result.scalars().all())
+    if len(matches) > 1:
+        raise ReleaseSourceConflictError(
+            "source PR and merge SHA already identify different release records"
+        )
+    return matches[0] if matches else None
+
+
+async def upsert_release(db: AsyncSession, payload: ReleaseUpsertRequest) -> Release:
+    """Create or update one GitHub-backed release idempotently."""
+    existing = await find_release_by_source(
+        db,
+        source_repository=payload.source_repository,
+        source_pr_number=payload.source_pr_number,
+        source_merge_sha=payload.source_merge_sha,
+    )
+
+    if existing is None:
+        release = Release(**payload.model_dump())
+        db.add(release)
+    else:
+        if (
+            payload.source_pr_number is not None
+            and existing.source_pr_number is not None
+            and payload.source_pr_number != existing.source_pr_number
+        ):
+            raise ReleaseSourceConflictError("merge SHA is already attached to another source PR")
+        if (
+            payload.source_merge_sha is not None
+            and existing.source_merge_sha is not None
+            and payload.source_merge_sha != existing.source_merge_sha
+        ):
+            raise ReleaseSourceConflictError("source PR is already attached to another merge SHA")
+        release = existing
+        for field, value in payload.model_dump().items():
+            setattr(release, field, value)
+
+    await db.commit()
+    await db.refresh(release)
+    return release

--- a/app/services/release_ledger.py
+++ b/app/services/release_ledger.py
@@ -1,6 +1,7 @@
 """Service layer for the durable What's New release ledger."""
 
 from sqlalchemy import func, or_, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.release import Release
@@ -80,8 +81,26 @@ async def find_release_by_source(
     return matches[0] if matches else None
 
 
+def _apply_payload(release: Release, payload: ReleaseUpsertRequest) -> None:
+    """Apply a validated publication payload while protecting established source identity."""
+    if (
+        payload.source_pr_number is not None
+        and release.source_pr_number is not None
+        and payload.source_pr_number != release.source_pr_number
+    ):
+        raise ReleaseSourceConflictError("merge SHA is already attached to another source PR")
+    if (
+        payload.source_merge_sha is not None
+        and release.source_merge_sha is not None
+        and payload.source_merge_sha != release.source_merge_sha
+    ):
+        raise ReleaseSourceConflictError("source PR is already attached to another merge SHA")
+    for field, value in payload.model_dump().items():
+        setattr(release, field, value)
+
+
 async def upsert_release(db: AsyncSession, payload: ReleaseUpsertRequest) -> Release:
-    """Create or update one GitHub-backed release idempotently."""
+    """Create or update one GitHub-backed release idempotently, including concurrent retries."""
     existing = await find_release_by_source(
         db,
         source_repository=payload.source_repository,
@@ -93,22 +112,23 @@ async def upsert_release(db: AsyncSession, payload: ReleaseUpsertRequest) -> Rel
         release = Release(**payload.model_dump())
         db.add(release)
     else:
-        if (
-            payload.source_pr_number is not None
-            and existing.source_pr_number is not None
-            and payload.source_pr_number != existing.source_pr_number
-        ):
-            raise ReleaseSourceConflictError("merge SHA is already attached to another source PR")
-        if (
-            payload.source_merge_sha is not None
-            and existing.source_merge_sha is not None
-            and payload.source_merge_sha != existing.source_merge_sha
-        ):
-            raise ReleaseSourceConflictError("source PR is already attached to another merge SHA")
         release = existing
-        for field, value in payload.model_dump().items():
-            setattr(release, field, value)
+        _apply_payload(release, payload)
 
-    await db.commit()
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        release = await find_release_by_source(
+            db,
+            source_repository=payload.source_repository,
+            source_pr_number=payload.source_pr_number,
+            source_merge_sha=payload.source_merge_sha,
+        )
+        if release is None:
+            raise
+        _apply_payload(release, payload)
+        await db.commit()
+
     await db.refresh(release)
     return release

--- a/docs/changelog.d/2026-08-11-1074.md
+++ b/docs/changelog.d/2026-08-11-1074.md
@@ -1,0 +1,5 @@
+## 2026-08-11
+
+### What's New
+
+- [#1074](https://github.com/JoshCLWren/comic-pile/pull/1074) adds a durable database-backed release ledger and API so future ComicPile release notes can be published idempotently from merged PRs instead of relying on Markdown as runtime truth.

--- a/frontend/src/generated/openapi.json
+++ b/frontend/src/generated/openapi.json
@@ -2282,6 +2282,312 @@
         "title": "RefreshTokenRequest",
         "type": "object"
       },
+      "ReleaseListResponse": {
+        "description": "Paginated published releases for What's New.",
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          },
+          "releases": {
+            "items": {
+              "$ref": "#/components/schemas/ReleaseResponse"
+            },
+            "title": "Releases",
+            "type": "array"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "releases",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "title": "ReleaseListResponse",
+        "type": "object"
+      },
+      "ReleaseResponse": {
+        "description": "One release ledger record returned by the API.",
+        "properties": {
+          "body": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Body"
+          },
+          "category": {
+            "title": "Category",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "merged_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Merged At"
+          },
+          "provenance_json": {
+            "additionalProperties": true,
+            "title": "Provenance Json",
+            "type": "object"
+          },
+          "released_at": {
+            "format": "date-time",
+            "title": "Released At",
+            "type": "string"
+          },
+          "sort_order": {
+            "title": "Sort Order",
+            "type": "integer"
+          },
+          "source_merge_sha": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Merge Sha"
+          },
+          "source_pr_number": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Pr Number"
+          },
+          "source_repository": {
+            "title": "Source Repository",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "draft",
+              "published",
+              "retracted"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "summary": {
+            "title": "Summary",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          },
+          "visibility": {
+            "enum": [
+              "public",
+              "internal"
+            ],
+            "title": "Visibility",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "source_repository",
+          "source_pr_number",
+          "source_merge_sha",
+          "merged_at",
+          "released_at",
+          "category",
+          "title",
+          "summary",
+          "body",
+          "visibility",
+          "status",
+          "sort_order",
+          "provenance_json",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ReleaseResponse",
+        "type": "object"
+      },
+      "ReleaseSourceResponse": {
+        "description": "Result of reconciling a GitHub source identity with the ledger.",
+        "properties": {
+          "exists": {
+            "title": "Exists",
+            "type": "boolean"
+          },
+          "release": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ReleaseResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "exists"
+        ],
+        "title": "ReleaseSourceResponse",
+        "type": "object"
+      },
+      "ReleaseUpsertRequest": {
+        "description": "Idempotent release publication payload from trusted automation.",
+        "properties": {
+          "body": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Body"
+          },
+          "category": {
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Category",
+            "type": "string"
+          },
+          "merged_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Merged At"
+          },
+          "provenance_json": {
+            "additionalProperties": true,
+            "title": "Provenance Json",
+            "type": "object"
+          },
+          "released_at": {
+            "format": "date-time",
+            "title": "Released At",
+            "type": "string"
+          },
+          "sort_order": {
+            "default": 0,
+            "title": "Sort Order",
+            "type": "integer"
+          },
+          "source_merge_sha": {
+            "anyOf": [
+              {
+                "maxLength": 64,
+                "minLength": 7,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Merge Sha"
+          },
+          "source_pr_number": {
+            "anyOf": [
+              {
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Pr Number"
+          },
+          "source_repository": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Source Repository",
+            "type": "string"
+          },
+          "status": {
+            "default": "published",
+            "enum": [
+              "draft",
+              "published",
+              "retracted"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "summary": {
+            "minLength": 1,
+            "title": "Summary",
+            "type": "string"
+          },
+          "title": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Title",
+            "type": "string"
+          },
+          "visibility": {
+            "default": "public",
+            "enum": [
+              "public",
+              "internal"
+            ],
+            "title": "Visibility",
+            "type": "string"
+          }
+        },
+        "required": [
+          "source_repository",
+          "released_at",
+          "category",
+          "title",
+          "summary"
+        ],
+        "title": "ReleaseUpsertRequest",
+        "type": "object"
+      },
       "RollBootstrapResponse": {
         "description": "Bounded bootstrap payload for the Roll initial render.\n\nReturns only the retained data required for the first interactive screen.\nDoes not include the full queue, collection data, or secondary detail panels.",
         "properties": {
@@ -7557,6 +7863,268 @@
           "dependencies",
           "dependencies",
           "reading-order-groups"
+        ]
+      }
+    },
+    "/api/v1/releases/": {
+      "get": {
+        "description": "List public published releases newest-first.",
+        "operationId": "list_releases_api_v1_releases__get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Releases",
+        "tags": [
+          "dependencies",
+          "dependencies",
+          "releases"
+        ]
+      },
+      "put": {
+        "description": "Idempotently create or update one merged-PR-backed release.",
+        "operationId": "publish_release_api_v1_releases__put",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-release-writer-token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Release-Writer-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReleaseUpsertRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Publish Release",
+        "tags": [
+          "dependencies",
+          "dependencies",
+          "releases"
+        ]
+      }
+    },
+    "/api/v1/releases/source": {
+      "get": {
+        "description": "Resolve whether trusted automation already published a GitHub source.",
+        "operationId": "reconcile_release_source_api_v1_releases_source_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "source_repository",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "title": "Source Repository",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_pr_number",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Source Pr Number"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_merge_sha",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 64,
+                  "minLength": 7,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Source Merge Sha"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-release-writer-token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Release-Writer-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseSourceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Reconcile Release Source",
+        "tags": [
+          "dependencies",
+          "dependencies",
+          "releases"
+        ]
+      }
+    },
+    "/api/v1/releases/{release_id}": {
+      "get": {
+        "description": "Fetch one public published release.",
+        "operationId": "get_release_api_v1_releases__release_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "release_id",
+            "required": true,
+            "schema": {
+              "title": "Release Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Release",
+        "tags": [
+          "dependencies",
+          "dependencies",
+          "releases"
         ]
       }
     },

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -2099,6 +2099,70 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/releases/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Releases
+         * @description List public published releases newest-first.
+         */
+        get: operations["list_releases_api_v1_releases__get"];
+        /**
+         * Publish Release
+         * @description Idempotently create or update one merged-PR-backed release.
+         */
+        put: operations["publish_release_api_v1_releases__put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/releases/source": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Reconcile Release Source
+         * @description Resolve whether trusted automation already published a GitHub source.
+         */
+        get: operations["reconcile_release_source_api_v1_releases_source_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/releases/{release_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Release
+         * @description Fetch one public published release.
+         */
+        get: operations["get_release_api_v1_releases__release_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/roll/": {
         parameters: {
             query?: never;
@@ -4195,6 +4259,132 @@ export interface components {
         RefreshTokenRequest: {
             /** Refresh Token */
             refresh_token: string;
+        };
+        /**
+         * ReleaseListResponse
+         * @description Paginated published releases for What's New.
+         */
+        ReleaseListResponse: {
+            /** Limit */
+            limit: number;
+            /** Offset */
+            offset: number;
+            /** Releases */
+            releases: components["schemas"]["ReleaseResponse"][];
+            /** Total */
+            total: number;
+        };
+        /**
+         * ReleaseResponse
+         * @description One release ledger record returned by the API.
+         */
+        ReleaseResponse: {
+            /** Body */
+            body: string | null;
+            /** Category */
+            category: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Id */
+            id: number;
+            /** Merged At */
+            merged_at: string | null;
+            /** Provenance Json */
+            provenance_json: {
+                [key: string]: unknown;
+            };
+            /**
+             * Released At
+             * Format: date-time
+             */
+            released_at: string;
+            /** Sort Order */
+            sort_order: number;
+            /** Source Merge Sha */
+            source_merge_sha: string | null;
+            /** Source Pr Number */
+            source_pr_number: number | null;
+            /** Source Repository */
+            source_repository: string;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "draft" | "published" | "retracted";
+            /** Summary */
+            summary: string;
+            /** Title */
+            title: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+            /**
+             * Visibility
+             * @enum {string}
+             */
+            visibility: "public" | "internal";
+        };
+        /**
+         * ReleaseSourceResponse
+         * @description Result of reconciling a GitHub source identity with the ledger.
+         */
+        ReleaseSourceResponse: {
+            /** Exists */
+            exists: boolean;
+            release?: components["schemas"]["ReleaseResponse"] | null;
+        };
+        /**
+         * ReleaseUpsertRequest
+         * @description Idempotent release publication payload from trusted automation.
+         */
+        ReleaseUpsertRequest: {
+            /** Body */
+            body?: string | null;
+            /** Category */
+            category: string;
+            /** Merged At */
+            merged_at?: string | null;
+            /** Provenance Json */
+            provenance_json?: {
+                [key: string]: unknown;
+            };
+            /**
+             * Released At
+             * Format: date-time
+             */
+            released_at: string;
+            /**
+             * Sort Order
+             * @default 0
+             */
+            sort_order: number;
+            /** Source Merge Sha */
+            source_merge_sha?: string | null;
+            /** Source Pr Number */
+            source_pr_number?: number | null;
+            /** Source Repository */
+            source_repository: string;
+            /**
+             * Status
+             * @default published
+             * @enum {string}
+             */
+            status: "draft" | "published" | "retracted";
+            /** Summary */
+            summary: string;
+            /** Title */
+            title: string;
+            /**
+             * Visibility
+             * @default public
+             * @enum {string}
+             */
+            visibility: "public" | "internal";
         };
         /**
          * RollBootstrapResponse
@@ -7178,6 +7368,139 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_releases_api_v1_releases__get: {
+        parameters: {
+            query?: {
+                limit?: number;
+                offset?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReleaseListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    publish_release_api_v1_releases__put: {
+        parameters: {
+            query?: never;
+            header?: {
+                "x-release-writer-token"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ReleaseUpsertRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReleaseResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    reconcile_release_source_api_v1_releases_source_get: {
+        parameters: {
+            query: {
+                source_repository: string;
+                source_pr_number?: number | null;
+                source_merge_sha?: string | null;
+            };
+            header?: {
+                "x-release-writer-token"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReleaseSourceResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_release_api_v1_releases__release_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                release_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReleaseResponse"];
+                };
             };
             /** @description Validation Error */
             422: {

--- a/tests/test_release_api.py
+++ b/tests/test_release_api.py
@@ -1,0 +1,123 @@
+"""Release ledger API regression coverage."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_release_writer_requires_server_only_credential(auth_client, monkeypatch):
+    """Normal authenticated users must not inherit release-writer authority."""
+    monkeypatch.setenv("RELEASE_WRITER_TOKEN", "writer-secret")
+    payload = _release_payload(pr_number=1201, merge_sha="a" * 40)
+
+    response = await auth_client.put("/api/v1/releases/", json=payload)
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_release_upsert_is_idempotent_and_reconcilable(auth_client, monkeypatch):
+    """Retrying the same merged PR updates one durable release record."""
+    monkeypatch.setenv("RELEASE_WRITER_TOKEN", "writer-secret")
+    headers = {"X-Release-Writer-Token": "writer-secret"}
+    payload = _release_payload(pr_number=1202, merge_sha="b" * 40)
+
+    first = await auth_client.put("/api/v1/releases/", json=payload, headers=headers)
+    assert first.status_code == 200
+    first_id = first.json()["id"]
+
+    payload["summary"] = "Updated release summary"
+    retry = await auth_client.put("/api/v1/releases/", json=payload, headers=headers)
+    assert retry.status_code == 200
+    assert retry.json()["id"] == first_id
+    assert retry.json()["summary"] == "Updated release summary"
+
+    reconcile = await auth_client.get(
+        "/api/v1/releases/source",
+        params={"source_repository": "JoshCLWren/comic-pile", "source_pr_number": 1202},
+        headers=headers,
+    )
+    assert reconcile.status_code == 200
+    assert reconcile.json()["exists"] is True
+    assert reconcile.json()["release"]["id"] == first_id
+
+
+@pytest.mark.asyncio
+async def test_release_source_conflict_returns_409(auth_client, monkeypatch):
+    """One merge SHA cannot silently move between distinct source PRs."""
+    monkeypatch.setenv("RELEASE_WRITER_TOKEN", "writer-secret")
+    headers = {"X-Release-Writer-Token": "writer-secret"}
+    shared_sha = "c" * 40
+
+    first = await auth_client.put(
+        "/api/v1/releases/",
+        json=_release_payload(pr_number=1203, merge_sha=shared_sha),
+        headers=headers,
+    )
+    assert first.status_code == 200
+
+    conflict = await auth_client.put(
+        "/api/v1/releases/",
+        json=_release_payload(pr_number=1204, merge_sha=shared_sha),
+        headers=headers,
+    )
+    assert conflict.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_public_release_list_filters_and_orders(auth_client, monkeypatch):
+    """What's New sees only public published rows in deterministic newest-first order."""
+    monkeypatch.setenv("RELEASE_WRITER_TOKEN", "writer-secret")
+    headers = {"X-Release-Writer-Token": "writer-secret"}
+    now = datetime.now(UTC)
+
+    older = _release_payload(pr_number=1205, merge_sha="d" * 40)
+    older["released_at"] = (now - timedelta(days=1)).isoformat()
+    newer_low = _release_payload(pr_number=1206, merge_sha="e" * 40)
+    newer_low["released_at"] = now.isoformat()
+    newer_low["sort_order"] = 1
+    newer_high = _release_payload(pr_number=1207, merge_sha="f" * 40)
+    newer_high["released_at"] = now.isoformat()
+    newer_high["sort_order"] = 5
+    internal = _release_payload(pr_number=1208, merge_sha="1" * 40)
+    internal["visibility"] = "internal"
+    draft = _release_payload(pr_number=1209, merge_sha="2" * 40)
+    draft["status"] = "draft"
+
+    for payload in (older, newer_low, newer_high, internal, draft):
+        response = await auth_client.put("/api/v1/releases/", json=payload, headers=headers)
+        assert response.status_code == 200
+
+    response = await auth_client.get("/api/v1/releases/", params={"limit": 2, "offset": 0})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 3
+    assert [item["source_pr_number"] for item in body["releases"]] == [1207, 1206]
+
+    second_page = await auth_client.get(
+        "/api/v1/releases/",
+        params={"limit": 2, "offset": 2},
+    )
+    assert second_page.status_code == 200
+    assert [item["source_pr_number"] for item in second_page.json()["releases"]] == [1205]
+
+
+def _release_payload(*, pr_number: int, merge_sha: str) -> dict[str, object]:
+    """Build a valid merged-PR-backed release payload for API tests."""
+    now = datetime.now(UTC).isoformat()
+    return {
+        "source_repository": "JoshCLWren/comic-pile",
+        "source_pr_number": pr_number,
+        "source_merge_sha": merge_sha,
+        "merged_at": now,
+        "released_at": now,
+        "category": "What's New",
+        "title": f"Release {pr_number}",
+        "summary": "A user-facing release summary",
+        "body": "More release detail",
+        "visibility": "public",
+        "status": "published",
+        "sort_order": 0,
+        "provenance_json": {"source": "github"},
+    }

--- a/tests/test_release_api.py
+++ b/tests/test_release_api.py
@@ -2,11 +2,15 @@
 
 from datetime import UTC, datetime, timedelta
 
+from httpx import AsyncClient
 import pytest
 
 
 @pytest.mark.asyncio
-async def test_release_writer_requires_server_only_credential(auth_client, monkeypatch):
+async def test_release_writer_requires_server_only_credential(
+    auth_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Normal authenticated users must not inherit release-writer authority."""
     monkeypatch.setenv("RELEASE_WRITER_TOKEN", "writer-secret")
     payload = _release_payload(pr_number=1201, merge_sha="a" * 40)
@@ -17,7 +21,10 @@ async def test_release_writer_requires_server_only_credential(auth_client, monke
 
 
 @pytest.mark.asyncio
-async def test_release_upsert_is_idempotent_and_reconcilable(auth_client, monkeypatch):
+async def test_release_upsert_is_idempotent_and_reconcilable(
+    auth_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Retrying the same merged PR updates one durable release record."""
     monkeypatch.setenv("RELEASE_WRITER_TOKEN", "writer-secret")
     headers = {"X-Release-Writer-Token": "writer-secret"}
@@ -44,7 +51,34 @@ async def test_release_upsert_is_idempotent_and_reconcilable(auth_client, monkey
 
 
 @pytest.mark.asyncio
-async def test_release_source_conflict_returns_409(auth_client, monkeypatch):
+async def test_release_partial_retry_preserves_source_identity(
+    auth_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitting one identity on retry must not erase established provenance."""
+    monkeypatch.setenv("RELEASE_WRITER_TOKEN", "writer-secret")
+    headers = {"X-Release-Writer-Token": "writer-secret"}
+    payload = _release_payload(pr_number=1210, merge_sha="3" * 40)
+
+    first = await auth_client.put("/api/v1/releases/", json=payload, headers=headers)
+    assert first.status_code == 200
+
+    retry_payload = dict(payload)
+    retry_payload["source_merge_sha"] = None
+    retry_payload["summary"] = "Retried with PR identity only"
+    retry = await auth_client.put("/api/v1/releases/", json=retry_payload, headers=headers)
+
+    assert retry.status_code == 200
+    assert retry.json()["source_pr_number"] == 1210
+    assert retry.json()["source_merge_sha"] == "3" * 40
+    assert retry.json()["summary"] == "Retried with PR identity only"
+
+
+@pytest.mark.asyncio
+async def test_release_source_conflict_returns_409(
+    auth_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """One merge SHA cannot silently move between distinct source PRs."""
     monkeypatch.setenv("RELEASE_WRITER_TOKEN", "writer-secret")
     headers = {"X-Release-Writer-Token": "writer-secret"}
@@ -66,7 +100,10 @@ async def test_release_source_conflict_returns_409(auth_client, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_public_release_list_filters_and_orders(auth_client, monkeypatch):
+async def test_public_release_list_filters_and_orders(
+    auth_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """What's New sees only public published rows in deterministic newest-first order."""
     monkeypatch.setenv("RELEASE_WRITER_TOKEN", "writer-secret")
     headers = {"X-Release-Writer-Token": "writer-secret"}

--- a/tests/test_release_api.py
+++ b/tests/test_release_api.py
@@ -11,7 +11,15 @@ async def test_release_writer_requires_server_only_credential(
     auth_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Normal authenticated users must not inherit release-writer authority."""
+    """Normal authenticated users must not inherit release-writer authority.
+
+    Args:
+        auth_client: Authenticated async API client.
+        monkeypatch: Pytest environment patch helper.
+
+    Returns:
+        None.
+    """
     monkeypatch.setenv("RELEASE_WRITER_TOKEN", "writer-secret")
     payload = _release_payload(pr_number=1201, merge_sha="a" * 40)
 
@@ -25,7 +33,15 @@ async def test_release_upsert_is_idempotent_and_reconcilable(
     auth_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Retrying the same merged PR updates one durable release record."""
+    """Retrying the same merged PR updates one durable release record.
+
+    Args:
+        auth_client: Authenticated async API client.
+        monkeypatch: Pytest environment patch helper.
+
+    Returns:
+        None.
+    """
     monkeypatch.setenv("RELEASE_WRITER_TOKEN", "writer-secret")
     headers = {"X-Release-Writer-Token": "writer-secret"}
     payload = _release_payload(pr_number=1202, merge_sha="b" * 40)
@@ -55,7 +71,15 @@ async def test_release_partial_retry_preserves_source_identity(
     auth_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Omitting one identity on retry must not erase established provenance."""
+    """Omitting one identity on retry must not erase established provenance.
+
+    Args:
+        auth_client: Authenticated async API client.
+        monkeypatch: Pytest environment patch helper.
+
+    Returns:
+        None.
+    """
     monkeypatch.setenv("RELEASE_WRITER_TOKEN", "writer-secret")
     headers = {"X-Release-Writer-Token": "writer-secret"}
     payload = _release_payload(pr_number=1210, merge_sha="3" * 40)
@@ -79,7 +103,15 @@ async def test_release_source_conflict_returns_409(
     auth_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """One merge SHA cannot silently move between distinct source PRs."""
+    """One merge SHA cannot silently move between distinct source PRs.
+
+    Args:
+        auth_client: Authenticated async API client.
+        monkeypatch: Pytest environment patch helper.
+
+    Returns:
+        None.
+    """
     monkeypatch.setenv("RELEASE_WRITER_TOKEN", "writer-secret")
     headers = {"X-Release-Writer-Token": "writer-secret"}
     shared_sha = "c" * 40
@@ -104,7 +136,15 @@ async def test_public_release_list_filters_and_orders(
     auth_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """What's New sees only public published rows in deterministic newest-first order."""
+    """What's New sees only public published rows in deterministic newest-first order.
+
+    Args:
+        auth_client: Authenticated async API client.
+        monkeypatch: Pytest environment patch helper.
+
+    Returns:
+        None.
+    """
     monkeypatch.setenv("RELEASE_WRITER_TOKEN", "writer-secret")
     headers = {"X-Release-Writer-Token": "writer-secret"}
     now = datetime.now(UTC)


### PR DESCRIPTION
## Summary
- add a durable `releases` table with GitHub PR/SHA provenance and deterministic publication ordering
- add typed release schemas and an idempotent service layer with explicit source-conflict detection
- add public paginated What's New reads plus server-only release-writer upsert/reconciliation endpoints
- add regression coverage for authorization, idempotency, provenance conflicts, filtering, ordering, and pagination

Closes #1067

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a release ledger for durable, database-backed release notes.
  * Added APIs to list and view published releases.
  * Added authorized publishing and source reconciliation with idempotent updates.
  * Added release metadata, visibility, status, provenance, pagination, and publication ordering.
* **Bug Fixes**
  * Added conflict detection to prevent duplicate or inconsistent release records.
* **Documentation**
  * Documented the new release ledger and publishing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->