### PR TITLE
Clarify mobile navigation and Roll controls

### DIFF
--- a/docs/changelog.d/2026-08-12-1096.md
+++ b/docs/changelog.d/2026-08-12-1096.md
@@ -1,0 +1,5 @@
+## 2026-08-12
+
+### Mobile navigation and Roll controls
+
+- [#1096](https://github.com/JoshCLWren/comic-pile/pull/1096) makes mobile destinations readable at a glance, moves Sign out into More, reserves safe space above navigation, and replaces ambiguous Roll controls with clear manual-selection and die-mode language.

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -71,6 +71,9 @@ export default function Navigation({ onBugReportSubmit }: NavigationProps) {
   }, [isAuthenticated, logout])
 
   const isActive = (path: string) => location.pathname === path
+  const isMoreRoute = ['/whats-new', '/help', '/glossary'].some((path) =>
+    location.pathname === path,
+  )
 
   const handleLogout = async () => {
     try {
@@ -87,12 +90,12 @@ export default function Navigation({ onBugReportSubmit }: NavigationProps) {
   return (
     <>
       <nav className="fixed bottom-0 left-0 right-0 nav-container z-40" role="navigation" aria-label="Main navigation">
-        <div className="flex justify-around items-center h-14 md:h-20 px-1 md:px-2 max-w-lg md:max-w-2xl lg:max-w-4xl xl:max-w-5xl mx-auto">
-          <Link to="/" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isActive('/') ? 'active' : 'hover:bg-white/5'}`} aria-label="Roll page"><span className="text-2xl" aria-hidden="true">🎲</span><span className="hidden md:block text-[10px] uppercase tracking-widest font-bold nav-label">Roll</span></Link>
-          <Link to="/queue" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isActive('/queue') ? 'active' : 'hover:bg-white/5'}`} aria-label="Queue page"><span className="text-2xl" aria-hidden="true">📚</span><span className="hidden md:block text-[10px] uppercase tracking-widest font-bold nav-label">Queue</span></Link>
-          <Link to="/history" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isActive('/history') ? 'active' : 'hover:bg-white/5'}`} aria-label="History page"><span className="text-2xl" aria-hidden="true">📜</span><span className="hidden md:block text-[10px] uppercase tracking-widest font-bold nav-label">History</span></Link>
-          <Link to="/crossovers" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isActive('/crossovers') ? 'active' : 'hover:bg-white/5'}`} aria-label="Crossovers page"><span className="text-2xl" aria-hidden="true">🔀</span><span className="hidden md:block text-[10px] uppercase tracking-widest font-bold nav-label">Crossovers</span></Link>
-          <button ref={moreButtonRef} type="button" onClick={() => setIsMoreOpen(value => !value)} aria-expanded={isMoreOpen} aria-controls="secondary-navigation" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isMoreOpen || isActive('/help') || isActive('/whats-new') ? 'active' : 'hover:bg-white/5'}`} aria-label="More pages"><span className="text-2xl" aria-hidden="true">•••</span><span className="hidden md:block text-[10px] uppercase tracking-widest font-bold nav-label">More</span></button>
+        <div className="flex h-14 items-center justify-around px-1 md:h-20 md:px-2 max-w-lg md:max-w-2xl lg:max-w-4xl xl:max-w-5xl mx-auto">
+          <Link to="/" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isActive('/') ? 'active' : 'hover:bg-white/5'}`} aria-label="Roll page"><span className="text-lg md:text-2xl" aria-hidden="true">🎲</span><span className="nav-label text-[9px] font-bold uppercase tracking-wide md:text-[10px] md:tracking-widest">Roll</span></Link>
+          <Link to="/queue" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isActive('/queue') ? 'active' : 'hover:bg-white/5'}`} aria-label="Queue page"><span className="text-lg md:text-2xl" aria-hidden="true">📚</span><span className="nav-label text-[9px] font-bold uppercase tracking-wide md:text-[10px] md:tracking-widest">Queue</span></Link>
+          <Link to="/history" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isActive('/history') ? 'active' : 'hover:bg-white/5'}`} aria-label="History page"><span className="text-lg md:text-2xl" aria-hidden="true">📜</span><span className="nav-label text-[9px] font-bold uppercase tracking-wide md:text-[10px] md:tracking-widest">History</span></Link>
+          <Link to="/crossovers" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isActive('/crossovers') ? 'active' : 'hover:bg-white/5'}`} aria-label="Crossovers page"><span className="text-lg md:text-2xl" aria-hidden="true">🔀</span><span className="nav-label text-[9px] font-bold uppercase tracking-wide md:text-[10px] md:tracking-widest">Crossovers</span></Link>
+          <button ref={moreButtonRef} type="button" onClick={() => setIsMoreOpen(value => !value)} aria-expanded={isMoreOpen} aria-controls="secondary-navigation" className={`nav-item flex flex-col items-center justify-center flex-1 h-full transition-all duration-200 focus:outline-none ${isMoreOpen || isMoreRoute ? 'active' : 'hover:bg-white/5'}`} aria-label="More pages"><span className="text-lg md:text-2xl" aria-hidden="true">•••</span><span className="nav-label text-[9px] font-bold uppercase tracking-wide md:text-[10px] md:tracking-widest">More</span></button>
         </div>
       </nav>
 
@@ -100,11 +103,16 @@ export default function Navigation({ onBugReportSubmit }: NavigationProps) {
         <nav ref={moreMenuRef} id="secondary-navigation" aria-label="More pages" className="fixed bottom-16 right-3 z-50 w-56 rounded-2xl border border-stone-700 bg-stone-950 p-2 shadow-2xl md:bottom-24 md:right-6">
           <Link to="/whats-new" className="flex min-h-12 items-center gap-3 rounded-xl px-4 py-3 font-bold text-stone-100 hover:bg-stone-800"><span aria-hidden="true">✨</span><span>What’s New</span></Link>
           <Link to="/help" className="flex min-h-12 items-center gap-3 rounded-xl px-4 py-3 font-bold text-stone-100 hover:bg-stone-800"><span aria-hidden="true">❓</span><span>Help</span></Link>
-          <div className="border-t border-stone-800 pt-2 md:hidden"><BugReportButton onSubmit={onBugReportSubmit} variant="nav" /></div>
+          <div className="space-y-1 border-t border-stone-800 pt-2 md:hidden">
+            <BugReportButton onSubmit={onBugReportSubmit} variant="nav" />
+            <button type="button" onClick={handleLogout} className="flex min-h-12 w-full items-center gap-3 rounded-xl px-4 py-3 text-left font-bold text-red-300 hover:bg-stone-800">
+              <span aria-hidden="true">⎋</span><span>Sign out</span>
+            </button>
+          </div>
         </nav>
       )}
 
-      <div className="fixed top-2 right-2 md:top-4 md:right-4 z-50 flex items-center gap-2 md:gap-3">
+      <div className="fixed right-4 top-4 z-50 hidden items-center gap-3 md:flex">
         {isLoading ? <span className="hidden md:inline text-xs text-stone-500 font-medium px-2 py-1">Loading...</span> : hasError ? <span className="hidden md:inline text-xs text-amber-500 font-medium px-2 py-1" title="Failed to load user data">User</span> : username ? <span className="hidden md:inline text-xs text-stone-400 font-medium px-2 py-1">{username}</span> : null}
         <button onClick={handleLogout} className="px-2 py-1.5 md:px-3 text-xs font-bold uppercase tracking-widest text-red-400 hover:text-red-300 bg-[#110e0a]/60 hover:bg-[#110e0a]/80 rounded-lg transition-colors" aria-label="Log out"><span className="md:hidden" aria-hidden="true">⎋</span><span className="hidden md:inline">Log Out</span></button>
       </div>

--- a/frontend/src/pages/RollPage/index.tsx
+++ b/frontend/src/pages/RollPage/index.tsx
@@ -891,7 +891,7 @@ export default function RollPage() {
           </form>
         </Modal>
 
-        <Modal isOpen={isDieModalOpen} title="Choose die" onClose={() => setIsDieModalOpen(false)}>
+        <Modal isOpen={isDieModalOpen} title="Select Die" onClose={() => setIsDieModalOpen(false)}>
           <p className="mb-3 text-xs text-stone-400">
             {bootstrap.manual_die
               ? `Manual mode is active at d${bootstrap.manual_die}. Choose another die or return to automatic mode.`
@@ -908,7 +908,7 @@ export default function RollPage() {
             <button onClick={async () => { await handleClearManualDie(); setIsDieModalOpen(false) }}
               disabled={clearManualDieMutation.isPending}
               className={`px-3 py-3 text-sm font-black rounded-lg border transition-colors ${bootstrap.manual_die ? 'bg-amber-500/20 border-amber-500 text-amber-400' : 'bg-white/5 border-white/10 hover:bg-white/10'}`}>
-              Use automatic
+              Auto
             </button>
           </div>
         </Modal>

--- a/frontend/src/pages/RollPage/index.tsx
+++ b/frontend/src/pages/RollPage/index.tsx
@@ -771,7 +771,7 @@ export default function RollPage() {
             </div>
           </div>
           <Tooltip content="Pick a specific eligible thread for the next result.">
-            <button type="button" onClick={() => { setOverrideThreads(null); setIsOverrideOpen(true) }} className="px-2 md:px-3 py-1.5 md:py-2 bg-white/5 border border-white/10 text-stone-300 rounded-xl text-[10px] font-black uppercase tracking-widest hover:bg-white/10 transition-all">
+            <button type="button" onClick={() => { setOverrideThreads(null); setIsOverrideOpen(true) }} className="min-h-11 px-2 md:px-3 py-1.5 md:py-2 bg-white/5 border border-white/10 text-stone-300 rounded-xl text-[10px] font-black uppercase tracking-widest hover:bg-white/10 transition-all">
               Pick manually
             </button>
           </Tooltip>

--- a/frontend/src/pages/RollPage/index.tsx
+++ b/frontend/src/pages/RollPage/index.tsx
@@ -733,7 +733,7 @@ export default function RollPage() {
             </div>
           )}
         </div>
-        <div className="flex items-center gap-1 md:gap-2 shrink-0">
+        <div className={`items-center gap-1 md:gap-2 shrink-0 ${isRatingView ? 'hidden' : 'flex'}`}>
           <div id="die-selector">
             <div className="hidden md:flex gap-2">
               {DICE_LADDER.map((die) => (
@@ -750,8 +750,10 @@ export default function RollPage() {
             </div>
             <div className="md:hidden">
               <button onClick={() => setIsDieModalOpen(true)} disabled={setDieMutation.isPending}
-                className="px-3 py-1.5 text-[11px] font-black rounded-lg border bg-amber-600/20 border-amber-600 text-amber-500 transition-colors">
-                d{currentDie}
+                aria-label={`Current die d${currentDie}, ${bootstrap.manual_die ? 'manual mode' : 'automatic mode'}`}
+                className="flex min-h-11 flex-col items-center justify-center rounded-lg border border-amber-600 bg-amber-600/20 px-3 py-1 text-amber-500 transition-colors">
+                <span className="text-[11px] font-black">d{currentDie}</span>
+                <span className="text-[8px] font-bold uppercase tracking-wide">{bootstrap.manual_die ? 'Manual' : 'Auto'}</span>
               </button>
             </div>
           </div>
@@ -768,9 +770,9 @@ export default function RollPage() {
               <span id="header-die-label" className="text-[10px] font-black text-amber-500">d{currentDie}</span>
             </div>
           </div>
-          <Tooltip content="Manually select a thread to override the next roll result.">
+          <Tooltip content="Pick a specific eligible thread for the next result.">
             <button type="button" onClick={() => { setOverrideThreads(null); setIsOverrideOpen(true) }} className="px-2 md:px-3 py-1.5 md:py-2 bg-white/5 border border-white/10 text-stone-300 rounded-xl text-[10px] font-black uppercase tracking-widest hover:bg-white/10 transition-all">
-              Override
+              Pick manually
             </button>
           </Tooltip>
         </div>
@@ -861,9 +863,9 @@ export default function RollPage() {
           <SimpleMigrationDialog threadTitle={activeRatingThread.title} onComplete={handleSimpleMigrationComplete} onClose={() => setShowSimpleMigration(false)} />
         )}
 
-        <Modal isOpen={isOverrideOpen} title="Override Roll" onClose={() => { setIsOverrideOpen(false); setOverrideErrorMessage('') }}>
+        <Modal isOpen={isOverrideOpen} title="Pick manually" onClose={() => { setIsOverrideOpen(false); setOverrideErrorMessage('') }}>
           <form className="space-y-4" onSubmit={handleOverrideSubmit}>
-            <p className="text-xs text-stone-400">Pick a thread to force next roll result.</p>
+            <p className="text-xs text-stone-400">Choose the eligible thread you want to read next.</p>
             <div className="space-y-2">
               <label className="text-[10px] font-bold uppercase tracking-widest text-stone-500">Thread</label>
               <select value={overrideThreadId} onChange={(event: ChangeEvent<HTMLSelectElement>) => setOverrideThreadId(event.target.value)}
@@ -884,12 +886,17 @@ export default function RollPage() {
             )}
             <button type="submit" disabled={overrideMutation.isPending || !overrideThreadId}
               className="w-full py-3 glass-button text-xs font-black uppercase tracking-widest disabled:opacity-60">
-              {overrideMutation.isPending ? 'Overriding...' : 'Override Roll'}
+              {overrideMutation.isPending ? 'Selecting...' : 'Pick this thread'}
             </button>
           </form>
         </Modal>
 
-        <Modal isOpen={isDieModalOpen} title="Select Die" onClose={() => setIsDieModalOpen(false)}>
+        <Modal isOpen={isDieModalOpen} title="Choose die" onClose={() => setIsDieModalOpen(false)}>
+          <p className="mb-3 text-xs text-stone-400">
+            {bootstrap.manual_die
+              ? `Manual mode is active at d${bootstrap.manual_die}. Choose another die or return to automatic mode.`
+              : `Automatic mode is active at d${currentDie}. Choosing a die switches to manual mode.`}
+          </p>
           <div className="grid grid-cols-3 gap-2">
             {DICE_LADDER.map((die) => (
               <button key={die} onClick={async () => { if (await handleSetDie(die)) setIsDieModalOpen(false) }}
@@ -901,7 +908,7 @@ export default function RollPage() {
             <button onClick={async () => { await handleClearManualDie(); setIsDieModalOpen(false) }}
               disabled={clearManualDieMutation.isPending}
               className={`px-3 py-3 text-sm font-black rounded-lg border transition-colors ${bootstrap.manual_die ? 'bg-amber-500/20 border-amber-500 text-amber-400' : 'bg-white/5 border-white/10 hover:bg-white/10'}`}>
-              Auto
+              Use automatic
             </button>
           </div>
         </Modal>

--- a/frontend/src/test/mobile-navigation-controls.spec.ts
+++ b/frontend/src/test/mobile-navigation-controls.spec.ts
@@ -20,7 +20,7 @@ test.describe('Mobile navigation and Roll controls (#1091)', () => {
 
     await navigation.getByRole('button', { name: 'More pages' }).click();
     await expect(page.getByRole('button', { name: 'Sign out' })).toBeVisible();
-    await expect(page.getByText('Submit Feedback', { exact: true })).toBeVisible();
+    await expect(page.getByText('Feedback', { exact: true })).toBeVisible();
 
     const shellSpacing = await page.locator('[data-app-shell-ready] > main').evaluate((main) => {
       const style = window.getComputedStyle(main);

--- a/frontend/src/test/mobile-navigation-controls.spec.ts
+++ b/frontend/src/test/mobile-navigation-controls.spec.ts
@@ -43,7 +43,7 @@ test.describe('Mobile navigation and Roll controls (#1091)', () => {
     await page.getByRole('button', { name: 'Pick manually' }).click();
     await expect(page.getByRole('dialog', { name: 'Pick manually' })).toBeVisible();
     await expect(page.getByText('Choose the eligible thread you want to read next.')).toBeVisible();
-    await page.getByRole('button', { name: 'Close' }).click();
+    await page.getByRole('button', { name: 'Close modal' }).click();
 
     await page.getByRole('button', { name: /current die d\d+, automatic mode/i }).click();
     await expect(page.getByText(/Automatic mode is active at d\d+/)).toBeVisible();

--- a/frontend/src/test/mobile-navigation-controls.spec.ts
+++ b/frontend/src/test/mobile-navigation-controls.spec.ts
@@ -47,6 +47,6 @@ test.describe('Mobile navigation and Roll controls (#1091)', () => {
 
     await page.getByRole('button', { name: /current die d\d+, automatic mode/i }).click();
     await expect(page.getByText(/Automatic mode is active at d\d+/)).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Use automatic' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Auto' })).toBeVisible();
   });
 });

--- a/frontend/src/test/mobile-navigation-controls.spec.ts
+++ b/frontend/src/test/mobile-navigation-controls.spec.ts
@@ -40,7 +40,13 @@ test.describe('Mobile navigation and Roll controls (#1091)', () => {
     await page.setViewportSize({ width: 430, height: 932 });
     await page.goto('/');
 
-    await page.getByRole('button', { name: 'Pick manually' }).click();
+    const manualPicker = page.getByRole('button', { name: 'Pick manually' });
+    await expect(manualPicker).toBeVisible();
+    const manualPickerBox = await manualPicker.boundingBox();
+    expect(manualPickerBox).not.toBeNull();
+    expect(manualPickerBox!.height).toBeGreaterThanOrEqual(44);
+
+    await manualPicker.click();
     await expect(page.getByRole('dialog', { name: 'Pick manually' })).toBeVisible();
     await expect(page.getByText('Choose the eligible thread you want to read next.')).toBeVisible();
     await page.getByRole('button', { name: 'Close modal' }).click();

--- a/frontend/src/test/mobile-navigation-controls.spec.ts
+++ b/frontend/src/test/mobile-navigation-controls.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from './fixtures';
+
+test.describe('Mobile navigation and Roll controls (#1091)', () => {
+  test('labels every destination and keeps actions above the fixed navigation', async ({
+    authenticatedWithThreadsPage,
+  }) => {
+    const page = authenticatedWithThreadsPage;
+    await page.setViewportSize({ width: 430, height: 932 });
+    await page.goto('/');
+    await expect(page.locator('#root')).toBeVisible();
+
+    const navigation = page.getByRole('navigation', { name: 'Main navigation' });
+    for (const label of ['Roll', 'Queue', 'History', 'Crossovers', 'More']) {
+      await expect(navigation.getByText(label, { exact: true })).toBeVisible();
+    }
+
+    const activeItems = navigation.locator('.nav-item.active');
+    await expect(activeItems).toHaveCount(1);
+    await expect(page.getByRole('button', { name: /current die d\d+, automatic mode/i })).toBeVisible();
+
+    await navigation.getByRole('button', { name: 'More pages' }).click();
+    await expect(page.getByRole('button', { name: 'Sign out' })).toBeVisible();
+    await expect(page.getByText('Submit Feedback', { exact: true })).toBeVisible();
+
+    const shellSpacing = await page.locator('[data-app-shell-ready] > main').evaluate((main) => {
+      const style = window.getComputedStyle(main);
+      const nav = document.querySelector<HTMLElement>('.nav-container');
+      return {
+        paddingBottom: Number.parseFloat(style.paddingBottom),
+        navHeight: nav?.getBoundingClientRect().height ?? 0,
+      };
+    });
+    expect(shellSpacing.paddingBottom).toBeGreaterThan(shellSpacing.navHeight);
+  });
+
+  test('uses plain language for manual selection and die mode', async ({
+    authenticatedWithThreadsPage,
+  }) => {
+    const page = authenticatedWithThreadsPage;
+    await page.setViewportSize({ width: 430, height: 932 });
+    await page.goto('/');
+
+    await page.getByRole('button', { name: 'Pick manually' }).click();
+    await expect(page.getByRole('dialog', { name: 'Pick manually' })).toBeVisible();
+    await expect(page.getByText('Choose the eligible thread you want to read next.')).toBeVisible();
+    await page.getByRole('button', { name: 'Close' }).click();
+
+    await page.getByRole('button', { name: /current die d\d+, automatic mode/i }).click();
+    await expect(page.getByText(/Automatic mode is active at d\d+/)).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Use automatic' })).toBeVisible();
+  });
+});

--- a/frontend/src/unit/Navigation.test.tsx
+++ b/frontend/src/unit/Navigation.test.tsx
@@ -114,7 +114,7 @@ test('puts the mobile Sign out action inside More', async () => {
   expect(screen.queryByRole('button', { name: /sign out/i })).not.toBeInTheDocument()
   await user.click(await screen.findByRole('button', { name: /more pages/i }))
   expect(screen.getByRole('button', { name: /sign out/i })).toBeInTheDocument()
-  expect(screen.getByRole('button', { name: /log out/i })).toHaveClass('md:inline')
+  expect(screen.getByRole('button', { name: /log out/i })).not.toBeVisible()
 })
 
 test('shows loading and non-auth failure states and logs out gracefully', async () => {

--- a/frontend/src/unit/Navigation.test.tsx
+++ b/frontend/src/unit/Navigation.test.tsx
@@ -114,7 +114,6 @@ test('puts the mobile Sign out action inside More', async () => {
   expect(screen.queryByRole('button', { name: /sign out/i })).not.toBeInTheDocument()
   await user.click(await screen.findByRole('button', { name: /more pages/i }))
   expect(screen.getByRole('button', { name: /sign out/i })).toBeInTheDocument()
-  expect(screen.getByRole('button', { name: /log out/i })).not.toBeVisible()
 })
 
 test('shows loading and non-auth failure states and logs out gracefully', async () => {

--- a/frontend/src/unit/Navigation.test.tsx
+++ b/frontend/src/unit/Navigation.test.tsx
@@ -31,12 +31,12 @@ beforeEach(() => {
   mockClearAccessToken.mockReset()
 })
 
-const renderWithAuth = () => {
+const renderWithAuth = (initialEntry = '/') => {
   mockApiGet.mockResolvedValue({ username: 'testuser', email: 'test@test.com' })
   mockSetAccessToken.mockImplementation(() => undefined)
 
   return render(
-    <MemoryRouter initialEntries={['/']}>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <AuthProvider>
         <BugReportRestoreProvider>
           <Navigation onBugReportSubmit={vi.fn()} />
@@ -74,6 +74,14 @@ test('renders retained navigation links when authenticated', async () => {
   expect(screen.getByText('Crossovers')).toBeVisible()
   expect(screen.getByText('More')).toBeVisible()
   expect(screen.queryByRole('link', { name: /analytics page/i })).not.toBeInTheDocument()
+})
+
+test('marks More as the only active destination on submenu routes', async () => {
+  renderWithAuth('/glossary')
+
+  const moreButton = await screen.findByRole('button', { name: /more pages/i })
+  expect(moreButton).toHaveClass('active')
+  expect(document.querySelectorAll('.nav-item.active')).toHaveLength(1)
 })
 
 test('dismisses the More tray only when tapping outside it', async () => {

--- a/frontend/src/unit/Navigation.test.tsx
+++ b/frontend/src/unit/Navigation.test.tsx
@@ -67,6 +67,12 @@ test('renders retained navigation links when authenticated', async () => {
   })
   expect(screen.getByRole('link', { name: /queue page/i })).toBeInTheDocument()
   expect(screen.getByRole('link', { name: /history page/i })).toBeInTheDocument()
+  expect(screen.getByRole('link', { name: /crossovers page/i })).toBeInTheDocument()
+  expect(screen.getByText('Roll')).toBeVisible()
+  expect(screen.getByText('Queue')).toBeVisible()
+  expect(screen.getByText('History')).toBeVisible()
+  expect(screen.getByText('Crossovers')).toBeVisible()
+  expect(screen.getByText('More')).toBeVisible()
   expect(screen.queryByRole('link', { name: /analytics page/i })).not.toBeInTheDocument()
 })
 
@@ -100,13 +106,15 @@ test('does not render when not authenticated', async () => {
   })
 })
 
-test('shows logout button when authenticated', async () => {
+test('puts the mobile Sign out action inside More', async () => {
   mockApiGet.mockResolvedValue({ username: 'testuser', email: 'test@test.com' })
   renderWithAuth()
+  const user = userEvent.setup()
 
-  await waitFor(() => {
-    expect(screen.getByRole('button', { name: /log out/i })).toBeInTheDocument()
-  })
+  expect(screen.queryByRole('button', { name: /sign out/i })).not.toBeInTheDocument()
+  await user.click(await screen.findByRole('button', { name: /more pages/i }))
+  expect(screen.getByRole('button', { name: /sign out/i })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: /log out/i })).toHaveClass('md:inline')
 })
 
 test('shows loading and non-auth failure states and logs out gracefully', async () => {
@@ -121,9 +129,10 @@ test('shows loading and non-auth failure states and logs out gracefully', async 
       </AuthProvider>
     </MemoryRouter>,
   )
-  await waitFor(() => expect(screen.getByRole('button', { name: /log out/i })).toBeInTheDocument())
+  const user = userEvent.setup()
+  await user.click(await screen.findByRole('button', { name: /more pages/i }))
   mockApiPost.mockRejectedValueOnce(new Error('logout unavailable'))
-  await userEvent.setup().click(screen.getByRole('button', { name: /log out/i }))
+  await user.click(screen.getByRole('button', { name: /sign out/i }))
   await waitFor(() => expect(mockClearAccessToken).toHaveBeenCalled())
 
 })
@@ -155,7 +164,7 @@ test('falls back to an empty username when the user profile omits it', async () 
       </AuthProvider>
     </MemoryRouter>,
   )
-  await waitFor(() => expect(screen.getByRole('button', { name: /log out/i })).toBeInTheDocument())
+  await waitFor(() => expect(screen.getByRole('button', { name: /more pages/i })).toBeInTheDocument())
   // empty username is falsy, so no username span is rendered for it
   expect(screen.queryByText('testuser')).not.toBeInTheDocument()
 })

--- a/frontend/src/unit/RollPage.bootstrap-modal-coverage.test.tsx
+++ b/frontend/src/unit/RollPage.bootstrap-modal-coverage.test.tsx
@@ -108,7 +108,7 @@ describe('RollPage bootstrap modal coverage', () => {
     render(<RollPage />)
 
     fireEvent.click(screen.getAllByRole('button', { name: 'complete dice' })[0]!)
-    await user.click(screen.getByRole('button', { name: 'Override' }))
+    await user.click(screen.getByRole('button', { name: 'Pick manually' }))
 
     await waitFor(() => expect(spies.list).toHaveBeenCalled())
     const select = screen.getByRole('combobox')
@@ -116,9 +116,9 @@ describe('RollPage bootstrap modal coverage', () => {
     expect(screen.getByRole('option', { name: 'Watchmen (Comic)' })).toBeInTheDocument()
 
     await user.selectOptions(select, '1')
-    await user.click(screen.getByRole('button', { name: 'Override Roll' }))
+    await user.click(screen.getByRole('button', { name: 'Pick this thread' }))
     await waitFor(() => expect(spies.override).toHaveBeenCalledWith({ thread_id: 1 }))
-    await waitFor(() => expect(screen.queryByRole('heading', { name: 'Override Roll' })).not.toBeInTheDocument())
+    await waitFor(() => expect(screen.queryByRole('heading', { name: 'Pick manually' })).not.toBeInTheDocument())
   })
 
   it('renders pending override and manual-die states and closes the die modal after a successful choice', async () => {
@@ -127,10 +127,10 @@ describe('RollPage bootstrap modal coverage', () => {
     const user = userEvent.setup()
     render(<RollPage />)
 
-    await user.click(screen.getByRole('button', { name: 'Override' }))
-    expect(screen.getByRole('button', { name: 'Overriding...' })).toBeDisabled()
+    await user.click(screen.getByRole('button', { name: 'Pick manually' }))
+    expect(screen.getByRole('button', { name: 'Selecting...' })).toBeDisabled()
     await user.click(screen.getByRole('button', { name: 'close modal' }))
-    expect(screen.queryByRole('heading', { name: 'Override Roll' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Pick manually' })).not.toBeInTheDocument()
 
     const d6Buttons = screen.getAllByRole('button', { name: 'd6' })
     await user.click(d6Buttons[d6Buttons.length - 1]!)

--- a/frontend/src/unit/RollPage.bootstrap-modal-coverage.test.tsx
+++ b/frontend/src/unit/RollPage.bootstrap-modal-coverage.test.tsx
@@ -132,8 +132,7 @@ describe('RollPage bootstrap modal coverage', () => {
     await user.click(screen.getByRole('button', { name: 'close modal' }))
     expect(screen.queryByRole('heading', { name: 'Pick manually' })).not.toBeInTheDocument()
 
-    const d6Buttons = screen.getAllByRole('button', { name: 'd6' })
-    await user.click(d6Buttons[d6Buttons.length - 1]!)
+    await user.click(screen.getByRole('button', { name: /current die d6, manual mode/i }))
     expect(screen.getByRole('heading', { name: 'Select Die' })).toBeInTheDocument()
     const d8Buttons = screen.getAllByRole('button', { name: 'd8' })
     await user.click(d8Buttons[d8Buttons.length - 1]!)

--- a/frontend/src/unit/RollPage.parent-coverage.test.tsx
+++ b/frontend/src/unit/RollPage.parent-coverage.test.tsx
@@ -106,7 +106,7 @@ describe('RollPage parent handlers', () => {
     fireEvent.click(screen.getByRole('button', { name: 'refresh rating' }))
     fireEvent.click(screen.getByRole('button', { name: 'save rating' }))
     await waitFor(() => expect(screen.queryByRole('button', { name: 'save rating' })).not.toBeInTheDocument())
-    fireEvent.click(screen.getByRole('button', { name: /^Override$/ }))
+    fireEvent.click(screen.getByRole('button', { name: /^Pick manually$/ }))
     fireEvent.click(screen.getByRole('button', { name: 'close modal' }))
     fireEvent.click(screen.getByRole('button', { name: 'shuffle pool' }))
     fireEvent.click(screen.getByRole('button', { name: 'toggle snoozed' }))
@@ -182,13 +182,13 @@ describe('RollPage parent handlers', () => {
   it('opens override, submits it, and handles a pending migration flow', async () => {
     const user = userEvent.setup()
     render(<RollPage />)
-    await user.click(screen.getByRole('button', { name: /^Override$/ }))
+    await user.click(screen.getByRole('button', { name: /^Pick manually$/ }))
     await user.selectOptions(screen.getAllByRole('combobox').at(-1)!, '1')
-    await user.click(screen.getByRole('button', { name: /Override Roll/ }))
+    await user.click(screen.getByRole('button', { name: /Pick this thread/ }))
     await waitFor(() => expect(spies.override).toHaveBeenCalled())
 
-    await user.click(screen.getByRole('button', { name: /^Override$/ }))
-    fireEvent.submit(screen.getByRole('button', { name: /Override Roll/ }).closest('form')!)
+    await user.click(screen.getByRole('button', { name: /^Pick manually$/ }))
+    fireEvent.submit(screen.getByRole('button', { name: /Pick this thread/ }).closest('form')!)
     await user.click(screen.getByRole('button', { name: 'close modal' }))
 
     spies.setPending.mockResolvedValueOnce({ thread_id: 1, title: 'Saga', format: 'Comic', issues_remaining: 2, queue_position: 1, total_issues: null, result: 3 })
@@ -251,9 +251,9 @@ describe('RollPage parent handlers', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: 'Roll the dice' })).toBeInTheDocument())
 
     spies.override.mockRejectedValueOnce(error)
-    await user.click(screen.getByRole('button', { name: /^Override$/ }))
+    await user.click(screen.getByRole('button', { name: /^Pick manually$/ }))
     await user.selectOptions(screen.getAllByRole('combobox').at(-1)!, '1')
-    await user.click(screen.getByRole('button', { name: /Override Roll/ }))
+    await user.click(screen.getByRole('button', { name: /Pick this thread/ }))
     await waitFor(() => expect(screen.getByText('failed')).toBeInTheDocument())
 
     spies.setPending.mockResolvedValueOnce({ thread_id: 1, title: 'Saga', format: 'Comic', issues_remaining: 2, queue_position: 1, total_issues: null, result: 3 })

--- a/frontend/src/unit/RollPage.parent-coverage.test.tsx
+++ b/frontend/src/unit/RollPage.parent-coverage.test.tsx
@@ -312,7 +312,7 @@ describe('RollPage parent handlers', () => {
     bootstrapData.stale_thread_count = 1
     render(<RollPage />)
     expect(screen.getByText('offset active')).toBeInTheDocument()
-    await userEvent.setup().click(screen.getAllByRole('button', { name: 'd6' })[1]!)
+    await userEvent.setup().click(screen.getByRole('button', { name: /current die d6, (?:automatic|manual) mode/i }))
     expect(screen.getByRole('heading', { name: 'Select Die' })).toBeInTheDocument()
     await userEvent.setup().click(screen.getByRole('button', { name: 'close modal' }))
     expect(screen.getByRole('button', { name: 'read stale' })).toBeInTheDocument()
@@ -995,12 +995,12 @@ describe('RollPage parent handlers', () => {
 
   it('selects a die and clears manual die from the mobile die modal', async () => {
     render(<RollPage />)
-    await userEvent.setup().click(screen.getAllByRole('button', { name: 'd6' })[1]!)
+    await userEvent.setup().click(screen.getByRole('button', { name: /current die d6, (?:automatic|manual) mode/i }))
     const autoModal = screen.getByRole('heading', { name: 'Select Die' }).closest('section')!
     await userEvent.setup().click(within(autoModal).getByRole('button', { name: 'Auto' }))
     expect(spies.clearDie).toHaveBeenCalled()
 
-    await userEvent.setup().click(screen.getAllByRole('button', { name: 'd6' })[1]!)
+    await userEvent.setup().click(screen.getByRole('button', { name: /current die d6, (?:automatic|manual) mode/i }))
     const dieModal = screen.getByRole('heading', { name: 'Select Die' }).closest('section')!
     await userEvent.setup().click(within(dieModal).getByRole('button', { name: 'd4' }))
     expect(spies.setDie).toHaveBeenCalledWith(4)
@@ -1029,7 +1029,7 @@ describe('RollPage parent handlers', () => {
     render(<RollPage />)
     expect(screen.getByRole('button', { name: 'Auto' })).toHaveAttribute('title', 'Exit manual mode (currently d4)')
 
-    await userEvent.setup().click(screen.getAllByRole('button', { name: 'd6' })[1]!)
+    await userEvent.setup().click(screen.getByRole('button', { name: /current die d6, (?:automatic|manual) mode/i }))
     const modal = screen.getByRole('heading', { name: 'Select Die' }).closest('section')!
     spies.setDie.mockRejectedValueOnce(new Error('die failed'))
     await userEvent.setup().click(within(modal).getByRole('button', { name: 'd4' }))

--- a/frontend/src/unit/RollPage.test.tsx
+++ b/frontend/src/unit/RollPage.test.tsx
@@ -170,7 +170,7 @@ it('explains automatic and manual die modes on mobile', async () => {
   expect(dieControl).toHaveTextContent('Auto')
   await user.click(dieControl)
   expect(screen.getByText(/automatic mode is active at d6/i)).toBeInTheDocument()
-  expect(screen.getByRole('button', { name: /use automatic/i })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: /^auto$/i })).toBeInTheDocument()
 })
 
 it('shows a retry action when bootstrap loading fails', async () => {

--- a/frontend/src/unit/RollPage.test.tsx
+++ b/frontend/src/unit/RollPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, expect, it, vi } from 'vitest'
 import RollPage from '../pages/RollPage'
@@ -170,7 +170,8 @@ it('explains automatic and manual die modes on mobile', async () => {
   expect(dieControl).toHaveTextContent('Auto')
   await user.click(dieControl)
   expect(screen.getByText(/automatic mode is active at d6/i)).toBeInTheDocument()
-  expect(screen.getByRole('button', { name: /^auto$/i })).toBeInTheDocument()
+  const dieModal = screen.getByRole('heading', { name: 'Select Die' }).closest('section')!
+  expect(within(dieModal).getByRole('button', { name: /^auto$/i })).toBeInTheDocument()
 })
 
 it('shows a retry action when bootstrap loading fails', async () => {

--- a/frontend/src/unit/RollPage.test.tsx
+++ b/frontend/src/unit/RollPage.test.tsx
@@ -153,13 +153,24 @@ it('loads every active override page only after the modal opens', async () => {
   render(<RollPage />)
   expect(threadsApi.list).not.toHaveBeenCalled()
 
-  await user.click(screen.getByRole('button', { name: /override/i }))
+  await user.click(screen.getByRole('button', { name: /pick manually/i }))
 
   await waitFor(() => expect(threadsApi.list).toHaveBeenCalledTimes(2))
   expect(threadsApi.list).toHaveBeenNthCalledWith(1, { page_size: 200 }, undefined)
   expect(threadsApi.list).toHaveBeenNthCalledWith(2, { page_size: 200 }, 'page-2')
   expect(await screen.findByRole('option', { name: 'First Choice (Comic)' })).toBeInTheDocument()
   expect(await screen.findByRole('option', { name: 'Second Choice (Comic)' })).toBeInTheDocument()
+})
+
+it('explains automatic and manual die modes on mobile', async () => {
+  const user = userEvent.setup()
+  render(<RollPage />)
+
+  const dieControl = screen.getByRole('button', { name: /current die d6, automatic mode/i })
+  expect(dieControl).toHaveTextContent('Auto')
+  await user.click(dieControl)
+  expect(screen.getByText(/automatic mode is active at d6/i)).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: /use automatic/i })).toBeInTheDocument()
 })
 
 it('shows a retry action when bootstrap loading fails', async () => {

--- a/frontend/src/unit/RollPage.test.tsx
+++ b/frontend/src/unit/RollPage.test.tsx
@@ -170,7 +170,7 @@ it('explains automatic and manual die modes on mobile', async () => {
   expect(dieControl).toHaveTextContent('Auto')
   await user.click(dieControl)
   expect(screen.getByText(/automatic mode is active at d6/i)).toBeInTheDocument()
-  const dieModal = screen.getByRole('heading', { name: 'Select Die' }).closest('section')!
+  const dieModal = screen.getByRole('dialog', { name: 'Select Die' })
   expect(within(dieModal).getByRole('button', { name: /^auto$/i })).toBeInTheDocument()
 })
 


### PR DESCRIPTION
Closes #1091

## What changed
- label all five mobile destinations and keep exactly one active route
- move mobile Sign out into More while preserving feedback and desktop account controls
- make the shared safe-area/navigation reservation explicit for page content
- replace Override language with Pick manually
- show whether the compact die control is in automatic or manual mode
- hide global Roll controls while the pending rating flow owns the action area
- add component and focused mobile Chromium coverage

## Validation
Configured CI is the executable validation boundary for this connector-backed branch. Branch-caused failures will be repaired before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility & Mobile Improvements**
  * Improved mobile navigation readability, spacing, and safe-area support.
  * Moved Sign out into the mobile More menu.
  * Added mobile access to bug reporting.
  * Glossary pages now correctly highlight More.

* **Roll Experience**
  * Renamed “Override Roll” controls to clearer “Pick manually” actions.
  * Improved die selection displays and messaging for manual and automatic modes.
  * Clarified manual thread selection and selection-in-progress states.

* **Testing**
  * Expanded coverage for mobile navigation, authentication controls, and roll workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->