### PR TITLE
Redesign Roll rating around continuity readiness

### DIFF
--- a/docs/changelog.d/2026-08-11-1088.md
+++ b/docs/changelog.d/2026-08-11-1088.md
@@ -1,5 +1,0 @@
-## 2026-08-11
-
-### Roll
-
-- [#1088](https://github.com/JoshCLWren/comic-pile/pull/1088) redesigns the active rating view around exact-issue continuity readiness, reading-route progress, and a compact mobile-safe rating action area so the next comic is easier to trust and finish without scrolling through unrelated metadata first.

--- a/docs/changelog.d/2026-08-11-1088.md
+++ b/docs/changelog.d/2026-08-11-1088.md
@@ -1,0 +1,5 @@
+## 2026-08-11
+
+### Roll
+
+- [#1088](https://github.com/JoshCLWren/comic-pile/pull/1088) redesigns the active rating view around exact-issue continuity readiness, reading-route progress, and a compact mobile-safe rating action area so the next comic is easier to trust and finish without scrolling through unrelated metadata first.

--- a/docs/changelog.d/2026-08-11-1094.md
+++ b/docs/changelog.d/2026-08-11-1094.md
@@ -1,0 +1,5 @@
+## 2026-08-11
+
+### Roll
+
+- [#1094](https://github.com/JoshCLWren/comic-pile/pull/1094) redesigns the active rating view around exact-issue continuity readiness, reading-route progress, and a compact mobile-safe rating action area so the next comic is easier to trust and finish without scrolling through unrelated metadata first.

--- a/frontend/src/hooks/useContinuityReadiness.ts
+++ b/frontend/src/hooks/useContinuityReadiness.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react'
+import {
+  continuityReadinessApi,
+  type ContinuityReadinessResponse,
+} from '../services/api-continuity-readiness'
+
+interface ContinuityReadinessState {
+  readiness: ContinuityReadinessResponse | null
+  isLoading: boolean
+  error: Error | null
+}
+
+const EMPTY_STATE: ContinuityReadinessState = {
+  readiness: null,
+  isLoading: false,
+  error: null,
+}
+
+export function useContinuityReadiness(
+  issueId: number | null | undefined,
+): ContinuityReadinessState {
+  const [state, setState] = useState<ContinuityReadinessState>(EMPTY_STATE)
+
+  useEffect(() => {
+    if (issueId == null) {
+      setState(EMPTY_STATE)
+      return
+    }
+
+    let isCurrent = true
+    setState({ readiness: null, isLoading: true, error: null })
+
+    continuityReadinessApi.get('issue', issueId).then(
+      (readiness) => {
+        if (isCurrent) {
+          setState({ readiness, isLoading: false, error: null })
+        }
+      },
+      (reason: unknown) => {
+        if (isCurrent) {
+          const error = reason instanceof Error ? reason : new Error('Unable to load readiness')
+          setState({ readiness: null, isLoading: false, error })
+        }
+      },
+    )
+
+    return () => {
+      isCurrent = false
+    }
+  }, [issueId])
+
+  return state
+}

--- a/frontend/src/hooks/useContinuityReadiness.ts
+++ b/frontend/src/hooks/useContinuityReadiness.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import {
   continuityReadinessApi,
   type ContinuityReadinessResponse,
@@ -8,38 +8,42 @@ interface ContinuityReadinessState {
   readiness: ContinuityReadinessResponse | null
   isLoading: boolean
   error: Error | null
+  refetch: () => void
 }
 
 const EMPTY_STATE: ContinuityReadinessState = {
   readiness: null,
   isLoading: false,
   error: null,
+  refetch: () => undefined,
 }
 
 export function useContinuityReadiness(
   issueId: number | null | undefined,
 ): ContinuityReadinessState {
-  const [state, setState] = useState<ContinuityReadinessState>(EMPTY_STATE)
+  const [state, setState] = useState(EMPTY_STATE)
+  const [attempt, setAttempt] = useState(0)
+  const refetch = useCallback(() => setAttempt((value) => value + 1), [])
 
   useEffect(() => {
     if (issueId == null) {
-      setState(EMPTY_STATE)
+      setState({ ...EMPTY_STATE, refetch })
       return
     }
 
     let isCurrent = true
-    setState({ readiness: null, isLoading: true, error: null })
+    setState({ readiness: null, isLoading: true, error: null, refetch })
 
-    continuityReadinessApi.get('issue', issueId).then(
+    continuityReadinessApi.evaluate('issue', issueId).then(
       (readiness) => {
         if (isCurrent) {
-          setState({ readiness, isLoading: false, error: null })
+          setState({ readiness, isLoading: false, error: null, refetch })
         }
       },
       (reason: unknown) => {
         if (isCurrent) {
           const error = reason instanceof Error ? reason : new Error('Unable to load readiness')
-          setState({ readiness: null, isLoading: false, error })
+          setState({ readiness: null, isLoading: false, error, refetch })
         }
       },
     )
@@ -47,7 +51,7 @@ export function useContinuityReadiness(
     return () => {
       isCurrent = false
     }
-  }, [issueId])
+  }, [attempt, issueId, refetch])
 
   return state
 }

--- a/frontend/src/pages/RollPage/components/ContinuityReadinessSummary.tsx
+++ b/frontend/src/pages/RollPage/components/ContinuityReadinessSummary.tsx
@@ -5,7 +5,7 @@ interface ContinuityReadinessSummaryProps {
 }
 
 export function ContinuityReadinessSummary({ issueId }: ContinuityReadinessSummaryProps) {
-  const { readiness, isLoading, error } = useContinuityReadiness(issueId)
+  const { readiness, isLoading, error, refetch } = useContinuityReadiness(issueId)
 
   if (issueId == null) {
     return (
@@ -51,6 +51,13 @@ export function ContinuityReadinessSummary({ issueId }: ContinuityReadinessSumma
         <p className="mt-1 text-[11px] leading-relaxed text-stone-400">
           The roll stays pending. Retry before treating this issue as safe to read.
         </p>
+        <button
+          type="button"
+          onClick={refetch}
+          className="mt-3 min-h-11 rounded-xl border border-rose-700/40 bg-rose-900/20 px-4 text-xs font-black text-rose-200 hover:bg-rose-900/35 focus:ring-2 focus:ring-rose-500"
+        >
+          Retry readiness
+        </button>
       </section>
     )
   }
@@ -82,14 +89,23 @@ export function ContinuityReadinessSummary({ issueId }: ContinuityReadinessSumma
       <h3 id="readiness-heading" className="text-xs font-black text-rose-300">
         Blocked by continuity
       </h3>
-      <ul className="mt-2 space-y-1.5" aria-label="Unresolved prerequisites">
-        {readiness.blockers.map((blocker) => (
-          <li key={blocker.rule_id} className="text-[11px] leading-relaxed text-stone-300">
-            <span className="font-bold text-rose-200">{blocker.source_label}</span>
-            {blocker.note ? <span className="text-stone-500"> · {blocker.note}</span> : null}
-          </li>
-        ))}
-      </ul>
+      {readiness.blockers.length > 0 ? (
+        <ul className="mt-2 space-y-1.5" aria-label="Unresolved prerequisites">
+          {readiness.blockers.map((blocker) => (
+            <li
+              key={`${blocker.rule_id}-${blocker.source_type}-${blocker.source_id}`}
+              className="text-[11px] leading-relaxed text-stone-300"
+            >
+              <span className="font-bold text-rose-200">{blocker.source_label}</span>
+              {blocker.note ? <span className="text-stone-500"> · {blocker.note}</span> : null}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-1 text-[11px] leading-relaxed text-stone-400">
+          The server reported this issue as blocked but returned no prerequisite details.
+        </p>
+      )}
     </section>
   )
 }

--- a/frontend/src/pages/RollPage/components/ContinuityReadinessSummary.tsx
+++ b/frontend/src/pages/RollPage/components/ContinuityReadinessSummary.tsx
@@ -1,0 +1,95 @@
+import { useContinuityReadiness } from '../../../hooks/useContinuityReadiness'
+
+interface ContinuityReadinessSummaryProps {
+  issueId: number | null | undefined
+}
+
+export function ContinuityReadinessSummary({ issueId }: ContinuityReadinessSummaryProps) {
+  const { readiness, isLoading, error } = useContinuityReadiness(issueId)
+
+  if (issueId == null) {
+    return (
+      <section
+        aria-labelledby="readiness-heading"
+        className="rounded-2xl border border-amber-700/30 bg-amber-900/10 p-3"
+      >
+        <h3 id="readiness-heading" className="text-xs font-black text-amber-300">
+          Readiness unavailable
+        </h3>
+        <p className="mt-1 text-[11px] leading-relaxed text-stone-400">
+          ComicPile does not have an exact issue identity for this pending roll yet.
+        </p>
+      </section>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <section
+        aria-labelledby="readiness-heading"
+        className="rounded-2xl border border-white/10 bg-white/5 p-3"
+        role="status"
+        aria-live="polite"
+      >
+        <h3 id="readiness-heading" className="text-xs font-black text-stone-300">
+          Checking reading readiness…
+        </h3>
+      </section>
+    )
+  }
+
+  if (error || !readiness) {
+    return (
+      <section
+        aria-labelledby="readiness-heading"
+        className="rounded-2xl border border-rose-700/30 bg-rose-950/20 p-3"
+        role="alert"
+      >
+        <h3 id="readiness-heading" className="text-xs font-black text-rose-300">
+          Readiness could not be verified
+        </h3>
+        <p className="mt-1 text-[11px] leading-relaxed text-stone-400">
+          The roll stays pending. Retry before treating this issue as safe to read.
+        </p>
+      </section>
+    )
+  }
+
+  if (readiness.is_readable) {
+    return (
+      <section
+        aria-labelledby="readiness-heading"
+        className="rounded-2xl border border-emerald-700/30 bg-emerald-950/20 p-3"
+      >
+        <div className="flex items-center gap-2">
+          <span aria-hidden="true" className="text-emerald-400">✓</span>
+          <h3 id="readiness-heading" className="text-xs font-black text-emerald-300">
+            Ready to read
+          </h3>
+        </div>
+        <p className="mt-1 text-[11px] leading-relaxed text-stone-400">
+          All known direct continuity prerequisites for this exact issue are satisfied.
+        </p>
+      </section>
+    )
+  }
+
+  return (
+    <section
+      aria-labelledby="readiness-heading"
+      className="rounded-2xl border border-rose-700/30 bg-rose-950/20 p-3"
+    >
+      <h3 id="readiness-heading" className="text-xs font-black text-rose-300">
+        Blocked by continuity
+      </h3>
+      <ul className="mt-2 space-y-1.5" aria-label="Unresolved prerequisites">
+        {readiness.blockers.map((blocker) => (
+          <li key={blocker.rule_id} className="text-[11px] leading-relaxed text-stone-300">
+            <span className="font-bold text-rose-200">{blocker.source_label}</span>
+            {blocker.note ? <span className="text-stone-500"> · {blocker.note}</span> : null}
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/frontend/src/pages/RollPage/components/RatingView.tsx
+++ b/frontend/src/pages/RollPage/components/RatingView.tsx
@@ -9,6 +9,12 @@ import { ComicVineIssueCard } from './ComicVineIssueCard'
 import { ContinuityReadinessSummary } from './ContinuityReadinessSummary'
 import { ReadingOrderGroups } from './ReadingOrderGroups'
 
+function getDieDirection(currentDie: number, predictedDie: number): string {
+  if (predictedDie < currentDie) return 'More focused next roll'
+  if (predictedDie > currentDie) return 'More variety next roll'
+  return 'Die stays the same'
+}
+
 interface RatingViewProps {
   activeRatingThread: RatingThread | null
   currentDie: number
@@ -58,7 +64,7 @@ export function RatingView({
   const totalIssues = activeRatingThread?.total_issues ?? null
   const issuesRemaining = activeRatingThread?.issues_remaining ?? 0
   const progress = getProgressPercentage(activeRatingThread)
-  const dieDirection = predictedDie < currentDie ? 'More focused next roll' : predictedDie > currentDie ? 'More variety next roll' : 'Die stays the same'
+  const dieDirection = getDieDirection(currentDie, predictedDie)
 
   async function handleCopyComicReference() {
     if (!activeRatingThread?.title || issueNumber == null) return
@@ -114,6 +120,11 @@ export function RatingView({
               </div>
             ) : null}
           </div>
+          {copyStatus === 'failed' ? (
+            <p className="mt-2 text-[10px] font-bold text-rose-400" role="status">
+              Copy failed. Use Retry copy to try again.
+            </p>
+          ) : null}
 
           <div className="mt-3 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] font-bold text-stone-500">
             {totalIssues && issueNumber != null ? (
@@ -210,6 +221,7 @@ export function RatingView({
           value={rating}
           className="h-4 w-full"
           aria-label="Rating from 0.5 to 5.0 in steps of 0.5"
+          aria-describedby="rating-value queue-effect"
           onChange={(event) => onUpdateRating(event.target.value)}
         />
         <p id="queue-effect" className="text-[11px] font-bold leading-relaxed text-stone-400">
@@ -231,6 +243,11 @@ export function RatingView({
         className="rating-actions sticky bottom-0 -mx-3 space-y-2 border-t border-white/10 bg-[#1a1410]/95 px-3 pt-3 pb-[calc(env(safe-area-inset-bottom)+5.5rem)] backdrop-blur md:static md:-mx-4 md:px-4 md:pb-3"
         data-testid="rating-actions"
       >
+        {errorMessage ? (
+          <div id="error-message" className="text-center text-[10px] font-bold text-rose-500" role="alert">
+            {errorMessage}
+          </div>
+        ) : null}
         <button
           type="button"
           onClick={() => onSubmitRating(false)}
@@ -259,12 +276,6 @@ export function RatingView({
           </button>
         </div>
       </div>
-
-      {errorMessage ? (
-        <div id="error-message" className="text-center text-[10px] font-bold text-rose-500" role="alert">
-          {errorMessage}
-        </div>
-      ) : null}
 
       <ComicVineIssueCard issueId={issueId} />
 

--- a/frontend/src/pages/RollPage/components/RatingView.tsx
+++ b/frontend/src/pages/RollPage/components/RatingView.tsx
@@ -1,15 +1,13 @@
-import type { KeyboardEvent } from 'react'
 import { useState } from 'react'
-import LazyDice3D from '../../../components/LazyDice3D'
-import { isDiceSide } from '../../../components/diceTypes'
-import Tooltip from '../../../components/Tooltip'
 import IssueCorrectionDialog from '../../../components/IssueCorrectionDialog'
-import { RATING_THRESHOLD, getProgressPercentage } from '../utils'
-import type { RatingThread } from '../types'
+import Tooltip from '../../../components/Tooltip'
 import type { ReadingOrder } from '../../../services/api-reading-orders'
 import type { ConnectedThreadInfo } from '../../../types'
-import { ReadingOrderGroups } from './ReadingOrderGroups'
+import { RATING_THRESHOLD, getProgressPercentage } from '../utils'
+import type { RatingThread } from '../types'
 import { ComicVineIssueCard } from './ComicVineIssueCard'
+import { ContinuityReadinessSummary } from './ContinuityReadinessSummary'
+import { ReadingOrderGroups } from './ReadingOrderGroups'
 
 interface RatingViewProps {
   activeRatingThread: RatingThread | null
@@ -54,12 +52,13 @@ export function RatingView({
 }: RatingViewProps) {
   const [isCorrectionDialogOpen, setIsCorrectionDialogOpen] = useState(false)
   const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'failed'>('idle')
-  const previewDie = isDiceSide(currentDie) ? currentDie : 6
-  const threadTitle = activeRatingThread?.title ?? 'Loading...'
+  const threadTitle = activeRatingThread?.title ?? 'Loading…'
   const issueNumber = activeRatingThread?.next_issue_number ?? activeRatingThread?.issue_number ?? null
+  const issueId = activeRatingThread?.issue_id ?? activeRatingThread?.next_issue_id
   const totalIssues = activeRatingThread?.total_issues ?? null
   const issuesRemaining = activeRatingThread?.issues_remaining ?? 0
-  const readingProgress = activeRatingThread?.reading_progress ?? null
+  const progress = getProgressPercentage(activeRatingThread)
+  const dieDirection = predictedDie < currentDie ? 'More focused next roll' : predictedDie > currentDie ? 'More variety next roll' : 'Die stays the same'
 
   async function handleCopyComicReference() {
     if (!activeRatingThread?.title || issueNumber == null) return
@@ -73,259 +72,203 @@ export function RatingView({
   }
 
   return (
-    <div className="p-3 md:p-4 space-y-5 md:space-y-8 relative z-10">
-      <div id="thread-info" role="status" aria-live="polite">
-        <div className="space-y-2 md:space-y-3 text-center">
-      <>
-        <h2 className="text-xl md:text-2xl font-black text-stone-200 truncate">
-          {threadTitle}
-          {issueNumber != null && (
-            <span className="text-stone-400"> #{issueNumber}</span>
-          )}
-        </h2>
-        <div className="flex items-center justify-center gap-3 flex-wrap">
-          {issueNumber != null && (
-            <>
-              <button
-                type="button"
-                onClick={handleCopyComicReference}
-                disabled={!activeRatingThread?.title}
-                className="min-h-11 px-3 flex items-center justify-center gap-2 bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg text-stone-400 hover:text-stone-300 transition-all disabled:opacity-30 disabled:cursor-not-allowed focus:ring-2 focus:ring-amber-500"
-                aria-label={`Copy ${threadTitle} ${issueNumber}`}
-                title="Copy comic reference"
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4" aria-hidden="true">
-                  <path d="M6 2a2 2 0 00-2 2v8a2 2 0 002 2h1v-2H6V4h8v1h2V4a2 2 0 00-2-2H6z" />
-                  <path d="M9 6a2 2 0 00-2 2v8a2 2 0 002 2h7a2 2 0 002-2V8a2 2 0 00-2-2H9zm0 2h7v8H9V8z" />
-                </svg>
-                <span className="text-[10px] font-black uppercase tracking-wider">
-                  {copyStatus === 'copied' ? 'Copied' : copyStatus === 'failed' ? 'Copy failed' : 'Copy'}
-                </span>
-              </button>
-              <button
-                type="button"
-                onClick={() => setIsCorrectionDialogOpen(true)}
-                disabled={!activeRatingThread?.id}
-                className="w-11 h-11 min-w-[44px] flex items-center justify-center bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg text-stone-400 hover:text-stone-300 transition-all disabled:opacity-30 disabled:cursor-not-allowed focus:ring-2 focus:ring-amber-500"
-                aria-label="Correct issue number"
-                title="Correct issue number"
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
-                  <path d="M2.695 14.763l-1.262 3.154a.5.5 0 00.65.65l3.155-1.262a4 4 0 001.343-.885L17.5 5.5a2.121 2.121 0 00-3-3L3.58 13.42a4 4 0 00-.885 1.343z" />
-                </svg>
-              </button>
-            </>
-          )}
-          {totalIssues && issueNumber != null && (
-            <span className="text-stone-400 text-xs font-bold">
-              (#{issueNumber} of {totalIssues})
-            </span>
-          )}
-          {!issueNumber && (
-            <span className="bg-red-800/20 text-red-600 px-3 py-1 rounded-lg text-[10px] font-black uppercase tracking-[0.2em] border border-red-800/20">
-              {activeRatingThread?.format || '...'}
-            </span>
-          )}
-        </div>
-        <div className="flex items-center justify-center gap-2 flex-wrap">
-          <span className="text-stone-400 text-xs font-bold">
-            {getProgressPercentage(activeRatingThread)}% complete
-          </span>
-          <span className="text-stone-600">·</span>
-          <span className="text-stone-500 text-xs font-bold">{issuesRemaining} issues left</span>
-        </div>
-        {hasValidRolledResult && (
-          <div className="flex items-center justify-center">
-            <span className="bg-amber-600/20 text-amber-400 px-3 py-1 rounded-lg text-[10px] font-black uppercase tracking-[0.2em] border border-amber-600/20">
-              You rolled a {rolledResult}!
-            </span>
-          </div>
-        )}
-      </>
-          {readingProgress && totalIssues && (
-            <div className="reading-progress max-w-md mx-auto">
-              <div className="h-3 bg-white/10 rounded-full overflow-hidden">
-                <div
-                  className="h-full bg-amber-600 transition-all duration-300"
-                  style={{
-                    width: `${getProgressPercentage(activeRatingThread)}%`
-                  }}
-                />
-              </div>
-              <span className="mt-1 block text-[10px] text-stone-400 font-bold uppercase tracking-wider">
-                {readingProgress === 'completed' ? 'Completed' : 'In Progress'}
-              </span>
+    <div className="relative z-10 space-y-4 p-3 md:p-4">
+      <section id="thread-info" aria-labelledby="selected-issue-heading" className="space-y-3">
+        <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-3">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-[10px] font-black uppercase tracking-[0.18em] text-stone-500">
+                Selected issue
+              </p>
+              <h2 id="selected-issue-heading" className="mt-1 text-xl font-black leading-tight text-stone-100">
+                {threadTitle}
+                {issueNumber != null ? <span className="text-amber-400"> #{issueNumber}</span> : null}
+              </h2>
+              {hasValidRolledResult ? (
+                <p className="mt-1 text-[11px] font-bold text-stone-400">
+                  Rolled {rolledResult} on d{currentDie}
+                  {currentDie > poolSize ? ` · ${poolSize} eligible` : ''}
+                </p>
+              ) : null}
             </div>
-          )}
-        </div>
-      </div>
+            {issueNumber != null ? (
+              <div className="flex shrink-0 gap-1.5">
+                <button
+                  type="button"
+                  onClick={handleCopyComicReference}
+                  disabled={!activeRatingThread?.title}
+                  className="min-h-11 rounded-xl border border-white/10 bg-white/5 px-3 text-[10px] font-black uppercase tracking-wider text-stone-300 transition hover:bg-white/10 focus:ring-2 focus:ring-amber-500 disabled:opacity-30"
+                  aria-label={`Copy ${threadTitle} ${issueNumber}`}
+                >
+                  {copyStatus === 'copied' ? 'Copied' : copyStatus === 'failed' ? 'Retry copy' : 'Copy'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setIsCorrectionDialogOpen(true)}
+                  disabled={!activeRatingThread?.id}
+                  className="min-h-11 rounded-xl border border-white/10 bg-white/5 px-3 text-[10px] font-black uppercase tracking-wider text-stone-300 transition hover:bg-white/10 focus:ring-2 focus:ring-amber-500 disabled:opacity-30"
+                  aria-label="Correct issue number"
+                >
+                  Edit
+                </button>
+              </div>
+            ) : null}
+          </div>
 
-      {connectedThreads.length > 0 && (
-        <div className="text-center">
-          <div className="inline-flex items-center gap-2 px-3 py-1.5 bg-blue-900/20 border border-blue-700/30 rounded-lg">
-            <span className="text-[10px] font-black uppercase tracking-wider text-blue-400">Connected</span>
-            <Tooltip content={`This thread is linked to ${connectedThreads.length} other thread${connectedThreads.length !== 1 ? 's' : ''} via dependencies.`}>
-              <span tabIndex={0} className="text-[9px] text-blue-500 cursor-help border-b border-dashed border-blue-800">
-                {connectedThreads.map((ct, i) => (
-                  <span key={ct.thread_id}>
-                    {i > 0 && ', '}
-                    {ct.title}
-                  </span>
-                ))}
-              </span>
-            </Tooltip>
+          <div className="mt-3 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] font-bold text-stone-500">
+            {totalIssues && issueNumber != null ? (
+              <span>Issue {issueNumber} of {totalIssues}</span>
+            ) : null}
+            {totalIssues && issueNumber != null ? <span aria-hidden="true">·</span> : null}
+            <span>{progress}% series progress</span>
+            <span aria-hidden="true">·</span>
+            <span>{issuesRemaining} left</span>
           </div>
         </div>
-      )}
+
+        <ContinuityReadinessSummary issueId={issueId} />
+      </section>
+
+      {connectedThreads.length > 0 ? (
+        <section aria-labelledby="connected-heading" className="rounded-2xl border border-blue-800/30 bg-blue-950/15 p-3">
+          <h3 id="connected-heading" className="text-[10px] font-black uppercase tracking-[0.18em] text-blue-400">
+            Verified dependency connections
+          </h3>
+          <ul className="mt-2 flex flex-wrap gap-1.5" aria-label="Connected threads">
+            {connectedThreads.map((connectedThread) => (
+              <li
+                key={`${connectedThread.thread_id}-${connectedThread.dependency_id}`}
+                className="rounded-full border border-blue-800/40 bg-blue-900/20 px-2.5 py-1 text-[10px] font-bold text-blue-200"
+              >
+                {connectedThread.title}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
 
       <ReadingOrderGroups threadId={activeRatingThread?.id} />
 
-      <ComicVineIssueCard issueId={activeRatingThread?.issue_id ?? activeRatingThread?.next_issue_id} />
-
-      <div className="space-y-5 md:space-y-8">
-        <div id="rating-preview-dice" className="dice-perspective">
-          <div
-            id="die-preview-wrapper"
-            className="dice-state-rate-flow relative flex items-center justify-center w-[96px] h-[96px] md:w-[120px] md:h-[120px] mx-auto"
-          >
-            <LazyDice3D
-              sides={previewDie}
-              value={rolledResult || 1}
-              isRolling={false}
-              showValue={false}
-              freeze
-              color={0xffffff}
-            />
+      {readingOrders.length > 0 ? (
+        <section aria-labelledby="routes-heading" className="space-y-2">
+          <div className="flex items-center justify-between gap-2">
+            <h3 id="routes-heading" className="text-[10px] font-black uppercase tracking-[0.18em] text-stone-500">
+              Reading routes
+            </h3>
+            <span className="text-[10px] font-bold text-stone-600">
+              {readingOrders.length} active
+            </span>
           </div>
-          {hasValidRolledResult && (
-            <div className="mt-3 md:mt-6 text-center space-y-1">
-              <p className="text-[10px] font-black uppercase tracking-[0.2em] text-stone-400">
-                Rolled {rolledResult} on d{currentDie}
-              </p>
-              {currentDie > poolSize && (
-                <p
-                  className="text-[9px] font-bold uppercase tracking-wider text-amber-500/80"
-                  data-pool-size-info
-                >
-                  pool size: {poolSize}
-                </p>
-              )}
-            </div>
-          )}
-        </div>
-
-        <div className="text-center space-y-4">
-          <Tooltip content={`Ratings of ${RATING_THRESHOLD.toFixed(1)}+ move the thread to the front and step the die down. Lower ratings move it past the next roll range and step the die up.`}>
-            <p className="text-[10px] font-black uppercase tracking-[0.4em] text-stone-500 cursor-help">How was it?</p>
-          </Tooltip>
-          <div id="rating-value" className={`text-4xl font-black ${rating >= RATING_THRESHOLD ? 'text-amber-500' : 'text-red-700'}`}>
-            {rating.toFixed(1)}
+          <div className="grid gap-2 md:grid-cols-2">
+            {readingOrders.map((order) => {
+              const routeProgress = order.total_items > 0
+                ? Math.round((order.completed_items / order.total_items) * 100)
+                : 0
+              return (
+                <article key={order.id} className="rounded-xl border border-white/10 bg-white/[0.04] p-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <h4 className="truncate text-xs font-black text-stone-200">{order.name}</h4>
+                    <span className="shrink-0 text-[10px] font-bold text-stone-500">
+                      {order.completed_items}/{order.total_items}
+                    </span>
+                  </div>
+                  <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-white/10" aria-hidden="true">
+                    <div className="h-full rounded-full bg-amber-600" style={{ width: `${routeProgress}%` }} />
+                  </div>
+                  <p className="mt-1 text-[10px] font-bold text-stone-500">{routeProgress}% complete</p>
+                </article>
+              )
+            })}
           </div>
-          <input
-            type="range"
-            id="rating-input"
-            name="rating"
-            min="0.5"
-            max="5.0"
-            step="0.5"
-            value={rating}
-            className="w-full h-4"
-            aria-label="Rating from 0.5 to 5.0 in steps of 0.5"
-            onChange={(e) => onUpdateRating(e.target.value)}
-          />
-        </div>
+        </section>
+      ) : null}
 
-        <div
-          className={`p-4 rounded-3xl border shadow-xl ${rating >= RATING_THRESHOLD
-            ? 'bg-amber-600/5 border-amber-600/20'
-            : 'bg-red-800/5 border-red-800/20'
-            }`}
-        >
-          <p id="queue-effect" className="text-[10px] font-black text-stone-300 text-center uppercase tracking-[0.15em] leading-relaxed">
-            {rating >= RATING_THRESHOLD
-              ? `Excellent! Die steps down 🎲 Move to front${predictedDie !== currentDie ? ` (d${predictedDie})` : ''}`
-              : `Okay. Die steps up 🎲 Move past next roll range${predictedDie !== currentDie ? ` (d${predictedDie})` : ''}`}
-          </p>
-        </div>
-
-        {activeRatingThread?.issues_remaining === 1 && (
-          <div className="p-3 rounded-xl bg-amber-600/10 border border-amber-600/20 text-center">
-            <p className="text-[10px] font-black uppercase tracking-[0.15em] text-amber-500">
-              🎉 This is the last issue!
+      <section aria-labelledby="rating-heading" className="space-y-3 rounded-2xl border border-white/10 bg-black/10 p-3">
+        <div className="flex items-end justify-between gap-3">
+          <div>
+            <Tooltip content={`Ratings of ${RATING_THRESHOLD.toFixed(1)}+ move the thread to the front and step the die down. Lower ratings move it past the next roll range and step the die up.`}>
+              <h3 id="rating-heading" className="cursor-help text-[10px] font-black uppercase tracking-[0.18em] text-stone-500">
+                Your rating
+              </h3>
+            </Tooltip>
+            <p id="rating-value" className={`mt-1 text-4xl font-black ${rating >= RATING_THRESHOLD ? 'text-amber-500' : 'text-red-600'}`}>
+              {rating.toFixed(1)}
             </p>
           </div>
-        )}
+          <div className="text-right">
+            <p className="text-sm font-black text-stone-200">d{currentDie} → d{predictedDie}</p>
+            <p className="text-[10px] font-bold text-stone-500">{dieDirection}</p>
+          </div>
+        </div>
+        <input
+          type="range"
+          id="rating-input"
+          name="rating"
+          min="0.5"
+          max="5.0"
+          step="0.5"
+          value={rating}
+          className="h-4 w-full"
+          aria-label="Rating from 0.5 to 5.0 in steps of 0.5"
+          onChange={(event) => onUpdateRating(event.target.value)}
+        />
+        <p id="queue-effect" className="text-[11px] font-bold leading-relaxed text-stone-400">
+          {rating >= RATING_THRESHOLD
+            ? 'Moves this thread to the front of the queue.'
+            : 'Moves this thread beyond the next roll range.'}
+        </p>
+      </section>
 
-        <div
-          className="rating-actions relative -mx-3 md:-mx-4 px-3 md:px-4 pt-4 pb-3 bg-gradient-to-t from-[#1a1410] via-[#1a1410]/95 to-transparent z-20 space-y-2 md:space-y-3"
-          data-testid="rating-actions"
+      {activeRatingThread?.issues_remaining === 1 ? (
+        <div className="rounded-xl border border-amber-600/20 bg-amber-600/10 p-3 text-center">
+          <p className="text-[10px] font-black uppercase tracking-[0.15em] text-amber-500">
+            This is the last issue in the thread
+          </p>
+        </div>
+      ) : null}
+
+      <div
+        className="rating-actions sticky bottom-0 -mx-3 space-y-2 border-t border-white/10 bg-[#1a1410]/95 px-3 pt-3 pb-[calc(env(safe-area-inset-bottom)+5.5rem)] backdrop-blur md:static md:-mx-4 md:px-4 md:pb-3"
+        data-testid="rating-actions"
+      >
+        <button
+          type="button"
+          onClick={() => onSubmitRating(false)}
+          disabled={rateIsPending}
+          data-testid="save-and-continue"
+          className="w-full rounded-xl border border-amber-600/50 bg-amber-600/25 py-3.5 text-xs font-black uppercase tracking-[0.15em] transition hover:bg-amber-600/35 focus:ring-2 focus:ring-amber-500 disabled:opacity-50 active:scale-[0.98]"
         >
+          {rateIsPending ? 'Saving…' : issuesRemaining === 1 ? 'Mark read & complete' : 'Mark read & save'}
+        </button>
+        <div className="flex gap-2">
           <button
             type="button"
-            onClick={() => onSubmitRating(false)}
-            disabled={rateIsPending}
-            data-testid="save-and-continue"
-            className="w-full py-3.5 md:py-4 bg-amber-600/25 hover:bg-amber-600/35 border border-amber-600/50 rounded-xl text-xs font-black uppercase tracking-[0.15em] md:tracking-[0.2em] transition-all disabled:opacity-50 active:scale-[0.98]"
+            onClick={onSnooze}
+            disabled={snoozeIsPending}
+            className="min-h-11 flex-1 rounded-xl border border-white/10 bg-white/5 py-3 text-xs font-black uppercase tracking-[0.15em] text-stone-300 transition hover:bg-white/10 focus:ring-2 focus:ring-amber-500 disabled:opacity-50"
           >
-            {rateIsPending ? 'Saving...' : (issuesRemaining === 1 ? 'Save & Complete' : 'Save & Continue')}
+            {snoozeIsPending ? 'Snoozing…' : 'Snooze'}
           </button>
-          <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={onSnooze}
-              disabled={snoozeIsPending}
-              className="flex-1 py-3 md:py-4 glass-button text-sm font-black uppercase tracking-[0.2em] shadow-[0_15px_40px_rgba(20,184,166,0.3)] disabled:opacity-50 active:scale-[0.98] rounded-xl"
-            >
-              {snoozeIsPending ? 'Snoozing...' : 'Snooze'}
-            </button>
-            <button
-              type="button"
-              onClick={onCancel}
-              disabled={dismissIsPending}
-              className="px-4 py-3 text-[10px] font-bold uppercase tracking-widest text-stone-500 hover:text-stone-300 bg-white/5 border border-white/10 rounded-xl transition-all disabled:opacity-50 active:scale-[0.98]"
-            >
-              Cancel
-            </button>
-          </div>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={dismissIsPending}
+            className="min-h-11 rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-xs font-black uppercase tracking-[0.15em] text-stone-400 transition hover:bg-white/10 focus:ring-2 focus:ring-amber-500 disabled:opacity-50"
+          >
+            Cancel roll
+          </button>
         </div>
-
-        {errorMessage && (
-          <div id="error-message" className="text-[10px] text-rose-500 text-center font-bold">
-            {errorMessage}
-          </div>
-        )}
       </div>
 
-      {readingOrders.length > 0 && (
-        <div className="space-y-3">
-          <h3 className="text-[10px] font-black uppercase tracking-[0.2em] text-stone-500 text-center">Reading Orders</h3>
-          <div className="space-y-2">
-            {readingOrders.map((order) => (
-              <div key={order.id} className="bg-white/5 border border-white/10 rounded-xl p-3">
-                <div className="flex items-center justify-between mb-2">
-                  <h4 className="text-xs font-bold text-stone-300 truncate">{order.name}</h4>
-                  <span className="text-[10px] text-stone-500 font-bold shrink-0 ml-2">
-                    {order.completed_items}/{order.total_items}
-                  </span>
-                </div>
-                {order.description && (
-                  <p className="text-[10px] text-stone-500 mb-2">{order.description}</p>
-                )}
-                <div className="h-1.5 bg-white/10 rounded-full overflow-hidden">
-                  <div
-                    className="h-full bg-amber-600 transition-all duration-300 rounded-full"
-                    style={{
-                      width: `${order.total_items > 0 ? Math.round((order.completed_items / order.total_items) * 100) : 0}%`
-                    }}
-                  />
-                </div>
-              </div>
-            ))}
-          </div>
+      {errorMessage ? (
+        <div id="error-message" className="text-center text-[10px] font-bold text-rose-500" role="alert">
+          {errorMessage}
         </div>
-      )}
+      ) : null}
 
-      {activeRatingThread && (
+      <ComicVineIssueCard issueId={issueId} />
+
+      {activeRatingThread ? (
         <IssueCorrectionDialog
           isOpen={isCorrectionDialogOpen}
           threadId={activeRatingThread.id}
@@ -338,7 +281,7 @@ export function RatingView({
             onRefreshThread()
           }}
         />
-      )}
+      ) : null}
     </div>
   )
 }

--- a/frontend/src/services/api-continuity-readiness.ts
+++ b/frontend/src/services/api-continuity-readiness.ts
@@ -8,7 +8,7 @@ export interface ContinuityBlocker {
   source_id: number
   source_label: string
   satisfaction_type: string
-  satisfied: false
+  satisfied: boolean
   causing_issue_ids: number[]
   causing_member_issue_ids: number[]
   note: string | null
@@ -23,7 +23,7 @@ export interface ContinuityReadinessResponse {
 }
 
 export const continuityReadinessApi = {
-  get: (
+  evaluate: (
     nodeType: ContinuityReadinessNodeType,
     nodeId: number,
   ): Promise<ContinuityReadinessResponse> =>

--- a/frontend/src/services/api-continuity-readiness.ts
+++ b/frontend/src/services/api-continuity-readiness.ts
@@ -1,0 +1,34 @@
+import api from './api'
+
+export type ContinuityReadinessNodeType = 'issue' | 'thread' | 'crossover'
+
+export interface ContinuityBlocker {
+  rule_id: number
+  source_type: 'issue' | 'thread' | 'crossover'
+  source_id: number
+  source_label: string
+  satisfaction_type: string
+  satisfied: false
+  causing_issue_ids: number[]
+  causing_member_issue_ids: number[]
+  note: string | null
+}
+
+export interface ContinuityReadinessResponse {
+  node_type: ContinuityReadinessNodeType
+  node_id: number
+  is_readable: boolean
+  evaluated_issue_id: number | null
+  blockers: ContinuityBlocker[]
+}
+
+export const continuityReadinessApi = {
+  get: (
+    nodeType: ContinuityReadinessNodeType,
+    nodeId: number,
+  ): Promise<ContinuityReadinessResponse> =>
+    api.post<ContinuityReadinessResponse>('/v1/continuity/readiness', {
+      node_type: nodeType,
+      node_id: nodeId,
+    }),
+}

--- a/frontend/src/test/rate.spec.ts
+++ b/frontend/src/test/rate.spec.ts
@@ -41,14 +41,15 @@ test.describe('Rate Thread Feature', () => {
     await expect(actions).toBeVisible();
     await expect(navigation).toBeVisible();
 
-    const [actionsBox, navigationBox] = await Promise.all([
-      actions.boundingBox(),
+    const primaryAction = page.getByRole('button', { name: /Mark read & (save|complete)/ });
+    await expect(primaryAction).toBeVisible();
+    const [buttonBox, navigationBox] = await Promise.all([
+      primaryAction.boundingBox(),
       navigation.boundingBox(),
     ]);
-    expect(actionsBox).not.toBeNull();
+    expect(buttonBox).not.toBeNull();
     expect(navigationBox).not.toBeNull();
-    expect(actionsBox!.y + actionsBox!.height).toBeGreaterThan(navigationBox!.y);
-    await expect(page.getByRole('button', { name: /Mark read & (save|complete)/ })).toBeVisible();
+    expect(buttonBox!.y + buttonBox!.height).toBeLessThanOrEqual(navigationBox!.y);
   });
 
   test('should display rating input on inline rating view', async ({ authenticatedWithThreadsPage }) => {

--- a/frontend/src/test/rate.spec.ts
+++ b/frontend/src/test/rate.spec.ts
@@ -27,6 +27,30 @@ test.describe('Rate Thread Feature', () => {
     await authenticatedWithThreadsPage.waitForSelector(SELECTORS.rate.ratingInput, { timeout: 10000 });
   });
 
+
+  test('keeps readiness, rating, and actions usable above mobile navigation', async ({ authenticatedWithThreadsPage }) => {
+    const page = authenticatedWithThreadsPage;
+    await page.setViewportSize({ width: 430, height: 932 });
+
+    await expect(page.getByRole('heading', { name: /Ready to read|Readiness unavailable|Readiness could not be verified/ })).toBeVisible();
+    await expect(page.locator(SELECTORS.rate.ratingInput)).toBeVisible();
+    await expect(page.locator('[data-roll-pool]')).toHaveCount(0);
+
+    const actions = page.getByTestId('rating-actions');
+    const navigation = page.getByRole('navigation', { name: 'Main navigation' });
+    await expect(actions).toBeVisible();
+    await expect(navigation).toBeVisible();
+
+    const [actionsBox, navigationBox] = await Promise.all([
+      actions.boundingBox(),
+      navigation.boundingBox(),
+    ]);
+    expect(actionsBox).not.toBeNull();
+    expect(navigationBox).not.toBeNull();
+    expect(actionsBox!.y + actionsBox!.height).toBeGreaterThan(navigationBox!.y);
+    await expect(page.getByRole('button', { name: /Mark read & (save|complete)/ })).toBeVisible();
+  });
+
   test('should display rating input on inline rating view', async ({ authenticatedWithThreadsPage }) => {
     await expect(authenticatedWithThreadsPage.locator(SELECTORS.rate.ratingInput)).toBeVisible();
     await expect(authenticatedWithThreadsPage.locator(SELECTORS.rate.submitButton)).toBeVisible();

--- a/frontend/src/unit/ContinuityReadinessSummary.test.tsx
+++ b/frontend/src/unit/ContinuityReadinessSummary.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ContinuityReadinessSummary } from '../pages/RollPage/components/ContinuityReadinessSummary'
+
+const mocks = vi.hoisted(() => ({ useContinuityReadiness: vi.fn() }))
+
+vi.mock('../hooks/useContinuityReadiness', () => ({
+  useContinuityReadiness: mocks.useContinuityReadiness,
+}))
+
+const refetch = vi.fn()
+
+beforeEach(() => {
+  refetch.mockReset()
+})
+
+describe('ContinuityReadinessSummary', () => {
+  it('explains missing identity and loading states', () => {
+    mocks.useContinuityReadiness.mockReturnValue({
+      readiness: null, isLoading: false, error: null, refetch,
+    })
+    const { rerender } = render(<ContinuityReadinessSummary issueId={null} />)
+    expect(screen.getByRole('heading', { name: 'Readiness unavailable' })).toBeVisible()
+
+    mocks.useContinuityReadiness.mockReturnValue({
+      readiness: null, isLoading: true, error: null, refetch,
+    })
+    rerender(<ContinuityReadinessSummary issueId={7} />)
+    expect(screen.getByRole('status')).toHaveTextContent('Checking reading readiness')
+  })
+
+  it('lets the reader retry a failed readiness request', async () => {
+    mocks.useContinuityReadiness.mockReturnValue({
+      readiness: null, isLoading: false, error: new Error('offline'), refetch,
+    })
+    render(<ContinuityReadinessSummary issueId={7} />)
+
+    await userEvent.setup().click(screen.getByRole('button', { name: 'Retry readiness' }))
+    expect(refetch).toHaveBeenCalledOnce()
+  })
+
+  it('renders readable, blocked, and unexplained blocked states', () => {
+    mocks.useContinuityReadiness.mockReturnValue({
+      readiness: { node_type: 'issue', node_id: 7, is_readable: true, evaluated_issue_id: 7, blockers: [] },
+      isLoading: false, error: null, refetch,
+    })
+    const { rerender } = render(<ContinuityReadinessSummary issueId={7} />)
+    expect(screen.getByRole('heading', { name: 'Ready to read' })).toBeVisible()
+
+    mocks.useContinuityReadiness.mockReturnValue({
+      readiness: {
+        node_type: 'issue',
+        node_id: 7,
+        is_readable: false,
+        evaluated_issue_id: 7,
+        blockers: [{
+          rule_id: 2,
+          source_type: 'issue',
+          source_id: 3,
+          source_label: 'Prelude #1',
+          satisfaction_type: 'item_read',
+          satisfied: false,
+          causing_issue_ids: [3],
+          causing_member_issue_ids: [],
+          note: null,
+        }],
+      },
+      isLoading: false, error: null, refetch,
+    })
+    rerender(<ContinuityReadinessSummary issueId={7} />)
+    expect(screen.getByText('Prelude #1')).toBeVisible()
+
+    mocks.useContinuityReadiness.mockReturnValue({
+      readiness: { node_type: 'issue', node_id: 7, is_readable: false, evaluated_issue_id: 7, blockers: [] },
+      isLoading: false, error: null, refetch,
+    })
+    rerender(<ContinuityReadinessSummary issueId={7} />)
+    expect(screen.getByText(/returned no prerequisite details/i)).toBeVisible()
+  })
+})

--- a/frontend/src/unit/RatingView.copy.test.tsx
+++ b/frontend/src/unit/RatingView.copy.test.tsx
@@ -80,6 +80,6 @@ describe('RatingView copy comic reference', () => {
     renderRatingView()
     await user.click(screen.getByRole('button', { name: 'Copy Ultimate X-Men 12' }))
 
-    expect(screen.getByText('Copy failed')).toBeInTheDocument()
+    expect(screen.getByText(/Copy failed/)).toBeInTheDocument()
   })
 })

--- a/frontend/src/unit/RatingView.copy.test.tsx
+++ b/frontend/src/unit/RatingView.copy.test.tsx
@@ -11,6 +11,14 @@ vi.mock('../components/IssueCorrectionDialog', () => ({ default: () => null }))
 vi.mock('../pages/RollPage/components/ReadingOrderGroups', () => ({
   ReadingOrderGroups: () => null,
 }))
+vi.mock('../hooks/useContinuityReadiness', () => ({
+  useContinuityReadiness: () => ({
+    readiness: null,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}))
 
 const callbacks = {
   onUpdateRating: vi.fn(),

--- a/frontend/src/unit/RollComponents.coverage.test.tsx
+++ b/frontend/src/unit/RollComponents.coverage.test.tsx
@@ -115,14 +115,14 @@ describe('RatingView', () => {
     const onUpdateRating = vi.fn(); const onSubmitRating = vi.fn(); const onSnooze = vi.fn(); const onCancel = vi.fn(); const onRefreshThread = vi.fn()
     const user = userEvent.setup()
     render(<RatingView activeRatingThread={{ ...thread, id: 1, issue_number: '2', next_issue_number: '3', reading_progress: 'in_progress' } as never} currentDie={20} rolledResult={19} rating={5} predictedDie={6} hasValidRolledResult poolSize={6} errorMessage="Problem" rateIsPending={false} snoozeIsPending={false} dismissIsPending={false} readingOrders={[]} connectedThreads={[{ thread_id: 2, title: 'Other', connection_type: 'blocks', dependency_id: 1 }]} onUpdateRating={onUpdateRating} onSubmitRating={onSubmitRating} onSnooze={onSnooze} onCancel={onCancel} onRefreshThread={onRefreshThread} />)
-    expect(screen.getByText(/You rolled a 19/)).toBeInTheDocument()
-    expect(screen.getByText(/pool size: 6/)).toBeInTheDocument()
+    expect(screen.getByText(/Rolled 19 on d20/)).toBeInTheDocument()
+    expect(screen.getByText(/6 eligible/)).toBeInTheDocument()
     await user.click(screen.getByRole('button', { name: /correct issue number/i }))
     await user.click(screen.getByRole('button', { name: /close correction/i }))
     const rating = screen.getByRole('slider')
     fireEvent.change(rating, { target: { value: '3' } })
     expect(onUpdateRating).toHaveBeenCalledWith('3')
-    await user.click(screen.getByRole('button', { name: /save & continue/i }))
+    await user.click(screen.getByRole('button', { name: /mark read & save/i }))
     await user.click(screen.getByRole('button', { name: /snooze/i }))
     expect(onSubmitRating).toHaveBeenCalled()
     expect(onSnooze).toHaveBeenCalled()
@@ -138,8 +138,8 @@ describe('RatingView', () => {
     await user.click(screen.getByRole('button', { name: 'Correct successfully' }))
     expect(callbacks.onRefreshThread).toHaveBeenCalled()
     fireEvent.change(screen.getByRole('slider'), { target: { value: '2' } })
-    await user.click(screen.getByRole('button', { name: 'Snoozing...' }))
-    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    await user.click(screen.getByRole('button', { name: 'Snoozing…' }))
+    await user.click(screen.getByRole('button', { name: 'Cancel roll' }))
   })
 
   it('renders safe fallbacks for missing thread metadata and populated reading-order details', () => {
@@ -163,9 +163,9 @@ describe('RatingView', () => {
       onCancel={vi.fn()}
       onRefreshThread={vi.fn()}
     />)
-    expect(screen.getByText('Loading...')).toBeInTheDocument()
-    expect(screen.getByText('A description')).toBeInTheDocument()
-    expect(screen.getByText('0 issues left')).toBeInTheDocument()
+    expect(screen.getByText('Loading…')).toBeInTheDocument()
+    expect(screen.getByText('Main order')).toBeInTheDocument()
+    expect(screen.getByText('0 left')).toBeInTheDocument()
   })
 
   it('renders alternate rating, progress, and order boundaries', async () => {
@@ -187,9 +187,9 @@ describe('RatingView', () => {
       connectedThreads={[{ thread_id: 2, title: 'Only connection', connection_type: 'blocks', dependency_id: 2 }]}
       {...callbacks}
     />)
-    expect(screen.getByText('Comic')).toBeInTheDocument()
-    expect(screen.getByText(/Excellent!/)).toBeInTheDocument()
-    await user.click(screen.getByRole('button', { name: 'Save & Continue' }))
+    expect(screen.getByText('Saga')).toBeInTheDocument()
+    expect(screen.getByText('Die stays the same')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Mark read & save' }))
     expect(callbacks.onSubmitRating).toHaveBeenCalledWith(false)
   })
 
@@ -221,6 +221,6 @@ describe('RatingView', () => {
     // L135 `connectedThreads.length !== 1 ? 's' : ''` is evaluated when building the Tooltip content prop;
     // L139 `i > 0 && ', '` renders the separator between the two connected thread titles.
     expect(screen.getByText('Alpha')).toBeInTheDocument()
-    expect(screen.getByText(', Beta')).toBeInTheDocument()
+    expect(screen.getByText('Beta')).toBeInTheDocument()
   })
 })

--- a/frontend/src/unit/useContinuityReadiness.test.ts
+++ b/frontend/src/unit/useContinuityReadiness.test.ts
@@ -1,0 +1,51 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useContinuityReadiness } from '../hooks/useContinuityReadiness'
+
+const mocks = vi.hoisted(() => ({ evaluate: vi.fn() }))
+
+vi.mock('../services/api-continuity-readiness', () => ({
+  continuityReadinessApi: { evaluate: mocks.evaluate },
+}))
+
+beforeEach(() => {
+  mocks.evaluate.mockReset()
+})
+
+describe('useContinuityReadiness', () => {
+  it('loads readiness and retries the same issue', async () => {
+    const readiness = {
+      node_type: 'issue',
+      node_id: 7,
+      is_readable: true,
+      evaluated_issue_id: 7,
+      blockers: [],
+    }
+    mocks.evaluate.mockResolvedValue(readiness)
+    const { result } = renderHook(() => useContinuityReadiness(7))
+
+    await waitFor(() => expect(result.current.readiness).toEqual(readiness))
+    act(() => result.current.refetch())
+    await waitFor(() => expect(mocks.evaluate).toHaveBeenCalledTimes(2))
+  })
+
+  it('ignores a late response after the issue changes', async () => {
+    let resolveFirst: (value: unknown) => void = () => undefined
+    mocks.evaluate
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveFirst = resolve }))
+      .mockResolvedValueOnce({
+        node_type: 'issue', node_id: 8, is_readable: true, evaluated_issue_id: 8, blockers: [],
+      })
+
+    const { result, rerender } = renderHook(({ issueId }) => useContinuityReadiness(issueId), {
+      initialProps: { issueId: 7 as number | null },
+    })
+    rerender({ issueId: 8 })
+    await waitFor(() => expect(result.current.readiness?.node_id).toBe(8))
+
+    act(() => resolveFirst({
+      node_type: 'issue', node_id: 7, is_readable: false, evaluated_issue_id: 7, blockers: [],
+    }))
+    expect(result.current.readiness?.node_id).toBe(8)
+  })
+})

--- a/frontend/src/unit/useContinuityReadiness.test.tsx
+++ b/frontend/src/unit/useContinuityReadiness.test.tsx
@@ -1,0 +1,88 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useContinuityReadiness } from '../hooks/useContinuityReadiness'
+
+const mocks = vi.hoisted(() => ({ evaluate: vi.fn() }))
+
+vi.mock('../services/api-continuity-readiness', () => ({
+  continuityReadinessApi: { evaluate: mocks.evaluate },
+}))
+
+const readiness = {
+  node_type: 'issue' as const,
+  node_id: 7,
+  is_readable: true,
+  evaluated_issue_id: 7,
+  blockers: [],
+}
+
+beforeEach(() => {
+  mocks.evaluate.mockReset()
+})
+
+describe('useContinuityReadiness', () => {
+  it('stays idle when there is no issue identity', () => {
+    const { result } = renderHook(() => useContinuityReadiness(null))
+
+    expect(result.current).toMatchObject({
+      readiness: null,
+      isLoading: false,
+      error: null,
+    })
+    expect(mocks.evaluate).not.toHaveBeenCalled()
+  })
+
+  it('loads readiness and refetches it on demand', async () => {
+    mocks.evaluate.mockResolvedValue(readiness)
+    const { result } = renderHook(() => useContinuityReadiness(7))
+
+    expect(result.current.isLoading).toBe(true)
+    await waitFor(() => expect(result.current.readiness).toEqual(readiness))
+
+    act(() => result.current.refetch())
+    await waitFor(() => expect(mocks.evaluate).toHaveBeenCalledTimes(2))
+  })
+
+  it.each([
+    [new Error('offline'), 'offline'],
+    ['offline', 'Unable to load readiness'],
+  ])('normalizes a failed readiness request', async (reason, message) => {
+    mocks.evaluate.mockRejectedValue(reason)
+    const { result } = renderHook(() => useContinuityReadiness(7))
+
+    await waitFor(() => expect(result.current.error?.message).toBe(message))
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('ignores a response after the active issue changes', async () => {
+    let resolveRequest: ((value: typeof readiness) => void) | undefined
+    mocks.evaluate.mockReturnValue(
+      new Promise<typeof readiness>((resolve) => {
+        resolveRequest = resolve
+      }),
+    )
+    const { result, rerender } = renderHook(
+      ({ issueId }) => useContinuityReadiness(issueId),
+      { initialProps: { issueId: 7 as number | null } },
+    )
+
+    rerender({ issueId: null })
+    await act(async () => resolveRequest?.(readiness))
+
+    expect(result.current.readiness).toBeNull()
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('ignores a rejection after unmount', async () => {
+    let rejectRequest: ((reason: Error) => void) | undefined
+    mocks.evaluate.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectRequest = reject
+      }),
+    )
+    const { unmount } = renderHook(() => useContinuityReadiness(7))
+
+    unmount()
+    await act(async () => rejectRequest?.(new Error('late')))
+  })
+})


### PR DESCRIPTION
Closes #1088

## What changed
- make exact-issue continuity readiness the first status shown for an active roll
- compact the selected issue, reading-route progress, rating, die consequence, and actions into the primary mobile flow
- remove the duplicated 3D die/result presentation from the rating state
- keep crossover membership informational while showing verified dependency connections separately
- make the rating action area safe above mobile navigation and safe-area insets
- rename the primary action to `Mark read & save` and make cancel semantics explicit

## Validation
This scheduled runtime has no repository checkout or local dependency execution surface. Configured CI is the executable validation boundary for this branch; branch-caused failures will be repaired before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the active rating view with clearer issue context, continuity status, reading progress, and queue effects.
  * Added connected-thread and reading-order progress information.
  * Added continuity readiness indicators showing loading, unavailable, readable, or blocked states with prerequisite details.
  * Added convenient copy and edit controls with updated, compact rating actions.

* **Bug Fixes**
  * Improved handling of continuity readiness errors and outdated requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->