### PR TITLE
Keep remote caching disabled pending production evidence

### DIFF
--- a/docs/CACHE_REENABLE_DECISION.md
+++ b/docs/CACHE_REENABLE_DECISION.md
@@ -1,0 +1,37 @@
+# Remote cache re-enable decision
+
+Updated: 2026-08-11
+
+## Decision
+
+**Keep remote caching disabled for now.**
+
+ComicPile now has bounded generation-based invalidation, privacy-safe command counting, conservative flow ceilings, and a 350,000-command monthly application budget against the documented 500,000-command Upstash free allowance. The remaining uncertainty is not correctness of the invalidation primitive. It is production demand. The repository does not yet contain a trustworthy recent production request mix that can be translated into an observed monthly cache-command projection, so enabling the provider would spend free-tier budget without evidence that the benefit justifies the risk.
+
+This is deliberately a remain-disabled decision, not a rejection of Redis. Re-enable only after production evidence can demonstrate that projected application commands stay below the 350,000 monthly operating budget with the existing 150,000-command provider headroom.
+
+## Evidence
+
+- `app/config.py` requires `CACHE_ENABLED=true` in addition to provider credentials, so a configured token cannot silently enable caching.
+- `app/cache.py` configures the client without a network probe. Startup therefore does not depend on Redis availability; the first real command is lazy and fail-open behavior remains in the cache wrappers.
+- `app/cache_generation.py` invalidates a user's cached state with one shared Redis generation `INCR`. Cached reads resolve the active generation and value atomically, so old generation keys become unreachable without `SCAN`.
+- `tests/test_cache_reenable_safety.py` exercises two independent application clients sharing one Redis state and proves that an invalidation issued through one client forces the other client to reload rather than serve the stale generation.
+- `docs/CACHE_COMMAND_BUDGET.md` and `tests/test_cache_command_budget.py` define conservative cold-cache ceilings for bootstrap, Queue, Roll, rating, snooze, thread, issue, and continuity flows.
+
+The historical benchmark corpus is useful for latency/load testing but is not a production traffic census. It must not be multiplied into a monthly provider forecast and presented as observed user demand.
+
+## Re-enable gate
+
+A future staged enablement may set `CACHE_ENABLED=true` only after all of these are true:
+
+1. A recent production observation window provides counts for the representative cached flows, or an equivalent trustworthy command-rate measurement.
+2. The observed mix, multiplied by the documented per-flow ceilings, projects below **350,000 application commands/month**.
+3. The projection preserves the **150,000-command (30%) provider headroom** for retries, diagnostics, provider-console activity, and measurement error.
+4. Multi-instance generation invalidation and lazy startup tests remain green.
+5. The first rollout is reversible without a code deploy.
+
+## Rollback boundary
+
+Rollback is the `CACHE_ENABLED` environment flag. Setting it to `false` disables remote caching while leaving database-backed application correctness intact. Provider URL/token values may remain configured because `RedisSettings.is_configured` is false unless the explicit flag is enabled.
+
+If a staged rollout shows unexpected command growth, cache errors, latency regressions, or stale-data symptoms, disable `CACHE_ENABLED` immediately and investigate from the database-backed path rather than increasing the command budget to accommodate the regression.

--- a/docs/changelog.d/2026-08-11-1078.md
+++ b/docs/changelog.d/2026-08-11-1078.md
@@ -1,0 +1,5 @@
+## 2026-08-11
+
+### Performance & reliability
+
+- [#1078](https://github.com/JoshCLWren/comic-pile/pull/1078) keeps remote caching explicitly disabled until recent production demand proves ComicPile can stay inside its conservative Upstash command budget, while adding cross-instance invalidation coverage and a documented instant rollback switch for any future staged rollout.

--- a/tests/test_cache_reenable_safety.py
+++ b/tests/test_cache_reenable_safety.py
@@ -1,0 +1,94 @@
+"""Safety evidence for the remote-cache re-enable decision."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+
+import pytest
+
+from app.cache import cache
+from app.cache_generation import bump_user_generation, generation_cached, generation_key
+from app.config import RedisSettings
+
+
+@dataclass
+class SharedRedisState:
+    """State shared by independent Redis-shaped application clients."""
+
+    generations: dict[str, int] = field(default_factory=dict)
+    values: dict[str, str] = field(default_factory=dict)
+
+
+class SharedUpstashClient:
+    """Minimal Upstash-shaped client backed by shared cross-instance state."""
+
+    def __init__(self, state: SharedRedisState) -> None:
+        self.state = state
+
+    async def eval(
+        self,
+        script: str,
+        keys: list[str],
+        args: list[str],
+    ) -> list[object | None]:
+        assert "redis.call('GET', KEYS[1])" in script
+        generation = self.state.generations.get(keys[0], 0)
+        value_key = f"{args[0]}{generation}:{args[1]}"
+        return [str(generation), self.state.values.get(value_key)]
+
+    async def set(self, key: str, value: str, ex: int | None = None) -> None:
+        _ = ex
+        self.state.values[key] = value
+
+    async def incr(self, key: str) -> int:
+        generation = self.state.generations.get(key, 0) + 1
+        self.state.generations[key] = generation
+        return generation
+
+
+@pytest.mark.asyncio
+async def test_generation_invalidation_is_visible_across_application_clients(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mutation on one instance invalidates another instance's cached view."""
+    shared = SharedRedisState()
+    instance_a = SharedUpstashClient(shared)
+    instance_b = SharedUpstashClient(shared)
+    source = {"title": "before"}
+    executions = 0
+
+    monkeypatch.setattr(cache, "_initialized", True)
+    monkeypatch.setattr(cache, "_is_upstash", True)
+    monkeypatch.setattr(cache, "_client", instance_a)
+
+    @generation_cached(ttl=60)
+    async def load_issue(user_id: int) -> dict[str, str]:
+        nonlocal executions
+        executions += 1
+        return dict(source)
+
+    assert await load_issue(7) == {"title": "before"}
+    assert await load_issue(7) == {"title": "before"}
+    assert executions == 1
+
+    source["title"] = "after"
+    assert await bump_user_generation(instance_b, 7) == 1
+    assert shared.generations[generation_key(7)] == 1
+
+    monkeypatch.setattr(cache, "_client", instance_a)
+    assert await load_issue(7) == {"title": "after"}
+    assert executions == 2
+
+
+def test_remote_cache_remains_explicitly_disabled_by_default() -> None:
+    """Provider credentials alone must not silently turn remote caching back on."""
+    settings = RedisSettings(
+        _env_file=None,
+        cache_enabled=False,
+        upstash_redis_rest_url="https://example.invalid",
+        upstash_redis_rest_token="test-token",
+    )
+
+    assert settings.cache_enabled is False
+    assert settings.is_configured is False

--- a/tests/test_cache_reenable_safety.py
+++ b/tests/test_cache_reenable_safety.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass, field
 
 import pytest
@@ -24,6 +23,7 @@ class SharedUpstashClient:
     """Minimal Upstash-shaped client backed by shared cross-instance state."""
 
     def __init__(self, state: SharedRedisState) -> None:
+        """Bind this client to the shared Redis state."""
         self.state = state
 
     async def eval(
@@ -32,16 +32,19 @@ class SharedUpstashClient:
         keys: list[str],
         args: list[str],
     ) -> list[object | None]:
+        """Return one atomic generation/value snapshot."""
         assert "redis.call('GET', KEYS[1])" in script
         generation = self.state.generations.get(keys[0], 0)
         value_key = f"{args[0]}{generation}:{args[1]}"
         return [str(generation), self.state.values.get(value_key)]
 
     async def set(self, key: str, value: str, ex: int | None = None) -> None:
+        """Store one serialized generation-scoped value."""
         _ = ex
         self.state.values[key] = value
 
     async def incr(self, key: str) -> int:
+        """Advance and return the shared generation counter."""
         generation = self.state.generations.get(key, 0) + 1
         self.state.generations[key] = generation
         return generation

--- a/tests/test_cache_reenable_safety.py
+++ b/tests/test_cache_reenable_safety.py
@@ -87,7 +87,6 @@ async def test_generation_invalidation_is_visible_across_application_clients(
 def test_remote_cache_remains_explicitly_disabled_by_default() -> None:
     """Provider credentials alone must not silently turn remote caching back on."""
     settings = RedisSettings(
-        _env_file=None,
         cache_enabled=False,
         upstash_redis_rest_url="https://example.invalid",
         upstash_redis_rest_token="test-token",


### PR DESCRIPTION
## Summary
- record the evidence-backed decision to keep remote caching disabled until observed production demand can be projected under the free-tier command budget
- add a cross-instance regression proving generation invalidation from one application client invalidates another client's cached view
- verify provider credentials cannot silently enable caching without the explicit `CACHE_ENABLED` flag
- document the no-deploy rollback boundary for any future staged rollout

Closes #961