### PR TITLE
Fix Chromium rating auth-recovery interception

### DIFF
--- a/docs/changelog.d/2026-08-12-1103.md
+++ b/docs/changelog.d/2026-08-12-1103.md
@@ -2,4 +2,4 @@
 
 ### Reliability
 
-- [PR #1103](https://github.com/JoshCLWren/comic-pile/pull/1103) restores maintained browser validation for expired-session rating recovery by intercepting the canonical rating API.
+- [#1103](https://github.com/JoshCLWren/comic-pile/pull/1103) restores maintained browser validation for expired-session rating recovery by intercepting the canonical rating API.

--- a/docs/changelog.d/2026-08-12-1103.md
+++ b/docs/changelog.d/2026-08-12-1103.md
@@ -1,5 +1,0 @@
-## 2026-08-12
-
-### Reliability
-
-- [#1103](https://github.com/JoshCLWren/comic-pile/pull/1103) restores maintained browser validation for expired-session rating recovery by intercepting the canonical rating API.

--- a/docs/changelog.d/2026-08-12-1103.md
+++ b/docs/changelog.d/2026-08-12-1103.md
@@ -1,0 +1,5 @@
+## 2026-08-12
+
+### Reliability
+
+- [PR #1103](https://github.com/JoshCLWren/comic-pile/pull/1103) restores maintained browser validation for expired-session rating recovery by intercepting the canonical rating API.

--- a/frontend/src/test/helpers.ts
+++ b/frontend/src/test/helpers.ts
@@ -194,7 +194,7 @@ export async function submitRatingAndWaitForRateResponse(
   submitAction: () => Promise<void>,
 ): Promise<void> {
   const rateResponse = page.waitForResponse(
-    (response) => response.url().includes('/api/rate/') && response.request().method() === 'POST',
+    (response) => response.url().includes('/api/v1/rate/') && response.request().method() === 'POST',
   )
 
   await submitAction()
@@ -373,7 +373,7 @@ export const SELECTORS = {
 	},
 	rate: {
 		ratingInput: '#rating-input',
-		submitButton: 'button:has-text("Save & Continue")',
+		submitButton: 'button:has-text("Mark read & save")',
 		snoozeButton: 'button:has-text("Snooze")',
 	},
 	thread: {

--- a/frontend/src/test/helpers.ts
+++ b/frontend/src/test/helpers.ts
@@ -373,7 +373,7 @@ export const SELECTORS = {
 	},
 	rate: {
 		ratingInput: '#rating-input',
-		submitButton: 'button:has-text("Mark read & save")',
+		submitButton: 'button[data-testid="save-and-continue"]',
 		snoozeButton: 'button:has-text("Snooze")',
 	},
 	thread: {

--- a/frontend/src/test/roll-auth-recovery.spec.ts
+++ b/frontend/src/test/roll-auth-recovery.spec.ts
@@ -16,7 +16,7 @@ async function openPendingThread(page: import('@playwright/test').Page): Promise
 
 async function injectExpiredMutationOnce(
   page: import('@playwright/test').Page,
-  endpoint: '/api/rate/' | '/api/snooze/',
+  endpoint: '/api/v1/rate/' | '/api/snooze/',
 ): Promise<() => { attempts: number; committedAttempts: number }> {
   let attempts = 0;
   let committedAttempts = 0;
@@ -49,7 +49,7 @@ test.describe('Roll mutation authentication recovery', () => {
     authenticatedWithThreadsPage,
   }) => {
     await openPendingThread(authenticatedWithThreadsPage);
-    const getCounts = await injectExpiredMutationOnce(authenticatedWithThreadsPage, '/api/rate/');
+    const getCounts = await injectExpiredMutationOnce(authenticatedWithThreadsPage, '/api/v1/rate/');
 
     await setRangeInput(authenticatedWithThreadsPage, SELECTORS.rate.ratingInput, '4.5');
     await authenticatedWithThreadsPage.click(SELECTORS.rate.submitButton);


### PR DESCRIPTION
Closes #1102.

## Summary
- intercept the canonical `/api/v1/rate/` request in maintained Chromium auth-recovery coverage
- restore truthful validation that an expired-token rating retries exactly once and commits once
- leave snooze interception on its current maintained path

## Validation
- source-level route contract verified against `rateApi.rate`
- configured CI and focused maintained Chromium coverage are the executable validation boundary for this connector-backed branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated rating and authentication-recovery test coverage to use the current versioned rating endpoint.
  * Updated test validation to reflect the “Mark read & save” button label.
  * Snooze behavior coverage remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->