### PR TITLE
Fix release backfill script execution from clean checkouts

### DIFF
--- a/docs/changelog.d/2026-08-11-1092.md
+++ b/docs/changelog.d/2026-08-11-1092.md
@@ -1,0 +1,5 @@
+## 2026-08-11
+
+### Release history
+
+- [#1092](https://github.com/JoshCLWren/comic-pile/pull/1092) makes the historical release-ledger backfill command runnable from a clean checkout, preventing the import tool from failing before it can load ComicPile's application code.

--- a/scripts/backfill_release_ledger.py
+++ b/scripts/backfill_release_ledger.py
@@ -16,13 +16,6 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 if str(REPOSITORY_ROOT) not in sys.path:
     sys.path.insert(0, str(REPOSITORY_ROOT))
 
-from app.database import AsyncSessionLocal  # noqa: E402
-from app.services.release_import import (  # noqa: E402
-    audit_changelog_corpus,
-    import_changelog_report,
-    reconcile_changelog_report,
-)
-
 
 def _parser() -> argparse.ArgumentParser:
     """Build the command-line parser with dry-run as the safe default."""
@@ -43,6 +36,13 @@ def _parser() -> argparse.ArgumentParser:
 
 async def _run(repository_root: Path, *, write: bool) -> int:
     """Execute one dry-run or write/reconciliation pass."""
+    from app.database import AsyncSessionLocal
+    from app.services.release_import import (
+        audit_changelog_corpus,
+        import_changelog_report,
+        reconcile_changelog_report,
+    )
+
     audit = audit_changelog_corpus(repository_root)
     print(json.dumps({"phase": "audit", **audit.as_dict()}, indent=2, sort_keys=True))
     if not write:

--- a/scripts/backfill_release_ledger.py
+++ b/scripts/backfill_release_ledger.py
@@ -7,9 +7,17 @@ import argparse
 import asyncio
 import json
 from pathlib import Path
+import sys
 
-from app.database import AsyncSessionLocal
-from app.services.release_import import (
+# Running a script by path puts scripts/ rather than the repository root on
+# sys.path. Add the checkout root before importing the application package so
+# the documented one-shot command works in CI and from a clean checkout.
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from app.database import AsyncSessionLocal  # noqa: E402
+from app.services.release_import import (  # noqa: E402
     audit_changelog_corpus,
     import_changelog_report,
     reconcile_changelog_report,
@@ -27,7 +35,7 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--repository-root",
         type=Path,
-        default=Path(__file__).resolve().parents[1],
+        default=REPOSITORY_ROOT,
         help="ComicPile checkout root containing docs/changelog.md and docs/changelog.d.",
     )
     return parser


### PR DESCRIPTION
Issue: #1068

Repairs the concrete post-merge failure observed in the historical release-ledger backfill: invoking `scripts/backfill_release_ledger.py` from a clean checkout did not put the repository root on Python's import path, so the command failed before any database work.

This PR makes the existing command self-contained when executed by path. It does not rerun or alter the already reconciled production backfill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the historical release-ledger backfill command so it can run successfully from a clean checkout.
  * Enabled direct execution of the command by file path without requiring additional setup.

* **Documentation**
  * Added a changelog entry describing the release-ledger backfill improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->