### PR TITLE
Fix crossover group lookup 404s

### DIFF
--- a/docs/changelog.d/2026-08-11-1085.md
+++ b/docs/changelog.d/2026-08-11-1085.md
@@ -1,0 +1,5 @@
+## 2026-08-11
+
+### Reading order
+
+- [#1085](https://github.com/JoshCLWren/comic-pile/pull/1085) fixes crossover group lookups that were hitting a missing API route, so queue and thread views can load reading-order group data without repeated 404 errors.

--- a/frontend/src/services/api-dependency-groups.ts
+++ b/frontend/src/services/api-dependency-groups.ts
@@ -60,10 +60,15 @@ export const dependencyGroupsApi = {
   listForThreads: async (
     threadIds: number[],
   ): Promise<Record<number, DependencyGroupSummary[]>> => {
-    return api.post<Record<number, DependencyGroupSummary[]>>(
-      '/v1/reading-order-groups/threads/groups:batch',
-      { thread_ids: threadIds },
+    const entries = await Promise.all(
+      threadIds.map(async (threadId) => [
+        threadId,
+        await api.get<DependencyGroupSummary[]>(
+          `/v1/reading-order-groups/threads/${threadId}/groups`,
+        ),
+      ] as const),
     )
+    return Object.fromEntries(entries)
   },
 
   addMember: async (

--- a/frontend/src/unit/api-dependency-groups.test.ts
+++ b/frontend/src/unit/api-dependency-groups.test.ts
@@ -79,6 +79,30 @@ describe('dependencyGroupsApi', () => {
     )
   })
 
+  it('loads multiple thread groups through routes that exist on the backend', async () => {
+    apiMock.get
+      .mockResolvedValueOnce([{ id: 7, name: 'Annihilation' }])
+      .mockResolvedValueOnce([])
+
+    await expect(dependencyGroupsApi.listForThreads([42, 43])).resolves.toEqual({
+      42: [{ id: 7, name: 'Annihilation' }],
+      43: [],
+    })
+
+    expect(apiMock.get).toHaveBeenNthCalledWith(
+      1,
+      '/v1/reading-order-groups/threads/42/groups',
+    )
+    expect(apiMock.get).toHaveBeenNthCalledWith(
+      2,
+      '/v1/reading-order-groups/threads/43/groups',
+    )
+    expect(apiMock.post).not.toHaveBeenCalledWith(
+      '/v1/reading-order-groups/threads/groups:batch',
+      expect.anything(),
+    )
+  })
+
   it('adds inclusive issue-position ranges', async () => {
     const result = {
       thread_id: 42,


### PR DESCRIPTION
## Summary
- stop calling the nonexistent reading-order group batch endpoint
- fan out through the existing ownership-scoped per-thread route
- add focused regression coverage for the request paths

This removes the 404 failure family surfaced by maintained Chromium discovery in #1084. The issue remains open until the focused Chromium coverage and discovery rerun confirm the failure family is gone.
