### PR TITLE
Normalize session, snooze, and undo APIs under /api/v1

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -200,8 +200,8 @@ def create_app(*, serve_frontend: bool = True) -> FastAPI:
     # API route prefix convention:
     # - Legacy resources remain available under /api/* as compatibility aliases.
     # - Retained client resources migrate to the versioned /api/v1/* surface.
-    # - /api/v1/auth/*, /api/v1/sessions/*, /api/v1/roll/*, and /api/v1/rate/*
-    #   are explicit aliases while maintained callers migrate to v1.
+    # - Retained auth, session, snooze, undo, roll, and rating resources have
+    #   explicit v1 aliases while legacy paths remain compatibility surfaces.
     # - Non-production tooling routes (debug, test) are also mounted under
     #   bare /api/* but only in non-production/test environments — they are
     #   intentional exceptions to the versioning rule, not client APIs.
@@ -226,7 +226,9 @@ def create_app(*, serve_frontend: bool = True) -> FastAPI:
     app.include_router(session.router, prefix="/api/sessions", tags=["session"])
     app.include_router(session.router, prefix="/api/v1/sessions", tags=["session"])
     app.include_router(snooze.router, prefix="/api/snooze", tags=["snooze"])
+    app.include_router(snooze.router, prefix="/api/v1/snooze", tags=["snooze"])
     app.include_router(undo.router, prefix="/api/undo", tags=["undo"])
+    app.include_router(undo.router, prefix="/api/v1/undo", tags=["undo"])
     app.include_router(dependency.router, prefix="/api/v1", tags=["dependencies"])
     if os.getenv("TEST_ENVIRONMENT") == "true":
         app.include_router(test_helpers.router, prefix="/api", tags=["test"])

--- a/docs/changelog.d/2026-08-12-1099.md
+++ b/docs/changelog.d/2026-08-12-1099.md
@@ -1,0 +1,5 @@
+## 2026-08-12
+
+### API reliability
+
+- ComicPile's maintained session, snooze, and undo requests now use the canonical versioned API while legacy clients remain compatible. [#1099](https://github.com/JoshCLWren/comic-pile/pull/1099)

--- a/frontend/src/generated/openapi.json
+++ b/frontend/src/generated/openapi.json
@@ -9074,6 +9074,81 @@
         ]
       }
     },
+    "/api/v1/snooze/": {
+      "post": {
+        "description": "Snooze the pending thread, demote it in the queue, and step the die up.\n\nThis endpoint:\n1. Gets the current session (must exist with a pending_thread_id)\n2. Moves the pending thread beyond the widened roll range\n3. Adds the pending_thread_id to snoozed_thread_ids\n4. Steps the die UP (wider pool) using dice ladder logic\n5. Records a \"snooze\" event\n6. Clears pending_thread_id\n7. Returns the updated session\n\nArgs:\n    request: FastAPI request object for rate limiting.\n    current_user: The authenticated user making the request.\n    db: SQLAlchemy session for database operations.\n\nReturns:\n    SessionResponse containing the updated session with snoozed_thread_ids,\n    cleared pending_thread_id, and current die state.\n\nRaises:\n    HTTPException: If no active session exists or no pending thread to snooze.",
+        "operationId": "snooze_thread_api_v1_snooze__post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Snooze Thread",
+        "tags": [
+          "snooze"
+        ]
+      }
+    },
+    "/api/v1/snooze/{thread_id}/unsnooze": {
+      "post": {
+        "description": "Remove thread from snoozed list.",
+        "operationId": "unsnooze_thread_api_v1_snooze__thread_id__unsnooze_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Unsnooze Thread",
+        "tags": [
+          "snooze"
+        ]
+      }
+    },
     "/api/v1/threads/": {
       "get": {
         "description": "List threads ordered by position with cursor-based pagination.\n\nArgs:\n    request: FastAPI request object for rate limiting.\n    search: Optional case-insensitive title search filter.\n    page_size: Number of threads to return per page (default 50, max 200).\n    page_token: Token for pagination continuation (queue_position,thread_id).\n    current_user: The authenticated user making the request.\n    db: SQLAlchemy session for database operations.\n\nReturns:\n    QueueThreadListResponse with paginated threads and next_page_token if more exist.\n\nRaises:\n    HTTPException: If a retired ``collection_id`` query parameter is present.",
@@ -10389,6 +10464,118 @@
         "tags": [
           "dependencies",
           "dependencies"
+        ]
+      }
+    },
+    "/api/v1/undo/{session_id}/snapshots": {
+      "get": {
+        "description": "List all snapshots for a session.\n\nArgs:\n    session_id: Session whose snapshots should be listed.\n    current_user: Authenticated user.\n    db: Database session.\n\nReturns:\n    Snapshot metadata in reverse chronological order.\n\nRaises:\n    HTTPException: If the session is not owned by the current user.",
+        "operationId": "list_session_snapshots_api_v1_undo__session_id__snapshots_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "title": "Response List Session Snapshots Api V1 Undo  Session Id  Snapshots Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "List Session Snapshots",
+        "tags": [
+          "undo",
+          "undo"
+        ]
+      }
+    },
+    "/api/v1/undo/{session_id}/undo/{snapshot_id}": {
+      "post": {
+        "description": "Undo session state to a snapshot with deadlock retry handling.\n\nArgs:\n    session_id: Session to restore.\n    snapshot_id: Snapshot to restore.\n    current_user: Authenticated user.\n    db: Database session.\n\nReturns:\n    Restored session response.\n\nRaises:\n    RuntimeError: If all deadlock retries fail.",
+        "operationId": "undo_to_snapshot_api_v1_undo__session_id__undo__snapshot_id__post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "snapshot_id",
+            "required": true,
+            "schema": {
+              "title": "Snapshot Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Undo To Snapshot",
+        "tags": [
+          "undo",
+          "undo"
         ]
       }
     },

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -2599,6 +2599,67 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/snooze/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Snooze Thread
+         * @description Snooze the pending thread, demote it in the queue, and step the die up.
+         *
+         *     This endpoint:
+         *     1. Gets the current session (must exist with a pending_thread_id)
+         *     2. Moves the pending thread beyond the widened roll range
+         *     3. Adds the pending_thread_id to snoozed_thread_ids
+         *     4. Steps the die UP (wider pool) using dice ladder logic
+         *     5. Records a "snooze" event
+         *     6. Clears pending_thread_id
+         *     7. Returns the updated session
+         *
+         *     Args:
+         *         request: FastAPI request object for rate limiting.
+         *         current_user: The authenticated user making the request.
+         *         db: SQLAlchemy session for database operations.
+         *
+         *     Returns:
+         *         SessionResponse containing the updated session with snoozed_thread_ids,
+         *         cleared pending_thread_id, and current die state.
+         *
+         *     Raises:
+         *         HTTPException: If no active session exists or no pending thread to snooze.
+         */
+        post: operations["snooze_thread_api_v1_snooze__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/snooze/{thread_id}/unsnooze": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Unsnooze Thread
+         * @description Remove thread from snoozed list.
+         */
+        post: operations["unsnooze_thread_api_v1_snooze__thread_id__unsnooze_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/threads/": {
         parameters: {
             query?: never;
@@ -3246,6 +3307,69 @@ export interface paths {
          * @description Return blocked status and human-readable blocking reasons for multiple threads.
          */
         post: operations["get_threads_blocking_info_api_v1_threads_getBlockingInfo_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/undo/{session_id}/snapshots": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Session Snapshots
+         * @description List all snapshots for a session.
+         *
+         *     Args:
+         *         session_id: Session whose snapshots should be listed.
+         *         current_user: Authenticated user.
+         *         db: Database session.
+         *
+         *     Returns:
+         *         Snapshot metadata in reverse chronological order.
+         *
+         *     Raises:
+         *         HTTPException: If the session is not owned by the current user.
+         */
+        get: operations["list_session_snapshots_api_v1_undo__session_id__snapshots_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/undo/{session_id}/undo/{snapshot_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Undo To Snapshot
+         * @description Undo session state to a snapshot with deadlock retry handling.
+         *
+         *     Args:
+         *         session_id: Session to restore.
+         *         snapshot_id: Snapshot to restore.
+         *         current_user: Authenticated user.
+         *         db: Database session.
+         *
+         *     Returns:
+         *         Restored session response.
+         *
+         *     Raises:
+         *         RuntimeError: If all deadlock retries fail.
+         */
+        post: operations["undo_to_snapshot_api_v1_undo__session_id__undo__snapshot_id__post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -8136,6 +8260,57 @@ export interface operations {
             };
         };
     };
+    snooze_thread_api_v1_snooze__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SessionResponse"];
+                };
+            };
+        };
+    };
+    unsnooze_thread_api_v1_snooze__thread_id__unsnooze_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                thread_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SessionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     list_threads_api_v1_threads__get: {
         parameters: {
             query?: {
@@ -8913,6 +9088,71 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["BatchBlockingExplanationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_session_snapshots_api_v1_undo__session_id__snapshots_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                session_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    }[];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    undo_to_snapshot_api_v1_undo__session_id__undo__snapshot_id__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                session_id: number;
+                snapshot_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SessionResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -310,16 +310,16 @@ export const sessionApi = {
     if (pageToken) {
       queryParams.page_token = pageToken;
     }
-    const response = await api.get<SessionListResponse>('/sessions/', {
+    const response = await api.get<SessionListResponse>('/v1/sessions/', {
       params: Object.keys(queryParams).length ? queryParams : undefined,
     })
     return response
   },
-  get: (id: number) => api.get<SessionSummary>(`/sessions/${id}`),
-  getCurrent: () => api.get<SessionCurrent>('/sessions/current/'),
-  getDetails: (id: number | string) => api.get<SessionDetails>(`/sessions/${id}/details`),
-  getSnapshots: (id: number | string) => api.get<SessionSnapshotsResponse>(`/sessions/${id}/snapshots`),
-  restoreSessionStart: (id: number | string) => api.post<void>(`/sessions/${id}/restore-session-start`),
+  get: (id: number) => api.get<SessionSummary>(`/v1/sessions/${id}`),
+  getCurrent: () => api.get<SessionCurrent>('/v1/sessions/current/'),
+  getDetails: (id: number | string) => api.get<SessionDetails>(`/v1/sessions/${id}/details`),
+  getSnapshots: (id: number | string) => api.get<SessionSnapshotsResponse>(`/v1/sessions/${id}/snapshots`),
+  restoreSessionStart: (id: number | string) => api.post<void>(`/v1/sessions/${id}/restore-session-start`),
 }
 
 export const queueApi = {
@@ -332,8 +332,8 @@ export const queueApi = {
 
 export const undoApi = {
   undo: (sessionId: number | string, snapshotId: number | string) =>
-    api.post<void>(`/undo/${sessionId}/undo/${snapshotId}`),
-  listSnapshots: (sessionId: number | string) => api.get<SessionSnapshotsResponse>(`/undo/${sessionId}/snapshots`),
+    api.post<void>(`/v1/undo/${sessionId}/undo/${snapshotId}`),
+  listSnapshots: (sessionId: number | string) => api.get<SessionSnapshotsResponse>(`/v1/undo/${sessionId}/snapshots`),
 }
 
 export const dependenciesApi = {
@@ -413,8 +413,8 @@ export const tasksApi = {
 }
 
 export const snoozeApi = {
-  snooze: () => api.post<void>('/snooze/'),
-  unsnooze: (threadId: number) => api.post<void>(`/snooze/${threadId}/unsnooze`),
+  snooze: () => api.post<void>('/v1/snooze/'),
+  unsnooze: (threadId: number) => api.post<void>(`/v1/snooze/${threadId}/unsnooze`),
 }
 
 export const migrationApi = {

--- a/frontend/src/services/protectedRollMutationApi.ts
+++ b/frontend/src/services/protectedRollMutationApi.ts
@@ -8,7 +8,7 @@ export const protectedRollMutationApi = {
   rate: (data: RatePayload): Promise<Thread> =>
     api.post<Thread, RatePayload>('/v1/rate/', data, RECOVERY_CONFIG),
   snooze: (): Promise<void> =>
-    api.post<void>('/snooze/', undefined, RECOVERY_CONFIG),
+    api.post<void>('/v1/snooze/', undefined, RECOVERY_CONFIG),
   bootstrap: (): Promise<RollBootstrapResponse> =>
     api.get<RollBootstrapResponse>('/v1/roll/bootstrap', RECOVERY_CONFIG),
 }

--- a/frontend/src/unit/api.test.ts
+++ b/frontend/src/unit/api.test.ts
@@ -140,6 +140,31 @@ it('calls every remaining API resource endpoint', async () => {
   expect(post).toHaveBeenCalledWith('/bug-reports/', { title: 'Bug', description: 'Description', diagnostics: {} })
 })
 
+
+it('uses canonical v1 paths for session, snooze, and undo resources', async () => {
+  await sessionApi.list()
+  await sessionApi.get(7)
+  await sessionApi.getCurrent()
+  await sessionApi.getDetails(7)
+  await sessionApi.getSnapshots(7)
+  await sessionApi.restoreSessionStart(7)
+  await snoozeApi.snooze()
+  await snoozeApi.unsnooze(9)
+  await undoApi.undo(7, 3)
+  await undoApi.listSnapshots(7)
+
+  expect(get).toHaveBeenCalledWith('/v1/sessions/', { params: undefined })
+  expect(get).toHaveBeenCalledWith('/v1/sessions/7')
+  expect(get).toHaveBeenCalledWith('/v1/sessions/current/')
+  expect(get).toHaveBeenCalledWith('/v1/sessions/7/details')
+  expect(get).toHaveBeenCalledWith('/v1/sessions/7/snapshots')
+  expect(post).toHaveBeenCalledWith('/v1/sessions/7/restore-session-start')
+  expect(post).toHaveBeenCalledWith('/v1/snooze/')
+  expect(post).toHaveBeenCalledWith('/v1/snooze/9/unsnooze')
+  expect(post).toHaveBeenCalledWith('/v1/undo/7/undo/3')
+  expect(get).toHaveBeenCalledWith('/v1/undo/7/snapshots')
+})
+
 it('adds auth and csrf headers to mutating requests', async () => {
   setAccessToken('access-token')
   document.cookie = 'csrf_token=cookie-token; path=/'
@@ -167,7 +192,7 @@ it('handles request defaults and issue dependency payloads', async () => {
     source_type: 'issue', source_id: 8, target_type: 'issue', target_id: 9,
   })
   await sessionApi.list()
-  expect(get).toHaveBeenCalledWith('/sessions/', { params: undefined })
+  expect(get).toHaveBeenCalledWith('/v1/sessions/', { params: undefined })
 })
 
 it('handles missing request URLs and cookies while sharing csrf bootstrap work', async () => {

--- a/frontend/src/unit/rollRatingV1Api.test.ts
+++ b/frontend/src/unit/rollRatingV1Api.test.ts
@@ -50,7 +50,7 @@ it('uses canonical v1 Roll and rating paths for maintained callers', async () =>
   expect(apiMock.get).toHaveBeenCalledWith('/v1/roll/bootstrap')
 })
 
-it('keeps auth-recovery Roll mutations on v1 while snooze remains on its own migration track', async () => {
+it('keeps auth-recovery Roll mutations on canonical v1 paths', async () => {
   await protectedRollMutationApi.rate({ thread_id: 9, rating: 3 })
   await protectedRollMutationApi.bootstrap()
   await protectedRollMutationApi.snooze()
@@ -61,5 +61,5 @@ it('keeps auth-recovery Roll mutations on v1 while snooze remains on its own mig
     { skipAuthRedirect: true },
   )
   expect(apiMock.get).toHaveBeenCalledWith('/v1/roll/bootstrap', { skipAuthRedirect: true })
-  expect(apiMock.post).toHaveBeenCalledWith('/snooze/', undefined, { skipAuthRedirect: true })
+  expect(apiMock.post).toHaveBeenCalledWith('/v1/snooze/', undefined, { skipAuthRedirect: true })
 })

--- a/scripts/benchmark_session_reads.py
+++ b/scripts/benchmark_session_reads.py
@@ -157,12 +157,12 @@ def summarize(samples: list[Sample]) -> dict[str, Any]:
 
 def _build_endpoints(page_size: int, later_page_token: str | None) -> list[str]:
     endpoints = [
-        "/api/sessions/current/",
-        f"/api/sessions/?{urlencode({'page_size': page_size})}",
+        "/api/v1/sessions/current/",
+        f"/api/v1/sessions/?{urlencode({'page_size': page_size})}",
     ]
     if later_page_token:
         endpoints.append(
-            f"/api/sessions/?{urlencode({'page_size': page_size, 'page_token': later_page_token})}"
+            f"/api/v1/sessions/?{urlencode({'page_size': page_size, 'page_token': later_page_token})}"
         )
     return endpoints
 

--- a/tests/test_benchmark_session_reads.py
+++ b/tests/test_benchmark_session_reads.py
@@ -21,13 +21,13 @@ def test_parse_db_queries_handles_missing_and_invalid_headers() -> None:
 def test_build_endpoints_includes_optional_later_history_page() -> None:
     """Verify endpoint construction includes the optional later-History-page entry."""
     assert _build_endpoints(25, None) == [
-        "/api/sessions/current/",
-        "/api/sessions/?page_size=25",
+        "/api/v1/sessions/current/",
+        "/api/v1/sessions/?page_size=25",
     ]
     assert _build_endpoints(25, "2026-08-01T12:00:00+00:00,42") == [
-        "/api/sessions/current/",
-        "/api/sessions/?page_size=25",
-        "/api/sessions/?page_size=25&page_token=2026-08-01T12%3A00%3A00%2B00%3A00%2C42",
+        "/api/v1/sessions/current/",
+        "/api/v1/sessions/?page_size=25",
+        "/api/v1/sessions/?page_size=25&page_token=2026-08-01T12%3A00%3A00%2B00%3A00%2C42",
     ]
 
 
@@ -35,10 +35,10 @@ def test_select_endpoints_supports_isolated_first_request_runs() -> None:
     """Verify each endpoint can be measured without earlier endpoints preconditioning it."""
     token = "2026-08-01T12:00:00+00:00,42"
 
-    assert _select_endpoints("current", 25, token) == ["/api/sessions/current/"]
-    assert _select_endpoints("history-first", 25, token) == ["/api/sessions/?page_size=25"]
+    assert _select_endpoints("current", 25, token) == ["/api/v1/sessions/current/"]
+    assert _select_endpoints("history-first", 25, token) == ["/api/v1/sessions/?page_size=25"]
     assert _select_endpoints("history-later", 25, token) == [
-        "/api/sessions/?page_size=25&page_token=2026-08-01T12%3A00%3A00%2B00%3A00%2C42"
+        "/api/v1/sessions/?page_size=25&page_token=2026-08-01T12%3A00%3A00%2B00%3A00%2C42"
     ]
     assert _select_endpoints("all", 25, token) == _build_endpoints(25, token)
 
@@ -53,7 +53,7 @@ def test_summarize_separates_first_observed_from_steady_state() -> None:
     """Verify summarize splits first-observed evidence from steady-state aggregate."""
     samples = [
         Sample(
-            endpoint="/api/sessions/current/",
+            endpoint="/api/v1/sessions/current/",
             iteration=1,
             elapsed_ms=40.0,
             status=200,
@@ -64,7 +64,7 @@ def test_summarize_separates_first_observed_from_steady_state() -> None:
             server_timing=None,
         ),
         Sample(
-            endpoint="/api/sessions/current/",
+            endpoint="/api/v1/sessions/current/",
             iteration=2,
             elapsed_ms=20.0,
             status=200,
@@ -75,7 +75,7 @@ def test_summarize_separates_first_observed_from_steady_state() -> None:
             server_timing="app;dur=19.5",
         ),
         Sample(
-            endpoint="/api/sessions/current/",
+            endpoint="/api/v1/sessions/current/",
             iteration=3,
             elapsed_ms=30.0,
             status=200,
@@ -88,7 +88,7 @@ def test_summarize_separates_first_observed_from_steady_state() -> None:
     ]
 
     assert summarize(samples) == {
-        "endpoint": "/api/sessions/current/",
+        "endpoint": "/api/v1/sessions/current/",
         "first_observed": {
             "elapsed_ms": 40.0,
             "status": 200,
@@ -120,7 +120,7 @@ def test_summarize_separates_first_observed_from_steady_state() -> None:
 def test_summarize_handles_a_single_recorded_sample() -> None:
     """Verify summarize correctly reports a single-sample run with no steady state."""
     sample = Sample(
-        endpoint="/api/sessions/?page_size=50",
+        endpoint="/api/v1/sessions/?page_size=50",
         iteration=1,
         elapsed_ms=15.0,
         status=200,

--- a/tests/test_route_versioning.py
+++ b/tests/test_route_versioning.py
@@ -14,6 +14,7 @@ This test file verifies two things:
 
 import pytest
 
+from fastapi.routing import APIRoute
 from httpx import AsyncClient
 
 from app.main import create_app
@@ -55,7 +56,7 @@ def test_v1_snooze_and_undo_aliases_match_legacy_route_methods() -> None:
     methods_by_path = {
         route.path: frozenset(route.methods or set())
         for route in app.routes
-        if getattr(route, "path", None)
+        if isinstance(route, APIRoute)
     }
 
     alias_pairs = (

--- a/tests/test_route_versioning.py
+++ b/tests/test_route_versioning.py
@@ -1,4 +1,4 @@
-"""Tests for the API route prefix convention and the sessions alias (issue #376).
+"""Tests for retained legacy and canonical API route aliases.
 
 The API exposes a legacy surface (/api/*) and a versioned surface (/api/v1/*).
 /api/v1/sessions/current/ is an explicit backwards-compat alias of
@@ -47,6 +47,29 @@ async def test_api_v1_alias_session_endpoint_matches_legacy(auth_client: AsyncCl
     else:
         assert resp_v1.text == resp_legacy.text
 
+
+
+def test_v1_snooze_and_undo_aliases_match_legacy_route_methods() -> None:
+    """Canonical aliases reuse the same snooze and undo handler contracts."""
+    app = create_app(serve_frontend=False)
+    methods_by_path = {
+        route.path: frozenset(route.methods or set())
+        for route in app.routes
+        if getattr(route, "path", None)
+    }
+
+    alias_pairs = (
+        ("/api/snooze/", "/api/v1/snooze/"),
+        ("/api/snooze/{thread_id}/unsnooze", "/api/v1/snooze/{thread_id}/unsnooze"),
+        (
+            "/api/undo/{session_id}/undo/{snapshot_id}",
+            "/api/v1/undo/{session_id}/undo/{snapshot_id}",
+        ),
+        ("/api/undo/{session_id}/snapshots", "/api/v1/undo/{session_id}/snapshots"),
+    )
+    for legacy_path, canonical_path in alias_pairs:
+        assert canonical_path in methods_by_path
+        assert methods_by_path[canonical_path] == methods_by_path[legacy_path]
 
 def test_no_new_bare_api_client_routes() -> None:
     """Regression guard: no client-facing routes under bare /api/* (non-v1)."""


### PR DESCRIPTION
Closes #953.

## Summary
- mount canonical `/api/v1/snooze` and `/api/v1/undo` aliases while retaining legacy compatibility routes
- move maintained frontend session, snooze, and undo callers to `/v1`
- move the authenticated session benchmark to canonical v1 paths
- verify legacy and canonical route methods stay aligned
- pin every maintained frontend caller to its canonical path

## Validation
- focused backend and frontend tests added
- configured CI is the executable validation boundary for this connector-backed branch
- generated OpenAPI validation is expected to identify whether refreshed artifacts are required