### PR TITLE
Show exact issue mappings in the eligible Roll pool

### DIFF
--- a/app/api/roll.py
+++ b/app/api/roll.py
@@ -18,7 +18,7 @@ from app.auth import get_current_user
 
 from app.database import get_db
 from app.middleware import limiter
-from app.models import Event, Thread
+from app.models import Event, Issue, Thread
 from app.models.user import User
 from app.roll_recovery import build_roll_recovery
 from app.schemas import (
@@ -396,7 +396,14 @@ async def roll_bootstrap(
     )
 
     pool_query = (
-        select(Thread.id, Thread.title, Thread.format)
+        select(
+            Thread.id,
+            Thread.title,
+            Thread.format,
+            Thread.next_unread_issue_id.label("issue_id"),
+            Issue.issue_number,
+        )
+        .outerjoin(Issue, Issue.id == Thread.next_unread_issue_id)
         .where(Thread.user_id == user_id)
         .where(Thread.status == "active")
         .where(Thread.queue_position >= 1)
@@ -411,7 +418,13 @@ async def roll_bootstrap(
 
     pool_result = await db.execute(pool_query)
     roll_pool = [
-        RollBootstrapThread(id=row.id, title=row.title, format=row.format)
+        RollBootstrapThread(
+            id=row.id,
+            title=row.title,
+            format=row.format,
+            issue_id=row.issue_id,
+            issue_number=row.issue_number,
+        )
         for row in pool_result.all()
     ]
 

--- a/app/api/roll.py
+++ b/app/api/roll.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Request, status
 from fastapi.responses import HTMLResponse
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import Annotated
 
@@ -18,7 +18,7 @@ from app.auth import get_current_user
 
 from app.database import get_db
 from app.middleware import limiter
-from app.models import Event, Issue, Thread
+from app.models import DependencyGroup, DependencyGroupMembership, Event, Issue, Thread
 from app.models.user import User
 from app.roll_recovery import build_roll_recovery
 from app.schemas import (
@@ -417,6 +417,34 @@ async def roll_bootstrap(
         pool_query = pool_query.where(Thread.id.not_in(snoozed_ids))
 
     pool_result = await db.execute(pool_query)
+    pool_rows = pool_result.all()
+    route_labels_by_thread: dict[int, list[str]] = {}
+    if pool_rows:
+        thread_ids = [row.id for row in pool_rows]
+        issue_to_thread = {row.issue_id: row.id for row in pool_rows if row.issue_id is not None}
+        route_result = await db.execute(
+            select(
+                DependencyGroupMembership.thread_id,
+                DependencyGroupMembership.issue_id,
+                DependencyGroup.name,
+            )
+            .join(DependencyGroup)
+            .where(
+                DependencyGroup.user_id == user_id,
+                or_(
+                    DependencyGroupMembership.thread_id.in_(thread_ids),
+                    DependencyGroupMembership.issue_id.in_(list(issue_to_thread)),
+                ),
+            )
+            .order_by(DependencyGroup.name, DependencyGroup.id)
+        )
+        for membership in route_result.all():
+            thread_id = membership.thread_id or issue_to_thread.get(membership.issue_id)
+            if thread_id is not None:
+                labels = route_labels_by_thread.setdefault(thread_id, [])
+                if membership.name not in labels:
+                    labels.append(membership.name)
+
     roll_pool = [
         RollBootstrapThread(
             id=row.id,
@@ -424,8 +452,9 @@ async def roll_bootstrap(
             format=row.format,
             issue_id=row.issue_id,
             issue_number=row.issue_number,
+            route_labels=route_labels_by_thread.get(row.id, []),
         )
-        for row in pool_result.all()
+        for row in pool_rows
     ]
 
     snoozed_threads: list[RollBootstrapThread] = []

--- a/app/schemas/roll.py
+++ b/app/schemas/roll.py
@@ -46,6 +46,9 @@ class RollBootstrapThread(BaseModel):
     id: int
     title: str
     format: str
+    issue_id: int | None = None
+    issue_number: str | None = None
+    route_labels: list[str] = Field(default_factory=list)
     last_activity_at: str | None = None
 
 

--- a/docs/changelog.d/2026-08-12-1097.md
+++ b/docs/changelog.d/2026-08-12-1097.md
@@ -1,0 +1,5 @@
+## 2026-08-12
+
+### Roll
+
+- [#1097](https://github.com/JoshCLWren/comic-pile/pull/1097) makes every eligible die face show the exact next issue it represents, clarifies that route names are informational, and explains that Shuffle queue randomizes the complete active queue.

--- a/frontend/src/generated/openapi.json
+++ b/frontend/src/generated/openapi.json
@@ -2912,6 +2912,28 @@
             "title": "Id",
             "type": "integer"
           },
+          "issue_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Issue Id"
+          },
+          "issue_number": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Issue Number"
+          },
           "last_activity_at": {
             "anyOf": [
               {
@@ -2922,6 +2944,13 @@
               }
             ],
             "title": "Last Activity At"
+          },
+          "route_labels": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Route Labels",
+            "type": "array"
           },
           "title": {
             "title": "Title",

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -4560,8 +4560,14 @@ export interface components {
             format: string;
             /** Id */
             id: number;
+            /** Issue Id */
+            issue_id?: number | null;
+            /** Issue Number */
+            issue_number?: string | null;
             /** Last Activity At */
             last_activity_at?: string | null;
+            /** Route Labels */
+            route_labels?: string[];
             /** Title */
             title: string;
         };

--- a/frontend/src/pages/RollPage/components/ThreadPool.tsx
+++ b/frontend/src/pages/RollPage/components/ThreadPool.tsx
@@ -70,22 +70,24 @@ export function ThreadPool({
         </p>
       )}
 
-      <div className="flex items-center gap-2 shrink-0 mb-4">
+      {!isRatingView && <div className="flex items-center gap-2 shrink-0 mb-4">
         <div className="w-2 h-2 rounded-full bg-amber-600 shadow-[0_0_15px_var(--accent-red)]"></div>
         <div className="flex-1">
-          <p className="text-[10px] font-black uppercase tracking-wider text-stone-300">Roll Pool</p>
+          <p className="text-[10px] font-black uppercase tracking-wider text-stone-300">Eligible now · {pool.length}</p>
         </div>
         <button
           type="button"
           onClick={onShuffle}
           disabled={shuffleIsPending || pool.length < 2}
+          aria-describedby="shuffle-queue-description"
           className="h-8 px-3 rounded-lg border border-white/10 bg-white/5 text-[10px] font-black uppercase tracking-widest text-stone-300 hover:bg-white/10 disabled:opacity-50"
         >
-          Shuffle
+          Shuffle queue
         </button>
-      </div>
+        <span id="shuffle-queue-description" className="sr-only">Randomizes the complete active queue, then refreshes these eligible die mappings.</span>
+      </div>}
 
-      <div className="space-y-2" data-roll-pool aria-label="Roll pool">
+      {!isRatingView && <div className="space-y-2" data-roll-pool aria-label={`Eligible now, ${pool.length} mapped result${pool.length === 1 ? '' : 's'}`}>
         {pool.length === 0 && blockedThreads.length === 0 && snoozedThreads.length === 0 ? (
           <div className="text-center py-6 space-y-4">
             <div className="text-4xl">🎲</div>
@@ -137,6 +139,7 @@ export function ThreadPool({
                 }}
                 role="button"
                 tabIndex={0}
+                aria-label={`Die face ${index + 1}: ${thread.issue_number ? `issue ${thread.issue_number}, ` : ''}${thread.title}${thread.route_labels?.length ? `, routes ${thread.route_labels.join(', ')}` : ''}. Open thread actions.`}
                 className={`flex items-center gap-3 px-4 py-3 bg-white/5 border border-white/5 rounded-xl group transition-all cursor-pointer hover:bg-white/10 ${isSelected ? 'pool-thread-selected border-amber-500/30' : ''
                   }`}
               >
@@ -144,14 +147,22 @@ export function ThreadPool({
                   {index + 1}
                 </span>
                 <div className="flex-1 min-w-0">
-                  <p className="font-bold text-stone-300 truncate text-sm">{thread.title}</p>
+                  <p className="font-bold text-stone-200 truncate text-sm">
+                    {thread.issue_number ? `Issue ${thread.issue_number}` : 'Next unread issue'}
+                  </p>
+                  <p className="truncate text-xs text-stone-400">{thread.title}</p>
                   <p className="text-[10px] font-black text-stone-500 uppercase tracking-widest mt-0.5">{thread.format}</p>
+                  {thread.route_labels?.length ? (
+                    <p className="mt-1 truncate text-[10px] text-sky-300">
+                      Routes: {thread.route_labels.join(' · ')}
+                    </p>
+                  ) : null}
                 </div>
               </div>
             )
           })
         )}
-      </div>
+      </div>}
 
       {blockedThreads.length > 0 && !isRatingView && (
         <div className="mt-4">

--- a/frontend/src/test/eligible-roll-pool.spec.ts
+++ b/frontend/src/test/eligible-roll-pool.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from './fixtures';
+
+test.describe('Eligible Roll pool mappings (#1089)', () => {
+  test('shows truthful issue mappings and explains full-queue shuffle on mobile', async ({
+    authenticatedWithThreadsPage,
+  }) => {
+    const page = authenticatedWithThreadsPage;
+    await page.setViewportSize({ width: 430, height: 932 });
+    await page.goto('/');
+
+    const pool = page.getByLabel(/Eligible now, \d+ mapped results?/i);
+    await expect(pool).toBeVisible();
+
+    const mappings = pool.getByRole('button', { name: /Die face \d+: issue \d+,/i });
+    await expect(mappings).toHaveCount(3);
+    await expect(mappings.first()).toBeVisible();
+
+    const shuffle = page.getByRole('button', { name: 'Shuffle queue' });
+    await expect(shuffle).toHaveAccessibleDescription(/complete active queue/i);
+    await shuffle.click();
+
+    await expect(page.getByLabel(/Eligible now, \d+ mapped results?/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /Die face 1: issue \d+,/i })).toBeVisible();
+  });
+});

--- a/frontend/src/types/rollBootstrap.ts
+++ b/frontend/src/types/rollBootstrap.ts
@@ -5,6 +5,9 @@ export interface RollBootstrapThread {
   id: number
   title: string
   format: string
+  issue_id?: number | null
+  issue_number?: string | null
+  route_labels?: string[]
   last_activity_at?: string | null
 }
 
@@ -91,6 +94,9 @@ declare module './index' {
     id: number
     title: string
     format: string
+    issue_id?: number | null
+    issue_number?: string | null
+    route_labels?: string[]
     last_activity_at?: string | null
   }
 }

--- a/frontend/src/unit/RollComponents.coverage.test.tsx
+++ b/frontend/src/unit/RollComponents.coverage.test.tsx
@@ -76,8 +76,8 @@ describe('ThreadPool', () => {
       shuffleIsPending
       {...actions}
     /></MemoryRouter>)
-    expect(screen.getByText('Saga')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Shuffle' })).toBeDisabled()
+    expect(screen.queryByText('Saga')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Shuffle queue' })).not.toBeInTheDocument()
     expect(screen.queryByText(/hidden \(blocked/)).not.toBeInTheDocument()
   })
 

--- a/frontend/src/unit/RollPage.test.tsx
+++ b/frontend/src/unit/RollPage.test.tsx
@@ -119,7 +119,7 @@ it('renders the bounded bootstrap pool without Collections state', () => {
   render(<RollPage />)
 
   expect(screen.getByText('Pile Roller')).toBeInTheDocument()
-  expect(screen.getByLabelText('Roll pool')).toBeInTheDocument()
+  expect(screen.getByLabelText(/Eligible now, 2 mapped results/i)).toBeInTheDocument()
   expect(screen.getByText('Saga')).toBeInTheDocument()
   expect(screen.getByText('X-Men')).toBeInTheDocument()
   expect(screen.queryByText(/collection/i)).not.toBeInTheDocument()

--- a/frontend/src/unit/ThreadPool.bootstrap-branches.test.tsx
+++ b/frontend/src/unit/ThreadPool.bootstrap-branches.test.tsx
@@ -37,7 +37,7 @@ describe('ThreadPool bootstrap edge branches', () => {
       />,
     )
 
-    const thread = screen.getByRole('button', { name: /Die face 1: Next unread issue, Saga/i })
+    const thread = screen.getByRole('button', { name: /Die face 1: Saga/i })
     expect(thread).not.toHaveClass('pool-thread-selected')
     fireEvent.keyDown(thread, { key: 'Enter' })
     expect(onThreadClick).toHaveBeenCalledWith({ id: 1, title: 'Saga', format: 'Comic' })

--- a/frontend/src/unit/ThreadPool.bootstrap-branches.test.tsx
+++ b/frontend/src/unit/ThreadPool.bootstrap-branches.test.tsx
@@ -37,7 +37,7 @@ describe('ThreadPool bootstrap edge branches', () => {
       />,
     )
 
-    const thread = screen.getByRole('button', { name: /Saga Comic/i })
+    const thread = screen.getByRole('button', { name: /Die face 1: Next unread issue, Saga/i })
     expect(thread).not.toHaveClass('pool-thread-selected')
     fireEvent.keyDown(thread, { key: 'Enter' })
     expect(onThreadClick).toHaveBeenCalledWith({ id: 1, title: 'Saga', format: 'Comic' })

--- a/frontend/src/unit/ThreadPoolEligibleMappings.test.tsx
+++ b/frontend/src/unit/ThreadPoolEligibleMappings.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+import { ThreadPool } from '../pages/RollPage/components/ThreadPool'
+
+const baseProps = {
+  blockedThreads: [],
+  blockingReasonMap: {},
+  isRatingView: false,
+  isRolling: false,
+  rolledResult: null,
+  selectedThreadId: null,
+  staleThread: null,
+  staleThreadCount: 0,
+  snoozedThreads: [],
+  snoozedExpanded: false,
+  blockedExpanded: false,
+  onThreadClick: vi.fn(),
+  onUnsnooze: vi.fn(),
+  onReadStale: vi.fn(),
+  onToggleSnoozed: vi.fn(),
+  onToggleBlocked: vi.fn(),
+  onShuffle: vi.fn(),
+  unsnoozeIsPending: false,
+  shuffleIsPending: false,
+}
+
+describe('ThreadPool eligible mappings', () => {
+  it('labels each die face with the authoritative issue identity', () => {
+    render(
+      <MemoryRouter>
+        <ThreadPool
+          {...baseProps}
+          pool={[{
+            id: 7,
+            title: 'Amazing Adventures',
+            format: 'ongoing',
+            issue_id: 42,
+            issue_number: '12',
+            route_labels: ['Secret War'],
+          }]}
+        />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('Eligible now · 1')).toBeVisible()
+    expect(screen.getByText('Issue 12')).toBeVisible()
+    expect(screen.getByRole('button', {
+      name: /Die face 1: issue 12, Amazing Adventures, routes Secret War/i,
+    })).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Shuffle queue' })).toHaveAccessibleDescription(
+      /complete active queue/i,
+    )
+  })
+
+  it('omits eligible mappings while rating', () => {
+    render(
+      <MemoryRouter>
+        <ThreadPool
+          {...baseProps}
+          isRatingView
+          pool={[{ id: 7, title: 'Amazing Adventures', format: 'ongoing', issue_number: '12' }]}
+        />
+      </MemoryRouter>,
+    )
+
+    expect(screen.queryByLabelText(/Eligible now/i)).not.toBeInTheDocument()
+    expect(screen.queryByText('Issue 12')).not.toBeInTheDocument()
+  })
+})

--- a/tests/test_roll_bootstrap_ownership.py
+++ b/tests/test_roll_bootstrap_ownership.py
@@ -72,6 +72,9 @@ async def test_bootstrap_scopes_snoozed_threads_and_returns_format(monkeypatch):
             "id": 101,
             "title": "Owned",
             "format": "ongoing",
+            "issue_id": None,
+            "issue_number": None,
+            "route_labels": [],
             "last_activity_at": None,
         }
     ]


### PR DESCRIPTION
Issue: #1089

## What changed
- add authoritative next-issue IDs and issue numbers to the bounded Roll bootstrap pool
- rename the pre-roll list to `Eligible now` and show its actual mapped count
- label each row as a die-face mapping with exact issue identity and a separate thread title
- rename `Shuffle` to `Shuffle queue` and explain that it randomizes the complete active queue
- remove eligible mappings from the pending rating state
- add focused component coverage for mapping fidelity and rating-state omission

## Validation
Configured CI is the executable validation boundary for this connector-backed branch. This PR remains in active implementation until route-membership context and focused Chromium coverage complete the issue contract.