### PR TITLE
Derive provenance-aware crossover templates

### DIFF
--- a/app/services/crossover_templates.py
+++ b/app/services/crossover_templates.py
@@ -1,0 +1,154 @@
+"""Derive deterministic crossover templates from CBL and ComicVine evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class TemplateEvidence:
+    """External evidence for one candidate crossover member."""
+
+    issue_id: int
+    cbl_positions: tuple[int, ...]
+    cbl_source_paths: tuple[str, ...]
+    story_arc_ids: tuple[str, ...] = ()
+    target_story_arc_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CrossoverTemplateItem:
+    """One suggested, non-blocking member of a derived crossover template."""
+
+    issue_id: int
+    suggested_position: int
+    role: str
+    confidence: str
+    explanation: str
+    source_paths: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class CrossoverTemplateConflict:
+    """A pair whose relative order disagrees across source lists."""
+
+    first_issue_id: int
+    second_issue_id: int
+
+
+@dataclass(frozen=True, slots=True)
+class DerivedCrossoverTemplate:
+    """Rebuildable crossover suggestion that never creates continuity rules."""
+
+    items: tuple[CrossoverTemplateItem, ...]
+    conflicts: tuple[CrossoverTemplateConflict, ...]
+
+
+def derive_crossover_template(
+    evidence: tuple[TemplateEvidence, ...],
+) -> DerivedCrossoverTemplate:
+    """Derive a stable template while preserving uncertainty and provenance.
+
+    ComicVine membership is sufficient for a ``core`` role only when the caller
+    supplies the target story-arc identity. CBL-only members remain contextual
+    candidates when they surround known core members, otherwise ``unknown``.
+    Source-order disagreements are reported rather than flattened into hard
+    dependency semantics.
+    """
+    if not evidence:
+        return DerivedCrossoverTemplate(items=(), conflicts=())
+
+    ordered = tuple(sorted(evidence, key=_sort_key))
+    core_positions = [
+        _median_position(item.cbl_positions)
+        for item in ordered
+        if _is_core(item) and item.cbl_positions
+    ]
+    first_core = min(core_positions) if core_positions else None
+    last_core = max(core_positions) if core_positions else None
+
+    items = tuple(
+        CrossoverTemplateItem(
+            issue_id=item.issue_id,
+            suggested_position=index,
+            role=_role(item, first_core=first_core, last_core=last_core),
+            confidence="high" if _is_core(item) else "medium" if item.cbl_positions else "low",
+            explanation=_explanation(item, first_core=first_core, last_core=last_core),
+            source_paths=tuple(sorted(set(item.cbl_source_paths))),
+        )
+        for index, item in enumerate(ordered, start=1)
+    )
+    return DerivedCrossoverTemplate(items=items, conflicts=_order_conflicts(evidence))
+
+
+def _is_core(item: TemplateEvidence) -> bool:
+    return bool(
+        item.target_story_arc_id
+        and item.target_story_arc_id in item.story_arc_ids
+    )
+
+
+def _role(
+    item: TemplateEvidence,
+    *,
+    first_core: float | None,
+    last_core: float | None,
+) -> str:
+    if _is_core(item):
+        return "core"
+    position = _median_position(item.cbl_positions) if item.cbl_positions else None
+    if position is None or first_core is None or last_core is None:
+        return "unknown"
+    if position < first_core:
+        return "context/prelude"
+    if position > last_core:
+        return "epilogue"
+    return "unknown"
+
+
+def _explanation(
+    item: TemplateEvidence,
+    *,
+    first_core: float | None,
+    last_core: float | None,
+) -> str:
+    role = _role(item, first_core=first_core, last_core=last_core)
+    if role == "core":
+        return f"ComicVine explicitly tags this issue with story arc {item.target_story_arc_id}."
+    if role == "context/prelude":
+        return "CBL places this issue before the explicit ComicVine core; role remains contextual."
+    if role == "epilogue":
+        return "CBL places this issue after the explicit ComicVine core; role remains contextual."
+    return "External evidence suggests membership but is insufficient to assign a core/context role."
+
+
+def _sort_key(item: TemplateEvidence) -> tuple[float, int]:
+    position = _median_position(item.cbl_positions)
+    return (position if position is not None else float("inf"), item.issue_id)
+
+
+def _median_position(positions: tuple[int, ...]) -> float | None:
+    if not positions:
+        return None
+    values = sorted(positions)
+    midpoint = len(values) // 2
+    if len(values) % 2:
+        return float(values[midpoint])
+    return (values[midpoint - 1] + values[midpoint]) / 2
+
+
+def _order_conflicts(
+    evidence: tuple[TemplateEvidence, ...],
+) -> tuple[CrossoverTemplateConflict, ...]:
+    conflicts: list[CrossoverTemplateConflict] = []
+    for index, first in enumerate(evidence):
+        for second in evidence[index + 1 :]:
+            comparisons = {
+                (left > right) - (left < right)
+                for left, right in zip(first.cbl_positions, second.cbl_positions, strict=False)
+                if left != right
+            }
+            if len(comparisons) > 1:
+                first_id, second_id = sorted((first.issue_id, second.issue_id))
+                conflicts.append(CrossoverTemplateConflict(first_id, second_id))
+    return tuple(sorted(set(conflicts), key=lambda item: (item.first_issue_id, item.second_issue_id)))

--- a/app/services/crossover_templates.py
+++ b/app/services/crossover_templates.py
@@ -4,14 +4,27 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.cbl_reference import CBLSource, CBLSourceEntry, CBLSourceList
+from app.models.external_identity import ExternalIdentity, IssueExternalIdentityMapping
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class CBLPlacement:
+    """One ordered CBL observation with inseparable provenance."""
+
+    source_path: str
+    position: int
+
 
 @dataclass(frozen=True, slots=True)
 class TemplateEvidence:
     """External evidence for one candidate crossover member."""
 
     issue_id: int
-    cbl_positions: tuple[int, ...]
-    cbl_source_paths: tuple[str, ...]
+    cbl_placements: tuple[CBLPlacement, ...]
     story_arc_ids: tuple[str, ...] = ()
     target_story_arc_id: str | None = None
 
@@ -34,6 +47,7 @@ class CrossoverTemplateConflict:
 
     first_issue_id: int
     second_issue_id: int
+    source_paths: tuple[str, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -42,6 +56,90 @@ class DerivedCrossoverTemplate:
 
     items: tuple[CrossoverTemplateItem, ...]
     conflicts: tuple[CrossoverTemplateConflict, ...]
+
+
+async def derive_crossover_template_from_lists(
+    db: AsyncSession,
+    *,
+    source_list_ids: tuple[int, ...],
+    target_story_arc_id: str,
+) -> DerivedCrossoverTemplate:
+    """Build a crossover template from persisted CBL and ComicVine evidence.
+
+    Only confirmed ComicVine issue mappings are eligible for ComicPile template
+    members. CBL ordering remains advisory evidence. This function reads source
+    state only and never creates or mutates continuity rules or user plans.
+
+    Args:
+        db: Async database session.
+        source_list_ids: Active imported CBL lists to combine.
+        target_story_arc_id: ComicVine story-arc identity defining explicit core membership.
+
+    Returns:
+        Deterministic derived template with inspectable provenance and conflicts.
+    """
+    if not source_list_ids:
+        return DerivedCrossoverTemplate(items=(), conflicts=())
+
+    rows = list(
+        (
+            await db.execute(
+                select(
+                    CBLSourceEntry,
+                    CBLSourceList,
+                    CBLSource,
+                    IssueExternalIdentityMapping,
+                    ExternalIdentity,
+                )
+                .join(CBLSourceList, CBLSourceList.id == CBLSourceEntry.list_id)
+                .join(CBLSource, CBLSource.id == CBLSourceList.source_id)
+                .join(
+                    IssueExternalIdentityMapping,
+                    IssueExternalIdentityMapping.external_identity_id
+                    == CBLSourceEntry.external_issue_identity_id,
+                )
+                .join(
+                    ExternalIdentity,
+                    ExternalIdentity.id == IssueExternalIdentityMapping.external_identity_id,
+                )
+                .where(
+                    CBLSourceEntry.list_id.in_(source_list_ids),
+                    CBLSourceList.active.is_(True),
+                    IssueExternalIdentityMapping.status == "confirmed",
+                    ExternalIdentity.provider == "comicvine",
+                    ExternalIdentity.entity_type == "issue",
+                )
+                .order_by(
+                    CBLSource.repository,
+                    CBLSourceList.source_path,
+                    CBLSourceEntry.position,
+                    IssueExternalIdentityMapping.issue_id,
+                )
+            )
+        ).all()
+    )
+
+    placements_by_issue: dict[int, list[CBLPlacement]] = {}
+    arcs_by_issue: dict[int, set[str]] = {}
+    for entry, source_list, source, mapping, identity in rows:
+        source_path = f"{source.repository}:{source_list.source_path}"
+        placements_by_issue.setdefault(mapping.issue_id, []).append(
+            CBLPlacement(source_path=source_path, position=entry.position)
+        )
+        arcs_by_issue.setdefault(mapping.issue_id, set()).update(
+            _story_arc_ids(identity.metadata_json)
+        )
+
+    evidence = tuple(
+        TemplateEvidence(
+            issue_id=issue_id,
+            cbl_placements=tuple(sorted(placements)),
+            story_arc_ids=tuple(sorted(arcs_by_issue.get(issue_id, set()))),
+            target_story_arc_id=target_story_arc_id,
+        )
+        for issue_id, placements in sorted(placements_by_issue.items())
+    )
+    return derive_crossover_template(evidence)
 
 
 def derive_crossover_template(
@@ -60,9 +158,11 @@ def derive_crossover_template(
 
     ordered = tuple(sorted(evidence, key=_sort_key))
     core_positions = [
-        _median_position(item.cbl_positions)
+        position
         for item in ordered
-        if _is_core(item) and item.cbl_positions
+        if _is_core(item)
+        for position in [_median_position(item)]
+        if position is not None
     ]
     first_core = min(core_positions) if core_positions else None
     last_core = max(core_positions) if core_positions else None
@@ -72,9 +172,9 @@ def derive_crossover_template(
             issue_id=item.issue_id,
             suggested_position=index,
             role=_role(item, first_core=first_core, last_core=last_core),
-            confidence="high" if _is_core(item) else "medium" if item.cbl_positions else "low",
+            confidence="high" if _is_core(item) else "medium" if item.cbl_placements else "low",
             explanation=_explanation(item, first_core=first_core, last_core=last_core),
-            source_paths=tuple(sorted(set(item.cbl_source_paths))),
+            source_paths=tuple(sorted({placement.source_path for placement in item.cbl_placements})),
         )
         for index, item in enumerate(ordered, start=1)
     )
@@ -82,10 +182,7 @@ def derive_crossover_template(
 
 
 def _is_core(item: TemplateEvidence) -> bool:
-    return bool(
-        item.target_story_arc_id
-        and item.target_story_arc_id in item.story_arc_ids
-    )
+    return bool(item.target_story_arc_id and item.target_story_arc_id in item.story_arc_ids)
 
 
 def _role(
@@ -96,7 +193,7 @@ def _role(
 ) -> str:
     if _is_core(item):
         return "core"
-    position = _median_position(item.cbl_positions) if item.cbl_positions else None
+    position = _median_position(item)
     if position is None or first_core is None or last_core is None:
         return "unknown"
     if position < first_core:
@@ -123,18 +220,18 @@ def _explanation(
 
 
 def _sort_key(item: TemplateEvidence) -> tuple[float, int]:
-    position = _median_position(item.cbl_positions)
+    position = _median_position(item)
     return (position if position is not None else float("inf"), item.issue_id)
 
 
-def _median_position(positions: tuple[int, ...]) -> float | None:
+def _median_position(item: TemplateEvidence) -> float | None:
+    positions = sorted(placement.position for placement in item.cbl_placements)
     if not positions:
         return None
-    values = sorted(positions)
-    midpoint = len(values) // 2
-    if len(values) % 2:
-        return float(values[midpoint])
-    return (values[midpoint - 1] + values[midpoint]) / 2
+    midpoint = len(positions) // 2
+    if len(positions) % 2:
+        return float(positions[midpoint])
+    return (positions[midpoint - 1] + positions[midpoint]) / 2
 
 
 def _order_conflicts(
@@ -142,13 +239,48 @@ def _order_conflicts(
 ) -> tuple[CrossoverTemplateConflict, ...]:
     conflicts: list[CrossoverTemplateConflict] = []
     for index, first in enumerate(evidence):
+        first_by_path = {placement.source_path: placement.position for placement in first.cbl_placements}
         for second in evidence[index + 1 :]:
+            second_by_path = {
+                placement.source_path: placement.position for placement in second.cbl_placements
+            }
+            shared_paths = sorted(first_by_path.keys() & second_by_path.keys())
             comparisons = {
-                (left > right) - (left < right)
-                for left, right in zip(first.cbl_positions, second.cbl_positions, strict=False)
-                if left != right
+                (first_by_path[path] > second_by_path[path])
+                - (first_by_path[path] < second_by_path[path])
+                for path in shared_paths
+                if first_by_path[path] != second_by_path[path]
             }
             if len(comparisons) > 1:
                 first_id, second_id = sorted((first.issue_id, second.issue_id))
-                conflicts.append(CrossoverTemplateConflict(first_id, second_id))
-    return tuple(sorted(set(conflicts), key=lambda item: (item.first_issue_id, item.second_issue_id)))
+                conflicts.append(
+                    CrossoverTemplateConflict(
+                        first_issue_id=first_id,
+                        second_issue_id=second_id,
+                        source_paths=tuple(shared_paths),
+                    )
+                )
+    return tuple(
+        sorted(
+            set(conflicts),
+            key=lambda item: (item.first_issue_id, item.second_issue_id, item.source_paths),
+        )
+    )
+
+
+def _story_arc_ids(metadata: dict[str, object]) -> set[str]:
+    """Extract normalized ComicVine story-arc identifiers from provider metadata."""
+    raw_arcs = metadata.get("story_arcs")
+    if not isinstance(raw_arcs, list):
+        return set()
+
+    result: set[str] = set()
+    for item in raw_arcs:
+        if not isinstance(item, dict):
+            continue
+        raw_id = item.get("id")
+        if isinstance(raw_id, int):
+            result.add(str(raw_id))
+        elif isinstance(raw_id, str) and raw_id.strip():
+            result.add(raw_id.strip())
+    return result

--- a/docs/changelog.d/2026-08-11-1079.md
+++ b/docs/changelog.d/2026-08-11-1079.md
@@ -1,0 +1,5 @@
+## 2026-08-11
+
+### Reading order intelligence
+
+- [#1079](https://github.com/JoshCLWren/comic-pile/pull/1079) derives crossover templates from imported CBL ordering and confirmed ComicVine story-arc evidence while keeping source provenance, disagreements, and uncertain roles visible instead of turning external reading lists into hard ComicPile dependencies.

--- a/tests/test_crossover_templates.py
+++ b/tests/test_crossover_templates.py
@@ -1,0 +1,56 @@
+"""Tests for deterministic, non-blocking crossover template derivation."""
+
+from app.services.crossover_templates import TemplateEvidence, derive_crossover_template
+
+
+def test_x_of_swords_preserves_context_around_explicit_core() -> None:
+    """CBL context stays distinct from ComicVine's explicit event membership."""
+    evidence = (
+        TemplateEvidence(12, (1,), ("x-of-swords.cbl",), ("dawn",), "xos"),
+        TemplateEvidence(13, (2,), ("x-of-swords.cbl",), ("dawn",), "xos"),
+        TemplateEvidence(14, (3,), ("x-of-swords.cbl",), ("xos",), "xos"),
+        TemplateEvidence(15, (24,), ("x-of-swords.cbl",), ("reign",), "xos"),
+    )
+
+    template = derive_crossover_template(evidence)
+
+    assert [item.role for item in template.items] == [
+        "context/prelude",
+        "context/prelude",
+        "core",
+        "epilogue",
+    ]
+    assert template.items[2].explanation.startswith("ComicVine explicitly tags")
+
+
+def test_conflicting_source_order_is_inspectable_not_serialized() -> None:
+    """A less-linear event keeps disagreement as evidence instead of an edge."""
+    template = derive_crossover_template(
+        (
+            TemplateEvidence(20, (1, 4), ("a.cbl", "b.cbl")),
+            TemplateEvidence(30, (3, 2), ("a.cbl", "b.cbl")),
+            TemplateEvidence(40, (5, 5), ("a.cbl", "b.cbl")),
+        )
+    )
+
+    assert [(item.issue_id, item.role) for item in template.items] == [
+        (20, "unknown"),
+        (30, "unknown"),
+        (40, "unknown"),
+    ]
+    assert [(item.first_issue_id, item.second_issue_id) for item in template.conflicts] == [
+        (20, 30)
+    ]
+
+
+def test_same_evidence_is_deterministic_and_unknown_stays_unknown() -> None:
+    """Input order cannot change output and weak evidence never invents a role."""
+    first = TemplateEvidence(2, (), ("context.cbl",))
+    second = TemplateEvidence(1, (), ("context.cbl",))
+
+    left = derive_crossover_template((first, second))
+    right = derive_crossover_template((second, first))
+
+    assert left == right
+    assert [item.issue_id for item in left.items] == [1, 2]
+    assert all(item.role == "unknown" for item in left.items)

--- a/tests/test_crossover_templates.py
+++ b/tests/test_crossover_templates.py
@@ -1,15 +1,33 @@
 """Tests for deterministic, non-blocking crossover template derivation."""
 
-from app.services.crossover_templates import TemplateEvidence, derive_crossover_template
+from app.services.crossover_templates import (
+    CBLPlacement,
+    TemplateEvidence,
+    derive_crossover_template,
+)
+
+
+def _evidence(
+    issue_id: int,
+    placements: tuple[tuple[str, int], ...],
+    story_arc_ids: tuple[str, ...] = (),
+    target_story_arc_id: str | None = "xos",
+) -> TemplateEvidence:
+    return TemplateEvidence(
+        issue_id=issue_id,
+        cbl_placements=tuple(CBLPlacement(path, position) for path, position in placements),
+        story_arc_ids=story_arc_ids,
+        target_story_arc_id=target_story_arc_id,
+    )
 
 
 def test_x_of_swords_preserves_context_around_explicit_core() -> None:
     """CBL context stays distinct from ComicVine's explicit event membership."""
     evidence = (
-        TemplateEvidence(12, (1,), ("x-of-swords.cbl",), ("dawn",), "xos"),
-        TemplateEvidence(13, (2,), ("x-of-swords.cbl",), ("dawn",), "xos"),
-        TemplateEvidence(14, (3,), ("x-of-swords.cbl",), ("xos",), "xos"),
-        TemplateEvidence(15, (24,), ("x-of-swords.cbl",), ("reign",), "xos"),
+        _evidence(12, (("x-of-swords.cbl", 1),), ("dawn",)),
+        _evidence(13, (("x-of-swords.cbl", 2),), ("dawn",)),
+        _evidence(14, (("x-of-swords.cbl", 3),), ("xos",)),
+        _evidence(15, (("x-of-swords.cbl", 24),), ("reign",)),
     )
 
     template = derive_crossover_template(evidence)
@@ -21,15 +39,16 @@ def test_x_of_swords_preserves_context_around_explicit_core() -> None:
         "epilogue",
     ]
     assert template.items[2].explanation.startswith("ComicVine explicitly tags")
+    assert template.items[0].source_paths == ("x-of-swords.cbl",)
 
 
 def test_conflicting_source_order_is_inspectable_not_serialized() -> None:
     """A less-linear event keeps disagreement as evidence instead of an edge."""
     template = derive_crossover_template(
         (
-            TemplateEvidence(20, (1, 4), ("a.cbl", "b.cbl")),
-            TemplateEvidence(30, (3, 2), ("a.cbl", "b.cbl")),
-            TemplateEvidence(40, (5, 5), ("a.cbl", "b.cbl")),
+            _evidence(20, (("a.cbl", 1), ("b.cbl", 4)), target_story_arc_id=None),
+            _evidence(30, (("a.cbl", 3), ("b.cbl", 2)), target_story_arc_id=None),
+            _evidence(40, (("a.cbl", 5), ("b.cbl", 5)), target_story_arc_id=None),
         )
     )
 
@@ -38,15 +57,36 @@ def test_conflicting_source_order_is_inspectable_not_serialized() -> None:
         (30, "unknown"),
         (40, "unknown"),
     ]
-    assert [(item.first_issue_id, item.second_issue_id) for item in template.conflicts] == [
-        (20, 30)
-    ]
+    assert [
+        (item.first_issue_id, item.second_issue_id, item.source_paths)
+        for item in template.conflicts
+    ] == [(20, 30, ("a.cbl", "b.cbl"))]
+
+
+def test_conflict_detection_binds_positions_to_source_provenance() -> None:
+    """Missing membership in one list cannot shift pairwise order comparisons."""
+    template = derive_crossover_template(
+        (
+            _evidence(
+                1,
+                (("a.cbl", 1), ("b.cbl", 9), ("c.cbl", 2)),
+                target_story_arc_id=None,
+            ),
+            _evidence(
+                2,
+                (("a.cbl", 3), ("c.cbl", 1)),
+                target_story_arc_id=None,
+            ),
+        )
+    )
+
+    assert template.conflicts[0].source_paths == ("a.cbl", "c.cbl")
 
 
 def test_same_evidence_is_deterministic_and_unknown_stays_unknown() -> None:
     """Input order cannot change output and weak evidence never invents a role."""
-    first = TemplateEvidence(2, (), ("context.cbl",))
-    second = TemplateEvidence(1, (), ("context.cbl",))
+    first = _evidence(2, (), target_story_arc_id=None)
+    second = _evidence(1, (), target_story_arc_id=None)
 
     left = derive_crossover_template((first, second))
     right = derive_crossover_template((second, first))

--- a/tests/test_crossover_templates.py
+++ b/tests/test_crossover_templates.py
@@ -21,25 +21,48 @@ def _evidence(
     )
 
 
-def test_x_of_swords_preserves_context_around_explicit_core() -> None:
-    """CBL context stays distinct from ComicVine's explicit event membership."""
+def test_x_of_swords_preserves_24_entry_cbl_order_around_22_chapter_core() -> None:
+    """The complete CBL event list keeps two preludes distinct from ComicVine's 22 chapters."""
+    path = "x-of-swords.cbl"
     evidence = (
-        _evidence(12, (("x-of-swords.cbl", 1),), ("dawn",)),
-        _evidence(13, (("x-of-swords.cbl", 2),), ("dawn",)),
-        _evidence(14, (("x-of-swords.cbl", 3),), ("xos",)),
-        _evidence(15, (("x-of-swords.cbl", 24),), ("reign",)),
+        _evidence(1, ((path, 1),), ("dawn",)),  # Excalibur #12
+        _evidence(2, ((path, 2),), ("dawn",)),  # X-Men #12
+        _evidence(3, ((path, 3),), ("xos",)),  # Creation #1, chapter 1
+        _evidence(4, ((path, 4),), ("xos",)),  # X-Factor #4
+        _evidence(5, ((path, 5),), ("xos",)),  # Wolverine #6
+        _evidence(6, ((path, 6),), ("xos",)),  # X-Force #13
+        _evidence(7, ((path, 7),), ("xos",)),  # Marauders #13
+        _evidence(8, ((path, 8),), ("xos",)),  # Hellions #5
+        _evidence(9, ((path, 9),), ("xos",)),  # New Mutants #13
+        _evidence(10, ((path, 10),), ("xos",)),  # Cable #5
+        _evidence(11, ((path, 11),), ("xos",)),  # Excalibur #13
+        _evidence(12, ((path, 12),), ("xos",)),  # X-Men #13
+        _evidence(13, ((path, 13),), ("xos",)),  # Stasis #1
+        _evidence(14, ((path, 14),), ("xos",)),  # X-Men #14
+        _evidence(15, ((path, 15),), ("xos",)),  # Marauders #14
+        _evidence(16, ((path, 16),), ("xos",)),  # Marauders #15
+        _evidence(17, ((path, 17),), ("xos",)),  # Excalibur #14
+        _evidence(18, ((path, 18),), ("xos",)),  # Wolverine #7
+        _evidence(19, ((path, 19),), ("xos",)),  # X-Force #14
+        _evidence(20, ((path, 20),), ("xos",)),  # Hellions #6
+        _evidence(21, ((path, 21),), ("xos",)),  # Cable #6
+        _evidence(22, ((path, 22),), ("xos",)),  # X-Men #15
+        _evidence(23, ((path, 23),), ("xos",)),  # Excalibur #15
+        _evidence(24, ((path, 24),), ("xos",)),  # Destruction #1, chapter 22
     )
 
     template = derive_crossover_template(evidence)
 
-    assert [item.role for item in template.items] == [
+    assert len(template.items) == 24
+    assert [item.suggested_position for item in template.items] == list(range(1, 25))
+    assert [item.role for item in template.items[:2]] == [
         "context/prelude",
         "context/prelude",
-        "core",
-        "epilogue",
     ]
+    assert all(item.role == "core" for item in template.items[2:])
     assert template.items[2].explanation.startswith("ComicVine explicitly tags")
-    assert template.items[0].source_paths == ("x-of-swords.cbl",)
+    assert template.items[-1].role == "core"
+    assert template.items[0].source_paths == (path,)
 
 
 def test_conflicting_source_order_is_inspectable_not_serialized() -> None:


### PR DESCRIPTION
Implements a substantive #1022 slice with deterministic, non-blocking crossover-template derivation over persisted CBL and confirmed ComicVine evidence.

The implementation keeps each CBL position bound to its source provenance, distinguishes explicit ComicVine story-arc core membership from contextual/unknown list membership, and preserves conflicting source orders as inspectable evidence rather than continuity rules. It also adds regression coverage for contextual core boundaries, less-linear conflicting lists, provenance-safe conflict detection, and deterministic unknown handling.

This connector runtime has no repository checkout/test execution surface, so focused local pytest could not be run here. CI is the configured validation boundary for this branch.

#1022 remains open until the full X of Swords fixture, remaining template semantics, exact-head review, and CI satisfy the complete issue contract.