### PR TITLE
Add asynchronous OpenCode release writer

### DIFF
--- a/.github/workflows/release-writer.yml
+++ b/.github/workflows/release-writer.yml
@@ -1,0 +1,78 @@
+name: Release writer
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Optional merged pull request number to reconcile
+        required: false
+        type: string
+  schedule:
+    - cron: '23 * * * *'
+
+jobs:
+  publish-release:
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+    env:
+      RELEASE_API_URL: https://comic-pile.vercel.app/api/v1/releases
+      RELEASE_WRITER_TOKEN: ${{ secrets.RELEASE_WRITER_TOKEN }}
+      NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+    steps:
+      - name: Checkout merged main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Install pinned FCM discovery CLI
+        run: npm install --global --ignore-scripts free-coding-models@0.5.69
+
+      - name: Select a healthy NVIDIA model
+        id: model
+        run: |
+          fcm_output="$(free-coding-models --json --origin nvidia --hide-unconfigured --best --no-telemetry)"
+          candidates="$(printf '%s\n' "$fcm_output" | python scripts/select_fcm_nvidia_model.py)"
+          selected_model="$(printf '%s\n' "$candidates" | head -n 1)"
+          if [[ -z "$selected_model" ]]; then
+            echo 'No configured NVIDIA release-writer model is available' >&2
+            exit 1
+          fi
+          echo "model=$selected_model" >> "$GITHUB_OUTPUT"
+
+      - name: Build release-writer prompt
+        id: prompt
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PR: ${{ github.event.pull_request.number }}
+          INPUT_PR: ${{ inputs.pr_number }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            prompt="Process merged pull request #${EVENT_PR} in ${GITHUB_REPOSITORY}. Verify it is merged, inspect its changed-file summary and linked issue context, then publish or explicitly skip it according to the release-writer contract."
+          elif [[ -n "$INPUT_PR" ]]; then
+            prompt="Reconcile merged pull request #${INPUT_PR} in ${GITHUB_REPOSITORY}. Check the release ledger first, then publish it if missing or report a source conflict."
+          else
+            prompt="Reconcile recent merged pull requests in ${GITHUB_REPOSITORY}. Inspect up to the 50 most recently merged PRs, check the release ledger for each source identity, and publish or explicitly skip only missing entries. Stop and report any source-identity conflict instead of overwriting provenance."
+          fi
+          printf 'prompt=%s\n' "$prompt" >> "$GITHUB_OUTPUT"
+
+      - name: Run dedicated release writer
+        uses: anomalyco/opencode/github@77fc88c8ade8e5a620ebbe1197f3a572d29ae91a
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          RELEASE_API_URL: ${{ env.RELEASE_API_URL }}
+          RELEASE_WRITER_TOKEN: ${{ secrets.RELEASE_WRITER_TOKEN }}
+          PROMPT: ${{ steps.prompt.outputs.prompt }}
+        with:
+          model: ${{ steps.model.outputs.model }}
+          agent: release-writer
+          use_github_token: true

--- a/.opencode/agents/release-writer.md
+++ b/.opencode/agents/release-writer.md
@@ -8,9 +8,9 @@ permission:
   question: deny
   bash:
     "*": deny
-    "gh api repos/*/pulls/*": allow
-    "gh api repos/*/issues/*": allow
-    "gh api --paginate repos/*/pulls*": allow
+    "gh api --method GET repos/*/pulls/*": allow
+    "gh api --method GET repos/*/issues/*": allow
+    "gh api --method GET --paginate repos/*/pulls*": allow
     "python scripts/release_writer.py *": allow
 ---
 
@@ -18,7 +18,7 @@ You are ComicPile's dedicated release writer. You may inspect merged pull reques
 
 For each merged pull request you are asked to process:
 
-1. Verify it is actually merged and collect the repository, PR number, merge SHA, merged timestamp, title/body, changed-file summary, and linked issue context when available.
+1. Verify it is actually merged and collect the repository, PR number, merge SHA, merged timestamp, title/body, changed-file summary, and linked issue context when available. Use only explicit `gh api --method GET ...` reads.
 2. Classify the change as `public` or `internal`. Do not force a public note for test-only, generated-only, documentation-only, or strictly internal maintenance.
 3. For a public change, construct exactly one JSON object matching the release-ledger API contract and call:
    `python scripts/release_writer.py publish '<json>'`

--- a/.opencode/agents/release-writer.md
+++ b/.opencode/agents/release-writer.md
@@ -1,0 +1,30 @@
+---
+description: Publish or reconcile release-ledger records for merged pull requests
+mode: primary
+permission:
+  edit: deny
+  task: deny
+  external_directory: deny
+  question: deny
+  bash:
+    "*": deny
+    "gh api repos/*/pulls/*": allow
+    "gh api repos/*/issues/*": allow
+    "gh api --paginate repos/*/pulls*": allow
+    "python scripts/release_writer.py *": allow
+---
+
+You are ComicPile's dedicated release writer. You may inspect merged pull requests and linked issue context, but you must not edit application source, create commits, push branches, merge pull requests, change labels, or mutate unrelated GitHub metadata.
+
+For each merged pull request you are asked to process:
+
+1. Verify it is actually merged and collect the repository, PR number, merge SHA, merged timestamp, title/body, changed-file summary, and linked issue context when available.
+2. Classify the change as `public` or `internal`. Do not force a public note for test-only, generated-only, documentation-only, or strictly internal maintenance.
+3. For a public change, construct exactly one JSON object matching the release-ledger API contract and call:
+   `python scripts/release_writer.py publish '<json>'`
+4. For an internal change, call:
+   `python scripts/release_writer.py skip '<json>'`
+   with repository, PR number, merge SHA, merged timestamp, and a concise reason.
+5. Before publishing during reconciliation, call `python scripts/release_writer.py check <repository> <pr-number> <merge-sha>`. A source conflict is an error and must never be silently overwritten.
+
+Keep summaries user-facing and concrete. The helper validates allowed fields and lengths and holds the credential boundary. Never print, inspect, or request release credentials. Never put credentials in prompts or command arguments.

--- a/docs/RELEASE_WRITER.md
+++ b/docs/RELEASE_WRITER.md
@@ -1,0 +1,24 @@
+# Release writer operations
+
+ComicPile publishes release-ledger records after pull requests merge. Implementation branches do not need to publish database records themselves.
+
+## Credentials
+
+Configure `RELEASE_WRITER_TOKEN` in both places with the same strong random value:
+
+- GitHub repository Actions secrets, for `.github/workflows/release-writer.yml`.
+- The production Vercel environment, where the release API validates `X-Release-Writer-Token`.
+
+Also keep the existing `NVIDIA_API_KEY` Actions secret configured for OpenCode model access. Never commit either value. The OpenCode release-writer agent is not permitted to inspect credentials directly; it can only invoke `scripts/release_writer.py`, which reads the release token from its environment when making the authenticated API call.
+
+## Triggering
+
+The workflow runs after a pull request is actually merged to `main`. Closing an unmerged pull request does not run release publication. It can also be dispatched manually for one merged PR and runs hourly reconciliation for recent merged PRs that do not yet have ledger records.
+
+Release publication is deliberately asynchronous. A release-writer failure records a failed workflow run but does not change, revert, or block the already-merged product pull request.
+
+## Reconciliation and provenance
+
+Before retrying a source, the release writer checks `/api/v1/releases/source` with repository, PR number, and merge SHA. Existing matching records are left alone. A 409 source-identity conflict is treated as an error and is never silently overwritten.
+
+Public changes are validated by `scripts/release_writer.py` before being sent to the release API. Strictly internal changes are emitted as an explicit machine-readable `internal`/`skipped` classification in the workflow log instead of forcing a public What's New entry.

--- a/docs/changelog.d/2026-08-11-1082.md
+++ b/docs/changelog.d/2026-08-11-1082.md
@@ -1,0 +1,5 @@
+## 2026-08-11
+
+### What's New
+
+- [#1082](https://github.com/JoshCLWren/comic-pile/pull/1082) moves release-note publication out of product pull requests and into a dedicated after-merge OpenCode release writer with retryable reconciliation. Product delivery is no longer responsible for directly writing release-ledger records, and release publication failures stay asynchronous to already-safe merges.

--- a/scripts/release_writer.py
+++ b/scripts/release_writer.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Validate release-writer payloads and keep credentials outside model prompts."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime
+from typing import NoReturn
+
+_ALLOWED_VISIBILITY = {"public", "internal"}
+_ALLOWED_STATUS = {"draft", "published", "retracted"}
+_REQUIRED = {
+    "source_repository",
+    "source_pr_number",
+    "source_merge_sha",
+    "merged_at",
+    "released_at",
+    "category",
+    "title",
+    "summary",
+}
+
+
+def _fail(message: str) -> NoReturn:
+    print(message, file=sys.stderr)
+    raise SystemExit(2)
+
+
+def _api_base() -> str:
+    value = os.getenv("RELEASE_API_URL", "").strip().rstrip("/")
+    if not value:
+        _fail("RELEASE_API_URL is required")
+    return value
+
+
+def _token() -> str:
+    value = os.getenv("RELEASE_WRITER_TOKEN", "").strip()
+    if not value:
+        _fail("RELEASE_WRITER_TOKEN is required")
+    return value
+
+
+def _request(method: str, url: str, payload: dict[str, object] | None = None) -> dict[str, object]:
+    body = None if payload is None else json.dumps(payload, separators=(",", ":")).encode()
+    request = urllib.request.Request(
+        url,
+        data=body,
+        method=method,
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "X-Release-Writer-Token": _token(),
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            return json.loads(response.read().decode())
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")
+        _fail(f"release API returned HTTP {exc.code}: {detail[:1000]}")
+    except urllib.error.URLError as exc:
+        _fail(f"release API request failed: {exc.reason}")
+
+
+def _parse_timestamp(value: object, name: str) -> str:
+    if not isinstance(value, str):
+        _fail(f"{name} must be an ISO-8601 string")
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        _fail(f"{name} must be a valid ISO-8601 timestamp")
+    return value
+
+
+def _validate_release(raw: str) -> dict[str, object]:
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        _fail(f"invalid release JSON: {exc}")
+    if not isinstance(payload, dict):
+        _fail("release payload must be an object")
+    missing = sorted(_REQUIRED - payload.keys())
+    if missing:
+        _fail(f"missing release fields: {', '.join(missing)}")
+    if set(payload) - (_REQUIRED | {"body", "visibility", "status", "sort_order", "provenance_json"}):
+        _fail("release payload contains unsupported fields")
+    repository = payload["source_repository"]
+    if not isinstance(repository, str) or not (1 <= len(repository) <= 255):
+        _fail("source_repository must be 1..255 characters")
+    pr_number = payload["source_pr_number"]
+    if not isinstance(pr_number, int) or pr_number < 1:
+        _fail("source_pr_number must be a positive integer")
+    merge_sha = payload["source_merge_sha"]
+    if not isinstance(merge_sha, str) or not (7 <= len(merge_sha) <= 64):
+        _fail("source_merge_sha must be 7..64 characters")
+    _parse_timestamp(payload["merged_at"], "merged_at")
+    _parse_timestamp(payload["released_at"], "released_at")
+    for name, maximum in (("category", 100), ("title", 255), ("summary", 1200)):
+        value = payload[name]
+        if not isinstance(value, str) or not value.strip() or len(value) > maximum:
+            _fail(f"{name} must be non-empty and at most {maximum} characters")
+    body = payload.get("body")
+    if body is not None and (not isinstance(body, str) or len(body) > 6000):
+        _fail("body must be null or at most 6000 characters")
+    if payload.get("visibility", "public") not in _ALLOWED_VISIBILITY:
+        _fail("unsupported visibility")
+    if payload.get("status", "published") not in _ALLOWED_STATUS:
+        _fail("unsupported status")
+    provenance = payload.get("provenance_json", {})
+    if not isinstance(provenance, dict):
+        _fail("provenance_json must be an object")
+    payload.setdefault("visibility", "public")
+    payload.setdefault("status", "published")
+    payload.setdefault("sort_order", 0)
+    payload.setdefault("provenance_json", {})
+    return payload
+
+
+def _check(repository: str, pr_number: str, merge_sha: str) -> None:
+    try:
+        pr = int(pr_number)
+    except ValueError:
+        _fail("PR number must be an integer")
+    query = urllib.parse.urlencode(
+        {
+            "source_repository": repository,
+            "source_pr_number": pr,
+            "source_merge_sha": merge_sha,
+        }
+    )
+    result = _request("GET", f"{_api_base()}/source?{query}")
+    print(json.dumps(result, separators=(",", ":")))
+
+
+def _skip(raw: str) -> None:
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        _fail(f"invalid skip JSON: {exc}")
+    required = {"source_repository", "source_pr_number", "source_merge_sha", "merged_at", "reason"}
+    if not isinstance(payload, dict) or required - payload.keys():
+        _fail("skip payload is missing required fields")
+    _parse_timestamp(payload["merged_at"], "merged_at")
+    reason = payload["reason"]
+    if not isinstance(reason, str) or not reason.strip() or len(reason) > 500:
+        _fail("skip reason must be non-empty and at most 500 characters")
+    print(json.dumps({"classification": "internal", "skipped": True, **payload}, separators=(",", ":")))
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        _fail("usage: release_writer.py check|publish|skip ...")
+    command = sys.argv[1]
+    if command == "check" and len(sys.argv) == 5:
+        _check(sys.argv[2], sys.argv[3], sys.argv[4])
+        return
+    if command == "publish" and len(sys.argv) == 3:
+        payload = _validate_release(sys.argv[2])
+        result = _request("PUT", _api_base() + "/", payload)
+        print(json.dumps({"published": True, "release": result}, separators=(",", ":")))
+        return
+    if command == "skip" and len(sys.argv) == 3:
+        _skip(sys.argv[2])
+        return
+    _fail("invalid release_writer.py arguments")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release_writer.py
+++ b/scripts/release_writer.py
@@ -153,6 +153,7 @@ def _skip(raw: str) -> None:
 
 
 def main() -> None:
+    """Run the release-writer command-line interface."""
     if len(sys.argv) < 2:
         _fail("usage: release_writer.py check|publish|skip ...")
     command = sys.argv[1]


### PR DESCRIPTION
Closes #1070.

Adds a dedicated read-only OpenCode release-writer role, an after-merge plus reconciliation workflow, and a validated credential-boundary helper that publishes through the release ledger API without exposing the service token in model prompts. Internal-only merges are explicitly classified and skipped instead of being forced into What's New.

The workflow also supports manual single-PR reconciliation and hourly discovery of recent merged PRs missing ledger records. Source identity conflicts fail rather than overwriting provenance.

This connector runtime does not provide a repository checkout or shell, so focused local execution was not available; configured CI is the validation boundary for this branch.