### PR TITLE
Repair Chromium browser-health noise classification

### DIFF
--- a/docs/changelog.d/2026-08-11-1080.md
+++ b/docs/changelog.d/2026-08-11-1080.md
@@ -2,4 +2,4 @@
 
 ### Testing & reliability
 
-- [PR #1080](https://github.com/JoshCLWren/comic-pile/pull/1080) makes Chromium discovery ignore expected anonymous authentication probes and third-party Google Fonts failures, so factory E2E runs surface real ComicPile defects instead of harness noise.
+- [#1080](https://github.com/JoshCLWren/comic-pile/pull/1080) makes Chromium discovery ignore expected anonymous authentication probes and third-party Google Fonts failures, so factory E2E runs surface real ComicPile defects instead of harness noise.

--- a/docs/changelog.d/2026-08-11-1080.md
+++ b/docs/changelog.d/2026-08-11-1080.md
@@ -1,0 +1,5 @@
+## 2026-08-11
+
+### Testing & reliability
+
+- [PR #1080](https://github.com/JoshCLWren/comic-pile/pull/1080) makes Chromium discovery ignore expected anonymous authentication probes and third-party Google Fonts failures, so factory E2E runs surface real ComicPile defects instead of harness noise.

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -229,6 +229,8 @@ function isExpectedAnonymousAuthProbe(message: string): boolean {
   const anonymousProbePaths = [
     'api/auth/me',
     'api/auth/refresh',
+    'api/v1/auth/me',
+    'api/v1/auth/refresh',
     'api/sessions/current',
     'api/threads/',
     'api/v1/dependencies/blocked',
@@ -238,13 +240,23 @@ function isExpectedAnonymousAuthProbe(message: string): boolean {
 }
 
 function isExpectedBrowserNoise(message: string): boolean {
+  const isExternalFontFailure = (
+    message.includes('fonts.googleapis.com')
+    || message.includes('fonts.gstatic.com')
+  ) && (
+    message.includes('404')
+    || message.includes('Failed to load resource')
+    || message.includes('downloadable font: download failed')
+  );
+
   return (
     (message.includes('GPU stall due to ReadPixels') && message.includes('GL Driver Message'))
     || message.includes("Couldn't load preload assets")
-    ||     (message.includes('Network Error') && message.includes('/assets/'))
+    || (message.includes('Network Error') && message.includes('/assets/'))
     || message.includes('Failed to fetch user: Error @')
     || message.includes('Failed to rate thread: Network error. Please check your connection and try again.')
     || message.includes('Failed to snooze thread: Network error. Please check your connection and try again.')
+    || isExternalFontFailure
     || message.includes('downloadable font: download failed')
     || message.includes('This site appears to use a scroll-linked positioning effect.')
     || (message.includes('XMLHttpRequest cannot load') && message.includes('due to access control checks.'))


### PR DESCRIPTION
Part of #938.

Repairs the Chromium discovery harness so expected anonymous `/api/v1/auth/me` and `/api/v1/auth/refresh` 401 probes do not fail browser health, and external Google Fonts 404/load failures are ignored without suppressing first-party failures.

Validation: no local checkout is available in this runtime; rely on configured PR CI for the exact branch head, then rerun the full Chromium discovery workflow before #938 can close.

Changelog: required because this changes factory/E2E delivery behavior; fragment will be added with this PR number before readiness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of anonymous authentication checks during browser-based testing.
  * Reduced false-positive test failures caused by third-party Google Fonts loading errors.
  * Improved Chromium discovery handling in factory end-to-end tests.

* **Documentation**
  * Added a changelog entry describing these test reliability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->