### PR TITLE
Add persisted continuity plans and explicit rule compilation

### DIFF
--- a/alembic/versions/c85000000001_add_continuity_plans.py
+++ b/alembic/versions/c85000000001_add_continuity_plans.py
@@ -1,0 +1,46 @@
+"""Add persisted continuity plans.
+
+Revision ID: c85000000001
+Revises: c84900000001
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "c85000000001"
+down_revision: str | None = "c84900000001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create user-scoped continuity plan storage."""
+    op.create_table(
+        "continuity_plans",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column("ordering_mode", sa.String(length=32), nullable=False),
+        sa.Column("nodes_json", sa.JSON(), nullable=False),
+        sa.Column("lanes_json", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "ordering_mode IN ('informational', 'strict_sequential')",
+            name="ck_continuity_plans_ordering_mode",
+        ),
+    )
+    op.create_index("ix_continuity_plans_user_id", "continuity_plans", ["user_id"])
+
+
+def downgrade() -> None:
+    """Remove continuity plan storage."""
+    op.drop_index("ix_continuity_plans_user_id", table_name="continuity_plans")
+    op.drop_table("continuity_plans")

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,6 +1,7 @@
 """API route handlers."""
 
 from app.api import analytics as analytics
+from app.api import continuity_plan as continuity_plan
 from app.api import continuity_readiness as continuity_readiness
 from app.api import continuity_rule as continuity_rule
 from app.api import dependency as dependency
@@ -16,12 +17,14 @@ dependency.router.include_router(issue_dependency_batch.router)
 dependency.router.include_router(dependency_group.router)
 dependency.router.include_router(dependency_group_batch.router)
 dependency.router.include_router(continuity_rule.router)
+dependency.router.include_router(continuity_plan.router)
 dependency.router.include_router(continuity_readiness.router)
 dependency.router.include_router(roll_recovery_switch.router, prefix="/roll")
 dependency.router.include_router(releases.router, prefix="/releases")
 
 __all__ = [
     "analytics",
+    "continuity_plan",
     "continuity_readiness",
     "continuity_rule",
     "dependency",

--- a/app/api/continuity_plan.py
+++ b/app/api/continuity_plan.py
@@ -77,7 +77,7 @@ async def _validate_node_ownership(
             await ensure_owned_continuity_node(
                 db,
                 user_id=user_id,
-                node_type=cast(ContinuityNodeType, node.node_type),
+                node_type=node.node_type,
                 node_id=node.ref_id,
             )
         except HTTPException as exc:

--- a/app/api/continuity_plan.py
+++ b/app/api/continuity_plan.py
@@ -1,0 +1,246 @@
+"""Authenticated continuity-plan CRUD and explicit strict-rule compilation."""
+
+from __future__ import annotations
+
+from typing import Annotated, cast
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.continuity_rule import _refresh_blocked_state, _would_create_cycle
+from app.auth import get_current_user
+from app.continuity_rules import ensure_owned_continuity_node
+from app.database import get_db
+from app.models.continuity_plan import ContinuityPlan
+from app.models.continuity_rule import ContinuityRule
+from app.models.thread import Thread
+from app.models.user import User
+from app.schemas.continuity_plan import ContinuityPlanNode, ContinuityPlanResponse, ContinuityPlanWrite
+from app.schemas.continuity_rule import ContinuityNodeType
+
+router = APIRouter(tags=["continuity-plans"])
+
+
+def _marker(plan_id: int) -> str:
+    """Return the durable ownership marker for rules compiled from one plan."""
+    return f"continuity-plan:{plan_id}"
+
+
+def _to_response(plan: ContinuityPlan) -> ContinuityPlanResponse:
+    """Convert persisted JSON into the typed API contract."""
+    return ContinuityPlanResponse(
+        id=plan.id,
+        user_id=plan.user_id,
+        name=plan.name,
+        ordering_mode=plan.ordering_mode,
+        lanes=plan.lanes_json,
+        nodes=plan.nodes_json,
+        created_at=plan.created_at,
+        updated_at=plan.updated_at,
+    )
+
+
+async def _get_owned_plan(db: AsyncSession, user_id: int, plan_id: int) -> ContinuityPlan:
+    """Load one plan without leaking another user's identifiers."""
+    plan = (
+        await db.execute(
+            select(ContinuityPlan).where(
+                ContinuityPlan.id == plan_id,
+                ContinuityPlan.user_id == user_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if plan is None:
+        raise HTTPException(status_code=404, detail=f"Continuity plan {plan_id} not found")
+    return plan
+
+
+async def _validate_node_ownership(
+    db: AsyncSession, *, user_id: int, nodes: list[ContinuityPlanNode]
+) -> None:
+    """Validate every referenced issue, crossover, or thread before any plan write."""
+    for node in nodes:
+        if node.node_type == "thread":
+            owned = (
+                await db.execute(
+                    select(Thread.id).where(Thread.id == node.ref_id, Thread.user_id == user_id)
+                )
+            ).scalar_one_or_none()
+            if owned is None:
+                raise HTTPException(
+                    status_code=422,
+                    detail={"code": "dangling_plan_reference", "node_id": node.id},
+                )
+            continue
+        try:
+            await ensure_owned_continuity_node(
+                db,
+                user_id=user_id,
+                node_type=cast(ContinuityNodeType, node.node_type),
+                node_id=node.ref_id,
+            )
+        except HTTPException as exc:
+            raise HTTPException(
+                status_code=422,
+                detail={"code": "dangling_plan_reference", "node_id": node.id},
+            ) from exc
+
+
+async def _replace_compiled_rules(
+    db: AsyncSession,
+    *,
+    user_id: int,
+    plan: ContinuityPlan,
+    payload: ContinuityPlanWrite,
+) -> bool:
+    """Replace only rules owned by this plan and compile strict linear intent explicitly."""
+    marker = _marker(plan.id)
+    await db.execute(
+        delete(ContinuityRule).where(
+            ContinuityRule.user_id == user_id,
+            ContinuityRule.note == marker,
+        )
+    )
+    if payload.ordering_mode != "strict_sequential" or len(payload.nodes) < 2:
+        return True
+
+    ordered = sorted(payload.nodes, key=lambda node: node.position)
+    for source, target in zip(ordered, ordered[1:], strict=False):
+        source_type = cast(ContinuityNodeType, source.node_type)
+        target_type = cast(ContinuityNodeType, target.node_type)
+        existing = (
+            await db.execute(
+                select(ContinuityRule).where(
+                    ContinuityRule.user_id == user_id,
+                    ContinuityRule.source_type == source_type,
+                    ContinuityRule.source_id == source.ref_id,
+                    ContinuityRule.target_type == target_type,
+                    ContinuityRule.target_id == target.ref_id,
+                )
+            )
+        ).scalar_one_or_none()
+        if existing is not None:
+            if existing.note == marker:
+                continue
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "plan_rule_conflict",
+                    "source_node_id": source.id,
+                    "target_node_id": target.id,
+                },
+            )
+        if await _would_create_cycle(
+            db,
+            user_id=user_id,
+            source_type=source_type,
+            source_id=source.ref_id,
+            target_type=target_type,
+            target_id=target.ref_id,
+        ):
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "continuity_cycle",
+                    "source_node_id": source.id,
+                    "target_node_id": target.id,
+                },
+            )
+        db.add(
+            ContinuityRule(
+                user_id=user_id,
+                source_type=source_type,
+                source_id=source.ref_id,
+                target_type=target_type,
+                target_id=target.ref_id,
+                satisfaction_type="item_read",
+                note=marker,
+            )
+        )
+        await db.flush()
+    return True
+
+
+@router.post("/continuity-plans/", response_model=ContinuityPlanResponse, status_code=201)
+async def create_continuity_plan(
+    payload: ContinuityPlanWrite,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ContinuityPlanResponse:
+    """Create a plan and compile rules only when strict intent is explicit."""
+    await _validate_node_ownership(db, user_id=current_user.id, nodes=payload.nodes)
+    plan = ContinuityPlan(
+        user_id=current_user.id,
+        name=payload.name,
+        ordering_mode=payload.ordering_mode,
+        lanes_json=[lane.model_dump() for lane in payload.lanes],
+        nodes_json=[node.model_dump() for node in payload.nodes],
+    )
+    db.add(plan)
+    await db.flush()
+    try:
+        await _replace_compiled_rules(db, user_id=current_user.id, plan=plan, payload=payload)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    await db.refresh(plan)
+    if payload.ordering_mode == "strict_sequential":
+        await _refresh_blocked_state(current_user.id, db)
+    return _to_response(plan)
+
+
+@router.get("/continuity-plans/{plan_id}", response_model=ContinuityPlanResponse)
+async def get_continuity_plan(
+    plan_id: int,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ContinuityPlanResponse:
+    """Return one owned continuity plan."""
+    return _to_response(await _get_owned_plan(db, current_user.id, plan_id))
+
+
+@router.put("/continuity-plans/{plan_id}", response_model=ContinuityPlanResponse)
+async def update_continuity_plan(
+    plan_id: int,
+    payload: ContinuityPlanWrite,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ContinuityPlanResponse:
+    """Replace a plan atomically, including rules explicitly owned by that plan."""
+    plan = await _get_owned_plan(db, current_user.id, plan_id)
+    await _validate_node_ownership(db, user_id=current_user.id, nodes=payload.nodes)
+    plan.name = payload.name
+    plan.ordering_mode = payload.ordering_mode
+    plan.lanes_json = [lane.model_dump() for lane in payload.lanes]
+    plan.nodes_json = [node.model_dump() for node in payload.nodes]
+    try:
+        await _replace_compiled_rules(db, user_id=current_user.id, plan=plan, payload=payload)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    await db.refresh(plan)
+    await _refresh_blocked_state(current_user.id, db)
+    return _to_response(plan)
+
+
+@router.delete("/continuity-plans/{plan_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_continuity_plan(
+    plan_id: int,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> Response:
+    """Delete one plan and only the hard rules compiled by that plan."""
+    plan = await _get_owned_plan(db, current_user.id, plan_id)
+    await db.execute(
+        delete(ContinuityRule).where(
+            ContinuityRule.user_id == current_user.id,
+            ContinuityRule.note == _marker(plan.id),
+        )
+    )
+    await db.delete(plan)
+    await db.commit()
+    await _refresh_blocked_state(current_user.id, db)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,6 +1,7 @@
 """SQLAlchemy database models."""
 
 from app.models.cbl_reference import CBLSource, CBLSourceEntry, CBLSourceList
+from app.models.continuity_plan import ContinuityPlan
 from app.models.continuity_rule import ContinuityRule, ContinuityRuleSelectedMember
 from app.models.dependency import Dependency
 from app.models.dependency_group import DependencyGroup, DependencyGroupMembership
@@ -24,6 +25,7 @@ __all__ = [
     "CBLSource",
     "CBLSourceEntry",
     "CBLSourceList",
+    "ContinuityPlan",
     "ContinuityRule",
     "ContinuityRuleSelectedMember",
     "Dependency",

--- a/app/models/continuity_plan.py
+++ b/app/models/continuity_plan.py
@@ -1,0 +1,34 @@
+"""Persisted user-authored continuity planning documents."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, JSON, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class ContinuityPlan(Base):
+    """A durable editable continuity plan separate from compiled blocking rules."""
+
+    __tablename__ = "continuity_plans"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    ordering_mode: Mapped[str] = mapped_column(String(32), nullable=False, default="informational")
+    nodes_json: Mapped[list[dict[str, object]]] = mapped_column(JSON, nullable=False, default=list)
+    lanes_json: Mapped[list[dict[str, object]]] = mapped_column(JSON, nullable=False, default=list)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+        nullable=False,
+    )
+
+    __table_args__ = (Index("ix_continuity_plans_user_id", "user_id"),)

--- a/app/schemas/continuity_plan.py
+++ b/app/schemas/continuity_plan.py
@@ -1,0 +1,73 @@
+"""Continuity-plan request and response schemas."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+PlanOrderingMode = Literal["informational", "strict_sequential"]
+PlanNodeType = Literal["issue", "crossover", "thread"]
+
+
+class ContinuityPlanLane(BaseModel):
+    """One visual lane in a continuity plan."""
+
+    id: str = Field(min_length=1, max_length=80)
+    name: str = Field(min_length=1, max_length=120)
+    order: int = Field(ge=0)
+
+
+class ContinuityPlanNode(BaseModel):
+    """One ordered reference in a continuity plan."""
+
+    id: str = Field(min_length=1, max_length=80)
+    node_type: PlanNodeType
+    ref_id: int = Field(gt=0)
+    lane_id: str = Field(min_length=1, max_length=80)
+    position: int = Field(ge=0)
+
+
+class ContinuityPlanWrite(BaseModel):
+    """Create/replace payload for a persisted continuity plan."""
+
+    name: str = Field(min_length=1, max_length=200)
+    ordering_mode: PlanOrderingMode = "informational"
+    lanes: list[ContinuityPlanLane] = Field(min_length=1, max_length=100)
+    nodes: list[ContinuityPlanNode] = Field(default_factory=list, max_length=1000)
+
+    @model_validator(mode="after")
+    def validate_structure(self) -> ContinuityPlanWrite:
+        """Reject duplicate identifiers and malformed lane ordering."""
+        lane_ids = [lane.id for lane in self.lanes]
+        if len(set(lane_ids)) != len(lane_ids):
+            raise ValueError("lane ids must be unique")
+        lane_orders = [lane.order for lane in self.lanes]
+        if len(set(lane_orders)) != len(lane_orders):
+            raise ValueError("lane order values must be unique")
+        node_ids = [node.id for node in self.nodes]
+        if len(set(node_ids)) != len(node_ids):
+            raise ValueError("node ids must be unique")
+        known_lanes = set(lane_ids)
+        if any(node.lane_id not in known_lanes for node in self.nodes):
+            raise ValueError("every node must reference an existing lane")
+        positions_by_lane: dict[str, list[int]] = {}
+        for node in self.nodes:
+            positions_by_lane.setdefault(node.lane_id, []).append(node.position)
+        if any(len(values) != len(set(values)) for values in positions_by_lane.values()):
+            raise ValueError("node positions must be unique within each lane")
+        if self.ordering_mode == "strict_sequential" and any(
+            node.node_type == "thread" for node in self.nodes
+        ):
+            raise ValueError("strict sequential plans may contain only issue/crossover nodes")
+        return self
+
+
+class ContinuityPlanResponse(ContinuityPlanWrite):
+    """Persisted continuity plan response."""
+
+    id: int
+    user_id: int
+    created_at: datetime
+    updated_at: datetime

--- a/app/schemas/continuity_plan.py
+++ b/app/schemas/continuity_plan.py
@@ -39,7 +39,7 @@ class ContinuityPlanWrite(BaseModel):
 
     @model_validator(mode="after")
     def validate_structure(self) -> ContinuityPlanWrite:
-        """Reject duplicate identifiers and malformed lane ordering."""
+        """Reject duplicate identifiers and malformed ordering before persistence."""
         lane_ids = [lane.id for lane in self.lanes]
         if len(set(lane_ids)) != len(lane_ids):
             raise ValueError("lane ids must be unique")
@@ -57,10 +57,14 @@ class ContinuityPlanWrite(BaseModel):
             positions_by_lane.setdefault(node.lane_id, []).append(node.position)
         if any(len(values) != len(set(values)) for values in positions_by_lane.values()):
             raise ValueError("node positions must be unique within each lane")
-        if self.ordering_mode == "strict_sequential" and any(
-            node.node_type == "thread" for node in self.nodes
-        ):
-            raise ValueError("strict sequential plans may contain only issue/crossover nodes")
+        if self.ordering_mode == "strict_sequential":
+            if len(self.lanes) != 1:
+                raise ValueError("strict sequential plans must use exactly one lane")
+            if any(node.node_type == "thread" for node in self.nodes):
+                raise ValueError("strict sequential plans may contain only issue/crossover nodes")
+            positions = sorted(node.position for node in self.nodes)
+            if positions != list(range(len(positions))):
+                raise ValueError("strict sequential positions must be contiguous starting at zero")
         return self
 
 

--- a/docs/changelog.d/2026-08-11-1087.md
+++ b/docs/changelog.d/2026-08-11-1087.md
@@ -1,0 +1,5 @@
+## 2026-08-11
+
+### Continuity planning
+
+- [#1087](https://github.com/JoshCLWren/comic-pile/pull/1087) adds durable editable continuity plans that keep imported or suggested reading order informational by default, while allowing an explicitly strict linear plan to compile into real blocking rules without silently turning every external list into dependencies.

--- a/frontend/src/generated/openapi.json
+++ b/frontend/src/generated/openapi.json
@@ -699,6 +699,188 @@
         "title": "ContinuityBlocker",
         "type": "object"
       },
+      "ContinuityPlanLane": {
+        "description": "One visual lane in a continuity plan.",
+        "properties": {
+          "id": {
+            "maxLength": 80,
+            "minLength": 1,
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "maxLength": 120,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "order": {
+            "minimum": 0.0,
+            "title": "Order",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "order"
+        ],
+        "title": "ContinuityPlanLane",
+        "type": "object"
+      },
+      "ContinuityPlanNode": {
+        "description": "One ordered reference in a continuity plan.",
+        "properties": {
+          "id": {
+            "maxLength": 80,
+            "minLength": 1,
+            "title": "Id",
+            "type": "string"
+          },
+          "lane_id": {
+            "maxLength": 80,
+            "minLength": 1,
+            "title": "Lane Id",
+            "type": "string"
+          },
+          "node_type": {
+            "enum": [
+              "issue",
+              "crossover",
+              "thread"
+            ],
+            "title": "Node Type",
+            "type": "string"
+          },
+          "position": {
+            "minimum": 0.0,
+            "title": "Position",
+            "type": "integer"
+          },
+          "ref_id": {
+            "exclusiveMinimum": 0.0,
+            "title": "Ref Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "node_type",
+          "ref_id",
+          "lane_id",
+          "position"
+        ],
+        "title": "ContinuityPlanNode",
+        "type": "object"
+      },
+      "ContinuityPlanResponse": {
+        "description": "Persisted continuity plan response.",
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "lanes": {
+            "items": {
+              "$ref": "#/components/schemas/ContinuityPlanLane"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "title": "Lanes",
+            "type": "array"
+          },
+          "name": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "nodes": {
+            "items": {
+              "$ref": "#/components/schemas/ContinuityPlanNode"
+            },
+            "maxItems": 1000,
+            "title": "Nodes",
+            "type": "array"
+          },
+          "ordering_mode": {
+            "default": "informational",
+            "enum": [
+              "informational",
+              "strict_sequential"
+            ],
+            "title": "Ordering Mode",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "name",
+          "lanes",
+          "id",
+          "user_id",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ContinuityPlanResponse",
+        "type": "object"
+      },
+      "ContinuityPlanWrite": {
+        "description": "Create/replace payload for a persisted continuity plan.",
+        "properties": {
+          "lanes": {
+            "items": {
+              "$ref": "#/components/schemas/ContinuityPlanLane"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "title": "Lanes",
+            "type": "array"
+          },
+          "name": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "nodes": {
+            "items": {
+              "$ref": "#/components/schemas/ContinuityPlanNode"
+            },
+            "maxItems": 1000,
+            "title": "Nodes",
+            "type": "array"
+          },
+          "ordering_mode": {
+            "default": "informational",
+            "enum": [
+              "informational",
+              "strict_sequential"
+            ],
+            "title": "Ordering Mode",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "lanes"
+        ],
+        "title": "ContinuityPlanWrite",
+        "type": "object"
+      },
       "ContinuityReadinessRequest": {
         "description": "Request readiness for one owned issue, thread, or crossover.",
         "properties": {
@@ -6515,6 +6697,204 @@
         "tags": [
           "auth",
           "auth"
+        ]
+      }
+    },
+    "/api/v1/continuity-plans/": {
+      "post": {
+        "description": "Create a plan and compile rules only when strict intent is explicit.",
+        "operationId": "create_continuity_plan_api_v1_continuity_plans__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ContinuityPlanWrite"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContinuityPlanResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Create Continuity Plan",
+        "tags": [
+          "dependencies",
+          "dependencies",
+          "continuity-plans"
+        ]
+      }
+    },
+    "/api/v1/continuity-plans/{plan_id}": {
+      "delete": {
+        "description": "Delete one plan and only the hard rules compiled by that plan.",
+        "operationId": "delete_continuity_plan_api_v1_continuity_plans__plan_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "plan_id",
+            "required": true,
+            "schema": {
+              "title": "Plan Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Delete Continuity Plan",
+        "tags": [
+          "dependencies",
+          "dependencies",
+          "continuity-plans"
+        ]
+      },
+      "get": {
+        "description": "Return one owned continuity plan.",
+        "operationId": "get_continuity_plan_api_v1_continuity_plans__plan_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "plan_id",
+            "required": true,
+            "schema": {
+              "title": "Plan Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContinuityPlanResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Continuity Plan",
+        "tags": [
+          "dependencies",
+          "dependencies",
+          "continuity-plans"
+        ]
+      },
+      "put": {
+        "description": "Replace a plan atomically, including rules explicitly owned by that plan.",
+        "operationId": "update_continuity_plan_api_v1_continuity_plans__plan_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "plan_id",
+            "required": true,
+            "schema": {
+              "title": "Plan Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ContinuityPlanWrite"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContinuityPlanResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Update Continuity Plan",
+        "tags": [
+          "dependencies",
+          "dependencies",
+          "continuity-plans"
         ]
       }
     },

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -1611,6 +1611,54 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/continuity-plans/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create Continuity Plan
+         * @description Create a plan and compile rules only when strict intent is explicit.
+         */
+        post: operations["create_continuity_plan_api_v1_continuity_plans__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/continuity-plans/{plan_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Continuity Plan
+         * @description Return one owned continuity plan.
+         */
+        get: operations["get_continuity_plan_api_v1_continuity_plans__plan_id__get"];
+        /**
+         * Update Continuity Plan
+         * @description Replace a plan atomically, including rules explicitly owned by that plan.
+         */
+        put: operations["update_continuity_plan_api_v1_continuity_plans__plan_id__put"];
+        post?: never;
+        /**
+         * Delete Continuity Plan
+         * @description Delete one plan and only the hard rules compiled by that plan.
+         */
+        delete: operations["delete_continuity_plan_api_v1_continuity_plans__plan_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/continuity-rules/": {
         parameters: {
             query?: never;
@@ -3586,6 +3634,87 @@ export interface components {
              * @enum {string}
              */
             source_type: "issue" | "crossover";
+        };
+        /**
+         * ContinuityPlanLane
+         * @description One visual lane in a continuity plan.
+         */
+        ContinuityPlanLane: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Order */
+            order: number;
+        };
+        /**
+         * ContinuityPlanNode
+         * @description One ordered reference in a continuity plan.
+         */
+        ContinuityPlanNode: {
+            /** Id */
+            id: string;
+            /** Lane Id */
+            lane_id: string;
+            /**
+             * Node Type
+             * @enum {string}
+             */
+            node_type: "issue" | "crossover" | "thread";
+            /** Position */
+            position: number;
+            /** Ref Id */
+            ref_id: number;
+        };
+        /**
+         * ContinuityPlanResponse
+         * @description Persisted continuity plan response.
+         */
+        ContinuityPlanResponse: {
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Id */
+            id: number;
+            /** Lanes */
+            lanes: components["schemas"]["ContinuityPlanLane"][];
+            /** Name */
+            name: string;
+            /** Nodes */
+            nodes?: components["schemas"]["ContinuityPlanNode"][];
+            /**
+             * Ordering Mode
+             * @default informational
+             * @enum {string}
+             */
+            ordering_mode: "informational" | "strict_sequential";
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+            /** User Id */
+            user_id: number;
+        };
+        /**
+         * ContinuityPlanWrite
+         * @description Create/replace payload for a persisted continuity plan.
+         */
+        ContinuityPlanWrite: {
+            /** Lanes */
+            lanes: components["schemas"]["ContinuityPlanLane"][];
+            /** Name */
+            name: string;
+            /** Nodes */
+            nodes?: components["schemas"]["ContinuityPlanNode"][];
+            /**
+             * Ordering Mode
+             * @default informational
+             * @enum {string}
+             */
+            ordering_mode: "informational" | "strict_sequential";
         };
         /**
          * ContinuityReadinessRequest
@@ -6510,6 +6639,134 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["TokenResponse"];
                 };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_continuity_plan_api_v1_continuity_plans__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ContinuityPlanWrite"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContinuityPlanResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_continuity_plan_api_v1_continuity_plans__plan_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plan_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContinuityPlanResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_continuity_plan_api_v1_continuity_plans__plan_id__put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plan_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ContinuityPlanWrite"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ContinuityPlanResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_continuity_plan_api_v1_continuity_plans__plan_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                plan_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {

--- a/tests/test_continuity_plan_api.py
+++ b/tests/test_continuity_plan_api.py
@@ -1,0 +1,177 @@
+"""API coverage for persisted continuity plans and explicit rule compilation."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api import continuity_plan as continuity_plan_api
+from app.models.continuity_plan import ContinuityPlan
+from app.models.continuity_rule import ContinuityRule
+from app.models.issue import Issue
+from app.models.thread import Thread
+from tests.conftest import get_or_create_user_async
+
+
+async def _make_issue(async_db: AsyncSession, *, user_id: int, suffix: str) -> Issue:
+    """Create one owned issue for continuity-plan tests."""
+    thread = Thread(
+        title=f"Plan {suffix}",
+        format="comic",
+        issues_remaining=1,
+        queue_position=1,
+        status="active",
+        user_id=user_id,
+        total_issues=1,
+        reading_progress="unstarted",
+        created_at=datetime.now(UTC),
+    )
+    async_db.add(thread)
+    await async_db.flush()
+    issue = Issue(thread_id=thread.id, issue_number="1", position=1, status="unread")
+    async_db.add(issue)
+    await async_db.flush()
+    return issue
+
+
+def _plan_payload(issue_ids: list[int], *, mode: str = "informational") -> dict[str, object]:
+    """Build a one-lane plan payload."""
+    return {
+        "name": "Imported crossover",
+        "ordering_mode": mode,
+        "lanes": [{"id": "main", "name": "Main", "order": 0}],
+        "nodes": [
+            {
+                "id": f"issue-{issue_id}",
+                "node_type": "issue",
+                "ref_id": issue_id,
+                "lane_id": "main",
+                "position": position,
+            }
+            for position, issue_id in enumerate(issue_ids)
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_informational_plan_round_trips_without_creating_rules(
+    auth_client: AsyncClient, async_db: AsyncSession
+) -> None:
+    """A long imported order remains purely informational by default."""
+    user = await get_or_create_user_async(async_db)
+    issues = [
+        await _make_issue(async_db, user_id=user.id, suffix=str(index)) for index in range(12)
+    ]
+    await async_db.commit()
+
+    response = await auth_client.post(
+        "/api/v1/continuity-plans/",
+        json=_plan_payload([issue.id for issue in issues]),
+    )
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["ordering_mode"] == "informational"
+    assert [node["ref_id"] for node in body["nodes"]] == [issue.id for issue in issues]
+
+    rules = (
+        await async_db.execute(select(ContinuityRule).where(ContinuityRule.user_id == user.id))
+    ).scalars().all()
+    assert rules == []
+
+    fetched = await auth_client.get(f"/api/v1/continuity-plans/{body['id']}")
+    assert fetched.status_code == 200
+    assert fetched.json()["nodes"] == body["nodes"]
+
+
+@pytest.mark.asyncio
+async def test_strict_plan_compiles_idempotently_then_informational_update_removes_owned_rules(
+    auth_client: AsyncClient,
+    async_db: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit strict intent creates adjacent edges; reverting intent removes only plan-owned edges."""
+    monkeypatch.setattr(continuity_plan_api, "_refresh_blocked_state", AsyncMock())
+    user = await get_or_create_user_async(async_db)
+    issues = [await _make_issue(async_db, user_id=user.id, suffix=str(i)) for i in range(3)]
+    await async_db.commit()
+    payload = _plan_payload([issue.id for issue in issues], mode="strict_sequential")
+
+    created = await auth_client.post("/api/v1/continuity-plans/", json=payload)
+    assert created.status_code == 201, created.text
+    plan_id = created.json()["id"]
+
+    rules = (
+        await async_db.execute(
+            select(ContinuityRule)
+            .where(ContinuityRule.user_id == user.id)
+            .order_by(ContinuityRule.id)
+        )
+    ).scalars().all()
+    assert [(rule.source_id, rule.target_id) for rule in rules] == [
+        (issues[0].id, issues[1].id),
+        (issues[1].id, issues[2].id),
+    ]
+    assert all(rule.note == f"continuity-plan:{plan_id}" for rule in rules)
+
+    repeated = await auth_client.put(f"/api/v1/continuity-plans/{plan_id}", json=payload)
+    assert repeated.status_code == 200, repeated.text
+    count_after_repeat = (
+        await async_db.execute(
+            select(ContinuityRule).where(ContinuityRule.user_id == user.id)
+        )
+    ).scalars().all()
+    assert len(count_after_repeat) == 2
+
+    informational = dict(payload)
+    informational["ordering_mode"] = "informational"
+    updated = await auth_client.put(
+        f"/api/v1/continuity-plans/{plan_id}", json=informational
+    )
+    assert updated.status_code == 200, updated.text
+    remaining = (
+        await async_db.execute(select(ContinuityRule).where(ContinuityRule.user_id == user.id))
+    ).scalars().all()
+    assert remaining == []
+
+
+@pytest.mark.asyncio
+async def test_dangling_reference_rejects_plan_before_write(
+    auth_client: AsyncClient, async_db: AsyncSession
+) -> None:
+    """Invalid references return an editor-friendly error without partial persistence."""
+    payload = _plan_payload([987654321])
+    response = await auth_client.post("/api/v1/continuity-plans/", json=payload)
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "dangling_plan_reference"
+    plans = (await async_db.execute(select(ContinuityPlan))).scalars().all()
+    assert plans == []
+
+
+def test_strict_plan_rejects_parallel_lanes_and_thread_nodes() -> None:
+    """Strict compilation is opt-in and limited to the simple linear shape."""
+    parallel = {
+        "name": "Parallel",
+        "ordering_mode": "strict_sequential",
+        "lanes": [
+            {"id": "a", "name": "A", "order": 0},
+            {"id": "b", "name": "B", "order": 1},
+        ],
+        "nodes": [],
+    }
+    response_shape = continuity_plan_api.ContinuityPlanWrite
+    with pytest.raises(ValueError, match="exactly one lane"):
+        response_shape.model_validate(parallel)
+
+    thread_payload = {
+        "name": "Thread",
+        "ordering_mode": "strict_sequential",
+        "lanes": [{"id": "a", "name": "A", "order": 0}],
+        "nodes": [
+            {"id": "t", "node_type": "thread", "ref_id": 1, "lane_id": "a", "position": 0}
+        ],
+    }
+    with pytest.raises(ValueError, match="issue/crossover"):
+        response_shape.model_validate(thread_payload)


### PR DESCRIPTION
Closes #924

## What changed

- add durable user-scoped continuity plans with typed lanes, nodes, references, and explicit ordering intent
- add authenticated `/api/v1/continuity-plans` create/read/update/delete endpoints
- validate duplicate IDs, lane ordering, dangling ownership references, and strict-linear shape before writes
- keep imported/suggested plans informational by default with zero generated continuity rules
- compile only explicit `strict_sequential` plans into adjacent continuity rules, mark those generated edges per plan, and replace/remove them idempotently
- add migration and regression coverage for informational imports, strict compilation, idempotency, and dangling references

## Validation

This runtime has no repository checkout, so focused tests could not be executed locally. The branch includes focused pytest coverage and will use configured CI as the executable validation boundary; branch-caused failures will be repaired before merge.