### PR TITLE
Add DB-first ComicVine metadata fallback

### DIFF
--- a/app/services/comicvine_fallback.py
+++ b/app/services/comicvine_fallback.py
@@ -9,6 +9,7 @@ import os
 from pathlib import Path
 
 from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.comicvine_hydration import hydrate_issue
 from app.database import AsyncSessionLocal
@@ -121,6 +122,48 @@ def schedule_issue_metadata_hydration(identity_id: int) -> bool:
     return True
 
 
+async def _hydrate_with_retries(
+    db: AsyncSession,
+    client: ComicVineClient,
+    *,
+    identity_id: int,
+    issue_id: int,
+) -> bool:
+    """Run one bounded provider hydration with retry and rate-limit handling."""
+    for attempt in range(1, COMICVINE_FALLBACK_MAX_ATTEMPTS + 1):
+        try:
+            await hydrate_issue(db, client, issue_id, refresh=True)
+            await db.commit()
+            logger.info(
+                "comicvine_fallback_hydrated identity_id=%s comicvine_issue_id=%s attempt=%s",
+                identity_id,
+                issue_id,
+                attempt,
+            )
+            return True
+        except ComicVineRateLimitError:
+            logger.warning(
+                "comicvine_fallback_deferred identity_id=%s comicvine_issue_id=%s "
+                "reason=rate_limit",
+                identity_id,
+                issue_id,
+            )
+            return False
+        except (ComicVineError, TimeoutError) as exc:
+            logger.warning(
+                "comicvine_fallback_attempt_failed identity_id=%s comicvine_issue_id=%s "
+                "attempt=%s error=%s",
+                identity_id,
+                issue_id,
+                attempt,
+                type(exc).__name__,
+            )
+            if attempt == COMICVINE_FALLBACK_MAX_ATTEMPTS:
+                return False
+            await asyncio.sleep(COMICVINE_FALLBACK_RETRY_DELAY_SECONDS * attempt)
+    return False
+
+
 async def _run_issue_hydration(identity_id: int) -> None:
     """Hydrate one confirmed identity under a cross-process advisory lock."""
     api_key = os.environ.get("COMICVINE_API_KEY", "").strip()
@@ -174,35 +217,9 @@ async def _run_issue_hydration(identity_id: int) -> None:
             cache_dir,
             timeout_seconds=COMICVINE_REQUEST_TIMEOUT_SECONDS,
         )
-
-        for attempt in range(1, COMICVINE_FALLBACK_MAX_ATTEMPTS + 1):
-            try:
-                await hydrate_issue(db, client, issue_id, refresh=True)
-                await db.commit()
-                logger.info(
-                    "comicvine_fallback_hydrated identity_id=%s comicvine_issue_id=%s attempt=%s",
-                    identity_id,
-                    issue_id,
-                    attempt,
-                )
-                return
-            except ComicVineRateLimitError:
-                logger.warning(
-                    "comicvine_fallback_deferred identity_id=%s comicvine_issue_id=%s "
-                    "reason=rate_limit",
-                    identity_id,
-                    issue_id,
-                )
-                return
-            except (ComicVineError, TimeoutError) as exc:
-                logger.warning(
-                    "comicvine_fallback_attempt_failed identity_id=%s comicvine_issue_id=%s "
-                    "attempt=%s error=%s",
-                    identity_id,
-                    issue_id,
-                    attempt,
-                    type(exc).__name__,
-                )
-                if attempt == COMICVINE_FALLBACK_MAX_ATTEMPTS:
-                    return
-                await asyncio.sleep(COMICVINE_FALLBACK_RETRY_DELAY_SECONDS * attempt)
+        await _hydrate_with_retries(
+            db,
+            client,
+            identity_id=identity_id,
+            issue_id=issue_id,
+        )

--- a/app/services/comicvine_fallback.py
+++ b/app/services/comicvine_fallback.py
@@ -1,0 +1,208 @@
+"""Best-effort DB-first ComicVine metadata fallback for issue intelligence."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+import logging
+import os
+from pathlib import Path
+
+from sqlalchemy import text
+
+from app.comicvine_hydration import hydrate_issue
+from app.database import AsyncSessionLocal
+from app.models.external_identity import ExternalIdentity
+from comic_pile.comicvine_provider import (
+    ComicVineClient,
+    ComicVineError,
+    ComicVineRateLimitError,
+)
+
+logger = logging.getLogger(__name__)
+
+COMICVINE_METADATA_MAX_AGE = timedelta(days=30)
+COMICVINE_REQUEST_TIMEOUT_SECONDS = 5.0
+COMICVINE_FALLBACK_MAX_ATTEMPTS = 2
+COMICVINE_FALLBACK_RETRY_DELAY_SECONDS = 0.5
+COMICVINE_FALLBACK_LOCK_NAMESPACE = 1_065_000_000
+
+_REQUIRED_DEEP_RAW_FIELDS = frozenset(
+    {
+        "id",
+        "name",
+        "issue_number",
+        "cover_date",
+        "store_date",
+        "image",
+        "volume",
+        "person_credits",
+        "character_credits",
+        "team_credits",
+        "story_arc_credits",
+        "date_last_updated",
+    }
+)
+
+_pending_hydrations: dict[int, asyncio.Task[None]] = {}
+
+
+def _normalized_timestamp(value: datetime) -> datetime:
+    """Normalize a database timestamp to timezone-aware UTC."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def metadata_needs_hydration(
+    identity: ExternalIdentity,
+    *,
+    now: datetime | None = None,
+) -> bool:
+    """Return whether a confirmed issue identity lacks fresh deep provider metadata.
+
+    Basic ComicVine volume-roster rows are intentionally treated as incomplete because their raw
+    payload does not contain the singular issue relationship fields used by the product UI.
+
+    Args:
+        identity: Confirmed ComicVine issue identity.
+        now: Optional clock override used by tests.
+
+    Returns:
+        True when deep metadata is missing or older than the refresh window.
+    """
+    metadata = identity.metadata_json
+    raw_payload = metadata.get("raw_provider_payload")
+    if not isinstance(raw_payload, dict):
+        return True
+    if not _REQUIRED_DEEP_RAW_FIELDS.issubset(raw_payload):
+        return True
+
+    current_time = now or datetime.now(UTC)
+    updated_at = _normalized_timestamp(identity.updated_at)
+    return current_time - updated_at >= COMICVINE_METADATA_MAX_AGE
+
+
+def _comicvine_issue_id(external_id: str) -> int | None:
+    """Parse a stored ComicVine issue identity without guessing from ComicPile metadata."""
+    normalized = external_id.removeprefix("4000-").strip()
+    return int(normalized) if normalized.isdigit() else None
+
+
+def _clear_pending(identity_id: int, task: asyncio.Task[None]) -> None:
+    """Remove a completed task only when it is still the registered hydration."""
+    if _pending_hydrations.get(identity_id) is task:
+        _pending_hydrations.pop(identity_id, None)
+
+
+def schedule_issue_metadata_hydration(identity_id: int) -> bool:
+    """Schedule at most one in-process hydration for one confirmed external identity.
+
+    Cross-process/provider deduplication is enforced again inside the database task with a
+    PostgreSQL advisory transaction lock, so concurrent serverless instances cannot fan out the
+    same provider lookup.
+
+    Args:
+        identity_id: ``external_identities.id`` for the confirmed ComicVine issue mapping.
+
+    Returns:
+        True when a new task was scheduled, False when one is already pending.
+    """
+    pending = _pending_hydrations.get(identity_id)
+    if pending is not None and not pending.done():
+        return False
+
+    task = asyncio.create_task(
+        _run_issue_hydration(identity_id),
+        name=f"comicvine-fallback-{identity_id}",
+    )
+    _pending_hydrations[identity_id] = task
+    task.add_done_callback(lambda finished: _clear_pending(identity_id, finished))
+    return True
+
+
+async def _run_issue_hydration(identity_id: int) -> None:
+    """Hydrate one confirmed identity under a cross-process advisory lock."""
+    api_key = os.environ.get("COMICVINE_API_KEY", "").strip()
+    if not api_key:
+        logger.info(
+            "comicvine_fallback_skipped identity_id=%s reason=missing_api_key",
+            identity_id,
+        )
+        return
+
+    async with AsyncSessionLocal() as db:
+        lock_key = COMICVINE_FALLBACK_LOCK_NAMESPACE + identity_id
+        lock_result = await db.execute(
+            text("SELECT pg_try_advisory_xact_lock(:lock_key)"),
+            {"lock_key": lock_key},
+        )
+        if not bool(lock_result.scalar()):
+            logger.info(
+                "comicvine_fallback_deduplicated identity_id=%s",
+                identity_id,
+            )
+            return
+
+        identity = await db.get(ExternalIdentity, identity_id)
+        if identity is None or identity.provider != "comicvine" or identity.entity_type != "issue":
+            logger.info(
+                "comicvine_fallback_skipped identity_id=%s reason=identity_not_eligible",
+                identity_id,
+            )
+            return
+        if not metadata_needs_hydration(identity):
+            logger.info(
+                "comicvine_fallback_skipped identity_id=%s reason=metadata_fresh",
+                identity_id,
+            )
+            return
+
+        issue_id = _comicvine_issue_id(identity.external_id)
+        if issue_id is None:
+            logger.warning(
+                "comicvine_fallback_skipped identity_id=%s reason=invalid_external_id",
+                identity_id,
+            )
+            return
+
+        cache_dir = Path(
+            os.environ.get("COMICVINE_CACHE_DIR", "/tmp/comicpile-comicvine")
+        )
+        client = ComicVineClient(
+            api_key,
+            cache_dir,
+            timeout_seconds=COMICVINE_REQUEST_TIMEOUT_SECONDS,
+        )
+
+        for attempt in range(1, COMICVINE_FALLBACK_MAX_ATTEMPTS + 1):
+            try:
+                await hydrate_issue(db, client, issue_id, refresh=True)
+                await db.commit()
+                logger.info(
+                    "comicvine_fallback_hydrated identity_id=%s comicvine_issue_id=%s attempt=%s",
+                    identity_id,
+                    issue_id,
+                    attempt,
+                )
+                return
+            except ComicVineRateLimitError:
+                logger.warning(
+                    "comicvine_fallback_deferred identity_id=%s comicvine_issue_id=%s "
+                    "reason=rate_limit",
+                    identity_id,
+                    issue_id,
+                )
+                return
+            except (ComicVineError, TimeoutError) as exc:
+                logger.warning(
+                    "comicvine_fallback_attempt_failed identity_id=%s comicvine_issue_id=%s "
+                    "attempt=%s error=%s",
+                    identity_id,
+                    issue_id,
+                    attempt,
+                    type(exc).__name__,
+                )
+                if attempt == COMICVINE_FALLBACK_MAX_ATTEMPTS:
+                    return
+                await asyncio.sleep(COMICVINE_FALLBACK_RETRY_DELAY_SECONDS * attempt)

--- a/app/services/comicvine_intelligence.py
+++ b/app/services/comicvine_intelligence.py
@@ -17,6 +17,10 @@ from app.schemas.comicvine import (
     ComicVineRelatedIssue,
     ComicVineStoryArc,
 )
+from app.services.comicvine_fallback import (
+    metadata_needs_hydration,
+    schedule_issue_metadata_hydration,
+)
 
 COMICVINE_PROVIDER = "comicvine"
 MAX_RELATED_ISSUES_PER_ARC = 60
@@ -209,6 +213,9 @@ async def get_issue_intelligence(
 ) -> ComicVineIssueIntelligence | None:
     """Build curated metadata and explicit story-arc relationships for one issue.
 
+    Missing or stale metadata is refreshed asynchronously from the confirmed issue-level ComicVine
+    identity. The current database-backed result is always returned without waiting on ComicVine.
+
     Args:
         db: Async database session.
         issue_id: ComicPile issue identifier.
@@ -220,6 +227,9 @@ async def get_issue_intelligence(
     identity = await _confirmed_identity(db, issue_id)
     if identity is None:
         return None
+
+    if metadata_needs_hydration(identity):
+        schedule_issue_metadata_hydration(identity.id)
 
     metadata = identity.metadata_json
     arc_refs = _arc_references(metadata)

--- a/docs/COMICVINE_RUNTIME_FALLBACK.md
+++ b/docs/COMICVINE_RUNTIME_FALLBACK.md
@@ -1,0 +1,50 @@
+# ComicVine runtime metadata fallback
+
+ComicPile serves issue intelligence from Postgres first. The product may request a best-effort
+ComicVine refresh only when the requested ComicPile issue already has a **confirmed issue-level
+ComicVine identity** and its stored singular-issue metadata is missing or stale.
+
+## Runtime behavior
+
+`GET /api/v1/issues/{issue_id}/comicvine` keeps the current database-backed response on the request
+path. It never waits for ComicVine. When a confirmed mapping needs deeper metadata, the service
+schedules a bounded refresh and returns whatever trusted data is already stored.
+
+The fallback does not search ComicVine by title, issue number, or thread mapping. A thread-to-volume
+mapping is never promoted into an issue identity. Provider relationship data remains informational
+metadata and cannot create dependencies or change Roll eligibility.
+
+Concurrent refreshes are deduplicated in-process and with a PostgreSQL advisory transaction lock so
+separate application instances do not intentionally fan out the same confirmed issue lookup. The
+provider call uses the existing ComicVine client, a five-second network timeout, one bounded retry
+for ordinary provider failures, and no immediate retry after rate limiting. Failures are logged and
+do not fail the Roll or rating experience.
+
+Successful refreshes flow through `app.comicvine_hydration.hydrate_issue`, which normalizes curated
+fields and retains the full singular provider payload in `external_identities.metadata_json`.
+
+## Production configuration
+
+`COMICVINE_API_KEY` must be configured in the **Vercel production project environment** for the
+application runtime. A GitHub Actions repository secret with the same name is available only to
+GitHub Actions and is not automatically injected into Vercel functions.
+
+Optional `COMICVINE_CACHE_DIR` controls the existing provider client's response cache and rolling
+request ledger. The runtime default is `/tmp/comicpile-comicvine`, which is suitable as a
+best-effort serverless cache but must not be treated as durable application state. Postgres remains
+the durable metadata store and the cross-instance deduplication boundary.
+
+Never place the API key in frontend environment variables, source files, logs, screenshots, or
+artifacts.
+
+## Operations and observability
+
+The fallback emits structured log messages prefixed with `comicvine_fallback_` for successful
+hydration, deduplication, missing configuration, rate-limit deferral, ineligible identities, and
+bounded provider failures. Logged context contains internal/external numeric IDs and error types,
+not credentials or provider URLs containing credentials.
+
+For explicit bulk research or repair work, continue to use the existing
+`scripts/hydrate_comicvine_issues.py` workflow. The runtime fallback is deliberately narrow: it
+repairs metadata for confirmed issue identities encountered by the product rather than becoming a
+candidate-discovery or bulk-import mechanism.

--- a/docs/changelog.d/2026-08-11-1086.md
+++ b/docs/changelog.d/2026-08-11-1086.md
@@ -1,0 +1,5 @@
+## 2026-08-11
+
+### Comic details
+
+- [#1086](https://github.com/JoshCLWren/comic-pile/pull/1086) lets ComicPile quietly refresh missing or stale ComicVine issue metadata after serving the trusted database result, so covers, creators, story arcs, and other issue details can repair themselves without making Roll or rating wait on ComicVine.

--- a/tests/test_comicvine_fallback.py
+++ b/tests/test_comicvine_fallback.py
@@ -1,0 +1,318 @@
+"""Tests for DB-first ComicVine issue metadata fallback hydration."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from typing import cast
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Issue, Thread, User
+from app.models.external_identity import ExternalIdentity, IssueExternalIdentityMapping
+from app.services import comicvine_fallback
+from app.services import comicvine_intelligence
+from app.services.comicvine_fallback import (
+    _hydrate_with_retries,
+    metadata_needs_hydration,
+    schedule_issue_metadata_hydration,
+)
+from app.services.comicvine_intelligence import get_issue_intelligence
+from comic_pile.comicvine_provider import ComicVineClient, ComicVineError, ComicVineRateLimitError
+
+
+def _deep_raw_payload() -> dict[str, object]:
+    """Build the singular issue field shape used to distinguish deep hydration from roster data."""
+    return {
+        "id": 123,
+        "name": "Issue title",
+        "issue_number": "1",
+        "cover_date": "2026-01-01",
+        "store_date": "2025-12-15",
+        "image": {},
+        "volume": {"id": 456, "name": "Series"},
+        "person_credits": [],
+        "character_credits": [],
+        "team_credits": [],
+        "story_arc_credits": [],
+        "date_last_updated": "2026-08-01T00:00:00+00:00",
+    }
+
+
+def _identity(*, metadata: dict[str, object], updated_at: datetime) -> ExternalIdentity:
+    """Construct an in-memory ComicVine issue identity for freshness tests."""
+    return ExternalIdentity(
+        id=10,
+        provider="comicvine",
+        entity_type="issue",
+        external_id="123",
+        metadata_json=metadata,
+        updated_at=updated_at,
+    )
+
+
+def test_metadata_freshness_distinguishes_deep_basic_and_stale_rows() -> None:
+    """Only fresh singular-issue metadata avoids a provider fallback."""
+    now = datetime(2026, 8, 11, tzinfo=UTC)
+    fresh = _identity(
+        metadata={"raw_provider_payload": _deep_raw_payload()},
+        updated_at=now - timedelta(days=5),
+    )
+    basic = _identity(
+        metadata={
+            "raw_provider_payload": {
+                "id": 123,
+                "issue_number": "1",
+                "volume": {"id": 456},
+            }
+        },
+        updated_at=now - timedelta(days=1),
+    )
+    stale = _identity(
+        metadata={"raw_provider_payload": _deep_raw_payload()},
+        updated_at=now - timedelta(days=31),
+    )
+
+    assert metadata_needs_hydration(fresh, now=now) is False
+    assert metadata_needs_hydration(basic, now=now) is True
+    assert metadata_needs_hydration(stale, now=now) is True
+
+
+@pytest.mark.asyncio
+async def test_scheduler_deduplicates_concurrent_in_process_requests(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Repeated views in one worker schedule only one live hydration task."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def fake_run(identity_id: int) -> None:
+        assert identity_id == 77
+        started.set()
+        await release.wait()
+
+    monkeypatch.setattr(comicvine_fallback, "_run_issue_hydration", fake_run)
+
+    assert schedule_issue_metadata_hydration(77) is True
+    await started.wait()
+    assert schedule_issue_metadata_hydration(77) is False
+
+    task = comicvine_fallback._pending_hydrations[77]
+    release.set()
+    await task
+    await asyncio.sleep(0)
+    assert 77 not in comicvine_fallback._pending_hydrations
+
+
+@pytest.mark.asyncio
+async def test_no_confirmed_mapping_never_schedules_provider_lookup(
+    async_db: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue intelligence never guesses a ComicVine identity from title, thread, or issue number."""
+    scheduled: list[int] = []
+    monkeypatch.setattr(
+        comicvine_intelligence,
+        "schedule_issue_metadata_hydration",
+        lambda identity_id: scheduled.append(identity_id) or True,
+    )
+
+    result = await get_issue_intelligence(async_db, issue_id=987_654_321, user_id=1)
+
+    assert result is None
+    assert scheduled == []
+
+
+async def _mapped_issue(
+    db: AsyncSession,
+    *,
+    metadata: dict[str, object],
+    username: str,
+) -> tuple[User, Issue, ExternalIdentity]:
+    """Create one owned issue with a confirmed ComicVine issue-level mapping."""
+    user = User(username=username)
+    db.add(user)
+    await db.flush()
+    thread = Thread(
+        title="Fallback test series",
+        format="Comic",
+        issues_remaining=1,
+        queue_position=1,
+        status="active",
+        user_id=user.id,
+    )
+    db.add(thread)
+    await db.flush()
+    issue = Issue(thread_id=thread.id, issue_number="1", position=1, status="unread")
+    db.add(issue)
+    identity = ExternalIdentity(
+        provider="comicvine",
+        entity_type="issue",
+        external_id="123",
+        metadata_json=metadata,
+        updated_at=datetime.now(UTC),
+    )
+    db.add(identity)
+    await db.flush()
+    db.add(
+        IssueExternalIdentityMapping(
+            issue_id=issue.id,
+            external_identity_id=identity.id,
+            status="confirmed",
+            confidence=1.0,
+        )
+    )
+    await db.flush()
+    return user, issue, identity
+
+
+@pytest.mark.asyncio
+async def test_missing_metadata_schedules_refresh_but_returns_current_db_result(
+    async_db: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing metadata row remains usable while its confirmed identity refreshes in background."""
+    user, issue, identity = await _mapped_issue(
+        async_db,
+        metadata={"issue_number": "1"},
+        username="comicvine_fallback_missing",
+    )
+    scheduled: list[int] = []
+    monkeypatch.setattr(
+        comicvine_intelligence,
+        "schedule_issue_metadata_hydration",
+        lambda identity_id: scheduled.append(identity_id) or True,
+    )
+
+    result = await get_issue_intelligence(async_db, issue.id, user.id)
+
+    assert result is not None
+    assert result.comicvine_issue_id == "123"
+    assert result.issue_number == "1"
+    assert scheduled == [identity.id]
+
+
+@pytest.mark.asyncio
+async def test_complete_metadata_causes_no_provider_schedule(
+    async_db: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fresh singular issue metadata is served entirely from Postgres."""
+    user, issue, _identity_row = await _mapped_issue(
+        async_db,
+        metadata={
+            "issue_number": "1",
+            "name": "Issue title",
+            "volume": {"id": 456, "name": "Series"},
+            "raw_provider_payload": _deep_raw_payload(),
+        },
+        username="comicvine_fallback_complete",
+    )
+    scheduled: list[int] = []
+    monkeypatch.setattr(
+        comicvine_intelligence,
+        "schedule_issue_metadata_hydration",
+        lambda identity_id: scheduled.append(identity_id) or True,
+    )
+
+    result = await get_issue_intelligence(async_db, issue.id, user.id)
+
+    assert result is not None
+    assert result.series_name == "Series"
+    assert result.name == "Issue title"
+    assert scheduled == []
+
+
+@pytest.mark.asyncio
+async def test_hydration_success_commits_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A successful live hydration persists through the existing hydrator and commits once."""
+    db = AsyncMock(spec=AsyncSession)
+    client = cast(ComicVineClient, object())
+    calls = 0
+
+    async def fake_hydrate(
+        db_arg: AsyncSession,
+        client_arg: ComicVineClient,
+        issue_id: int,
+        *,
+        refresh: bool = False,
+    ) -> ExternalIdentity:
+        nonlocal calls
+        calls += 1
+        assert db_arg is db
+        assert client_arg is client
+        assert issue_id == 123
+        assert refresh is True
+        return _identity(metadata={}, updated_at=datetime.now(UTC))
+
+    monkeypatch.setattr(comicvine_fallback, "hydrate_issue", fake_hydrate)
+
+    result = await _hydrate_with_retries(db, client, identity_id=10, issue_id=123)
+
+    assert result is True
+    assert calls == 1
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [ComicVineError("malformed provider payload"), TimeoutError("provider timed out")],
+)
+async def test_provider_failure_retries_are_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+) -> None:
+    """Malformed responses and timeouts retry once, then stop without committing."""
+    db = AsyncMock(spec=AsyncSession)
+    client = cast(ComicVineClient, object())
+    calls = 0
+
+    async def fake_hydrate(
+        db_arg: AsyncSession,
+        client_arg: ComicVineClient,
+        issue_id: int,
+        *,
+        refresh: bool = False,
+    ) -> ExternalIdentity:
+        del db_arg, client_arg, issue_id, refresh
+        nonlocal calls
+        calls += 1
+        raise error
+
+    monkeypatch.setattr(comicvine_fallback, "hydrate_issue", fake_hydrate)
+    monkeypatch.setattr(comicvine_fallback, "COMICVINE_FALLBACK_RETRY_DELAY_SECONDS", 0.0)
+
+    result = await _hydrate_with_retries(db, client, identity_id=10, issue_id=123)
+
+    assert result is False
+    assert calls == 2
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_defers_without_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A provider rate limit never creates a retry burst from a product view."""
+    db = AsyncMock(spec=AsyncSession)
+    client = cast(ComicVineClient, object())
+    calls = 0
+
+    async def fake_hydrate(
+        db_arg: AsyncSession,
+        client_arg: ComicVineClient,
+        issue_id: int,
+        *,
+        refresh: bool = False,
+    ) -> ExternalIdentity:
+        del db_arg, client_arg, issue_id, refresh
+        nonlocal calls
+        calls += 1
+        raise ComicVineRateLimitError("rate limited")
+
+    monkeypatch.setattr(comicvine_fallback, "hydrate_issue", fake_hydrate)
+
+    result = await _hydrate_with_retries(db, client, identity_id=10, issue_id=123)
+
+    assert result is False
+    assert calls == 1
+    db.commit.assert_not_awaited()


### PR DESCRIPTION
Issue: #1065

## What changed

- keep issue-intelligence responses DB-first and non-blocking
- refresh only confirmed issue-level ComicVine identities whose deep metadata is missing or stale
- deduplicate concurrent refreshes in-process and with a PostgreSQL advisory lock
- reuse the existing ComicVine client/hydrator with bounded timeout, retry, rate-limit handling, and full provider-payload persistence
- document Vercel production secret placement and runtime operations
- add focused regression coverage for no-mapping, fresh/missing/stale metadata, deduplication, success, timeout/malformed failure, and rate limiting
- add the required user-facing changelog fragment for #1086

## Validation

This runtime does not provide a repository checkout, so no local test command was executed. The branch includes focused tests and relies on configured exact-head CI for executable validation; any branch-caused failure will be repaired before merge.