### PR TITLE
Backfill historical changelog into release ledger

### DIFF
--- a/.github/workflows/backfill-release-ledger.yml
+++ b/.github/workflows/backfill-release-ledger.yml
@@ -1,0 +1,65 @@
+name: Backfill Release Ledger
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/backfill-release-ledger.yml
+  workflow_dispatch:
+
+concurrency:
+  group: release-ledger-backfill
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  backfill:
+    name: Import and reconcile historical releases
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.14"
+          enable-cache: true
+
+      - name: Install locked runtime dependencies
+        run: uv sync --locked --no-dev
+
+      - name: Get production database connection string
+        id: neon
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$NEON_API_KEY" || -z "$NEON_PROJECT_ID" ]]; then
+            echo "NEON_API_KEY secret and NEON_PROJECT_ID variable are required for release backfill." >&2
+            exit 1
+          fi
+          uri="$(curl --fail --silent --show-error \
+            --url "https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}/connection_uri?database_name=neondb&role_name=neondb_owner" \
+            --header 'Accept: application/json' \
+            --header "Authorization: Bearer ${NEON_API_KEY}" \
+            | jq -r '.uri')"
+          if [[ -z "$uri" || "$uri" == "null" ]]; then
+            echo "Failed to retrieve the Neon production connection string." >&2
+            exit 1
+          fi
+          echo "::add-mask::$uri"
+          echo "db_url=$uri" >> "$GITHUB_OUTPUT"
+
+      - name: Audit, import, and reconcile release history
+        env:
+          DATABASE_URL: ${{ steps.neon.outputs.db_url }}
+        run: .venv/bin/python scripts/backfill_release_ledger.py --write

--- a/app/services/release_import.py
+++ b/app/services/release_import.py
@@ -22,7 +22,8 @@ from app.services.release_ledger import (
 IMPORTER_VERSION = "release-import-v1"
 SOURCE_REPOSITORY = "JoshCLWren/comic-pile"
 _DATE_HEADING_RE = re.compile(r"^##\s+(\d{4}-\d{2}-\d{2})(?:[ T].*)?\s*$")
-_CATEGORY_HEADING_RE = re.compile(r"^###\s+(.+?)\s*$")
+_MARKDOWN_CATEGORY_RE = re.compile(r"^###\s+(.+?)\s*$")
+_BOLD_CATEGORY_RE = re.compile(r"^\*\*(.+?)\*\*\s*$")
 _PR_LINK_RE = re.compile(r"github\.com/[^/]+/[^/]+/pull/(\d+)")
 _FRAGMENT_RE = re.compile(r"^(\d{4}-\d{2}-\d{2})-(\d+)\.md$")
 
@@ -128,11 +129,19 @@ def _fragment_identity(path: Path) -> tuple[str | None, int | None]:
     return match.group(1), int(match.group(2))
 
 
-def _extract_pr_number(text: str) -> int | None:
-    """Extract one explicit GitHub pull-request identity without guessing."""
-    matches = {int(value) for value in _PR_LINK_RE.findall(text)}
-    if len(matches) == 1:
-        return matches.pop()
+def _extract_pr_numbers(text: str) -> tuple[int, ...]:
+    """Extract explicit GitHub pull-request identities without guessing."""
+    return tuple(dict.fromkeys(int(value) for value in _PR_LINK_RE.findall(text)))
+
+
+def _category(stripped: str) -> str | None:
+    """Recognize both modern Markdown and frozen-archive feature-area headings."""
+    markdown_match = _MARKDOWN_CATEGORY_RE.match(stripped)
+    if markdown_match is not None:
+        return markdown_match.group(1).strip()
+    bold_match = _BOLD_CATEGORY_RE.match(stripped)
+    if bold_match is not None:
+        return bold_match.group(1).strip()
     return None
 
 
@@ -140,15 +149,7 @@ def parse_changelog_source(
     path: Path,
     text: str,
 ) -> tuple[list[ReleaseImportCandidate], list[ReleaseImportAnomaly]]:
-    """Parse one changelog source into ordered candidates and anomalies.
-
-    Args:
-        path: Repository-relative Markdown source path.
-        text: Exact source text.
-
-    Returns:
-        Ordered import candidates and preserved anomalies.
-    """
+    """Parse one changelog source into ordered candidates and anomalies."""
     checksum = _checksum(text)
     fragment_date, fragment_pr = _fragment_identity(path)
     current_date = fragment_date
@@ -174,9 +175,9 @@ def parse_changelog_source(
                 )
             continue
 
-        category_match = _CATEGORY_HEADING_RE.match(stripped)
-        if category_match is not None:
-            current_category = category_match.group(1).strip()
+        category = _category(stripped)
+        if category is not None:
+            current_category = category
             continue
 
         if stripped.startswith("#"):
@@ -196,13 +197,31 @@ def parse_changelog_source(
         if not summary:
             continue
 
-        linked_pr = _extract_pr_number(summary)
+        linked_prs = _extract_pr_numbers(summary)
+        linked_pr = linked_prs[0] if len(linked_prs) == 1 else None
+        if len(linked_prs) > 1:
+            anomalies.append(
+                ReleaseImportAnomaly(
+                    str(path),
+                    line_number,
+                    "entry references multiple PRs; preserving it without a singular PR identity",
+                )
+            )
         if fragment_pr is not None and linked_pr not in {None, fragment_pr}:
             anomalies.append(
                 ReleaseImportAnomaly(
                     str(path),
                     line_number,
                     f"fragment filename PR {fragment_pr} conflicts with linked PR {linked_pr}",
+                )
+            )
+            continue
+        if fragment_pr is not None and len(linked_prs) > 1 and fragment_pr not in linked_prs:
+            anomalies.append(
+                ReleaseImportAnomaly(
+                    str(path),
+                    line_number,
+                    f"fragment filename PR {fragment_pr} is absent from linked PR set {linked_prs}",
                 )
             )
             continue
@@ -226,20 +245,23 @@ def parse_changelog_source(
 
 
 def audit_changelog_corpus(repository_root: Path) -> ReleaseImportReport:
-    """Parse the frozen archive and every current fragment without mutating data.
-
-    Args:
-        repository_root: ComicPile repository root.
-
-    Returns:
-        Complete deterministic dry-run report for the source corpus.
-    """
+    """Parse the frozen archive and every valid current fragment without mutating data."""
     sources = [repository_root / "docs" / "changelog.md"]
     fragments_dir = repository_root / "docs" / "changelog.d"
-    if fragments_dir.exists():
-        sources.extend(sorted(fragments_dir.glob("*.md")))
-
     report = ReleaseImportReport()
+    if fragments_dir.exists():
+        for fragment in sorted(fragments_dir.glob("*.md")):
+            if _FRAGMENT_RE.fullmatch(fragment.name) is None:
+                report.anomalies.append(
+                    ReleaseImportAnomaly(
+                        str(fragment.relative_to(repository_root)),
+                        0,
+                        "ignored changelog fragment with invalid filename",
+                    )
+                )
+                continue
+            sources.append(fragment)
+
     for source in sources:
         relative_path = source.relative_to(repository_root)
         text = source.read_text(encoding="utf-8")
@@ -260,7 +282,7 @@ def _title(candidate: ReleaseImportCandidate) -> str:
     return candidate.summary[:255]
 
 
-def _payload(candidate: ReleaseImportCandidate) -> ReleaseUpsertRequest:
+def _payload(candidate: ReleaseImportCandidate, *, sort_order: int) -> ReleaseUpsertRequest:
     """Build the release-service payload for a PR-backed candidate."""
     if candidate.source_pr_number is None:
         raise ValueError("PR-backed payload requires source_pr_number")
@@ -271,7 +293,7 @@ def _payload(candidate: ReleaseImportCandidate) -> ReleaseUpsertRequest:
         category=candidate.category,
         title=_title(candidate),
         summary=candidate.summary,
-        sort_order=-candidate.source_order,
+        sort_order=sort_order,
         provenance_json=candidate.provenance(),
     )
 
@@ -287,7 +309,8 @@ async def import_changelog_report(
 ) -> ReleaseWriteReport:
     """Persist audited candidates idempotently while refusing silent source rewrites."""
     result = ReleaseWriteReport(source_count=len(report.candidates))
-    for candidate in report.candidates:
+    for corpus_order, candidate in enumerate(report.candidates):
+        sort_order = -corpus_order
         if candidate.source_pr_number is not None:
             existing = await find_release_by_source(
                 db,
@@ -310,7 +333,7 @@ async def import_changelog_report(
             if existing is not None:
                 result.unchanged_count += 1
                 continue
-            await upsert_release(db, _payload(candidate))
+            await upsert_release(db, _payload(candidate, sort_order=sort_order))
             result.imported_count += 1
             continue
 
@@ -343,7 +366,7 @@ async def import_changelog_report(
                 category=candidate.category,
                 title=_title(candidate),
                 summary=candidate.summary,
-                sort_order=-candidate.source_order,
+                sort_order=sort_order,
                 provenance_json=candidate.provenance(),
             )
         except ReleaseSourceConflictError as error:
@@ -361,7 +384,7 @@ async def reconcile_changelog_report(
 ) -> ReleaseWriteReport:
     """Verify source-to-database coverage, provenance, dates, content, and ordering."""
     result = ReleaseWriteReport(source_count=len(report.candidates))
-    for candidate in report.candidates:
+    for corpus_order, candidate in enumerate(report.candidates):
         if candidate.source_pr_number is not None:
             release = await find_release_by_source(
                 db,
@@ -386,7 +409,7 @@ async def reconcile_changelog_report(
             "released_at": released_at(candidate),
             "category": candidate.category,
             "summary": candidate.summary,
-            "sort_order": -candidate.source_order,
+            "sort_order": -corpus_order,
         }
         actual = {
             "checksum": (release.provenance_json or {}).get("source_checksum"),

--- a/app/services/release_import.py
+++ b/app/services/release_import.py
@@ -1,4 +1,4 @@
-"""Parse historical changelog Markdown into auditable release-import candidates."""
+"""Parse and import historical changelog Markdown into the durable release ledger."""
 
 from __future__ import annotations
 
@@ -8,7 +8,19 @@ import hashlib
 from pathlib import Path
 import re
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.release import ReleaseUpsertRequest
+from app.services.release_ledger import (
+    ReleaseSourceConflictError,
+    create_historical_release,
+    find_historical_release,
+    find_release_by_source,
+    upsert_release,
+)
+
 IMPORTER_VERSION = "release-import-v1"
+SOURCE_REPOSITORY = "JoshCLWren/comic-pile"
 _DATE_HEADING_RE = re.compile(r"^##\s+(\d{4}-\d{2}-\d{2})(?:[ T].*)?\s*$")
 _CATEGORY_HEADING_RE = re.compile(r"^###\s+(.+?)\s*$")
 _PR_LINK_RE = re.compile(r"github\.com/[^/]+/[^/]+/pull/(\d+)")
@@ -72,6 +84,37 @@ class ReleaseImportReport:
         }
 
 
+@dataclass(frozen=True)
+class ReleaseImportConflict:
+    """One source record that could not be safely reconciled with durable state."""
+
+    source_path: str
+    source_order: int
+    message: str
+
+
+@dataclass
+class ReleaseWriteReport:
+    """Machine-readable result of a write or reconciliation pass."""
+
+    source_count: int
+    imported_count: int = 0
+    unchanged_count: int = 0
+    missing_count: int = 0
+    conflicts: list[ReleaseImportConflict] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, object]:
+        """Serialize write/reconciliation totals and conflicts."""
+        return {
+            "source_count": self.source_count,
+            "imported_count": self.imported_count,
+            "unchanged_count": self.unchanged_count,
+            "missing_count": self.missing_count,
+            "conflict_count": len(self.conflicts),
+            "conflicts": [asdict(conflict) for conflict in self.conflicts],
+        }
+
+
 def _checksum(text: str) -> str:
     """Return a stable checksum for exact source-content reconciliation."""
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
@@ -93,7 +136,10 @@ def _extract_pr_number(text: str) -> int | None:
     return None
 
 
-def parse_changelog_source(path: Path, text: str) -> tuple[list[ReleaseImportCandidate], list[ReleaseImportAnomaly]]:
+def parse_changelog_source(
+    path: Path,
+    text: str,
+) -> tuple[list[ReleaseImportCandidate], list[ReleaseImportAnomaly]]:
     """Parse one changelog source into ordered candidates and anomalies.
 
     Args:
@@ -207,3 +253,156 @@ def audit_changelog_corpus(repository_root: Path) -> ReleaseImportReport:
 def released_at(candidate: ReleaseImportCandidate) -> datetime:
     """Convert a source date into the deterministic UTC release timestamp used by importers."""
     return datetime.strptime(candidate.source_date, "%Y-%m-%d").replace(tzinfo=UTC)
+
+
+def _title(candidate: ReleaseImportCandidate) -> str:
+    """Derive a stable display title without discarding the full summary."""
+    return candidate.summary[:255]
+
+
+def _payload(candidate: ReleaseImportCandidate) -> ReleaseUpsertRequest:
+    """Build the release-service payload for a PR-backed candidate."""
+    if candidate.source_pr_number is None:
+        raise ValueError("PR-backed payload requires source_pr_number")
+    return ReleaseUpsertRequest(
+        source_repository=SOURCE_REPOSITORY,
+        source_pr_number=candidate.source_pr_number,
+        released_at=released_at(candidate),
+        category=candidate.category,
+        title=_title(candidate),
+        summary=candidate.summary,
+        sort_order=-candidate.source_order,
+        provenance_json=candidate.provenance(),
+    )
+
+
+def _checksum_matches(candidate: ReleaseImportCandidate, provenance: dict[str, object]) -> bool:
+    """Return whether durable provenance still matches the exact source corpus."""
+    return provenance.get("source_checksum") == candidate.source_checksum
+
+
+async def import_changelog_report(
+    db: AsyncSession,
+    report: ReleaseImportReport,
+) -> ReleaseWriteReport:
+    """Persist audited candidates idempotently while refusing silent source rewrites."""
+    result = ReleaseWriteReport(source_count=len(report.candidates))
+    for candidate in report.candidates:
+        if candidate.source_pr_number is not None:
+            existing = await find_release_by_source(
+                db,
+                source_repository=SOURCE_REPOSITORY,
+                source_pr_number=candidate.source_pr_number,
+                source_merge_sha=None,
+            )
+            if existing is not None and not _checksum_matches(
+                candidate,
+                existing.provenance_json or {},
+            ):
+                result.conflicts.append(
+                    ReleaseImportConflict(
+                        candidate.source_path,
+                        candidate.source_order,
+                        f"source checksum changed for PR #{candidate.source_pr_number}",
+                    )
+                )
+                continue
+            if existing is not None:
+                result.unchanged_count += 1
+                continue
+            await upsert_release(db, _payload(candidate))
+            result.imported_count += 1
+            continue
+
+        existing = await find_historical_release(
+            db,
+            source_repository=SOURCE_REPOSITORY,
+            source_path=candidate.source_path,
+            source_order=candidate.source_order,
+        )
+        if existing is not None and not _checksum_matches(
+            candidate,
+            existing.provenance_json or {},
+        ):
+            result.conflicts.append(
+                ReleaseImportConflict(
+                    candidate.source_path,
+                    candidate.source_order,
+                    "historical source checksum changed",
+                )
+            )
+            continue
+        if existing is not None:
+            result.unchanged_count += 1
+            continue
+        try:
+            await create_historical_release(
+                db,
+                source_repository=SOURCE_REPOSITORY,
+                released_at=released_at(candidate),
+                category=candidate.category,
+                title=_title(candidate),
+                summary=candidate.summary,
+                sort_order=-candidate.source_order,
+                provenance_json=candidate.provenance(),
+            )
+        except ReleaseSourceConflictError as error:
+            result.conflicts.append(
+                ReleaseImportConflict(candidate.source_path, candidate.source_order, str(error))
+            )
+            continue
+        result.imported_count += 1
+    return result
+
+
+async def reconcile_changelog_report(
+    db: AsyncSession,
+    report: ReleaseImportReport,
+) -> ReleaseWriteReport:
+    """Verify source-to-database coverage, provenance, dates, content, and ordering."""
+    result = ReleaseWriteReport(source_count=len(report.candidates))
+    for candidate in report.candidates:
+        if candidate.source_pr_number is not None:
+            release = await find_release_by_source(
+                db,
+                source_repository=SOURCE_REPOSITORY,
+                source_pr_number=candidate.source_pr_number,
+                source_merge_sha=None,
+            )
+        else:
+            release = await find_historical_release(
+                db,
+                source_repository=SOURCE_REPOSITORY,
+                source_path=candidate.source_path,
+                source_order=candidate.source_order,
+            )
+
+        if release is None:
+            result.missing_count += 1
+            continue
+
+        expected = {
+            "checksum": candidate.source_checksum,
+            "released_at": released_at(candidate),
+            "category": candidate.category,
+            "summary": candidate.summary,
+            "sort_order": -candidate.source_order,
+        }
+        actual = {
+            "checksum": (release.provenance_json or {}).get("source_checksum"),
+            "released_at": release.released_at,
+            "category": release.category,
+            "summary": release.summary,
+            "sort_order": release.sort_order,
+        }
+        if actual != expected:
+            result.conflicts.append(
+                ReleaseImportConflict(
+                    candidate.source_path,
+                    candidate.source_order,
+                    "durable release does not match source provenance/content/order",
+                )
+            )
+            continue
+        result.unchanged_count += 1
+    return result

--- a/app/services/release_import.py
+++ b/app/services/release_import.py
@@ -1,0 +1,209 @@
+"""Parse historical changelog Markdown into auditable release-import candidates."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+import hashlib
+from pathlib import Path
+import re
+
+IMPORTER_VERSION = "release-import-v1"
+_DATE_HEADING_RE = re.compile(r"^##\s+(\d{4}-\d{2}-\d{2})(?:[ T].*)?\s*$")
+_CATEGORY_HEADING_RE = re.compile(r"^###\s+(.+?)\s*$")
+_PR_LINK_RE = re.compile(r"github\.com/[^/]+/[^/]+/pull/(\d+)")
+_FRAGMENT_RE = re.compile(r"^(\d{4}-\d{2}-\d{2})-(\d+)\.md$")
+
+
+@dataclass(frozen=True)
+class ReleaseImportCandidate:
+    """One source-backed release note candidate discovered in Markdown."""
+
+    source_path: str
+    source_checksum: str
+    source_date: str
+    category: str
+    summary: str
+    source_pr_number: int | None
+    source_order: int
+    raw_source: str
+    importer_version: str = IMPORTER_VERSION
+
+    def provenance(self) -> dict[str, object]:
+        """Return stable provenance metadata suitable for the release ledger."""
+        return {
+            "source_path": self.source_path,
+            "source_checksum": self.source_checksum,
+            "source_date": self.source_date,
+            "source_order": self.source_order,
+            "raw_source": self.raw_source,
+            "importer_version": self.importer_version,
+        }
+
+
+@dataclass(frozen=True)
+class ReleaseImportAnomaly:
+    """One ambiguous or malformed source condition preserved for audit."""
+
+    source_path: str
+    line_number: int
+    message: str
+
+
+@dataclass
+class ReleaseImportReport:
+    """Machine-readable dry-run report for a changelog corpus."""
+
+    files_scanned: int = 0
+    candidates: list[ReleaseImportCandidate] = field(default_factory=list)
+    anomalies: list[ReleaseImportAnomaly] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, object]:
+        """Serialize the report without losing source-level audit detail."""
+        return {
+            "importer_version": IMPORTER_VERSION,
+            "files_scanned": self.files_scanned,
+            "candidate_count": len(self.candidates),
+            "pr_backed_count": sum(c.source_pr_number is not None for c in self.candidates),
+            "historical_count": sum(c.source_pr_number is None for c in self.candidates),
+            "anomaly_count": len(self.anomalies),
+            "candidates": [asdict(candidate) for candidate in self.candidates],
+            "anomalies": [asdict(anomaly) for anomaly in self.anomalies],
+        }
+
+
+def _checksum(text: str) -> str:
+    """Return a stable checksum for exact source-content reconciliation."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _fragment_identity(path: Path) -> tuple[str | None, int | None]:
+    """Read authoritative date and PR identity from a valid fragment filename."""
+    match = _FRAGMENT_RE.fullmatch(path.name)
+    if match is None:
+        return None, None
+    return match.group(1), int(match.group(2))
+
+
+def _extract_pr_number(text: str) -> int | None:
+    """Extract one explicit GitHub pull-request identity without guessing."""
+    matches = {int(value) for value in _PR_LINK_RE.findall(text)}
+    if len(matches) == 1:
+        return matches.pop()
+    return None
+
+
+def parse_changelog_source(path: Path, text: str) -> tuple[list[ReleaseImportCandidate], list[ReleaseImportAnomaly]]:
+    """Parse one changelog source into ordered candidates and anomalies.
+
+    Args:
+        path: Repository-relative Markdown source path.
+        text: Exact source text.
+
+    Returns:
+        Ordered import candidates and preserved anomalies.
+    """
+    checksum = _checksum(text)
+    fragment_date, fragment_pr = _fragment_identity(path)
+    current_date = fragment_date
+    current_category = "General"
+    candidates: list[ReleaseImportCandidate] = []
+    anomalies: list[ReleaseImportAnomaly] = []
+
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        date_match = _DATE_HEADING_RE.match(stripped)
+        if date_match is not None:
+            current_date = date_match.group(1)
+            if fragment_date is not None and current_date != fragment_date:
+                anomalies.append(
+                    ReleaseImportAnomaly(
+                        str(path),
+                        line_number,
+                        f"fragment heading date {current_date} does not match filename date {fragment_date}",
+                    )
+                )
+            continue
+
+        category_match = _CATEGORY_HEADING_RE.match(stripped)
+        if category_match is not None:
+            current_category = category_match.group(1).strip()
+            continue
+
+        if stripped.startswith("#"):
+            continue
+
+        if current_date is None:
+            anomalies.append(
+                ReleaseImportAnomaly(
+                    str(path),
+                    line_number,
+                    "content appears before any parseable release date",
+                )
+            )
+            continue
+
+        summary = stripped[2:].strip() if stripped.startswith("- ") else stripped
+        if not summary:
+            continue
+
+        linked_pr = _extract_pr_number(summary)
+        if fragment_pr is not None and linked_pr not in {None, fragment_pr}:
+            anomalies.append(
+                ReleaseImportAnomaly(
+                    str(path),
+                    line_number,
+                    f"fragment filename PR {fragment_pr} conflicts with linked PR {linked_pr}",
+                )
+            )
+            continue
+
+        candidates.append(
+            ReleaseImportCandidate(
+                source_path=str(path),
+                source_checksum=checksum,
+                source_date=current_date,
+                category=current_category,
+                summary=summary,
+                source_pr_number=fragment_pr if fragment_pr is not None else linked_pr,
+                source_order=len(candidates),
+                raw_source=line,
+            )
+        )
+
+    if not candidates:
+        anomalies.append(ReleaseImportAnomaly(str(path), 0, "source produced no release candidates"))
+    return candidates, anomalies
+
+
+def audit_changelog_corpus(repository_root: Path) -> ReleaseImportReport:
+    """Parse the frozen archive and every current fragment without mutating data.
+
+    Args:
+        repository_root: ComicPile repository root.
+
+    Returns:
+        Complete deterministic dry-run report for the source corpus.
+    """
+    sources = [repository_root / "docs" / "changelog.md"]
+    fragments_dir = repository_root / "docs" / "changelog.d"
+    if fragments_dir.exists():
+        sources.extend(sorted(fragments_dir.glob("*.md")))
+
+    report = ReleaseImportReport()
+    for source in sources:
+        relative_path = source.relative_to(repository_root)
+        text = source.read_text(encoding="utf-8")
+        candidates, anomalies = parse_changelog_source(relative_path, text)
+        report.files_scanned += 1
+        report.candidates.extend(candidates)
+        report.anomalies.extend(anomalies)
+    return report
+
+
+def released_at(candidate: ReleaseImportCandidate) -> datetime:
+    """Convert a source date into the deterministic UTC release timestamp used by importers."""
+    return datetime.strptime(candidate.source_date, "%Y-%m-%d").replace(tzinfo=UTC)

--- a/app/services/release_ledger.py
+++ b/app/services/release_ledger.py
@@ -1,5 +1,7 @@
 """Service layer for the durable What's New release ledger."""
 
+from datetime import datetime
+
 from sqlalchemy import func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -208,7 +210,7 @@ async def create_historical_release(
     db: AsyncSession,
     *,
     source_repository: str,
-    released_at: object,
+    released_at: datetime,
     category: str,
     title: str,
     summary: str,

--- a/app/services/release_ledger.py
+++ b/app/services/release_ledger.py
@@ -9,7 +9,7 @@ from app.schemas.release import ReleaseUpsertRequest
 
 
 class ReleaseSourceConflictError(ValueError):
-    """Raised when PR and merge-SHA provenance identify different releases."""
+    """Raised when durable source provenance conflicts with an existing release."""
 
 
 async def list_published_releases(
@@ -107,6 +107,36 @@ async def find_release_by_source(
     return matches[0] if matches else None
 
 
+async def find_historical_release(
+    db: AsyncSession,
+    *,
+    source_repository: str,
+    source_path: str,
+    source_order: int,
+) -> Release | None:
+    """Resolve a historical release by its durable Markdown source position.
+
+    Historical changelog entries often predate pull-request provenance. Their stable
+    identity is therefore the source path plus original entry order, while the exact
+    source checksum protects that identity from silent rewrites.
+    """
+    result = await db.execute(
+        select(Release).where(
+            Release.source_repository == source_repository,
+            Release.source_pr_number.is_(None),
+            Release.source_merge_sha.is_(None),
+        )
+    )
+    for release in result.scalars().all():
+        provenance = release.provenance_json or {}
+        if (
+            provenance.get("source_path") == source_path
+            and provenance.get("source_order") == source_order
+        ):
+            return release
+    return None
+
+
 def _apply_payload(release: Release, payload: ReleaseUpsertRequest) -> None:
     """Apply a validated publication payload while protecting established source identity."""
     if (
@@ -170,5 +200,65 @@ async def upsert_release(db: AsyncSession, payload: ReleaseUpsertRequest) -> Rel
         _apply_payload(release, payload)
         await db.commit()
 
+    await db.refresh(release)
+    return release
+
+
+async def create_historical_release(
+    db: AsyncSession,
+    *,
+    source_repository: str,
+    released_at: object,
+    category: str,
+    title: str,
+    summary: str,
+    sort_order: int,
+    provenance_json: dict[str, object],
+) -> Release:
+    """Create or return one PR-less historical release without inventing GitHub identity.
+
+    Raises:
+        ReleaseSourceConflictError: If the same source position already exists with a
+            different checksum.
+    """
+    source_path = provenance_json.get("source_path")
+    source_order = provenance_json.get("source_order")
+    source_checksum = provenance_json.get("source_checksum")
+    if not isinstance(source_path, str) or not isinstance(source_order, int):
+        raise ValueError("historical releases require source_path and source_order provenance")
+    if not isinstance(source_checksum, str):
+        raise ValueError("historical releases require source_checksum provenance")
+
+    existing = await find_historical_release(
+        db,
+        source_repository=source_repository,
+        source_path=source_path,
+        source_order=source_order,
+    )
+    if existing is not None:
+        existing_checksum = (existing.provenance_json or {}).get("source_checksum")
+        if existing_checksum != source_checksum:
+            raise ReleaseSourceConflictError(
+                f"historical source changed at {source_path} entry {source_order}"
+            )
+        return existing
+
+    release = Release(
+        source_repository=source_repository,
+        source_pr_number=None,
+        source_merge_sha=None,
+        merged_at=None,
+        released_at=released_at,
+        category=category,
+        title=title,
+        summary=summary,
+        body=None,
+        visibility="public",
+        status="published",
+        sort_order=sort_order,
+        provenance_json=provenance_json,
+    )
+    db.add(release)
+    await db.commit()
     await db.refresh(release)
     return release

--- a/docs/changelog.d/2026-08-11-1081.md
+++ b/docs/changelog.d/2026-08-11-1081.md
@@ -2,4 +2,4 @@
 
 ### What's New
 
-- [#1081](https://github.com/JoshCLWren/comic-pile/pull/1081) adds the provenance-safe parser and audit foundation for migrating ComicPile's historical What's New entries into the database release ledger without guessing missing pull-request identities or silently losing malformed source data.
+- [#1081](https://github.com/JoshCLWren/comic-pile/pull/1081) adds an auditable historical What's New backfill that safely imports the frozen changelog and current fragments into the release ledger, preserves entries without pull-request identities, reports ambiguous source material, prevents silent checksum rewrites, and verifies source-to-database coverage after writes.

--- a/docs/changelog.d/2026-08-11-1081.md
+++ b/docs/changelog.d/2026-08-11-1081.md
@@ -1,0 +1,5 @@
+## 2026-08-11
+
+### What's New
+
+- [#1081](https://github.com/JoshCLWren/comic-pile/pull/1081) adds the provenance-safe parser and audit foundation for migrating ComicPile's historical What's New entries into the database release ledger without guessing missing pull-request identities or silently losing malformed source data.

--- a/scripts/backfill_release_ledger.py
+++ b/scripts/backfill_release_ledger.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Audit, import, and reconcile the historical ComicPile changelog release ledger."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+
+from app.database import AsyncSessionLocal
+from app.services.release_import import (
+    audit_changelog_corpus,
+    import_changelog_report,
+    reconcile_changelog_report,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    """Build the command-line parser with dry-run as the safe default."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Persist validated candidates after printing the complete dry-run audit.",
+    )
+    parser.add_argument(
+        "--repository-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="ComicPile checkout root containing docs/changelog.md and docs/changelog.d.",
+    )
+    return parser
+
+
+async def _run(repository_root: Path, *, write: bool) -> int:
+    """Execute one dry-run or write/reconciliation pass."""
+    audit = audit_changelog_corpus(repository_root)
+    print(json.dumps({"phase": "audit", **audit.as_dict()}, indent=2, sort_keys=True))
+    if not write:
+        return 0
+
+    async with AsyncSessionLocal() as db:
+        write_report = await import_changelog_report(db, audit)
+        print(
+            json.dumps(
+                {"phase": "write", **write_report.as_dict()},
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        verification = await reconcile_changelog_report(db, audit)
+        print(
+            json.dumps(
+                {"phase": "reconciliation", **verification.as_dict()},
+                indent=2,
+                sort_keys=True,
+            )
+        )
+
+    if write_report.conflicts:
+        return 2
+    if verification.conflicts or verification.missing_count:
+        return 3
+    return 0
+
+
+def main() -> int:
+    """Run the backfill command and return a machine-friendly exit status."""
+    args = _parser().parse_args()
+    return asyncio.run(_run(args.repository_root.resolve(), write=args.write))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_import.py
+++ b/tests/test_release_import.py
@@ -26,7 +26,9 @@ def test_fragment_preserves_filename_pr_and_provenance() -> None:
     assert candidate.source_date == "2026-08-11"
     assert candidate.category == "Roll"
     assert candidate.source_order == 0
-    assert candidate.provenance()["raw_source"].startswith("- [#1077]")
+    assert candidate.provenance()["raw_source"] == (
+        "- [#1077](https://github.com/JoshCLWren/comic-pile/pull/1077) repairs feedback E2E."
+    )
     assert len(candidate.source_checksum) == 64
 
 

--- a/tests/test_release_import.py
+++ b/tests/test_release_import.py
@@ -1,0 +1,84 @@
+"""Tests for historical changelog import parsing and provenance."""
+
+from pathlib import Path
+
+from app.services.release_import import parse_changelog_source
+
+
+def test_fragment_preserves_filename_pr_and_provenance() -> None:
+    """A valid fragment keeps its authoritative filename identity and exact source audit data."""
+    text = """## 2026-08-11
+
+### Roll
+
+- [#1077](https://github.com/JoshCLWren/comic-pile/pull/1077) repairs feedback E2E.
+"""
+
+    candidates, anomalies = parse_changelog_source(
+        Path("docs/changelog.d/2026-08-11-1077.md"),
+        text,
+    )
+
+    assert anomalies == []
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate.source_pr_number == 1077
+    assert candidate.source_date == "2026-08-11"
+    assert candidate.category == "Roll"
+    assert candidate.source_order == 0
+    assert candidate.provenance()["raw_source"].startswith("- [#1077]")
+    assert len(candidate.source_checksum) == 64
+
+
+def test_archive_keeps_historical_entry_without_inventing_pr_identity() -> None:
+    """Historical notes without explicit PR evidence remain representable without a fake mapping."""
+    text = """## 2025-12-30
+
+### Foundation
+
+ComicPile launched with dice-driven reading queues.
+"""
+
+    candidates, anomalies = parse_changelog_source(Path("docs/changelog.md"), text)
+
+    assert anomalies == []
+    assert len(candidates) == 1
+    assert candidates[0].source_pr_number is None
+    assert candidates[0].summary == "ComicPile launched with dice-driven reading queues."
+
+
+def test_conflicting_fragment_identity_is_reported_instead_of_guessed() -> None:
+    """A filename/link disagreement becomes an anomaly and never silently rewrites provenance."""
+    text = """## 2026-08-11
+
+### Reliability
+
+- [#999](https://github.com/JoshCLWren/comic-pile/pull/999) conflicting note.
+"""
+
+    candidates, anomalies = parse_changelog_source(
+        Path("docs/changelog.d/2026-08-11-1078.md"),
+        text,
+    )
+
+    assert candidates == []
+    assert any("conflicts with linked PR 999" in anomaly.message for anomaly in anomalies)
+
+
+def test_fragment_date_mismatch_is_preserved_as_anomaly() -> None:
+    """Filename and heading date disagreements stay visible to the dry-run audit."""
+    text = """## 2026-08-10
+
+### Reliability
+
+- fixed a thing
+"""
+
+    candidates, anomalies = parse_changelog_source(
+        Path("docs/changelog.d/2026-08-11-1078.md"),
+        text,
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].source_date == "2026-08-10"
+    assert any("does not match filename date" in anomaly.message for anomaly in anomalies)

--- a/tests/test_release_import.py
+++ b/tests/test_release_import.py
@@ -36,7 +36,7 @@ def test_archive_keeps_historical_entry_without_inventing_pr_identity() -> None:
     """Historical notes without explicit PR evidence remain representable without a fake mapping."""
     text = """## 2025-12-30
 
-### Foundation
+**Foundation**
 
 ComicPile launched with dice-driven reading queues.
 """
@@ -46,7 +46,40 @@ ComicPile launched with dice-driven reading queues.
     assert anomalies == []
     assert len(candidates) == 1
     assert candidates[0].source_pr_number is None
+    assert candidates[0].category == "Foundation"
     assert candidates[0].summary == "ComicPile launched with dice-driven reading queues."
+
+
+def test_archive_preserves_bold_feature_area_heading() -> None:
+    """The frozen archive's bold headings remain feature areas instead of becoming notes."""
+    text = """## 2026-08-06
+
+**Crossovers and reading order**
+
+- Reading-order groups are now presented as Crossovers.
+"""
+
+    candidates, anomalies = parse_changelog_source(Path("docs/changelog.md"), text)
+
+    assert anomalies == []
+    assert len(candidates) == 1
+    assert candidates[0].category == "Crossovers and reading order"
+
+
+def test_archive_multi_pr_entry_is_preserved_as_ambiguous() -> None:
+    """A historical bullet with several PRs stays readable without inventing one identity."""
+    text = """## 2026-08-05
+
+**Maintenance**
+
+- Fixed both paths ([#810](https://github.com/JoshCLWren/comic-pile/pull/810), [#811](https://github.com/JoshCLWren/comic-pile/pull/811)).
+"""
+
+    candidates, anomalies = parse_changelog_source(Path("docs/changelog.md"), text)
+
+    assert len(candidates) == 1
+    assert candidates[0].source_pr_number is None
+    assert any("multiple PRs" in anomaly.message for anomaly in anomalies)
 
 
 def test_conflicting_fragment_identity_is_reported_instead_of_guessed() -> None:

--- a/tests/test_release_import.py
+++ b/tests/test_release_import.py
@@ -1,8 +1,11 @@
 """Tests for historical changelog import parsing and provenance."""
 
 from pathlib import Path
+import re
 
-from app.services.release_import import parse_changelog_source
+from app.services.release_import import audit_changelog_corpus, parse_changelog_source
+
+_FRAGMENT_RE = re.compile(r"^\d{4}-\d{2}-\d{2}-(\d+)\.md$")
 
 
 def test_fragment_preserves_filename_pr_and_provenance() -> None:
@@ -117,3 +120,21 @@ def test_fragment_date_mismatch_is_preserved_as_anomaly() -> None:
     assert len(candidates) == 1
     assert candidates[0].source_date == "2026-08-10"
     assert any("does not match filename date" in anomaly.message for anomaly in anomalies)
+
+
+def test_repository_changelog_corpus_represents_every_valid_fragment() -> None:
+    """The dry-run parser covers the real frozen archive and every valid current fragment."""
+    repository_root = Path(__file__).resolve().parents[1]
+    report = audit_changelog_corpus(repository_root)
+    fragment_paths: dict[str, int] = {}
+    for path in (repository_root / "docs" / "changelog.d").glob("*.md"):
+        match = _FRAGMENT_RE.fullmatch(path.name)
+        if match is not None:
+            fragment_paths[str(path.relative_to(repository_root))] = int(match.group(1))
+
+    assert report.candidates
+    assert any(candidate.category != "General" for candidate in report.candidates)
+    candidates_by_path = {candidate.source_path: candidate for candidate in report.candidates}
+    assert fragment_paths.keys() <= candidates_by_path.keys()
+    for source_path, pr_number in fragment_paths.items():
+        assert candidates_by_path[source_path].source_pr_number == pr_number


### PR DESCRIPTION
Implements the full #1068 historical release-ledger backfill path.

This PR adds deterministic parsing for the frozen changelog and valid current fragments, preserves exact source provenance and ordering, keeps ambiguous/multi-PR history without inventing a singular GitHub identity, supports PR-less historical release rows, refuses silent checksum rewrites, and provides machine-readable dry-run, write, and reconciliation reports.

It also adds `scripts/backfill_release_ledger.py`, which is dry-run by default and performs idempotent production writes only with `--write`. A one-shot main-branch workflow runs that command after this PR merges, using the same Neon credential path as production deployment. #1068 must remain open until that post-merge production backfill finishes successfully and source-to-database reconciliation is verified.

Local checkout validation was unavailable in this runtime because outbound GitHub DNS resolution failed. Repository CI is the validation boundary for this head.