### PR TITLE
Fix Queue thread-card navigation

### DIFF
--- a/docs/changelog.d/2026-08-12-1101.md
+++ b/docs/changelog.d/2026-08-12-1101.md
@@ -2,4 +2,4 @@
 
 ### Queue
 
-- [PR #1101](https://github.com/JoshCLWren/comic-pile/pull/1101) makes the full Queue card surface open thread details while keeping its menus, links, and reading actions independent.
+- [#1101](https://github.com/JoshCLWren/comic-pile/pull/1101) makes the full Queue card surface open thread details while keeping its menus, links, and reading actions independent.

--- a/docs/changelog.d/2026-08-12-1101.md
+++ b/docs/changelog.d/2026-08-12-1101.md
@@ -1,0 +1,5 @@
+## 2026-08-12
+
+### Queue
+
+- [PR #1101](https://github.com/JoshCLWren/comic-pile/pull/1101) makes the full Queue card surface open thread details while keeping its menus, links, and reading actions independent.

--- a/frontend/src/pages/QueuePage/QueueThreadCard.tsx
+++ b/frontend/src/pages/QueuePage/QueueThreadCard.tsx
@@ -72,12 +72,15 @@ export default function QueueThreadCard({
   const resolvedCrossoverGroupsLoading = crossoverGroupsLoading ?? fallbackCrossoverGroups.isPending
   const resolvedCrossoverGroupsError = crossoverGroupsError ?? Boolean(fallbackCrossoverGroups.error)
 
-  const isInteractiveTarget = (target: EventTarget | null) =>
-    target instanceof Element
-    && target.closest('button, a, input, select, textarea, [role="button"], [role="link"]')
+  const isInteractiveTarget = (target: EventTarget | null, card: HTMLDivElement) => {
+    const interactive = target instanceof Element
+      ? target.closest('button, a, input, select, textarea, [role="button"], [role="link"]')
+      : null
+    return interactive !== null && interactive !== card
+  }
 
   const handleCardClick = (event: React.MouseEvent<HTMLDivElement>) => {
-    if (isInteractiveTarget(event.target)) {
+    if (isInteractiveTarget(event.target, event.currentTarget)) {
       return
     }
     onCardClick()

--- a/frontend/src/pages/QueuePage/QueueThreadCard.tsx
+++ b/frontend/src/pages/QueuePage/QueueThreadCard.tsx
@@ -72,22 +72,34 @@ export default function QueueThreadCard({
   const resolvedCrossoverGroupsLoading = crossoverGroupsLoading ?? fallbackCrossoverGroups.isPending
   const resolvedCrossoverGroupsError = crossoverGroupsError ?? Boolean(fallbackCrossoverGroups.error)
 
+  const isInteractiveTarget = (target: EventTarget | null) =>
+    target instanceof Element
+    && target.closest('button, a, input, select, textarea, [role="button"], [role="link"]')
+
   const handleCardClick = (event: React.MouseEvent<HTMLDivElement>) => {
-    const target = event.target
-    if (
-      target instanceof Element
-      && target.closest('button, a, input, select, textarea, [role="button"], [role="link"]')
-    ) {
+    if (isInteractiveTarget(event.target)) {
       return
     }
+    onCardClick()
+  }
+
+  const handleCardKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.target !== event.currentTarget || (event.key !== 'Enter' && event.key !== ' ')) {
+      return
+    }
+    event.preventDefault()
     onCardClick()
   }
 
   return (
     <div
       data-testid="queue-thread-item"
-      className={`queue-thread-card glass-card h-full p-3 md:p-4 space-y-2 md:space-y-3 group cursor-pointer transition-all hover:border-white/20 ${isDragOver ? 'border-amber-400/60' : ''} ${isBlocked ? 'border-red-400/30 bg-red-500/5' : ''}`}
+      className={`queue-thread-card glass-card h-full p-3 md:p-4 space-y-2 md:space-y-3 group cursor-pointer transition-all hover:border-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/80 ${isDragOver ? 'border-amber-400/60' : ''} ${isBlocked ? 'border-red-400/30 bg-red-500/5' : ''}`}
+      role="link"
+      tabIndex={0}
+      aria-label={`Open ${thread.title} details`}
       onClick={handleCardClick}
+      onKeyDown={handleCardKeyDown}
       onDragOver={onDragOver}
       onDrop={onDrop}
     >

--- a/frontend/src/pages/QueuePage/QueueThreadCard.tsx
+++ b/frontend/src/pages/QueuePage/QueueThreadCard.tsx
@@ -72,10 +72,22 @@ export default function QueueThreadCard({
   const resolvedCrossoverGroupsLoading = crossoverGroupsLoading ?? fallbackCrossoverGroups.isPending
   const resolvedCrossoverGroupsError = crossoverGroupsError ?? Boolean(fallbackCrossoverGroups.error)
 
+  const handleCardClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    const target = event.target
+    if (
+      target instanceof Element
+      && target.closest('button, a, input, select, textarea, [role="button"], [role="link"]')
+    ) {
+      return
+    }
+    onCardClick()
+  }
+
   return (
     <div
       data-testid="queue-thread-item"
-      className={`queue-thread-card glass-card h-full p-3 md:p-4 space-y-2 md:space-y-3 group transition-all hover:border-white/20 ${isDragOver ? 'border-amber-400/60' : ''} ${isBlocked ? 'border-red-400/30 bg-red-500/5' : ''}`}
+      className={`queue-thread-card glass-card h-full p-3 md:p-4 space-y-2 md:space-y-3 group cursor-pointer transition-all hover:border-white/20 ${isDragOver ? 'border-amber-400/60' : ''} ${isBlocked ? 'border-red-400/30 bg-red-500/5' : ''}`}
+      onClick={handleCardClick}
       onDragOver={onDragOver}
       onDrop={onDrop}
     >

--- a/frontend/src/unit/QueueThreadCard.test.tsx
+++ b/frontend/src/unit/QueueThreadCard.test.tsx
@@ -20,10 +20,36 @@ vi.mock('../components/MarqueeTitle', () => ({
 }))
 
 vi.mock('../components/PositionMenu', () => ({
-  default: ({ onDependencies }: { onDependencies: () => void }) => (
-    <button type="button" data-testid="mock-position-menu" onClick={onDependencies}>
-      Position Menu
-    </button>
+  default: ({ 
+    onDependencies, 
+    onMoveToFront, 
+    onMoveToBack, 
+    onEdit, 
+    onDelete 
+  }: { 
+    onDependencies: () => void; 
+    onMoveToFront: () => void; 
+    onMoveToBack: () => void; 
+    onEdit: () => void; 
+    onDelete: () => void 
+  }) => (
+    <div data-testid="mock-position-menu">
+      <button type="button" data-testid="mock-position-move-to-front" onClick={onMoveToFront}>
+        Move to Front
+      </button>
+      <button type="button" data-testid="mock-position-move-to-back" onClick={onMoveToBack}>
+        Move to Back
+      </button>
+      <button type="button" data-testid="mock-position-edit" onClick={onEdit}>
+        Edit
+      </button>
+      <button type="button" data-testid="mock-position-dependencies" onClick={onDependencies}>
+        Dependencies
+      </button>
+      <button type="button" data-testid="mock-position-delete" onClick={onDelete}>
+        Delete
+      </button>
+    </div>
   ),
 }))
 
@@ -124,17 +150,17 @@ describe('QueueThreadCard', () => {
     expect(onCardClick).toHaveBeenCalledTimes(2)
   })
 
-  it('uses the shared action menu for dependency management without opening details', async () => {
-    const user = userEvent.setup()
-    const onDependencies = vi.fn()
-    const onCardClick = vi.fn()
-    renderCard(createMockThread(), { onDependencies, onCardClick })
+    it('uses the shared action menu for dependency management without opening details', async () => {
+      const user = userEvent.setup()
+      const onDependencies = vi.fn()
+      const onCardClick = vi.fn()
+      renderCard(createMockThread(), { onDependencies, onCardClick })
 
-    await user.click(screen.getByTestId('mock-position-menu'))
+      await user.click(screen.getByTestId('mock-position-dependencies'))
 
-    expect(onDependencies).toHaveBeenCalledTimes(1)
-    expect(onCardClick).not.toHaveBeenCalled()
-  })
+      expect(onDependencies).toHaveBeenCalledTimes(1)
+      expect(onCardClick).not.toHaveBeenCalled()
+    })
 
   it('does not treat shared action-menu keyboard activation as card activation', () => {
     const onCardClick = vi.fn()
@@ -273,7 +299,207 @@ describe('QueueThreadCard', () => {
     expect(callbacks.onDragEnd).toHaveBeenCalled()
     expect(callbacks.onDragOver).toHaveBeenCalled()
     expect(callbacks.onDrop).toHaveBeenCalled()
-    await user.click(screen.getByTestId('mock-position-menu'))
+    await user.click(screen.getByTestId('mock-position-dependencies'))
     expect(callbacks.onDependencies).toHaveBeenCalledTimes(2)
+    })
+    
+    it('exercises PositionMenu descendants and confirms onCardClick is not invoked', async () => {
+      const user = userEvent.setup()
+      const onCardClick = vi.fn()
+      const onDependencies = vi.fn()
+      const onMoveToFront = vi.fn()
+      const onMoveToBack = vi.fn()
+      const onEdit = vi.fn()
+      const onDelete = vi.fn()
+      
+      renderCard(createMockThread(), { onCardClick, onDependencies, onMoveToFront, onMoveToBack, onEdit, onDelete })
+
+      // Test PositionMenu buttons using specific testids
+      const moveToFrontBtn = screen.getByTestId('mock-position-move-to-front')
+      const moveToBackBtn = screen.getByTestId('mock-position-move-to-back')
+      const editBtn = screen.getByTestId('mock-position-edit')
+      const dependenciesBtn = screen.getByTestId('mock-position-dependencies')
+      const deleteBtn = screen.getByTestId('mock-position-delete')
+      
+      // Test Move to Front
+      await user.click(moveToFrontBtn)
+      expect(onMoveToFront).toHaveBeenCalledTimes(1)
+      expect(onCardClick).not.toHaveBeenCalled()
+      
+      // Reset mocks
+      vi.clearAllMocks()
+      
+      // Test Move to Back
+      await user.click(moveToBackBtn)
+      expect(onMoveToBack).toHaveBeenCalledTimes(1)
+      expect(onCardClick).not.toHaveBeenCalled()
+      
+      // Reset mocks
+      vi.clearAllMocks()
+      
+      // Test Edit
+      await user.click(editBtn)
+      expect(onEdit).toHaveBeenCalledTimes(1)
+      expect(onCardClick).not.toHaveBeenCalled()
+      
+      // Reset mocks
+      vi.clearAllMocks()
+      
+      // Test Dependencies
+      await user.click(dependenciesBtn)
+      expect(onDependencies).toHaveBeenCalledTimes(1)
+      expect(onCardClick).not.toHaveBeenCalled()
+      
+      // Reset mocks
+      vi.clearAllMocks()
+      
+      // Test Delete
+      await user.click(deleteBtn)
+      expect(onDelete).toHaveBeenCalledTimes(1)
+      expect(onCardClick).not.toHaveBeenCalled()
+    })
+    
+    it('exercises QueueThreadActions descendants and confirms onCardClick is not invoked', async () => {
+      const user = userEvent.setup()
+      const onCardClick = vi.fn()
+      const onRead = vi.fn()
+      const onOpenThread = vi.fn()
+      const onSnooze = vi.fn()
+      const onActionDelete = vi.fn()
+      
+      renderCard(createMockThread(), { 
+        onCardClick, 
+        onRead, 
+        onOpenThread, 
+        onSnooze, 
+        onActionDelete,
+        snoozeLabel: 'Snooze',
+        snoozeIcon: ''
+      })
+      
+      // Get the QueueThreadActions container (it has aria-label="Actions for Test Thread")
+      const actionsContainer = screen.getByRole('group', { name: /Actions for Test Thread/i })
+      
+      // Test QueueThreadActions buttons within the container using label text
+      const readButton = actionsContainer.querySelector('button[aria-label="Read"]')
+      const editButton = actionsContainer.querySelector('button[aria-label="Edit"]') // This is actually for opening thread
+      const snoozeButton = actionsContainer.querySelector('button[aria-label="Snooze"]')
+      const deleteButton = actionsContainer.querySelector('button[aria-label="Delete"]')
+      
+      // Test Read
+      await user.click(readButton as HTMLElement)
+      expect(onRead).toHaveBeenCalledTimes(1)
+      expect(onCardClick).not.toHaveBeenCalled()
+      
+      // Reset mocks
+      vi.clearAllMocks()
+      
+      // Test Open Thread (bound to Edit button in QueueThreadActions)
+      await user.click(editButton as HTMLElement)
+      expect(onOpenThread).toHaveBeenCalledTimes(1)
+      expect(onCardClick).not.toHaveBeenCalled()
+      
+      // Reset mocks
+      vi.clearAllMocks()
+      
+      // Test Snooze
+      await user.click(snoozeButton as HTMLElement)
+      expect(onSnooze).toHaveBeenCalledTimes(1)
+      expect(onCardClick).not.toHaveBeenCalled()
+      
+      // Reset mocks
+      vi.clearAllMocks()
+      
+      // Test Delete Action (bound to Delete button in QueueThreadActions)
+      await user.click(deleteButton as HTMLElement)
+      expect(onActionDelete).toHaveBeenCalledTimes(1)
+      expect(onCardClick).not.toHaveBeenCalled()
+    })
+    
+    it('exercises CrossoverTags links and confirms onCardClick is not invoked', async () => {
+      const user = userEvent.setup()
+      const onCardClick = vi.fn()
+      
+      renderCard(createMockThread({ 
+        id: 1, 
+        title: 'Test Thread with Crossovers' 
+      }), { 
+        onCardClick,
+        crossoverGroups: [
+          { id: 11, name: 'Rotworld' },
+          { id: 12, name: 'Night of the Owls' },
+        ]
+      })
+
+      // Test CrossoverTags links
+      const rotworldLink = screen.getByRole('link', { name: 'Rotworld' })
+      const nightOfOwlsLink = screen.getByRole('link', { name: 'Night of the Owls' })
+      
+      // Test Rotworld link
+      await user.click(rotworldLink)
+      expect(onCardClick).not.toHaveBeenCalled()
+      
+      // Test Night of the Owls link
+      await user.click(nightOfOwlsLink)
+      expect(onCardClick).not.toHaveBeenCalled()
+    })
+    
+    it('exercises drag handle and confirms onCardClick is not invoked', async () => {
+      const user = userEvent.setup()
+      const onCardClick = vi.fn()
+      const onDragStart = vi.fn()
+      const onDragEnd = vi.fn()
+      const onDragOver = vi.fn()
+      const onDrop = vi.fn()
+      
+      renderCard(createMockThread(), { 
+        onCardClick, 
+        onDragStart, 
+        onDragEnd, 
+        onDragOver, 
+        onDrop 
+      })
+
+      // Test drag handle
+      const dragHandle = screen.getByRole('button', { name: /Drag to reorder/i })
+      
+      await user.click(dragHandle)
+      expect(onCardClick).not.toHaveBeenCalled()
+      
+      // Simulate drag events
+      fireEvent.dragStart(dragHandle)
+      expect(onDragStart).toHaveBeenCalledTimes(1)
+      fireEvent.dragEnd(dragHandle)
+      
+      const threadCard = screen.getByTestId('queue-thread-item')
+      fireEvent.dragOver(threadCard)
+      fireEvent.drop(threadCard)
+      
+      expect(onDragOver).toHaveBeenCalledTimes(1)
+      expect(onDrop).toHaveBeenCalledTimes(1)
+      expect(onCardClick).not.toHaveBeenCalled()
+    })
+    
+    it('exercises blocked dependency button and confirms onCardClick is not invoked', async () => {
+      const user = userEvent.setup()
+      const onCardClick = vi.fn()
+      const onDependencies = vi.fn()
+      
+      renderCard(createMockThread({ 
+        id: 1, 
+        title: 'Blocked Test Thread' 
+      }), { 
+        onCardClick, 
+        onDependencies,
+        isBlocked: true,
+        blockingReasons: ['Blocked by: Prequel Thread']
+      })
+
+      // Test blocked dependency button
+      const blockedButton = screen.getByRole('button', { name: /View dependencies for Blocked Test Thread/ })
+      
+      await user.click(blockedButton)
+      expect(onDependencies).toHaveBeenCalledTimes(1)
+      expect(onCardClick).not.toHaveBeenCalled()
+    })
   })
-})

--- a/frontend/src/unit/QueueThreadCard.test.tsx
+++ b/frontend/src/unit/QueueThreadCard.test.tsx
@@ -111,6 +111,19 @@ describe('QueueThreadCard', () => {
     expect(onCardClick).toHaveBeenCalledTimes(1)
   })
 
+  it('opens thread details from the focused card with Enter or Space', async () => {
+    const user = userEvent.setup()
+    const onCardClick = vi.fn()
+    renderCard(createMockThread(), { onCardClick })
+
+    const card = screen.getByRole('link', { name: 'Open Test Thread details' })
+    card.focus()
+    await user.keyboard('{Enter}')
+    await user.keyboard(' ')
+
+    expect(onCardClick).toHaveBeenCalledTimes(2)
+  })
+
   it('uses the shared action menu for dependency management without opening details', async () => {
     const user = userEvent.setup()
     const onDependencies = vi.fn()

--- a/frontend/src/unit/QueueThreadCard.test.tsx
+++ b/frontend/src/unit/QueueThreadCard.test.tsx
@@ -101,13 +101,26 @@ describe('QueueThreadCard', () => {
     expect(screen.queryByTestId('mobile-dependency-action')).not.toBeInTheDocument()
   })
 
-  it('uses the shared action menu for dependency management', async () => {
+  it('opens thread details when the card surface is clicked', async () => {
+    const user = userEvent.setup()
+    const onCardClick = vi.fn()
+    renderCard(createMockThread(), { onCardClick })
+
+    await user.click(screen.getByTestId('queue-thread-item'))
+
+    expect(onCardClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses the shared action menu for dependency management without opening details', async () => {
     const user = userEvent.setup()
     const onDependencies = vi.fn()
-    renderCard(createMockThread(), { onDependencies })
+    const onCardClick = vi.fn()
+    renderCard(createMockThread(), { onDependencies, onCardClick })
 
     await user.click(screen.getByTestId('mock-position-menu'))
+
     expect(onDependencies).toHaveBeenCalledTimes(1)
+    expect(onCardClick).not.toHaveBeenCalled()
   })
 
   it('does not treat shared action-menu keyboard activation as card activation', () => {


### PR DESCRIPTION
Closes #1100.

## Summary
- make the full non-interactive Queue card surface open thread details
- preserve drag handles, menus, crossover links, and action buttons without accidental navigation
- add focused unit coverage for card-surface activation and nested-action isolation

## Validation
- focused unit coverage added in `QueueThreadCard.test.tsx`
- configured CI is the executable validation boundary for this connector-backed branch
- maintained Chromium `thread-detail-view.spec.ts` must pass before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Queue cards can now be clicked anywhere on their surface to open thread details.
  * Menus, links, reading controls, and other interactive elements continue to work independently.

* **Bug Fixes**
  * Prevented clicks on dependency menus and other controls from unintentionally opening thread details.

* **Documentation**
  * Added a changelog entry describing the updated Queue card behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->