### PR TITLE
Enable factory-triggered Chromium discovery

### DIFF
--- a/.github/workflows/chromium-discovery.yml
+++ b/.github/workflows/chromium-discovery.yml
@@ -2,6 +2,9 @@ name: Chromium E2E discovery
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - chromium-discovery
 
 permissions:
   contents: read

--- a/docs/changelog.d/2026-08-11-1075.md
+++ b/docs/changelog.d/2026-08-11-1075.md
@@ -1,0 +1,5 @@
+## 2026-08-11
+
+### Factory infrastructure
+
+- [PR #1075](https://github.com/JoshCLWren/comic-pile/pull/1075) lets autonomous factories start the complete maintained Chromium discovery suite through a dedicated branch trigger when their GitHub runtime cannot invoke `workflow_dispatch`, keeping backlog-zero browser defect discovery moving instead of stalling on a tooling gap.

--- a/docs/changelog.d/2026-08-11-1075.md
+++ b/docs/changelog.d/2026-08-11-1075.md
@@ -2,4 +2,4 @@
 
 ### Factory infrastructure
 
-- [PR #1075](https://github.com/JoshCLWren/comic-pile/pull/1075) lets autonomous factories start the complete maintained Chromium discovery suite through a dedicated branch trigger when their GitHub runtime cannot invoke `workflow_dispatch`, keeping backlog-zero browser defect discovery moving instead of stalling on a tooling gap.
+- [#1075](https://github.com/JoshCLWren/comic-pile/pull/1075) lets autonomous factories start the complete maintained Chromium discovery suite through a dedicated branch trigger when their GitHub runtime cannot invoke `workflow_dispatch`, keeping backlog-zero browser defect discovery moving instead of stalling on a tooling gap.


### PR DESCRIPTION
## Summary
- keep the existing manual Chromium discovery workflow
- add a dedicated `chromium-discovery` branch trigger so factory runtimes without `workflow_dispatch` can start the complete six-shard suite by moving that branch to current main
- preserve the existing image build, Chromium-only execution, and failure artifacts

This repairs the runtime/tooling boundary blocking #938. It does not close #938; the issue remains open until the complete Chromium run is classified and reproducible product defects are filed.