### PR TITLE
Add external factory heartbeat watchdog

### DIFF
--- a/.github/workflows/factory-heartbeat-watchdog.yml
+++ b/.github/workflows/factory-heartbeat-watchdog.yml
@@ -1,0 +1,168 @@
+name: Factory heartbeat watchdog
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: factory-heartbeat-watchdog
+  cancel-in-progress: true
+
+jobs:
+  inspect-heartbeats:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Inspect factory heartbeat registry
+        uses: actions/github-script@v7
+        env:
+          REGISTRY_ISSUE: "1093"
+          STALE_MINUTES: "135"
+          RUNNING_MINUTES: "90"
+        with:
+          script: |
+            const registryIssue = Number(process.env.REGISTRY_ISSUE);
+            const staleMinutes = Number(process.env.STALE_MINUTES);
+            const runningMinutes = Number(process.env.RUNNING_MINUTES);
+            const expectedWorkers = new Map([
+              ["chatgpt-factory-1", { name: "Nova", slot: ":40" }],
+              ["chatgpt-factory-2", { name: "Booster Gold", slot: ":52" }],
+              ["chatgpt-factory-3", { name: "Starman", slot: ":04" }],
+              ["chatgpt-factory-4", { name: "Mister Miracle", slot: ":16" }],
+              ["chatgpt-factory-5", { name: "Death's Head", slot: ":28" }],
+            ]);
+            const marker = "<!-- factory-heartbeat-alert:v1 -->";
+            const now = new Date();
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: registryIssue,
+              per_page: 100,
+            });
+
+            const rows = [];
+            const stale = [];
+            for (const [worker, metadata] of expectedWorkers) {
+              const heartbeatMarker =
+                `<!-- factory-heartbeat:v1 worker=${worker} -->`;
+              const matches = comments.filter((comment) =>
+                comment.body?.includes(heartbeatMarker),
+              );
+              const comment = matches.sort(
+                (left, right) =>
+                  new Date(right.updated_at) - new Date(left.updated_at),
+              )[0];
+
+              if (!comment) {
+                rows.push(
+                  `| ${worker} | ${metadata.name} | ${metadata.slot} | missing | 🔴 missing |`,
+                );
+                stale.push(`${worker} has no heartbeat comment`);
+                continue;
+              }
+
+              const ageMinutes = Math.floor(
+                (now - new Date(comment.updated_at)) / 60000,
+              );
+              const running = /^Outcome:\s*running\s*$/im.test(comment.body ?? "");
+              const unhealthy =
+                ageMinutes > staleMinutes ||
+                (running && ageMinutes > runningMinutes);
+              const status = unhealthy
+                ? running
+                  ? "🔴 stuck running"
+                  : "🔴 stale"
+                : running
+                  ? "🟡 running"
+                  : "🟢 healthy";
+              rows.push(
+                `| ${worker} | ${metadata.name} | ${metadata.slot} | ${ageMinutes}m | ${status} |`,
+              );
+              if (unhealthy) {
+                stale.push(
+                  running
+                    ? `${worker} has reported running for ${ageMinutes} minutes`
+                    : `${worker} has not reported for ${ageMinutes} minutes`,
+                );
+              }
+            }
+
+            const report = [
+              marker,
+              "# Factory heartbeat alert",
+              "",
+              stale.length
+                ? "The external watchdog detected missing or stuck factory heartbeats."
+                : "All five scheduled factories are reporting normally.",
+              "",
+              "| Worker | Call sign | Slot (America/Chicago) | Age | Status |",
+              "|---|---|---:|---:|---|",
+              ...rows,
+              "",
+              `Registry: #${registryIssue}`,
+              `Checked: ${now.toISOString()}`,
+              "",
+              stale.length
+                ? "Open ChatGPT Scheduled to determine whether the task paused, exhausted usage, or needs action. Do not assign this alert to a factory."
+                : "This alert closed automatically after every worker recovered.",
+            ].join("\n");
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "all",
+              per_page: 100,
+            });
+            const alert = issues.find(
+              (issue) =>
+                !issue.pull_request &&
+                issue.body?.includes(marker),
+            );
+
+            if (stale.length) {
+              if (alert) {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: alert.number,
+                  body: report,
+                  state: "open",
+                  assignees: [context.repo.owner],
+                });
+              } else {
+                await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: "Factory heartbeat alert",
+                  body: report,
+                  assignees: [context.repo.owner],
+                });
+              }
+              await core.summary
+                .addHeading("Factory heartbeat warning")
+                .addList(stale)
+                .write();
+            } else if (alert?.state === "open") {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: alert.number,
+                body: report,
+                state: "closed",
+                state_reason: "completed",
+              });
+              await core.summary
+                .addHeading("Factory heartbeat recovery")
+                .addRaw("All five factories are reporting normally.")
+                .write();
+            } else {
+              await core.summary
+                .addHeading("Factory heartbeats healthy")
+                .addRaw("All five factories are reporting normally.")
+                .write();
+            }

--- a/docs/AUTONOMOUS_FACTORY_POLICY.md
+++ b/docs/AUTONOMOUS_FACTORY_POLICY.md
@@ -1,6 +1,6 @@
 # ComicPile Autonomous Factory Policy
 
-Version: 19
+Version: 20
 
 This is the canonical policy for every scheduled ChatGPT worker, the local OpenCode factory, and interactive factory repair sessions.
 
@@ -271,6 +271,14 @@ The packet is operational state, not a substitute for commits, tests, review mar
 acceptance criteria, or truthful labels. Completed and verified work does not require a packet.
 
 Review leases last 45 minutes. Repair and implementation leases last 60 minutes after the latest real progress. Lease expiry permits another worker to continue that issue but does not require a peer to choose it over higher-priority work.
+
+## External scheduled-factory heartbeat
+
+Scheduled ChatGPT workers must update their assigned permanent comment on registry issue #1093 at the start and completion of every run, following `docs/FACTORY_GITHUB_VISIBILITY.md`. The registry and the watchdog's alert issue are operational telemetry, not executable backlog work. Workers must never claim, implement, label, or close them.
+
+A start update records current UTC and `Outcome: running`. A completion update preserves the start time and records current UTC, the actual work item, and truthful outcome. If an update fails, retry once through another available GitHub path and continue delivery; telemetry failure is not authority to stop.
+
+Heartbeat telemetry never counts as substantive progress, never satisfies a valid heartbeat outcome, never outranks executable product work, never extends a lease, and never justifies ending a run. The external watchdog may report missing or stuck heartbeats, but only Josh or an interactive session acting on his direct instruction may change a scheduled task.
 
 ## Communication
 

--- a/docs/CHATGPT_FACTORY_PROMPT.md
+++ b/docs/CHATGPT_FACTORY_PROMPT.md
@@ -1,11 +1,11 @@
 # ChatGPT Scheduled Factory Prompt
 
-Version: 19
+Version: 20
 
 Use this template for every scheduled ComicPile ChatGPT factory. Replace `<WORKER_NUMBER>`, `<WORKER_ID>`, and `<CALL_SIGN>` with the worker-specific values. The worker-specific identity is the only intended difference between scheduled factory prompts.
 
 ```text
-FACTORY POLICY V19 + GITHUB VISIBILITY + DURABLE RESUME PACKET V1. Act as one high-ownership autonomous software-delivery heartbeat for JoshCLWren/comic-pile. Durable worker ID: `<WORKER_ID>`. Factory call sign: `<CALL_SIGN>`.
+FACTORY POLICY V20 + GITHUB VISIBILITY + DURABLE RESUME PACKET V1. Act as one high-ownership autonomous software-delivery heartbeat for JoshCLWren/comic-pile. Durable worker ID: `<WORKER_ID>`. Factory call sign: `<CALL_SIGN>`.
 
 Read and follow current-main `docs/AUTONOMOUS_FACTORY_POLICY.md`, `docs/ISSUE_EXECUTION_PROTOCOL.md`, relevant `AGENTS.md`, and `docs/FACTORY_GITHUB_VISIBILITY.md` when present. Canonical policy wins over conflicting instructions.
 
@@ -14,6 +14,8 @@ Drive every executable issue to truthful closure. Defer #679 while other executa
 Select branch-caused CI/conflict/actionable-review blockers first; then newest unclaimed `user-reported` + `bug`; then E2E bugs; then highest-value unclaimed executable work excluding #679; then required existing-PR work; then factory maintenance only when it blocks delivery. Keep workers separate. Waiting never reserves a worker. Prefer a separate coherent implementation when fewer than four substantive PRs exist.
 
 Use every available GitHub, file, CI, review-thread, commit, push, and merge path. One failed tool call is not permanent capability loss. Never mutate factory schedules or automations unless Josh explicitly instructs you to do so.
+
+At the start of every scheduled run, replace your permanent heartbeat comment on registry issue #1093 using the worker-specific comment ID in `docs/FACTORY_GITHUB_VISIBILITY.md`. Preserve the previous completion timestamp, set `Last run started` to current UTC, and set `Outcome: running`. Before ending the run, replace it again with current UTC completion time, the actual PR/issue worked on, and the truthful outcome. Retry a failed heartbeat update once through another available GitHub path, then continue delivery even if telemetry remains unavailable. Heartbeat telemetry never counts as substantive progress, never outranks executable work, and never justifies ending a run. Never claim, implement, label, or close registry issue #1093 or the watchdog's alert issue.
 
 Keep canonical GitHub marker comments exact. Maintain `factory`, exactly one owner label, and exactly one stage label. Your owner label is `factory:<WORKER_NUMBER>`. Reconcile labels with one full atomic label-set replacement; never use sequential remove/add calls that expose contradictory intermediate states. Labels are internal visibility only.
 

--- a/docs/FACTORY_GITHUB_VISIBILITY.md
+++ b/docs/FACTORY_GITHUB_VISIBILITY.md
@@ -47,3 +47,37 @@ The current factories authenticate as `JoshCLWren`, and their pull requests are 
 CodeRabbit currently submits `COMMENTED` reviews even when it reports actionable comments. The visibility workflow therefore maps a CodeRabbit review body reporting one or more actionable comments to `factory:changes-requested`, while preserving GitHub's real formal review state.
 
 If factory pull requests later use a separate GitHub App or machine-user identity, independent reviewers should submit formal `APPROVE` or `REQUEST_CHANGES` reviews. At that point the built-in review filters can become a stronger first-class view. Do not add a required-approval branch rule until a reliable independent reviewer identity exists, because the present single-account setup would deadlock factory-authored pull requests.
+
+## External heartbeat watchdog
+
+Registry issue [#1093](https://github.com/JoshCLWren/comic-pile/issues/1093) is operational telemetry, not executable backlog work. Factories must never claim, implement, label, or close the registry or the watchdog's alert issue.
+
+Each scheduled factory owns one permanent registry comment:
+
+| Worker | Call sign | Slot (America/Chicago) | Comment ID |
+|---|---|---:|---:|
+| `chatgpt-factory-1` | Nova | `:40` | `5260477681` |
+| `chatgpt-factory-2` | Booster Gold | `:52` | `5260477944` |
+| `chatgpt-factory-3` | Starman | `:04` | `5260478160` |
+| `chatgpt-factory-4` | Mister Miracle | `:16` | `5260478414` |
+| `chatgpt-factory-5` | Death's Head | `:28` | `5260478724` |
+
+At run start, replace only the assigned comment with:
+
+```text
+<!-- factory-heartbeat:v1 worker=<WORKER_ID> -->
+## 🏭 Factory <WORKER_NUMBER> · <CALL_SIGN>
+Scheduled slot: `<SLOT>` America/Chicago
+Last run started: `<current UTC timestamp>`
+Last run completed: `<previous completion timestamp or not yet reported>`
+Worked on: selecting work
+Outcome: running
+Updated by: `<WORKER_ID>`
+```
+
+At run end, replace the same comment again, preserving the start timestamp and recording the current UTC completion timestamp, actual PR or issue, and truthful outcome. Do not create additional heartbeat comments.
+
+The independent `.github/workflows/factory-heartbeat-watchdog.yml` workflow checks every 15 minutes. It reports a worker after 135 minutes without an update or after 90 minutes continuously marked `Outcome: running`. It maintains at most one alert issue and closes that alert when all five workers recover.
+
+Heartbeat writes are mandatory telemetry but never substantive factory progress. They do not satisfy a heartbeat outcome, outrank delivery work, extend a lease, justify ending a run, or excuse a missing implementation. If the update fails, retry once through another available GitHub path, preserve the telemetry failure in the user-visible update when material, and continue delivery.
+

--- a/docs/changelog.d/2026-08-12-1095.md
+++ b/docs/changelog.d/2026-08-12-1095.md
@@ -2,4 +2,4 @@
 
 ### Factory reliability
 
-- [PR #1095](https://github.com/JoshCLWren/comic-pile/pull/1095) adds an external GitHub heartbeat watchdog for all five scheduled factories, making missed runs and stuck workers visible even when ChatGPT pauses silently.
+- [#1095](https://github.com/JoshCLWren/comic-pile/pull/1095) adds an external GitHub heartbeat watchdog for all five scheduled factories, making missed runs and stuck workers visible even when ChatGPT pauses silently.

--- a/docs/changelog.d/2026-08-12-1095.md
+++ b/docs/changelog.d/2026-08-12-1095.md
@@ -1,0 +1,5 @@
+## 2026-08-12
+
+### Factory reliability
+
+- [PR #1095](https://github.com/JoshCLWren/comic-pile/pull/1095) adds an external GitHub heartbeat watchdog for all five scheduled factories, making missed runs and stuck workers visible even when ChatGPT pauses silently.

--- a/scripts/check-autonomous-factory-policy.py
+++ b/scripts/check-autonomous-factory-policy.py
@@ -56,7 +56,7 @@ def validate_texts(policy: str, protocol: str, entrypoint: str) -> None:
         None.
     """
     for needle in (
-        "Version: 19",
+        "Version: 20",
         "Every product, behavior, deployment, operational, or factory-tooling PR must update",
         "exactly one isolated Markdown fragment",
         "`docs/changelog.md` is the frozen historical archive",
@@ -90,6 +90,8 @@ def validate_texts(policy: str, protocol: str, entrypoint: str) -> None:
         "<!-- factory-resume:v1 -->",
         "one full label-set replacement",
         "Never implement a transition as separate remove-then-add calls",
+        "Heartbeat telemetry never counts as substantive progress",
+        "registry issue #1093",
     ):
         require(policy, needle, POLICY)
 
@@ -205,8 +207,10 @@ def validate_local_guidance() -> None:
         require(text, "factory-resume:v1", source)
 
     scheduled = SCHEDULED_PROMPT.read_text(encoding="utf-8")
-    require(scheduled, "Version: 19", SCHEDULED_PROMPT)
+    require(scheduled, "Version: 20", SCHEDULED_PROMPT)
     require(scheduled, "one full atomic label-set replacement", SCHEDULED_PROMPT)
+    require(scheduled, "At the start of every scheduled run", SCHEDULED_PROMPT)
+    require(scheduled, "Heartbeat telemetry never counts as substantive progress", SCHEDULED_PROMPT)
 
     next_task = NEXT_TASK_PROMPT.read_text(encoding="utf-8")
     require(next_task, "only\n  after the PR merges", NEXT_TASK_PROMPT)

--- a/scripts/tests/test_autonomous_factory_policy.py
+++ b/scripts/tests/test_autonomous_factory_policy.py
@@ -95,7 +95,7 @@ class AutonomousFactoryPolicyTests(unittest.TestCase):
             self.validate(entrypoint=f"{self.entrypoint}\n{rule}\n")
 
     def test_current_sources_are_aligned(self) -> None:
-        """Accept the current V19 policy, protocol, and runtime prompts.
+        """Accept the current V20 policy, protocol, and runtime prompts.
 
         Returns:
             None.
@@ -104,12 +104,12 @@ class AutonomousFactoryPolicyTests(unittest.TestCase):
         CHECKER.validate_local_guidance()
 
     def test_version_and_backlog_goal_are_required(self) -> None:
-        """Require V19 and issue-backlog closure as the prime directive.
+        """Require V20 and issue-backlog closure as the prime directive.
 
         Returns:
             None.
         """
-        self.assert_policy_change_fails("Version: 19", "Version: 18")
+        self.assert_policy_change_fails("Version: 20", "Version: 19")
         self.assert_policy_change_fails(
             "Drive the open issue backlog to zero",
             "Keep existing pull requests busy",
@@ -313,6 +313,21 @@ class AutonomousFactoryPolicyTests(unittest.TestCase):
         self.assert_policy_change_fails(
             "one full label-set replacement",
             "several label mutations",
+        )
+
+    def test_external_heartbeat_cannot_count_as_progress(self) -> None:
+        """Require watchdog telemetry without weakening substantive outcomes.
+
+        Returns:
+            None.
+        """
+        self.assert_policy_change_fails(
+            "Heartbeat telemetry never counts as substantive progress",
+            "Heartbeat telemetry satisfies a scheduled run",
+        )
+        self.assert_policy_change_fails(
+            "registry issue #1093",
+            "an unspecified registry",
         )
 
     def test_runtime_rejects_hook_bypass_and_failed_test_commits(self) -> None:


### PR DESCRIPTION
## What changed

- creates registry issue #1093 with one stable comment per scheduled factory
- adds an independent GitHub Actions watchdog that checks every 15 minutes
- reports workers after two missed hourly runs or 90 minutes stuck as running
- maintains one assigned alert issue and closes it automatically after recovery
- documents the exact worker comment IDs and start/completion heartbeat protocol
- updates the canonical scheduled prompt and policy to V20
- adds regression coverage preventing heartbeat telemetry from counting as substantive progress

## Why

ChatGPT Scheduled Tasks can pause automatically or be paused by a worker without an external status webhook. GitHub now provides an independent dead-man switch that remains observable when ChatGPT stops running.

## Validation

- registry issue and five permanent worker comments created successfully
- workflow uses repository-scoped `contents: read` and `issues: write` permissions only
- factory-policy regression suite validates V20 and the telemetry boundary
- workflow supports manual dispatch for exact behavior verification after merge
- changelog fragment added for #1095
