### PR TITLE
feat(roll): explain readiness from named reading routes

### DIFF
--- a/docs/changelog.d/2026-08-12-1098.md
+++ b/docs/changelog.d/2026-08-12-1098.md
@@ -2,4 +2,4 @@
 
 ### Roll
 
-- Named reading routes can now explain the pending issue's verified readiness and route context without losing an unsaved rating. [#1098](https://github.com/JoshCLWren/comic-pile/pull/1098)
+- Named reading routes can now explain the pending issue's direct readiness blockers and informational route memberships without losing an unsaved rating. [#1098](https://github.com/JoshCLWren/comic-pile/pull/1098)

--- a/docs/changelog.d/2026-08-12-1098.md
+++ b/docs/changelog.d/2026-08-12-1098.md
@@ -1,0 +1,5 @@
+## 2026-08-12
+
+### Roll
+
+- Named reading routes can now explain the pending issue's verified readiness and route context without losing an unsaved rating. [#1098](https://github.com/JoshCLWren/comic-pile/pull/1098)

--- a/frontend/src/pages/RollPage/components/RatingView.tsx
+++ b/frontend/src/pages/RollPage/components/RatingView.tsx
@@ -192,9 +192,11 @@ export function RatingView({
                   <div className="mt-2 flex items-center justify-between gap-2">
                     <p className="text-[10px] font-bold text-stone-500">{routeProgress}% complete</p>
                     <button
-                      ref={routeExplanationTriggerRef}
                       type="button"
-                      onClick={() => setIsRouteExplanationOpen(true)}
+                      onClick={(event) => {
+                        routeExplanationTriggerRef.current = event.currentTarget
+                        setIsRouteExplanationOpen(true)
+                      }}
                       className="min-h-11 rounded-lg border border-amber-700/40 bg-amber-900/15 px-3 text-[10px] font-black text-amber-200 focus:ring-2 focus:ring-amber-500"
                       aria-label={`Explain why ${threadTitle} ${issueNumber != null ? `#${issueNumber}` : ''} is next in ${order.name}`}
                     >

--- a/frontend/src/pages/RollPage/components/RatingView.tsx
+++ b/frontend/src/pages/RollPage/components/RatingView.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import IssueCorrectionDialog from '../../../components/IssueCorrectionDialog'
 import Tooltip from '../../../components/Tooltip'
 import type { ReadingOrder } from '../../../services/api-reading-orders'
@@ -59,7 +59,6 @@ export function RatingView({
 }: RatingViewProps) {
   const [isCorrectionDialogOpen, setIsCorrectionDialogOpen] = useState(false)
   const [isRouteExplanationOpen, setIsRouteExplanationOpen] = useState(false)
-  const routeExplanationTriggerRef = useRef<HTMLButtonElement>(null)
   const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'failed'>('idle')
   const threadTitle = activeRatingThread?.title ?? 'Loading…'
   const issueNumber = activeRatingThread?.next_issue_number ?? activeRatingThread?.issue_number ?? null
@@ -193,10 +192,7 @@ export function RatingView({
                     <p className="text-[10px] font-bold text-stone-500">{routeProgress}% complete</p>
                     <button
                       type="button"
-                      onClick={(event) => {
-                        routeExplanationTriggerRef.current = event.currentTarget
-                        setIsRouteExplanationOpen(true)
-                      }}
+                      onClick={() => setIsRouteExplanationOpen(true)}
                       className="min-h-11 rounded-lg border border-amber-700/40 bg-amber-900/15 px-3 text-[10px] font-black text-amber-200 focus:ring-2 focus:ring-amber-500"
                       aria-label={`Explain why ${threadTitle} ${issueNumber != null ? `#${issueNumber}` : ''} is next in ${order.name}`}
                     >
@@ -301,10 +297,7 @@ export function RatingView({
         issueLabel={`${threadTitle}${issueNumber != null ? ` #${issueNumber}` : ''}`}
         readingOrders={readingOrders}
         connectedThreads={connectedThreads}
-        onClose={() => {
-          setIsRouteExplanationOpen(false)
-          requestAnimationFrame(() => routeExplanationTriggerRef.current?.focus())
-        }}
+        onClose={() => setIsRouteExplanationOpen(false)}
       />
 
       {activeRatingThread ? (

--- a/frontend/src/pages/RollPage/components/RatingView.tsx
+++ b/frontend/src/pages/RollPage/components/RatingView.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import IssueCorrectionDialog from '../../../components/IssueCorrectionDialog'
 import Tooltip from '../../../components/Tooltip'
 import type { ReadingOrder } from '../../../services/api-reading-orders'
@@ -8,6 +8,7 @@ import type { RatingThread } from '../types'
 import { ComicVineIssueCard } from './ComicVineIssueCard'
 import { ContinuityReadinessSummary } from './ContinuityReadinessSummary'
 import { ReadingOrderGroups } from './ReadingOrderGroups'
+import { ReadingRouteExplanation } from './ReadingRouteExplanation'
 
 function getDieDirection(currentDie: number, predictedDie: number): string {
   if (predictedDie < currentDie) return 'More focused next roll'
@@ -57,6 +58,8 @@ export function RatingView({
   onRefreshThread,
 }: RatingViewProps) {
   const [isCorrectionDialogOpen, setIsCorrectionDialogOpen] = useState(false)
+  const [isRouteExplanationOpen, setIsRouteExplanationOpen] = useState(false)
+  const routeExplanationTriggerRef = useRef<HTMLButtonElement>(null)
   const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'failed'>('idle')
   const threadTitle = activeRatingThread?.title ?? 'Loading…'
   const issueNumber = activeRatingThread?.next_issue_number ?? activeRatingThread?.issue_number ?? null
@@ -186,7 +189,18 @@ export function RatingView({
                   <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-white/10" aria-hidden="true">
                     <div className="h-full rounded-full bg-amber-600" style={{ width: `${routeProgress}%` }} />
                   </div>
-                  <p className="mt-1 text-[10px] font-bold text-stone-500">{routeProgress}% complete</p>
+                  <div className="mt-2 flex items-center justify-between gap-2">
+                    <p className="text-[10px] font-bold text-stone-500">{routeProgress}% complete</p>
+                    <button
+                      ref={routeExplanationTriggerRef}
+                      type="button"
+                      onClick={() => setIsRouteExplanationOpen(true)}
+                      className="min-h-11 rounded-lg border border-amber-700/40 bg-amber-900/15 px-3 text-[10px] font-black text-amber-200 focus:ring-2 focus:ring-amber-500"
+                      aria-label={`Explain why ${threadTitle} ${issueNumber != null ? `#${issueNumber}` : ''} is next in ${order.name}`}
+                    >
+                      Explain route
+                    </button>
+                  </div>
                 </article>
               )
             })}
@@ -278,6 +292,18 @@ export function RatingView({
       </div>
 
       <ComicVineIssueCard issueId={issueId} />
+
+      <ReadingRouteExplanation
+        isOpen={isRouteExplanationOpen}
+        issueId={issueId}
+        issueLabel={`${threadTitle}${issueNumber != null ? ` #${issueNumber}` : ''}`}
+        readingOrders={readingOrders}
+        connectedThreads={connectedThreads}
+        onClose={() => {
+          setIsRouteExplanationOpen(false)
+          requestAnimationFrame(() => routeExplanationTriggerRef.current?.focus())
+        }}
+      />
 
       {activeRatingThread ? (
         <IssueCorrectionDialog

--- a/frontend/src/pages/RollPage/components/ReadingRouteExplanation.tsx
+++ b/frontend/src/pages/RollPage/components/ReadingRouteExplanation.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useRef } from 'react'
+import { useContinuityReadiness } from '../../../hooks/useContinuityReadiness'
+import type { ReadingOrder } from '../../../services/api-reading-orders'
+import type { ConnectedThreadInfo } from '../../../types'
+
+interface ReadingRouteExplanationProps {
+  isOpen: boolean
+  issueId: number | null | undefined
+  issueLabel: string
+  readingOrders: ReadingOrder[]
+  connectedThreads: ConnectedThreadInfo[]
+  onClose: () => void
+}
+
+export function ReadingRouteExplanation({
+  isOpen,
+  issueId,
+  issueLabel,
+  readingOrders,
+  connectedThreads,
+  onClose,
+}: ReadingRouteExplanationProps) {
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
+  const { readiness, isLoading, error, refetch } = useContinuityReadiness(isOpen ? issueId : null)
+
+  useEffect(() => {
+    if (!isOpen) return
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    closeButtonRef.current?.focus()
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.body.style.overflow = previousOverflow
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end bg-black/70 p-0 backdrop-blur-sm md:items-center md:justify-center md:p-6">
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="route-explanation-heading"
+        className="max-h-[92dvh] w-full overflow-y-auto rounded-t-3xl border border-white/10 bg-[#1a1410] p-4 shadow-2xl md:max-w-2xl md:rounded-3xl md:p-6"
+      >
+        <div className="sticky top-0 z-10 flex items-start justify-between gap-4 bg-[#1a1410] pb-3">
+          <div>
+            <p className="text-[10px] font-black uppercase tracking-[0.18em] text-amber-500">Why this issue is next</p>
+            <h2 id="route-explanation-heading" className="mt-1 text-xl font-black text-stone-100">{issueLabel}</h2>
+          </div>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            onClick={onClose}
+            className="min-h-11 rounded-xl border border-white/10 bg-white/5 px-4 text-xs font-black text-stone-200 focus:ring-2 focus:ring-amber-500"
+          >
+            Back to rating
+          </button>
+        </div>
+
+        <div className="space-y-4">
+          <section aria-labelledby="eligibility-heading" className="rounded-2xl border border-white/10 bg-white/[0.04] p-3">
+            <h3 id="eligibility-heading" className="text-xs font-black text-stone-200">Continuity eligibility</h3>
+            {issueId == null ? (
+              <p className="mt-2 text-[11px] text-amber-200">The exact issue identity is unavailable, so eligibility cannot be verified.</p>
+            ) : isLoading ? (
+              <p className="mt-2 text-[11px] text-stone-400" role="status">Checking authoritative readiness…</p>
+            ) : error || !readiness ? (
+              <div className="mt-2">
+                <p className="text-[11px] text-rose-200" role="alert">Readiness is unavailable. The pending roll has not been changed.</p>
+                <button type="button" onClick={refetch} className="mt-3 min-h-11 rounded-xl border border-rose-700/40 px-4 text-xs font-black text-rose-200">Retry readiness</button>
+              </div>
+            ) : readiness.is_readable ? (
+              <div className="mt-2">
+                <p className="text-[11px] font-bold text-emerald-300">Currently readable</p>
+                <p className="mt-1 text-[11px] leading-relaxed text-stone-400">All known direct prerequisites are satisfied. No unresolved hard prerequisite was returned for this issue.</p>
+              </div>
+            ) : (
+              <div className="mt-2">
+                <p className="text-[11px] font-bold text-rose-300">Blocked by continuity</p>
+                {readiness.blockers.length > 0 ? (
+                  <ul className="mt-2 grid gap-2" aria-label="Unresolved direct blockers">
+                    {readiness.blockers.map((blocker) => (
+                      <li key={blocker.rule_id} className="rounded-xl border border-rose-800/30 bg-rose-950/20 p-3">
+                        <span className="text-[10px] font-black uppercase tracking-wider text-rose-400">Unresolved direct blocker</span>
+                        <p className="mt-1 text-sm font-bold text-stone-200">{blocker.source_label}</p>
+                        {blocker.note ? <p className="mt-1 text-[11px] text-stone-400">{blocker.note}</p> : null}
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="mt-1 text-[11px] text-rose-200">The server marked this issue blocked without returning prerequisite details.</p>
+                )}
+              </div>
+            )}
+          </section>
+
+          {readingOrders.length > 0 ? (
+            <section aria-labelledby="named-routes-heading">
+              <h3 id="named-routes-heading" className="text-xs font-black text-stone-200">Named reading routes</h3>
+              <p className="mt-1 text-[11px] text-stone-500">Membership is informational and does not imply a hard dependency.</p>
+              <ul className="mt-2 grid gap-2 md:grid-cols-2">
+                {[...readingOrders].sort((a, b) => a.name.localeCompare(b.name)).map((order) => {
+                  const progress = order.total_items > 0 ? Math.round((order.completed_items / order.total_items) * 100) : 0
+                  return (
+                    <li key={order.id} className="rounded-xl border border-blue-800/30 bg-blue-950/15 p-3">
+                      <p className="text-sm font-black text-blue-100">{order.name}</p>
+                      <p className="mt-1 text-[11px] text-stone-400">{order.completed_items} of {order.total_items} complete · {progress}%</p>
+                    </li>
+                  )
+                })}
+              </ul>
+            </section>
+          ) : null}
+
+          {connectedThreads.length > 0 ? (
+            <section aria-labelledby="connections-heading">
+              <h3 id="connections-heading" className="text-xs font-black text-stone-200">Verified connected threads</h3>
+              <p className="mt-1 text-[11px] text-stone-500">These verified connections are shown for context, not as an inferred sequence.</p>
+              <ul className="mt-2 flex flex-wrap gap-2">
+                {connectedThreads.map((thread) => (
+                  <li key={`${thread.thread_id}-${thread.dependency_id}`} className="rounded-full border border-blue-800/40 px-3 py-1.5 text-[11px] font-bold text-blue-200">{thread.title}</li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/pages/RollPage/components/ReadingRouteExplanation.tsx
+++ b/frontend/src/pages/RollPage/components/ReadingRouteExplanation.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef } from 'react'
+import { useMemo } from 'react'
+import Modal from '../../../components/Modal'
 import { useContinuityReadiness } from '../../../hooks/useContinuityReadiness'
 import type { ReadingOrder } from '../../../services/api-reading-orders'
 import type { ConnectedThreadInfo } from '../../../types'
@@ -20,118 +21,88 @@ export function ReadingRouteExplanation({
   connectedThreads,
   onClose,
 }: ReadingRouteExplanationProps) {
-  const closeButtonRef = useRef<HTMLButtonElement>(null)
   const { readiness, isLoading, error, refetch } = useContinuityReadiness(isOpen ? issueId : null)
-
-  useEffect(() => {
-    if (!isOpen) return
-    const previousOverflow = document.body.style.overflow
-    document.body.style.overflow = 'hidden'
-    closeButtonRef.current?.focus()
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') onClose()
-    }
-    window.addEventListener('keydown', handleKeyDown)
-    return () => {
-      document.body.style.overflow = previousOverflow
-      window.removeEventListener('keydown', handleKeyDown)
-    }
-  }, [isOpen, onClose])
-
-  if (!isOpen) return null
+  const sortedReadingOrders = useMemo(
+    () => [...readingOrders].sort((a, b) => a.name.localeCompare(b.name)),
+    [readingOrders],
+  )
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end bg-black/70 p-0 backdrop-blur-sm md:items-center md:justify-center md:p-6">
-      <section
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="route-explanation-heading"
-        className="max-h-[92dvh] w-full overflow-y-auto rounded-t-3xl border border-white/10 bg-[#1a1410] p-4 shadow-2xl md:max-w-2xl md:rounded-3xl md:p-6"
-      >
-        <div className="sticky top-0 z-10 flex items-start justify-between gap-4 bg-[#1a1410] pb-3">
-          <div>
-            <p className="text-[10px] font-black uppercase tracking-[0.18em] text-amber-500">Why this issue is next</p>
-            <h2 id="route-explanation-heading" className="mt-1 text-xl font-black text-stone-100">{issueLabel}</h2>
+    <Modal
+      isOpen={isOpen}
+      title={issueLabel}
+      onClose={onClose}
+      autoFocus={false}
+      data-testid="reading-route-explanation"
+      overlayClassName="bg-black/70 backdrop-blur-sm"
+    >
+      <p className="text-[10px] font-black uppercase tracking-[0.18em] text-amber-500">Why this issue is next</p>
+
+      <section aria-labelledby="eligibility-heading" className="rounded-2xl border border-white/10 bg-white/[0.04] p-3">
+        <h3 id="eligibility-heading" className="text-xs font-black text-stone-200">Continuity eligibility</h3>
+        {issueId == null ? (
+          <p className="mt-2 text-[11px] text-amber-200">The exact issue identity is unavailable, so eligibility cannot be verified.</p>
+        ) : isLoading ? (
+          <p className="mt-2 text-[11px] text-stone-400" role="status">Checking authoritative readiness…</p>
+        ) : error || !readiness ? (
+          <div className="mt-2">
+            <p className="text-[11px] text-rose-200" role="alert">Readiness is unavailable. The pending roll has not been changed.</p>
+            <button type="button" onClick={refetch} className="mt-3 min-h-11 rounded-xl border border-rose-700/40 px-4 text-xs font-black text-rose-200">Retry readiness</button>
           </div>
-          <button
-            ref={closeButtonRef}
-            type="button"
-            onClick={onClose}
-            className="min-h-11 rounded-xl border border-white/10 bg-white/5 px-4 text-xs font-black text-stone-200 focus:ring-2 focus:ring-amber-500"
-          >
-            Back to rating
-          </button>
-        </div>
-
-        <div className="space-y-4">
-          <section aria-labelledby="eligibility-heading" className="rounded-2xl border border-white/10 bg-white/[0.04] p-3">
-            <h3 id="eligibility-heading" className="text-xs font-black text-stone-200">Continuity eligibility</h3>
-            {issueId == null ? (
-              <p className="mt-2 text-[11px] text-amber-200">The exact issue identity is unavailable, so eligibility cannot be verified.</p>
-            ) : isLoading ? (
-              <p className="mt-2 text-[11px] text-stone-400" role="status">Checking authoritative readiness…</p>
-            ) : error || !readiness ? (
-              <div className="mt-2">
-                <p className="text-[11px] text-rose-200" role="alert">Readiness is unavailable. The pending roll has not been changed.</p>
-                <button type="button" onClick={refetch} className="mt-3 min-h-11 rounded-xl border border-rose-700/40 px-4 text-xs font-black text-rose-200">Retry readiness</button>
-              </div>
-            ) : readiness.is_readable ? (
-              <div className="mt-2">
-                <p className="text-[11px] font-bold text-emerald-300">Currently readable</p>
-                <p className="mt-1 text-[11px] leading-relaxed text-stone-400">All known direct prerequisites are satisfied. No unresolved hard prerequisite was returned for this issue.</p>
-              </div>
-            ) : (
-              <div className="mt-2">
-                <p className="text-[11px] font-bold text-rose-300">Blocked by continuity</p>
-                {readiness.blockers.length > 0 ? (
-                  <ul className="mt-2 grid gap-2" aria-label="Unresolved direct blockers">
-                    {readiness.blockers.map((blocker) => (
-                      <li key={blocker.rule_id} className="rounded-xl border border-rose-800/30 bg-rose-950/20 p-3">
-                        <span className="text-[10px] font-black uppercase tracking-wider text-rose-400">Unresolved direct blocker</span>
-                        <p className="mt-1 text-sm font-bold text-stone-200">{blocker.source_label}</p>
-                        {blocker.note ? <p className="mt-1 text-[11px] text-stone-400">{blocker.note}</p> : null}
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <p className="mt-1 text-[11px] text-rose-200">The server marked this issue blocked without returning prerequisite details.</p>
-                )}
-              </div>
-            )}
-          </section>
-
-          {readingOrders.length > 0 ? (
-            <section aria-labelledby="named-routes-heading">
-              <h3 id="named-routes-heading" className="text-xs font-black text-stone-200">Named reading routes</h3>
-              <p className="mt-1 text-[11px] text-stone-500">Membership is informational and does not imply a hard dependency.</p>
-              <ul className="mt-2 grid gap-2 md:grid-cols-2">
-                {[...readingOrders].sort((a, b) => a.name.localeCompare(b.name)).map((order) => {
-                  const progress = order.total_items > 0 ? Math.round((order.completed_items / order.total_items) * 100) : 0
-                  return (
-                    <li key={order.id} className="rounded-xl border border-blue-800/30 bg-blue-950/15 p-3">
-                      <p className="text-sm font-black text-blue-100">{order.name}</p>
-                      <p className="mt-1 text-[11px] text-stone-400">{order.completed_items} of {order.total_items} complete · {progress}%</p>
-                    </li>
-                  )
-                })}
-              </ul>
-            </section>
-          ) : null}
-
-          {connectedThreads.length > 0 ? (
-            <section aria-labelledby="connections-heading">
-              <h3 id="connections-heading" className="text-xs font-black text-stone-200">Verified connected threads</h3>
-              <p className="mt-1 text-[11px] text-stone-500">These verified connections are shown for context, not as an inferred sequence.</p>
-              <ul className="mt-2 flex flex-wrap gap-2">
-                {connectedThreads.map((thread) => (
-                  <li key={`${thread.thread_id}-${thread.dependency_id}`} className="rounded-full border border-blue-800/40 px-3 py-1.5 text-[11px] font-bold text-blue-200">{thread.title}</li>
+        ) : readiness.is_readable ? (
+          <div className="mt-2">
+            <p className="text-[11px] font-bold text-emerald-300">Currently readable</p>
+            <p className="mt-1 text-[11px] leading-relaxed text-stone-400">All known direct prerequisites are satisfied. No unresolved hard prerequisite was returned for this issue.</p>
+          </div>
+        ) : (
+          <div className="mt-2">
+            <p className="text-[11px] font-bold text-rose-300">Blocked by continuity</p>
+            {readiness.blockers.length > 0 ? (
+              <ul className="mt-2 grid gap-2" aria-label="Unresolved direct blockers">
+                {readiness.blockers.map((blocker) => (
+                  <li key={blocker.rule_id} className="rounded-xl border border-rose-800/30 bg-rose-950/20 p-3">
+                    <span className="text-[10px] font-black uppercase tracking-wider text-rose-400">Unresolved direct blocker</span>
+                    <p className="mt-1 text-sm font-bold text-stone-200">{blocker.source_label}</p>
+                    {blocker.note ? <p className="mt-1 text-[11px] text-stone-400">{blocker.note}</p> : null}
+                  </li>
                 ))}
               </ul>
-            </section>
-          ) : null}
-        </div>
+            ) : (
+              <p className="mt-1 text-[11px] text-rose-200">The server marked this issue blocked without returning prerequisite details.</p>
+            )}
+          </div>
+        )}
       </section>
-    </div>
+
+      {sortedReadingOrders.length > 0 ? (
+        <section aria-labelledby="named-routes-heading">
+          <h3 id="named-routes-heading" className="text-xs font-black text-stone-200">Named reading routes</h3>
+          <p className="mt-1 text-[11px] text-stone-500">Membership is informational and does not imply a hard dependency.</p>
+          <ul className="mt-2 grid gap-2 md:grid-cols-2">
+            {sortedReadingOrders.map((order) => {
+              const progress = order.total_items > 0 ? Math.round((order.completed_items / order.total_items) * 100) : 0
+              return (
+                <li key={order.id} className="rounded-xl border border-blue-800/30 bg-blue-950/15 p-3">
+                  <p className="text-sm font-black text-blue-100">{order.name}</p>
+                  <p className="mt-1 text-[11px] text-stone-400">{order.completed_items} of {order.total_items} complete · {progress}%</p>
+                </li>
+              )
+            })}
+          </ul>
+        </section>
+      ) : null}
+
+      {connectedThreads.length > 0 ? (
+        <section aria-labelledby="connections-heading">
+          <h3 id="connections-heading" className="text-xs font-black text-stone-200">Verified connected threads</h3>
+          <p className="mt-1 text-[11px] text-stone-500">These verified connections are shown for context, not as an inferred sequence.</p>
+          <ul className="mt-2 flex flex-wrap gap-2">
+            {connectedThreads.map((thread) => (
+              <li key={`${thread.thread_id}-${thread.dependency_id}`} className="rounded-full border border-blue-800/40 px-3 py-1.5 text-[11px] font-bold text-blue-200">{thread.title}</li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </Modal>
   )
 }

--- a/frontend/src/unit/ReadingRouteExplanation.test.tsx
+++ b/frontend/src/unit/ReadingRouteExplanation.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReadingOrder } from '../services/api-reading-orders'
+import type { ConnectedThreadInfo } from '../types'
+import { ReadingRouteExplanation } from '../pages/RollPage/components/ReadingRouteExplanation'
+
+const mocks = vi.hoisted(() => ({ useContinuityReadiness: vi.fn() }))
+
+vi.mock('../hooks/useContinuityReadiness', () => ({
+  useContinuityReadiness: mocks.useContinuityReadiness,
+}))
+
+const refetch = vi.fn()
+const routes = [
+  { id: 2, name: 'Secret Wars', completed_items: 2, total_items: 8 },
+  { id: 1, name: 'Avengers path', completed_items: 5, total_items: 10 },
+] as ReadingOrder[]
+const connections = [
+  { thread_id: 9, dependency_id: 4, title: 'Prelude' },
+] as ConnectedThreadInfo[]
+
+beforeEach(() => {
+  refetch.mockReset()
+  mocks.useContinuityReadiness.mockReturnValue({
+    readiness: {
+      node_type: 'issue',
+      node_id: 7,
+      is_readable: false,
+      evaluated_issue_id: 7,
+      blockers: [{
+        rule_id: 2,
+        source_type: 'issue',
+        source_id: 3,
+        source_label: 'Prelude #1',
+        satisfaction_type: 'item_read',
+        satisfied: false,
+        causing_issue_ids: [3],
+        causing_member_issue_ids: [],
+        note: 'Finish the prelude first',
+      }],
+    },
+    isLoading: false,
+    error: null,
+    refetch,
+  })
+})
+
+describe('ReadingRouteExplanation', () => {
+  it('keeps hard blockers distinct from deterministic informational routes', () => {
+    render(
+      <ReadingRouteExplanation
+        isOpen
+        issueId={7}
+        issueLabel="Avengers #7"
+        readingOrders={routes}
+        connectedThreads={connections}
+        onClose={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('dialog', { name: 'Avengers #7' })).toBeVisible()
+    expect(screen.getByText('Prelude #1')).toBeVisible()
+    expect(screen.getByText('Finish the prelude first')).toBeVisible()
+    expect(screen.getByText(/membership is informational/i)).toBeVisible()
+    const names = screen.getAllByRole('listitem').map((item) => item.textContent)
+    expect(names.join(' ')).toMatch(/Avengers path.*Secret Wars/)
+  })
+
+  it('dismisses with Escape without changing the pending rating state', async () => {
+    const onClose = vi.fn()
+    render(
+      <ReadingRouteExplanation
+        isOpen
+        issueId={7}
+        issueLabel="Avengers #7"
+        readingOrders={routes}
+        connectedThreads={[]}
+        onClose={onClose}
+      />,
+    )
+
+    await userEvent.setup().keyboard('{Escape}')
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('states when an eligible issue has no unresolved hard prerequisites', () => {
+    mocks.useContinuityReadiness.mockReturnValue({
+      readiness: { node_type: 'issue', node_id: 7, is_readable: true, evaluated_issue_id: 7, blockers: [] },
+      isLoading: false,
+      error: null,
+      refetch,
+    })
+    render(
+      <ReadingRouteExplanation
+        isOpen
+        issueId={7}
+        issueLabel="Avengers #7"
+        readingOrders={[]}
+        connectedThreads={[]}
+        onClose={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('Currently readable')).toBeVisible()
+    expect(screen.getByText(/no unresolved hard prerequisite/i)).toBeVisible()
+  })
+})

--- a/frontend/src/unit/ReadingRouteExplanation.test.tsx
+++ b/frontend/src/unit/ReadingRouteExplanation.test.tsx
@@ -104,4 +104,93 @@ describe('ReadingRouteExplanation', () => {
     expect(screen.getByText('Currently readable')).toBeVisible()
     expect(screen.getByText(/no unresolved hard prerequisite/i)).toBeVisible()
   })
+
+
+  it('covers unavailable identity, loading, and retryable readiness states', async () => {
+    const { rerender } = render(
+      <ReadingRouteExplanation
+        isOpen
+        issueId={null}
+        issueLabel="Unknown issue"
+        readingOrders={[]}
+        connectedThreads={[]}
+        onClose={vi.fn()}
+      />,
+    )
+    expect(screen.getByText(/identity is unavailable/i)).toBeVisible()
+
+    mocks.useContinuityReadiness.mockReturnValue({
+      readiness: null,
+      isLoading: true,
+      error: null,
+      refetch,
+    })
+    rerender(
+      <ReadingRouteExplanation
+        isOpen
+        issueId={7}
+        issueLabel="Avengers #7"
+        readingOrders={[]}
+        connectedThreads={[]}
+        onClose={vi.fn()}
+      />,
+    )
+    expect(screen.getByRole('status')).toHaveTextContent(/checking authoritative readiness/i)
+
+    mocks.useContinuityReadiness.mockReturnValue({
+      readiness: null,
+      isLoading: false,
+      error: new Error('offline'),
+      refetch,
+    })
+    rerender(
+      <ReadingRouteExplanation
+        isOpen
+        issueId={7}
+        issueLabel="Avengers #7"
+        readingOrders={[]}
+        connectedThreads={[]}
+        onClose={vi.fn()}
+      />,
+    )
+    await userEvent.click(screen.getByRole('button', { name: /retry readiness/i }))
+    expect(refetch).toHaveBeenCalledOnce()
+  })
+
+  it('explains incomplete server details and zero-length route progress', () => {
+    mocks.useContinuityReadiness.mockReturnValue({
+      readiness: { node_type: 'issue', node_id: 7, is_readable: false, evaluated_issue_id: 7, blockers: [] },
+      isLoading: false,
+      error: null,
+      refetch,
+    })
+    render(
+      <ReadingRouteExplanation
+        isOpen
+        issueId={7}
+        issueLabel="Avengers #7"
+        readingOrders={[{ id: 3, name: 'Empty route', completed_items: 0, total_items: 0 } as ReadingOrder]}
+        connectedThreads={[]}
+        onClose={vi.fn()}
+      />,
+    )
+    expect(screen.getByText(/blocked without returning prerequisite details/i)).toBeVisible()
+    expect(screen.getByText(/0 of 0 complete · 0%/i)).toBeVisible()
+  })
+
+  it('does not render or lock scrolling while closed', () => {
+    document.body.style.overflow = 'auto'
+    render(
+      <ReadingRouteExplanation
+        isOpen={false}
+        issueId={7}
+        issueLabel="Avengers #7"
+        readingOrders={routes}
+        connectedThreads={connections}
+        onClose={vi.fn()}
+      />,
+    )
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(document.body.style.overflow).toBe('auto')
+  })
 })

--- a/frontend/src/unit/ReadingRouteExplanation.test.tsx
+++ b/frontend/src/unit/ReadingRouteExplanation.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -82,6 +83,34 @@ describe('ReadingRouteExplanation', () => {
 
     await userEvent.setup().keyboard('{Escape}')
     expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('traps focus and restores it to the route trigger after Escape', async () => {
+    function Harness() {
+      const [isOpen, setIsOpen] = useState(false)
+      return (
+        <>
+          <button type="button" onClick={() => setIsOpen(true)}>Explain route</button>
+          <ReadingRouteExplanation
+            isOpen={isOpen}
+            issueId={7}
+            issueLabel="Avengers #7"
+            readingOrders={routes}
+            connectedThreads={[]}
+            onClose={() => setIsOpen(false)}
+          />
+        </>
+      )
+    }
+
+    const user = userEvent.setup()
+    render(<Harness />)
+    const trigger = screen.getByRole('button', { name: 'Explain route' })
+    await user.click(trigger)
+    expect(screen.getByRole('button', { name: 'Close modal' })).toHaveFocus()
+
+    await user.keyboard('{Escape}')
+    expect(trigger).toHaveFocus()
   })
 
   it('states when an eligible issue has no unresolved hard prerequisites', () => {


### PR DESCRIPTION
Part of #1090.

## Summary
- opens a focused reading-route explanation directly from every named route summary
- keeps the pending Roll and unsaved rating mounted while the explanation is open
- separates authoritative hard blockers from informational route memberships and verified connections
- restores keyboard focus to the exact route that opened the view
- adds unit coverage for blocked, readable, deterministic-route, and Escape-dismissal states

## Validation
- CI requested (connector-backed implementation; no local checkout is available in this worker)
- focused unit coverage added in `ReadingRouteExplanation.test.tsx`

## Remaining #1090 scope
The current readiness response exposes unresolved direct blockers only. A follow-up on this PR must add the smallest user-scoped structured contract for satisfied prerequisites, bounded transitive branches, verified downstream unlocks, crossover memberships, diagnostics, and focused Chromium coverage before #1090 can close.