### PR TITLE
feat(planner): add sequential continuity workspace

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -60,9 +60,6 @@ RUN pnpm install --frozen-lockfile && \
 # Stage 6: Frontend build.
 FROM frontend-deps AS frontend-build
 COPY frontend/ frontend/
-COPY app/ app/
-COPY comic_pile/ comic_pile/
-COPY pyproject.toml ./
 RUN pnpm --filter frontend run build
 
 # Stage 7: Final image with everything.
@@ -71,5 +68,8 @@ RUN .venv/bin/python -c "import sys; assert sys.version_info[:2] == (3, 14), sys
     mkdir -p /opt/ci-assets/static
 COPY --from=frontend-build /workspace/static/react /opt/ci-assets/static/react
 COPY --from=frontend-build /workspace/static/react /workspace/static/react
+COPY app/ app/
+COPY comic_pile/ comic_pile/
+COPY pyproject.toml ./
 ENV PATH="/workspace/.venv/bin:$PATH"
 CMD ["/bin/bash"]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -60,6 +60,9 @@ RUN pnpm install --frozen-lockfile && \
 # Stage 6: Frontend build.
 FROM frontend-deps AS frontend-build
 COPY frontend/ frontend/
+COPY app/ app/
+COPY comic_pile/ comic_pile/
+COPY pyproject.toml ./
 RUN pnpm --filter frontend run build
 
 # Stage 7: Final image with everything.

--- a/docs/changelog.d/2026-08-12-1107.md
+++ b/docs/changelog.d/2026-08-12-1107.md
@@ -1,5 +1,0 @@
-## 2026-08-12
-
-### Continuity planning
-
-- [#1107](https://github.com/JoshCLWren/comic-pile/pull/1107) adds a mobile-friendly sequential planner where readers can arrange issues and crossovers, save the chosen order, and return later without exposing internal ComicPile IDs.

--- a/docs/changelog.d/2026-08-12-1107.md
+++ b/docs/changelog.d/2026-08-12-1107.md
@@ -2,4 +2,4 @@
 
 ### Continuity planning
 
-- [PR #1107](https://github.com/JoshCLWren/comic-pile/pull/1107) adds a mobile-friendly sequential planner where readers can arrange issues and crossovers, save the chosen order, and return later without exposing internal ComicPile IDs.
+- [#1107](https://github.com/JoshCLWren/comic-pile/pull/1107) adds a mobile-friendly sequential planner where readers can arrange issues and crossovers, save the chosen order, and return later without exposing internal ComicPile IDs.

--- a/docs/changelog.d/2026-08-12-1107.md
+++ b/docs/changelog.d/2026-08-12-1107.md
@@ -1,0 +1,5 @@
+## 2026-08-12
+
+### Continuity planning
+
+- [PR #1107](https://github.com/JoshCLWren/comic-pile/pull/1107) adds a mobile-friendly sequential planner where readers can arrange issues and crossovers, save the chosen order, and return later without exposing internal ComicPile IDs.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,6 +41,7 @@ const ThreadDetailView = lazyRoute('threadDetail')
 const HistoryPage = lazyRoute('history')
 const SessionPage = lazyRoute('session')
 const CrossoversPage = lazyRoute('crossovers')
+const ContinuityPlannerPage = lazyRoute('continuityPlanner')
 const HelpPage = lazyRoute('help')
 const WhatsNewPage = lazyRoute('whatsNew')
 const LoginPage = lazyRoute('login')
@@ -254,6 +255,8 @@ function AppRoutes() {
         <Route path="/history" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><HistoryPage /></AuthenticatedLayout></ProtectedRoute>} />
         <Route path="/sessions/:id" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><SessionPage /></AuthenticatedLayout></ProtectedRoute>} />
         <Route path="/crossovers" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><CrossoversPage /></AuthenticatedLayout></ProtectedRoute>} />
+        <Route path="/continuity-plans" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><ContinuityPlannerPage /></AuthenticatedLayout></ProtectedRoute>} />
+        <Route path="/continuity-plans/:id" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><ContinuityPlannerPage /></AuthenticatedLayout></ProtectedRoute>} />
         <Route path="/whats-new" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><WhatsNewPage /></AuthenticatedLayout></ProtectedRoute>} />
         <Route path="/help" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><HelpPage /></AuthenticatedLayout></ProtectedRoute>} />
         <Route path="/glossary" element={<ProtectedRoute><AuthenticatedLayout onBugReportSubmit={submit}><HelpPage /></AuthenticatedLayout></ProtectedRoute>} />

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -72,7 +72,7 @@ export default function Navigation({ onBugReportSubmit }: NavigationProps) {
 
   const isActive = (path: string) => location.pathname === path
   const isMoreRoute = ['/continuity-plans', '/whats-new', '/help', '/glossary'].some((path) =>
-    location.pathname === path,
+    location.pathname === path || location.pathname.startsWith(`${path}/`),
   )
 
   const handleLogout = async () => {

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -71,7 +71,7 @@ export default function Navigation({ onBugReportSubmit }: NavigationProps) {
   }, [isAuthenticated, logout])
 
   const isActive = (path: string) => location.pathname === path
-  const isMoreRoute = ['/whats-new', '/help', '/glossary'].some((path) =>
+  const isMoreRoute = ['/continuity-plans', '/whats-new', '/help', '/glossary'].some((path) =>
     location.pathname === path,
   )
 
@@ -101,6 +101,7 @@ export default function Navigation({ onBugReportSubmit }: NavigationProps) {
 
       {isMoreOpen && (
         <nav ref={moreMenuRef} id="secondary-navigation" aria-label="More pages" className="fixed bottom-16 right-3 z-50 w-56 rounded-2xl border border-stone-700 bg-stone-950 p-2 shadow-2xl md:bottom-24 md:right-6">
+          <Link to="/continuity-plans" className="flex min-h-12 items-center gap-3 rounded-xl px-4 py-3 font-bold text-stone-100 hover:bg-stone-800"><span aria-hidden="true">🧭</span><span>Continuity Planner</span></Link>
           <Link to="/whats-new" className="flex min-h-12 items-center gap-3 rounded-xl px-4 py-3 font-bold text-stone-100 hover:bg-stone-800"><span aria-hidden="true">✨</span><span>What’s New</span></Link>
           <Link to="/help" className="flex min-h-12 items-center gap-3 rounded-xl px-4 py-3 font-bold text-stone-100 hover:bg-stone-800"><span aria-hidden="true">❓</span><span>Help</span></Link>
           <div className="space-y-1 border-t border-stone-800 pt-2 md:hidden">

--- a/frontend/src/pages/ContinuityPlannerPage.tsx
+++ b/frontend/src/pages/ContinuityPlannerPage.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react'
+import { FormEvent, useCallback, useEffect, useState } from 'react'
 import axios from 'axios'
 import { useNavigate, useParams } from 'react-router-dom'
 import {
@@ -13,6 +13,7 @@ import type { Issue, Thread } from '../types'
 
 const LAST_PLAN_KEY = 'comic-pile:last-continuity-plan'
 const LANE_ID = 'main'
+const DEFAULT_PLAN_NAME = 'My reading plan'
 
 interface PlannerNode extends ContinuityPlanNode {
   label: string
@@ -84,7 +85,7 @@ export default function ContinuityPlannerPage() {
   const { id } = useParams()
   const navigate = useNavigate()
   const planId = id ? Number(id) : null
-  const [name, setName] = useState('My reading plan')
+  const [name, setName] = useState(DEFAULT_PLAN_NAME)
   const [nodes, setNodes] = useState<PlannerNode[]>([])
   const [savedName, setSavedName] = useState('')
   const [savedNodes, setSavedNodes] = useState<PlannerNode[]>([])
@@ -127,7 +128,7 @@ export default function ContinuityPlannerPage() {
         setThreads(loadedThreads)
         setGroups(loadedGroups)
         if (!planId) {
-          setSavedName(name)
+          setSavedName(DEFAULT_PLAN_NAME)
           return
         }
         const plan = await continuityPlansApi.get(planId)
@@ -234,7 +235,7 @@ export default function ContinuityPlannerPage() {
   }
 
   const cancel = () => {
-    setName(savedName || 'My reading plan')
+    setName(savedName || DEFAULT_PLAN_NAME)
     setNodes(savedNodes)
     setSaveError(null)
   }

--- a/frontend/src/pages/ContinuityPlannerPage.tsx
+++ b/frontend/src/pages/ContinuityPlannerPage.tsx
@@ -1,0 +1,324 @@
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react'
+import axios from 'axios'
+import { useNavigate, useParams } from 'react-router-dom'
+import {
+  ContinuityIssueSelector,
+  ContinuityThreadSelector,
+} from '../components/continuity'
+import { continuityPlansApi, type ContinuityPlanNode } from '../services/api-continuity-plans'
+import { dependencyGroupsApi, type DependencyGroup } from '../services/api-dependency-groups'
+import { issuesApi } from '../services/api-issues'
+import { threadsApi } from '../services/api'
+import type { Issue, Thread } from '../types'
+
+const LAST_PLAN_KEY = 'comic-pile:last-continuity-plan'
+const LANE_ID = 'main'
+
+interface PlannerNode extends ContinuityPlanNode {
+  label: string
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+  if (axios.isAxiosError(error)) {
+    const detail = error.response?.data?.detail
+    if (typeof detail === 'string' && detail.trim()) return detail
+    if (detail && typeof detail === 'object' && 'code' in detail) {
+      if (detail.code === 'plan_rule_conflict') {
+        return 'This order conflicts with an existing continuity rule. Change the sequence and try again.'
+      }
+      if (detail.code === 'continuity_cycle') {
+        return 'This order would create a continuity cycle. Change the sequence and try again.'
+      }
+    }
+  }
+  return error instanceof Error && error.message ? error.message : fallback
+}
+
+async function fetchAllThreads(): Promise<Thread[]> {
+  const result: Thread[] = []
+  const seen = new Set<string>()
+  let token: string | null = null
+  do {
+    const page = await threadsApi.list({ page_size: 100 }, token)
+    result.push(...page.threads)
+    token = page.next_page_token
+    if (token && seen.has(token)) break
+    if (token) seen.add(token)
+  } while (token)
+  return result
+}
+
+async function fetchAllIssues(threadId: number): Promise<Issue[]> {
+  const result: Issue[] = []
+  const seen = new Set<string>()
+  let token: string | null = null
+  do {
+    const page = await issuesApi.list(threadId, {
+      page_size: 100,
+      ...(token ? { page_token: token } : {}),
+    })
+    result.push(...page.issues)
+    token = page.next_page_token
+    if (token && seen.has(token)) break
+    if (token) seen.add(token)
+  } while (token)
+  return result
+}
+
+function toPayload(name: string, nodes: PlannerNode[]) {
+  return {
+    name: name.trim(),
+    ordering_mode: 'strict_sequential' as const,
+    lanes: [{ id: LANE_ID, name: 'Reading order', order: 0 }],
+    nodes: nodes.map(({ id, node_type, ref_id }, position) => ({
+      id,
+      node_type,
+      ref_id,
+      lane_id: LANE_ID,
+      position,
+    })),
+  }
+}
+
+export default function ContinuityPlannerPage() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const planId = id ? Number(id) : null
+  const [name, setName] = useState('My reading plan')
+  const [nodes, setNodes] = useState<PlannerNode[]>([])
+  const [savedName, setSavedName] = useState('')
+  const [savedNodes, setSavedNodes] = useState<PlannerNode[]>([])
+  const [threads, setThreads] = useState<Thread[]>([])
+  const [groups, setGroups] = useState<DependencyGroup[]>([])
+  const [selectedThread, setSelectedThread] = useState<Thread | null>(null)
+  const [issues, setIssues] = useState<Issue[]>([])
+  const [selectedIssue, setSelectedIssue] = useState<Issue | null>(null)
+  const [selectedGroupId, setSelectedGroupId] = useState('')
+  const [isLoading, setIsLoading] = useState(Boolean(planId))
+  const [isLoadingIssues, setIsLoadingIssues] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const lastPlanId = typeof window === 'undefined' ? null : window.localStorage.getItem(LAST_PLAN_KEY)
+
+  const isDirty = name !== savedName || JSON.stringify(nodes) !== JSON.stringify(savedNodes)
+
+  const hydrateLabels = useCallback(async (rawNodes: ContinuityPlanNode[], loadedGroups: DependencyGroup[]) => {
+    const groupNames = new Map(loadedGroups.map((group) => [group.id, group.name]))
+    return Promise.all(rawNodes.map(async (node): Promise<PlannerNode> => {
+      if (node.node_type === 'crossover') {
+        return { ...node, label: groupNames.get(node.ref_id) ?? 'Unavailable crossover' }
+      }
+      try {
+        const issue = await issuesApi.get(node.ref_id)
+        const thread = await threadsApi.get(issue.thread_id)
+        return { ...node, label: `${thread.title} #${issue.issue_number}` }
+      } catch {
+        return { ...node, label: 'Unavailable issue' }
+      }
+    }))
+  }, [])
+
+  useEffect(() => {
+    let active = true
+    void Promise.all([fetchAllThreads(), dependencyGroupsApi.list()])
+      .then(async ([loadedThreads, loadedGroups]) => {
+        if (!active) return
+        setThreads(loadedThreads)
+        setGroups(loadedGroups)
+        if (!planId) {
+          setSavedName(name)
+          return
+        }
+        const plan = await continuityPlansApi.get(planId)
+        const hydrated = await hydrateLabels(plan.nodes, loadedGroups)
+        if (!active) return
+        setName(plan.name)
+        setNodes(hydrated)
+        setSavedName(plan.name)
+        setSavedNodes(hydrated)
+        window.localStorage.setItem(LAST_PLAN_KEY, String(plan.id))
+      })
+      .catch((error) => active && setLoadError(errorMessage(error, 'Unable to load the continuity planner.')))
+      .finally(() => active && setIsLoading(false))
+    return () => { active = false }
+  }, [hydrateLabels, planId])
+
+  const selectThread = async (thread: Thread | null) => {
+    setSelectedThread(thread)
+    setSelectedIssue(null)
+    setIssues([])
+    if (!thread) return
+    setIsLoadingIssues(true)
+    try {
+      setIssues(await fetchAllIssues(thread.id))
+    } catch (error) {
+      setLoadError(errorMessage(error, 'Unable to load issues for that comic.'))
+    } finally {
+      setIsLoadingIssues(false)
+    }
+  }
+
+  const addIssue = (event: FormEvent) => {
+    event.preventDefault()
+    if (!selectedThread || !selectedIssue) return
+    const key = `issue-${selectedIssue.id}`
+    if (nodes.some((node) => node.id === key)) {
+      setSaveError('That issue is already in this plan.')
+      return
+    }
+    setNodes((current) => [...current, {
+      id: key,
+      node_type: 'issue',
+      ref_id: selectedIssue.id,
+      lane_id: LANE_ID,
+      position: current.length,
+      label: `${selectedThread.title} #${selectedIssue.issue_number}`,
+    }])
+    setSelectedIssue(null)
+    setSaveError(null)
+  }
+
+  const addCrossover = () => {
+    const group = groups.find((candidate) => candidate.id === Number(selectedGroupId))
+    if (!group) return
+    const key = `crossover-${group.id}`
+    if (nodes.some((node) => node.id === key)) {
+      setSaveError('That crossover is already in this plan.')
+      return
+    }
+    setNodes((current) => [...current, {
+      id: key,
+      node_type: 'crossover',
+      ref_id: group.id,
+      lane_id: LANE_ID,
+      position: current.length,
+      label: group.name,
+    }])
+    setSelectedGroupId('')
+    setSaveError(null)
+  }
+
+  const move = (index: number, offset: -1 | 1) => {
+    const nextIndex = index + offset
+    if (nextIndex < 0 || nextIndex >= nodes.length) return
+    setNodes((current) => {
+      const next = [...current]
+      ;[next[index], next[nextIndex]] = [next[nextIndex], next[index]]
+      return next.map((node, position) => ({ ...node, position }))
+    })
+  }
+
+  const save = async () => {
+    if (!name.trim()) {
+      setSaveError('Enter a plan name.')
+      return
+    }
+    setIsSaving(true)
+    setSaveError(null)
+    try {
+      const saved = planId
+        ? await continuityPlansApi.update(planId, toPayload(name, nodes))
+        : await continuityPlansApi.create(toPayload(name, nodes))
+      const normalized = nodes.map((node, position) => ({ ...node, position }))
+      setNodes(normalized)
+      setSavedName(saved.name)
+      setSavedNodes(normalized)
+      window.localStorage.setItem(LAST_PLAN_KEY, String(saved.id))
+      if (!planId) navigate(`/continuity-plans/${saved.id}`, { replace: true })
+    } catch (error) {
+      setSaveError(errorMessage(error, 'Unable to save this continuity plan.'))
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const cancel = () => {
+    setName(savedName || 'My reading plan')
+    setNodes(savedNodes)
+    setSaveError(null)
+  }
+
+  const statusText = isSaving ? 'Saving…' : saveError ? null : isDirty ? 'Unsaved changes' : planId ? 'Saved' : 'New plan'
+
+  if (isLoading) return <p role="status" className="text-stone-400">Loading continuity plan…</p>
+  if (loadError) return <div role="alert" className="rounded-2xl border border-red-800 bg-red-950/30 p-4 text-red-200">{loadError}</div>
+
+  return (
+    <section className="space-y-5" aria-labelledby="planner-heading">
+      <header>
+        <p className="text-xs font-black uppercase tracking-[0.2em] text-amber-500">Continuity</p>
+        <h1 id="planner-heading" className="mt-1 text-3xl font-black text-stone-100">Sequential planner</h1>
+        <p className="mt-2 text-sm text-stone-400">Arrange issues and crossovers in one explicit reading lane. Saving creates only the continuity rules you chose.</p>
+      </header>
+
+      {!planId && lastPlanId && (
+        <button type="button" onClick={() => navigate(`/continuity-plans/${lastPlanId}`)} className="min-h-11 rounded-xl border border-amber-700 px-4 font-bold text-amber-200">
+          Reopen last saved plan
+        </button>
+      )}
+
+      <label className="block text-xs font-bold uppercase tracking-widest text-stone-500">
+        Plan name
+        <input value={name} onChange={(event) => setName(event.target.value)} maxLength={200} className="mt-1 w-full rounded-xl border border-stone-700 bg-stone-950 px-3 py-3 text-stone-100" />
+      </label>
+
+      <div className="grid gap-4 rounded-2xl border border-stone-800 bg-stone-900/50 p-4 md:grid-cols-2">
+        <form onSubmit={addIssue} className="space-y-3" aria-label="Add an issue">
+          <h2 className="font-black text-stone-100">Add an issue</h2>
+          <ContinuityThreadSelector threads={threads} value={selectedThread} onChange={(thread) => void selectThread(thread)} label="Comic series" />
+          <ContinuityIssueSelector issues={issues} value={selectedIssue} onChange={setSelectedIssue} isLoading={isLoadingIssues} disabled={!selectedThread} />
+          <button type="submit" disabled={!selectedIssue} className="min-h-11 w-full rounded-xl bg-amber-500 px-4 font-black text-stone-950 disabled:opacity-50">Add issue</button>
+        </form>
+
+        <div className="space-y-3">
+          <h2 className="font-black text-stone-100">Add a crossover</h2>
+          <label className="block text-xs font-bold uppercase tracking-widest text-stone-500">
+            Crossover
+            <select value={selectedGroupId} onChange={(event) => setSelectedGroupId(event.target.value)} className="mt-1 min-h-11 w-full rounded-xl border border-stone-700 bg-stone-950 px-3 text-stone-100">
+              <option value="">Select a crossover</option>
+              {groups.map((group) => <option key={group.id} value={group.id}>{group.name}</option>)}
+            </select>
+          </label>
+          <button type="button" onClick={addCrossover} disabled={!selectedGroupId} className="min-h-11 w-full rounded-xl bg-violet-500 px-4 font-black text-stone-950 disabled:opacity-50">Add crossover</button>
+        </div>
+      </div>
+
+      <section aria-labelledby="lane-heading">
+        <div className="flex items-end justify-between">
+          <div>
+            <h2 id="lane-heading" className="text-xl font-black text-stone-100">Reading order</h2>
+            <p className="text-xs text-stone-500">{nodes.length} {nodes.length === 1 ? 'step' : 'steps'}</p>
+          </div>
+          {statusText && <p role="status" className={isDirty ? 'text-amber-300' : 'text-emerald-300'}>{statusText}</p>}
+        </div>
+        {nodes.length === 0 ? (
+          <p className="mt-3 rounded-2xl border border-dashed border-stone-700 p-6 text-center text-stone-500">Add an issue or crossover to begin.</p>
+        ) : (
+          <ol className="mt-3 grid gap-2">
+            {nodes.map((node, index) => (
+              <li key={node.id} className="flex items-center gap-3 rounded-2xl border border-stone-700 bg-stone-900 p-3">
+                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-stone-800 font-black text-amber-300">{index + 1}</span>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate font-bold text-stone-100">{node.label}</p>
+                  <p className="text-xs uppercase tracking-wider text-stone-500">{node.node_type}</p>
+                </div>
+                <div className="flex gap-1">
+                  <button type="button" onClick={() => move(index, -1)} disabled={index === 0} aria-label={`Move ${node.label} earlier`} className="min-h-11 min-w-11 rounded-lg border border-stone-700 disabled:opacity-30">↑</button>
+                  <button type="button" onClick={() => move(index, 1)} disabled={index === nodes.length - 1} aria-label={`Move ${node.label} later`} className="min-h-11 min-w-11 rounded-lg border border-stone-700 disabled:opacity-30">↓</button>
+                  <button type="button" onClick={() => setNodes((current) => current.filter((item) => item.id !== node.id).map((item, position) => ({ ...item, position })))} aria-label={`Remove ${node.label}`} className="min-h-11 rounded-lg border border-red-900 px-3 text-red-300">Remove</button>
+                </div>
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+
+      {saveError && <p role="alert" className="rounded-xl border border-red-800 bg-red-950/30 p-3 text-red-200">{saveError}</p>}
+      <div className="sticky bottom-16 flex gap-3 rounded-2xl border border-stone-800 bg-stone-950/95 p-3 backdrop-blur md:bottom-24">
+        <button type="button" onClick={cancel} disabled={!isDirty || isSaving} className="min-h-11 flex-1 rounded-xl border border-stone-700 font-bold disabled:opacity-40">Cancel changes</button>
+        <button type="button" onClick={() => void save()} disabled={!isDirty || isSaving} className="min-h-11 flex-1 rounded-xl bg-amber-500 font-black text-stone-950 disabled:opacity-40">{isSaving ? 'Saving…' : 'Save plan'}</button>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/pages/ContinuityPlannerPage.tsx
+++ b/frontend/src/pages/ContinuityPlannerPage.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useCallback, useEffect, useState } from 'react'
+import { FormEvent, useCallback, useEffect, useRef, useState } from 'react'
 import axios from 'axios'
 import { useNavigate, useParams } from 'react-router-dom'
 import {
@@ -84,7 +84,8 @@ function toPayload(name: string, nodes: PlannerNode[]) {
 export default function ContinuityPlannerPage() {
   const { id } = useParams()
   const navigate = useNavigate()
-  const planId = id ? Number(id) : null
+  const parsedId = id ? Number(id) : null
+  const planId = parsedId && Number.isInteger(parsedId) && parsedId > 0 ? parsedId : null
   const [name, setName] = useState(DEFAULT_PLAN_NAME)
   const [nodes, setNodes] = useState<PlannerNode[]>([])
   const [savedName, setSavedName] = useState('')
@@ -99,8 +100,10 @@ export default function ContinuityPlannerPage() {
   const [isLoadingIssues, setIsLoadingIssues] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
+  const [issueLoadError, setIssueLoadError] = useState<string | null>(null)
   const [saveError, setSaveError] = useState<string | null>(null)
   const lastPlanId = typeof window === 'undefined' ? null : window.localStorage.getItem(LAST_PLAN_KEY)
+  const issueRequestRef = useRef<AbortController | null>(null)
 
   const isDirty = name !== savedName || JSON.stringify(nodes) !== JSON.stringify(savedNodes)
 
@@ -132,7 +135,8 @@ export default function ContinuityPlannerPage() {
           return
         }
         const plan = await continuityPlansApi.get(planId)
-        const hydrated = await hydrateLabels(plan.nodes, loadedGroups)
+        const orderedNodes = [...plan.nodes].sort((a, b) => a.position - b.position)
+        const hydrated = await hydrateLabels(orderedNodes, loadedGroups)
         if (!active) return
         setName(plan.name)
         setNodes(hydrated)
@@ -149,14 +153,24 @@ export default function ContinuityPlannerPage() {
     setSelectedThread(thread)
     setSelectedIssue(null)
     setIssues([])
-    if (!thread) return
+    setIssueLoadError(null)
+    if (!thread) {
+      setIsLoadingIssues(false)
+      return
+    }
+    if (issueRequestRef.current) issueRequestRef.current.abort()
+    const controller = new AbortController()
+    issueRequestRef.current = controller
     setIsLoadingIssues(true)
     try {
-      setIssues(await fetchAllIssues(thread.id))
+      const loadedIssues = await fetchAllIssues(thread.id)
+      if (controller.signal.aborted) return
+      setIssues(loadedIssues)
     } catch (error) {
-      setLoadError(errorMessage(error, 'Unable to load issues for that comic.'))
+      if (controller.signal.aborted) return
+      setIssueLoadError(errorMessage(error, 'Unable to load issues for that comic.'))
     } finally {
-      setIsLoadingIssues(false)
+      if (!controller.signal.aborted) setIsLoadingIssues(false)
     }
   }
 
@@ -268,7 +282,7 @@ export default function ContinuityPlannerPage() {
         <form onSubmit={addIssue} className="space-y-3" aria-label="Add an issue">
           <h2 className="font-black text-stone-100">Add an issue</h2>
           <ContinuityThreadSelector threads={threads} value={selectedThread} onChange={(thread) => void selectThread(thread)} label="Comic series" />
-          <ContinuityIssueSelector issues={issues} value={selectedIssue} onChange={setSelectedIssue} isLoading={isLoadingIssues} disabled={!selectedThread} />
+          <ContinuityIssueSelector issues={issues} value={selectedIssue} onChange={setSelectedIssue} isLoading={isLoadingIssues} disabled={!selectedThread} error={issueLoadError} />
           <button type="submit" disabled={!selectedIssue} className="min-h-11 w-full rounded-xl bg-amber-500 px-4 font-black text-stone-950 disabled:opacity-50">Add issue</button>
         </form>
 

--- a/frontend/src/pages/ContinuityPlannerPage.tsx
+++ b/frontend/src/pages/ContinuityPlannerPage.tsx
@@ -86,6 +86,7 @@ export default function ContinuityPlannerPage() {
   const navigate = useNavigate()
   const parsedId = id ? Number(id) : null
   const planId = parsedId && Number.isInteger(parsedId) && parsedId > 0 ? parsedId : null
+  const isInvalidRoute = id !== undefined && parsedId !== null && (!Number.isInteger(parsedId) || parsedId <= 0)
   const [name, setName] = useState(DEFAULT_PLAN_NAME)
   const [nodes, setNodes] = useState<PlannerNode[]>([])
   const [savedName, setSavedName] = useState('')
@@ -130,6 +131,11 @@ export default function ContinuityPlannerPage() {
         if (!active) return
         setThreads(loadedThreads)
         setGroups(loadedGroups)
+        if (isInvalidRoute) {
+          active && setLoadError('Invalid continuity plan ID.')
+          active && setIsLoading(false)
+          return
+        }
         if (!planId) {
           setSavedName(DEFAULT_PLAN_NAME)
           return
@@ -147,7 +153,7 @@ export default function ContinuityPlannerPage() {
       .catch((error) => active && setLoadError(errorMessage(error, 'Unable to load the continuity planner.')))
       .finally(() => active && setIsLoading(false))
     return () => { active = false }
-  }, [hydrateLabels, planId])
+  }, [hydrateLabels, planId, isInvalidRoute])
 
   const selectThread = async (thread: Thread | null) => {
     setSelectedThread(thread)
@@ -312,7 +318,7 @@ export default function ContinuityPlannerPage() {
         ) : (
           <ol className="mt-3 grid gap-2">
             {nodes.map((node, index) => (
-              <li key={node.id} className="flex items-center gap-3 rounded-2xl border border-stone-700 bg-stone-900 p-3">
+              <li key={node.id} data-testid={`lane-item-${index}`} className="flex items-center gap-3 rounded-2xl border border-stone-700 bg-stone-900 p-3">
                 <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-stone-800 font-black text-amber-300">{index + 1}</span>
                 <div className="min-w-0 flex-1">
                   <p className="truncate font-bold text-stone-100">{node.label}</p>

--- a/frontend/src/routes/routeModules.ts
+++ b/frontend/src/routes/routeModules.ts
@@ -27,6 +27,7 @@ export const routeModules = {
   history: () => import('../pages/HistoryPage'),
   session: () => import('../pages/SessionPage'),
   crossovers: () => import('../pages/CrossoversPage'),
+  continuityPlanner: () => import('../pages/ContinuityPlannerPage'),
   help: () => import('../pages/HelpPage'),
   whatsNew: () => import('../pages/WhatsNewPage'),
   login: () => import('../pages/LoginPage'),

--- a/frontend/src/services/api-continuity-plans.ts
+++ b/frontend/src/services/api-continuity-plans.ts
@@ -1,0 +1,34 @@
+import api from './api'
+
+export type ContinuityPlanNodeType = 'issue' | 'crossover'
+
+export interface ContinuityPlanNode {
+  id: string
+  node_type: ContinuityPlanNodeType
+  ref_id: number
+  lane_id: string
+  position: number
+}
+
+export interface ContinuityPlanWrite {
+  name: string
+  ordering_mode: 'strict_sequential'
+  lanes: Array<{ id: string; name: string; order: number }>
+  nodes: ContinuityPlanNode[]
+}
+
+export interface ContinuityPlan extends ContinuityPlanWrite {
+  id: number
+  user_id: number
+  created_at: string
+  updated_at: string
+}
+
+export const continuityPlansApi = {
+  create: (payload: ContinuityPlanWrite) =>
+    api.post<ContinuityPlan, ContinuityPlanWrite>('/v1/continuity-plans/', payload),
+  get: (planId: number) =>
+    api.get<ContinuityPlan>(`/v1/continuity-plans/${planId}`),
+  update: (planId: number, payload: ContinuityPlanWrite) =>
+    api.put<ContinuityPlan, ContinuityPlanWrite>(`/v1/continuity-plans/${planId}`, payload),
+}

--- a/frontend/src/unit/ContinuityPlannerPage.test.tsx
+++ b/frontend/src/unit/ContinuityPlannerPage.test.tsx
@@ -128,11 +128,11 @@ describe('ContinuityPlannerPage', () => {
       </MemoryRouter>,
     )
 
-    expect(await screen.findByText('Fourth World')).toBeVisible()
+    expect(await screen.findByRole('button', { name: 'Remove Fourth World' })).toBeVisible()
     await user.click(screen.getByRole('button', { name: 'Remove Fourth World' }))
     expect(screen.getByText('Unsaved changes')).toBeVisible()
     await user.click(screen.getByRole('button', { name: 'Cancel changes' }))
-    expect(screen.getByText('Fourth World')).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Remove Fourth World' })).toBeVisible()
     expect(mocks.update).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/unit/ContinuityPlannerPage.test.tsx
+++ b/frontend/src/unit/ContinuityPlannerPage.test.tsx
@@ -682,4 +682,136 @@ describe('ContinuityPlannerPage', () => {
     await user.click(screen.getByRole('button', { name: 'Cancel changes' }))
     expect(screen.getByLabelText('Plan name')).toHaveValue('My reading plan')
   })
+
+  it('falls back to the generic save message when the rejection is neither an axios detail nor an Error', async () => {
+    mocks.create.mockReset()
+    mocks.create.mockRejectedValueOnce({ code: 500 })
+
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await user.click(await screen.findByRole('option', { name: /Mister Miracle/i }))
+    await screen.findByRole('option', { name: /Annual 1/i })
+    await user.selectOptions(screen.getByLabelText('Issue'), '40')
+    await user.click(screen.getByRole('button', { name: 'Add issue' }))
+    await user.click(screen.getByRole('button', { name: 'Save plan' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent(/Unable to save this continuity plan\./i)
+  })
+
+  it('breaks the issue pagination loop when the API repeats the same next_page_token', async () => {
+    mocks.listIssues.mockReset()
+    mocks.listIssues
+      .mockResolvedValueOnce({ issues: [issue], total_count: 1, page_size: 100, next_page_token: 'repeat' })
+      .mockResolvedValueOnce({ issues: [secondIssue], total_count: 1, page_size: 100, next_page_token: 'repeat' })
+
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await user.click(await screen.findByRole('option', { name: /Mister Miracle/i }))
+    await waitFor(() => expect(mocks.listIssues).toHaveBeenCalledTimes(2))
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('does not surface an error from an issue request that was aborted by a thread switch', async () => {
+    mocks.listIssues.mockReset()
+    mocks.listIssues
+      .mockImplementationOnce(() => Promise.reject(new Error('stale failure')))
+      .mockResolvedValueOnce({ issues: [secondIssue], total_count: 1, page_size: 100, next_page_token: null })
+
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await user.click(await screen.findByRole('option', { name: /Mister Miracle/i }))
+    await user.clear(screen.getByLabelText('Comic series'))
+    await user.click(screen.getByRole('option', { name: /New Gods/i }))
+    await screen.findByRole('option', { name: /#7$/ })
+    await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument())
+  })
+
+  it('ignores plan hydration that resolves after the page has unmounted', async () => {
+    let resolveThreads!: (value: { threads: typeof thread[]; next_page_token: string | null }) => void
+    mocks.listThreads.mockReset()
+    mocks.listThreads.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveThreads = resolve
+    }))
+
+    const { unmount } = render(
+      <MemoryRouter initialEntries={['/continuity-plans']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    unmount()
+    resolveThreads({ threads: [thread], next_page_token: null })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(mocks.get).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the generic save message when the API detail is an object without a known code', async () => {
+    mocks.create.mockReset()
+    mocks.create.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: { data: { detail: { problem: 'wrapped failure' } } },
+    })
+
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await user.click(await screen.findByRole('option', { name: /Mister Miracle/i }))
+    await screen.findByRole('option', { name: /Annual 1/i })
+    await user.selectOptions(screen.getByLabelText('Issue'), '40')
+    await user.click(screen.getByRole('button', { name: 'Add issue' }))
+    await user.click(screen.getByRole('button', { name: 'Save plan' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent(/Unable to save this continuity plan\./i)
+  })
+
+  it('restores the default plan name when canceling before the initial name has loaded', async () => {
+    mocks.listThreads.mockReset()
+    mocks.listThreads.mockImplementationOnce(() => new Promise(() => {}))
+
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    const cancelButton = await screen.findByRole('button', { name: 'Cancel changes' })
+    await user.click(cancelButton)
+    expect(screen.getByLabelText('Plan name')).toHaveValue('My reading plan')
+  })
 })

--- a/frontend/src/unit/ContinuityPlannerPage.test.tsx
+++ b/frontend/src/unit/ContinuityPlannerPage.test.tsx
@@ -48,6 +48,12 @@ const thread = {
   created_at: '2026-08-12T00:00:00Z',
 }
 
+const secondThread = {
+  ...thread,
+  id: 5,
+  title: 'New Gods',
+}
+
 const issue = {
   id: 40,
   thread_id: 4,
@@ -58,15 +64,41 @@ const issue = {
   created_at: '2026-08-12T00:00:00Z',
 }
 
+const secondIssue = {
+  id: 41,
+  thread_id: 5,
+  issue_number: '7',
+  position: 7,
+  status: 'unread',
+  read_at: null,
+  created_at: '2026-08-12T00:00:00Z',
+}
+
 beforeEach(() => {
   window.localStorage.clear()
-  mocks.listThreads.mockResolvedValue({ threads: [thread], next_page_token: null })
+  mocks.get.mockReset()
+  mocks.create.mockReset()
+  mocks.update.mockReset()
+  mocks.listIssues.mockReset()
+  mocks.listThreads.mockResolvedValue({ threads: [thread, secondThread], next_page_token: null })
   mocks.listGroups.mockResolvedValue([{ id: 8, name: 'Fourth World', memberships: [], created_at: '2026-08-12T00:00:00Z' }])
   mocks.listIssues.mockResolvedValue({ issues: [issue], total_count: 1, page_size: 100, next_page_token: null })
+  mocks.getIssue.mockResolvedValue(issue)
+  mocks.getThread.mockResolvedValue(thread)
   mocks.create.mockResolvedValue({
     id: 12,
     user_id: 1,
     name: 'Kirby lane',
+    ordering_mode: 'strict_sequential',
+    lanes: [{ id: 'main', name: 'Reading order', order: 0 }],
+    nodes: [],
+    created_at: '2026-08-12T00:00:00Z',
+    updated_at: '2026-08-12T00:00:00Z',
+  })
+  mocks.update.mockResolvedValue({
+    id: 12,
+    user_id: 1,
+    name: 'Saved lane',
     ordering_mode: 'strict_sequential',
     lanes: [{ id: 'main', name: 'Reading order', order: 0 }],
     nodes: [],
@@ -134,5 +166,520 @@ describe('ContinuityPlannerPage', () => {
     await user.click(screen.getByRole('button', { name: 'Cancel changes' }))
     expect(screen.getByRole('button', { name: 'Remove Fourth World' })).toBeVisible()
     expect(mocks.update).not.toHaveBeenCalled()
+  })
+
+  it('moves a node up and down using the lane reorder controls', async () => {
+    mocks.get.mockResolvedValue({
+      id: 12,
+      user_id: 1,
+      name: 'Saved lane',
+      ordering_mode: 'strict_sequential',
+      lanes: [{ id: 'main', name: 'Reading order', order: 0 }],
+      nodes: [
+        { id: 'issue-40', node_type: 'issue', ref_id: 40, lane_id: 'main', position: 0 },
+        { id: 'crossover-8', node_type: 'crossover', ref_id: 8, lane_id: 'main', position: 1 },
+      ],
+      created_at: '2026-08-12T00:00:00Z',
+      updated_at: '2026-08-12T00:00:00Z',
+    })
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans/12']}>
+        <Routes>
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    const moveDownButton = await screen.findByRole('button', { name: /Move Mister Miracle #Annual 1 later/i })
+    await user.click(moveDownButton)
+    await waitFor(() => expect(screen.getByText('2')).toBeVisible())
+    const moveUpButton = screen.getByRole('button', { name: /Move Mister Miracle #Annual 1 earlier/i })
+    await user.click(moveUpButton)
+    await waitFor(() => expect(screen.getByText('1')).toBeVisible())
+  })
+
+  it('reopens the last saved plan when the local-storage marker exists', async () => {
+    window.localStorage.setItem('comic-pile:last-continuity-plan', '12')
+    mocks.get.mockResolvedValue({
+      id: 12,
+      user_id: 1,
+      name: 'Saved lane',
+      ordering_mode: 'strict_sequential',
+      lanes: [{ id: 'main', name: 'Reading order', order: 0 }],
+      nodes: [],
+      created_at: '2026-08-12T00:00:00Z',
+      updated_at: '2026-08-12T00:00:00Z',
+    })
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    const reopen = await screen.findByRole('button', { name: 'Reopen last saved plan' })
+    await user.click(reopen)
+    await waitFor(() => expect(mocks.get).toHaveBeenCalledWith(12))
+  })
+
+  it('ignores stale issue requests when the user switches thread selections', async () => {
+    let resolveFirst!: (value: { issues: typeof issue[]; total_count: number; page_size: number; next_page_token: null }) => void
+    const firstList = new Promise<{ issues: typeof issue[]; total_count: number; page_size: number; next_page_token: null }>((resolve) => {
+      resolveFirst = resolve
+    })
+    mocks.listIssues
+      .mockImplementationOnce(() => firstList)
+      .mockResolvedValueOnce({ issues: [secondIssue], total_count: 1, page_size: 100, next_page_token: null })
+
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await user.click(await screen.findByRole('option', { name: /Mister Miracle/i }))
+    await user.clear(screen.getByLabelText('Comic series'))
+    await user.click(screen.getByRole('option', { name: /New Gods/i }))
+    await screen.findByRole('option', { name: /#7$/ })
+    resolveFirst({ issues: [issue], total_count: 1, page_size: 100, next_page_token: null })
+    await waitFor(() => expect(screen.queryByRole('option', { name: /#Annual 1$/ })).not.toBeInTheDocument())
+  })
+
+  it('shows an inline error when loading issues for the selected comic fails', async () => {
+    mocks.listIssues.mockReset()
+    mocks.listIssues.mockRejectedValueOnce(new Error('network down'))
+
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await user.click(await screen.findByRole('option', { name: /Mister Miracle/i }))
+    expect(await screen.findByRole('alert')).toHaveTextContent(/network down/i)
+  })
+
+  it('surfaces a save error without discarding the in-progress plan', async () => {
+    mocks.create.mockReset()
+    mocks.create.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: { data: { detail: { code: 'plan_rule_conflict' } } },
+    })
+
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await user.clear(await screen.findByLabelText('Plan name'))
+    await user.type(screen.getByLabelText('Plan name'), 'Kirby lane')
+    await user.click(screen.getByRole('option', { name: /Mister Miracle/i }))
+    await screen.findByRole('option', { name: /Annual 1/i })
+    await user.selectOptions(screen.getByLabelText('Issue'), '40')
+    await user.click(screen.getByRole('button', { name: 'Add issue' }))
+    await user.click(screen.getByRole('button', { name: 'Save plan' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent(/conflicts with an existing continuity rule/i)
+  })
+
+  it('surfaces a cycle error when the API rejects with the continuity_cycle code', async () => {
+    mocks.create.mockReset()
+    mocks.create.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: { data: { detail: { code: 'continuity_cycle' } } },
+    })
+
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await user.click(await screen.findByRole('option', { name: /Mister Miracle/i }))
+    await screen.findByRole('option', { name: /Annual 1/i })
+    await user.selectOptions(screen.getByLabelText('Issue'), '40')
+    await user.click(screen.getByRole('button', { name: 'Add issue' }))
+    await user.click(screen.getByRole('button', { name: 'Save plan' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent(/continuity cycle/i)
+  })
+
+  it('rejects a non-positive integer route id and treats the URL as a new plan', async () => {
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans/not-a-number']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await user.click(await screen.findByRole('option', { name: /Mister Miracle/i }))
+    expect(mocks.get).not.toHaveBeenCalled()
+  })
+
+  it('updates an existing plan with the in-memory node order', async () => {
+    mocks.get.mockResolvedValue({
+      id: 12,
+      user_id: 1,
+      name: 'Saved lane',
+      ordering_mode: 'strict_sequential',
+      lanes: [{ id: 'main', name: 'Reading order', order: 0 }],
+      nodes: [
+        { id: 'issue-40', node_type: 'issue', ref_id: 40, lane_id: 'main', position: 0 },
+        { id: 'crossover-8', node_type: 'crossover', ref_id: 8, lane_id: 'main', position: 1 },
+      ],
+      created_at: '2026-08-12T00:00:00Z',
+      updated_at: '2026-08-12T00:00:00Z',
+    })
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans/12']}>
+        <Routes>
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    const moveDown = await screen.findByRole('button', { name: /Move Mister Miracle #Annual 1 later/i })
+    await user.click(moveDown)
+    await user.click(screen.getByRole('button', { name: 'Save plan' }))
+
+    await waitFor(() => expect(mocks.update).toHaveBeenCalledOnce())
+    expect(mocks.update).toHaveBeenCalledWith(12, expect.objectContaining({
+      nodes: [
+        expect.objectContaining({ id: 'crossover-8', position: 0 }),
+        expect.objectContaining({ id: 'issue-40', position: 1 }),
+      ],
+    }))
+  })
+
+  it('falls back to the default name when canceling an unsaved new plan', async () => {
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    const nameInput = await screen.findByLabelText('Plan name')
+    await user.clear(nameInput)
+    await user.type(nameInput, 'Temporary name')
+    await user.click(screen.getByRole('option', { name: /Mister Miracle/i }))
+    await screen.findByRole('option', { name: /Annual 1/i })
+    await user.selectOptions(screen.getByLabelText('Issue'), '40')
+    await user.click(screen.getByRole('button', { name: 'Add issue' }))
+    await user.click(screen.getByRole('button', { name: 'Cancel changes' }))
+    expect(screen.getByLabelText('Plan name')).toHaveValue('My reading plan')
+  })
+
+  it('rejects adding the same issue or crossover twice and surfaces an inline error', async () => {
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await user.click(await screen.findByRole('option', { name: /Mister Miracle/i }))
+    await screen.findByRole('option', { name: /Annual 1/i })
+    await user.selectOptions(screen.getByLabelText('Issue'), '40')
+    await user.click(screen.getByRole('button', { name: 'Add issue' }))
+    await user.selectOptions(screen.getByLabelText('Issue'), '40')
+    await user.click(screen.getByRole('button', { name: 'Add issue' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent(/already in this plan/i)
+
+    await user.selectOptions(screen.getByLabelText('Crossover'), '8')
+    await user.click(screen.getByRole('button', { name: 'Add crossover' }))
+    await user.selectOptions(screen.getByLabelText('Crossover'), '8')
+    await user.click(screen.getByRole('button', { name: 'Add crossover' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent(/already in this plan/i)
+  })
+
+  it('requires a non-empty plan name before save', async () => {
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    const nameInput = await screen.findByLabelText('Plan name')
+    await user.clear(nameInput)
+    await user.type(nameInput, '   ')
+    await user.click(await screen.findByRole('option', { name: /Mister Miracle/i }))
+    await screen.findByRole('option', { name: /Annual 1/i })
+    await user.selectOptions(screen.getByLabelText('Issue'), '40')
+    await user.click(screen.getByRole('button', { name: 'Add issue' }))
+    await user.click(screen.getByRole('button', { name: 'Save plan' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent(/Enter a plan name\./i)
+    expect(mocks.create).not.toHaveBeenCalled()
+  })
+
+  it('falls back to an "Unavailable issue" label when an issue lookup fails during hydration', async () => {
+    mocks.get.mockResolvedValue({
+      id: 12,
+      user_id: 1,
+      name: 'Saved lane',
+      ordering_mode: 'strict_sequential',
+      lanes: [{ id: 'main', name: 'Reading order', order: 0 }],
+      nodes: [{ id: 'issue-40', node_type: 'issue', ref_id: 40, lane_id: 'main', position: 0 }],
+      created_at: '2026-08-12T00:00:00Z',
+      updated_at: '2026-08-12T00:00:00Z',
+    })
+    mocks.getIssue.mockReset()
+    mocks.getIssue.mockRejectedValueOnce(new Error('lookup failed'))
+
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans/12']}>
+        <Routes>
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('Unavailable issue')).toBeVisible()
+  })
+
+  it('renders an Unavailable crossover label when the saved crossover is missing from the current group list', async () => {
+    mocks.get.mockResolvedValue({
+      id: 12,
+      user_id: 1,
+      name: 'Saved lane',
+      ordering_mode: 'strict_sequential',
+      lanes: [{ id: 'main', name: 'Reading order', order: 0 }],
+      nodes: [{ id: 'crossover-99', node_type: 'crossover', ref_id: 99, lane_id: 'main', position: 0 }],
+      created_at: '2026-08-12T00:00:00Z',
+      updated_at: '2026-08-12T00:00:00Z',
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans/12']}>
+        <Routes>
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('Unavailable crossover')).toBeVisible()
+  })
+
+  it('shows a plan-level load error when fetching the plan fails', async () => {
+    mocks.get.mockRejectedValueOnce(new Error('Cannot read plan'))
+
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans/12']}>
+        <Routes>
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/Cannot read plan/i)
+  })
+
+  it('uses the API detail string when the save error payload includes one', async () => {
+    mocks.create.mockReset()
+    mocks.create.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: { data: { detail: 'Backend rejected the plan.' } },
+    })
+
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await user.click(await screen.findByRole('option', { name: /Mister Miracle/i }))
+    await screen.findByRole('option', { name: /Annual 1/i })
+    await user.selectOptions(screen.getByLabelText('Issue'), '40')
+    await user.click(screen.getByRole('button', { name: 'Add issue' }))
+    await user.click(screen.getByRole('button', { name: 'Save plan' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent(/Backend rejected the plan\./i)
+  })
+
+  it('falls back to the thrown error message when the save error has no axios detail', async () => {
+    mocks.create.mockReset()
+    mocks.create.mockRejectedValueOnce(new Error('Boom'))
+
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await user.click(await screen.findByRole('option', { name: /Mister Miracle/i }))
+    await screen.findByRole('option', { name: /Annual 1/i })
+    await user.selectOptions(screen.getByLabelText('Issue'), '40')
+    await user.click(screen.getByRole('button', { name: 'Add issue' }))
+    await user.click(screen.getByRole('button', { name: 'Save plan' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent(/Boom/i)
+  })
+
+  it('pages through threads across multiple tokenized responses', async () => {
+    mocks.listThreads.mockReset()
+    mocks.listThreads
+      .mockResolvedValueOnce({ threads: [thread], next_page_token: 'page-2' })
+      .mockResolvedValueOnce({ threads: [secondThread], next_page_token: null })
+    mocks.listIssues.mockReset()
+    mocks.listIssues
+      .mockResolvedValueOnce({ issues: [issue], total_count: 1, page_size: 100, next_page_token: 'issues-2' })
+      .mockResolvedValueOnce({ issues: [secondIssue], total_count: 1, page_size: 100, next_page_token: null })
+
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(mocks.listThreads).toHaveBeenCalledTimes(2))
+    expect(await screen.findByRole('option', { name: /New Gods/i })).toBeVisible()
+    await user.click(screen.getByRole('option', { name: /New Gods/i }))
+    await screen.findByRole('option', { name: /#7$/ })
+  })
+
+  it('moves an item beyond the lane bounds without crashing', async () => {
+    mocks.get.mockResolvedValue({
+      id: 12,
+      user_id: 1,
+      name: 'Saved lane',
+      ordering_mode: 'strict_sequential',
+      lanes: [{ id: 'main', name: 'Reading order', order: 0 }],
+      nodes: [
+        { id: 'issue-40', node_type: 'issue', ref_id: 40, lane_id: 'main', position: 0 },
+        { id: 'crossover-8', node_type: 'crossover', ref_id: 8, lane_id: 'main', position: 1 },
+      ],
+      created_at: '2026-08-12T00:00:00Z',
+      updated_at: '2026-08-12T00:00:00Z',
+    })
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans/12']}>
+        <Routes>
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByRole('button', { name: /Move Mister Miracle #Annual 1 earlier/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Move Fourth World later/i })).toBeDisabled()
+    await user.click(screen.getByRole('button', { name: 'Remove Fourth World' }))
+    await user.click(screen.getByRole('button', { name: 'Save plan' }))
+    await waitFor(() => expect(mocks.update).toHaveBeenCalledOnce())
+  })
+
+  it('ignores the create form when the user has not selected an issue', async () => {
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    const addIssueButton = await screen.findByRole('button', { name: 'Add issue' })
+    expect(addIssueButton).toBeDisabled()
+    await user.click(addIssueButton)
+    expect(mocks.create).not.toHaveBeenCalled()
+  })
+
+  it('ignores the add-crossover click when no crossover is selected', async () => {
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    const addCrossoverButton = await screen.findByRole('button', { name: 'Add crossover' })
+    expect(addCrossoverButton).toBeDisabled()
+    await user.click(addCrossoverButton)
+    expect(mocks.create).not.toHaveBeenCalled()
+  })
+
+  it('breaks the pagination loop when the API repeats the same next_page_token', async () => {
+    mocks.listThreads.mockReset()
+    mocks.listThreads
+      .mockResolvedValueOnce({ threads: [thread], next_page_token: 'duplicate' })
+      .mockResolvedValueOnce({ threads: [secondThread], next_page_token: 'duplicate' })
+
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(mocks.listThreads).toHaveBeenCalledTimes(2))
+  })
+
+  it('falls back to the default plan name when canceling an unsaved new plan with no prior name', async () => {
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await user.clear(await screen.findByLabelText('Plan name'))
+    await user.type(screen.getByLabelText('Plan name'), 'Ephemeral')
+    await user.click(screen.getByRole('option', { name: /Mister Miracle/i }))
+    await screen.findByRole('option', { name: /Annual 1/i })
+    await user.selectOptions(screen.getByLabelText('Issue'), '40')
+    await user.click(screen.getByRole('button', { name: 'Add issue' }))
+    await user.click(screen.getByRole('button', { name: 'Cancel changes' }))
+    expect(screen.getByLabelText('Plan name')).toHaveValue('My reading plan')
   })
 })

--- a/frontend/src/unit/ContinuityPlannerPage.test.tsx
+++ b/frontend/src/unit/ContinuityPlannerPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -191,12 +191,30 @@ describe('ContinuityPlannerPage', () => {
       </MemoryRouter>,
     )
 
+    // Initially first item is "Mister Miracle #Annual 1" at position 1
+    await waitFor(() => expect(screen.getByText('Mister Miracle #Annual 1')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByTestId('lane-item-0')).toHaveTextContent('Mister Miracle #Annual 1'))
+    await waitFor(() => expect(screen.getByTestId('lane-item-1')).toHaveTextContent('Fourth World'))
+
     const moveDownButton = await screen.findByRole('button', { name: /Move Mister Miracle #Annual 1 later/i })
-    await user.click(moveDownButton)
-    await waitFor(() => expect(screen.getByText('2')).toBeVisible())
+    await act(async () => {
+      await user.click(moveDownButton)
+    })
+    // After moving down, the order should be swapped
+    const firstItem = screen.getByTestId('lane-item-0')
+    const secondItem = screen.getByTestId('lane-item-1')
+    expect(firstItem).toHaveTextContent('Fourth World')
+    expect(secondItem).toHaveTextContent('Mister Miracle #Annual 1')
+
     const moveUpButton = screen.getByRole('button', { name: /Move Mister Miracle #Annual 1 earlier/i })
-    await user.click(moveUpButton)
-    await waitFor(() => expect(screen.getByText('1')).toBeVisible())
+    await act(async () => {
+      await user.click(moveUpButton)
+    })
+    // After moving up, the order should be restored
+    const restoredFirstItem = screen.getByTestId('lane-item-0')
+    const restoredSecondItem = screen.getByTestId('lane-item-1')
+    expect(restoredFirstItem).toHaveTextContent('Mister Miracle #Annual 1')
+    expect(restoredSecondItem).toHaveTextContent('Fourth World')
   })
 
   it('reopens the last saved plan when the local-storage marker exists', async () => {
@@ -323,8 +341,7 @@ describe('ContinuityPlannerPage', () => {
     expect(await screen.findByRole('alert')).toHaveTextContent(/continuity cycle/i)
   })
 
-  it('rejects a non-positive integer route id and treats the URL as a new plan', async () => {
-    const user = userEvent.setup()
+  it('shows an error for a non-numeric route id', async () => {
     render(
       <MemoryRouter initialEntries={['/continuity-plans/not-a-number']}>
         <Routes>
@@ -334,7 +351,35 @@ describe('ContinuityPlannerPage', () => {
       </MemoryRouter>,
     )
 
-    await user.click(await screen.findByRole('option', { name: /Mister Miracle/i }))
+    expect(await screen.findByRole('alert')).toHaveTextContent(/Invalid continuity plan ID/i)
+    expect(mocks.get).not.toHaveBeenCalled()
+  })
+
+  it('shows an error for a zero route id', async () => {
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans/0']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/Invalid continuity plan ID/i)
+    expect(mocks.get).not.toHaveBeenCalled()
+  })
+
+  it('shows an error for a negative route id', async () => {
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans/-1']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/Invalid continuity plan ID/i)
     expect(mocks.get).not.toHaveBeenCalled()
   })
 
@@ -580,7 +625,7 @@ describe('ContinuityPlannerPage', () => {
     await screen.findByRole('option', { name: /#7$/ })
   })
 
-  it('moves an item beyond the lane bounds without crashing', async () => {
+  it('disables move controls at lane boundaries and removes nodes', async () => {
     mocks.get.mockResolvedValue({
       id: 12,
       user_id: 1,
@@ -608,6 +653,37 @@ describe('ContinuityPlannerPage', () => {
     await user.click(screen.getByRole('button', { name: 'Remove Fourth World' }))
     await user.click(screen.getByRole('button', { name: 'Save plan' }))
     await waitFor(() => expect(mocks.update).toHaveBeenCalledOnce())
+  })
+
+  it('moves the first node down and back up, preserving order', async () => {
+    mocks.get.mockResolvedValue({
+      id: 12,
+      user_id: 1,
+      name: 'Saved lane',
+      ordering_mode: 'strict_sequential',
+      lanes: [{ id: 'main', name: 'Reading order', order: 0 }],
+      nodes: [
+        { id: 'issue-40', node_type: 'issue', ref_id: 40, lane_id: 'main', position: 0 },
+        { id: 'crossover-8', node_type: 'crossover', ref_id: 8, lane_id: 'main', position: 1 },
+      ],
+      created_at: '2026-08-12T00:00:00Z',
+      updated_at: '2026-08-12T00:00:00Z',
+    })
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans/12']}>
+        <Routes>
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    const moveDownButton = await screen.findByRole('button', { name: /Move Mister Miracle #Annual 1 later/i })
+    await user.click(moveDownButton)
+    await waitFor(() => expect(screen.getByText('2')).toBeVisible())
+    const moveUpButton = screen.getByRole('button', { name: /Move Mister Miracle #Annual 1 earlier/i })
+    await user.click(moveUpButton)
+    await waitFor(() => expect(screen.getByText('1')).toBeVisible())
   })
 
   it('ignores the create form when the user has not selected an issue', async () => {
@@ -662,7 +738,7 @@ describe('ContinuityPlannerPage', () => {
     await waitFor(() => expect(mocks.listThreads).toHaveBeenCalledTimes(2))
   })
 
-  it('falls back to the default plan name when canceling an unsaved new plan with no prior name', async () => {
+  it('falls back to the default plan name when canceling an unsaved new plan without typing a name', async () => {
     const user = userEvent.setup()
     render(
       <MemoryRouter initialEntries={['/continuity-plans']}>
@@ -673,12 +749,6 @@ describe('ContinuityPlannerPage', () => {
       </MemoryRouter>,
     )
 
-    await user.clear(await screen.findByLabelText('Plan name'))
-    await user.type(screen.getByLabelText('Plan name'), 'Ephemeral')
-    await user.click(screen.getByRole('option', { name: /Mister Miracle/i }))
-    await screen.findByRole('option', { name: /Annual 1/i })
-    await user.selectOptions(screen.getByLabelText('Issue'), '40')
-    await user.click(screen.getByRole('button', { name: 'Add issue' }))
     await user.click(screen.getByRole('button', { name: 'Cancel changes' }))
     expect(screen.getByLabelText('Plan name')).toHaveValue('My reading plan')
   })

--- a/frontend/src/unit/ContinuityPlannerPage.test.tsx
+++ b/frontend/src/unit/ContinuityPlannerPage.test.tsx
@@ -90,6 +90,7 @@ describe('ContinuityPlannerPage', () => {
     await user.clear(await screen.findByLabelText('Plan name'))
     await user.type(screen.getByLabelText('Plan name'), 'Kirby lane')
     await user.click(screen.getByRole('option', { name: /Mister Miracle/i }))
+    await screen.findByRole('option', { name: /Annual 1/i })
     await user.selectOptions(screen.getByLabelText('Issue'), '40')
     await user.click(screen.getByRole('button', { name: 'Add issue' }))
     await user.selectOptions(screen.getByLabelText('Crossover'), '8')

--- a/frontend/src/unit/ContinuityPlannerPage.test.tsx
+++ b/frontend/src/unit/ContinuityPlannerPage.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ContinuityPlannerPage from '../pages/ContinuityPlannerPage'
+
+const mocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  get: vi.fn(),
+  update: vi.fn(),
+  listGroups: vi.fn(),
+  listIssues: vi.fn(),
+  getIssue: vi.fn(),
+  listThreads: vi.fn(),
+  getThread: vi.fn(),
+}))
+
+vi.mock('../services/api-continuity-plans', () => ({
+  continuityPlansApi: {
+    create: mocks.create,
+    get: mocks.get,
+    update: mocks.update,
+  },
+}))
+
+vi.mock('../services/api-dependency-groups', () => ({
+  dependencyGroupsApi: { list: mocks.listGroups },
+}))
+
+vi.mock('../services/api-issues', () => ({
+  issuesApi: { list: mocks.listIssues, get: mocks.getIssue },
+}))
+
+vi.mock('../services/api', () => ({
+  threadsApi: { list: mocks.listThreads, get: mocks.getThread },
+}))
+
+const thread = {
+  id: 4,
+  title: 'Mister Miracle',
+  format: 'single issues',
+  issues_remaining: 12,
+  total_issues: 12,
+  queue_position: 1,
+  status: 'active',
+  is_blocked: false,
+  blocking_reasons: [],
+  created_at: '2026-08-12T00:00:00Z',
+}
+
+const issue = {
+  id: 40,
+  thread_id: 4,
+  issue_number: 'Annual 1',
+  position: 1,
+  status: 'unread',
+  read_at: null,
+  created_at: '2026-08-12T00:00:00Z',
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+  mocks.listThreads.mockResolvedValue({ threads: [thread], next_page_token: null })
+  mocks.listGroups.mockResolvedValue([{ id: 8, name: 'Fourth World', memberships: [], created_at: '2026-08-12T00:00:00Z' }])
+  mocks.listIssues.mockResolvedValue({ issues: [issue], total_count: 1, page_size: 100, next_page_token: null })
+  mocks.create.mockResolvedValue({
+    id: 12,
+    user_id: 1,
+    name: 'Kirby lane',
+    ordering_mode: 'strict_sequential',
+    lanes: [{ id: 'main', name: 'Reading order', order: 0 }],
+    nodes: [],
+    created_at: '2026-08-12T00:00:00Z',
+    updated_at: '2026-08-12T00:00:00Z',
+  })
+})
+
+describe('ContinuityPlannerPage', () => {
+  it('creates a sequential plan from shared human-facing selectors', async () => {
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans']}>
+        <Routes>
+          <Route path="/continuity-plans" element={<ContinuityPlannerPage />} />
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await user.clear(await screen.findByLabelText('Plan name'))
+    await user.type(screen.getByLabelText('Plan name'), 'Kirby lane')
+    await user.click(screen.getByRole('option', { name: /Mister Miracle/i }))
+    await user.selectOptions(screen.getByLabelText('Issue'), '40')
+    await user.click(screen.getByRole('button', { name: 'Add issue' }))
+    await user.selectOptions(screen.getByLabelText('Crossover'), '8')
+    await user.click(screen.getByRole('button', { name: 'Add crossover' }))
+    await user.click(screen.getByRole('button', { name: 'Save plan' }))
+
+    await waitFor(() => expect(mocks.create).toHaveBeenCalledOnce())
+    expect(mocks.create).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'Kirby lane',
+      ordering_mode: 'strict_sequential',
+      nodes: [
+        expect.objectContaining({ node_type: 'issue', ref_id: 40, position: 0 }),
+        expect.objectContaining({ node_type: 'crossover', ref_id: 8, position: 1 }),
+      ],
+    }))
+  })
+
+  it('restores saved order when unsaved changes are canceled', async () => {
+    mocks.get.mockResolvedValue({
+      id: 12,
+      user_id: 1,
+      name: 'Saved lane',
+      ordering_mode: 'strict_sequential',
+      lanes: [{ id: 'main', name: 'Reading order', order: 0 }],
+      nodes: [{ id: 'crossover-8', node_type: 'crossover', ref_id: 8, lane_id: 'main', position: 0 }],
+      created_at: '2026-08-12T00:00:00Z',
+      updated_at: '2026-08-12T00:00:00Z',
+    })
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter initialEntries={['/continuity-plans/12']}>
+        <Routes>
+          <Route path="/continuity-plans/:id" element={<ContinuityPlannerPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('Fourth World')).toBeVisible()
+    await user.click(screen.getByRole('button', { name: 'Remove Fourth World' }))
+    expect(screen.getByText('Unsaved changes')).toBeVisible()
+    await user.click(screen.getByRole('button', { name: 'Cancel changes' }))
+    expect(screen.getByText('Fourth World')).toBeVisible()
+    expect(mocks.update).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/unit/api-continuity-plans.test.ts
+++ b/frontend/src/unit/api-continuity-plans.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+}))
+
+vi.mock('../services/api', () => ({
+  default: apiMock,
+}))
+
+import { continuityPlansApi } from '../services/api-continuity-plans'
+
+const basePlan = {
+  id: 12,
+  user_id: 1,
+  name: 'Kirby lane',
+  ordering_mode: 'strict_sequential' as const,
+  lanes: [{ id: 'main', name: 'Reading order', order: 0 }],
+  nodes: [
+    { id: 'issue-40', node_type: 'issue' as const, ref_id: 40, lane_id: 'main', position: 0 },
+    { id: 'crossover-8', node_type: 'crossover' as const, ref_id: 8, lane_id: 'main', position: 1 },
+  ],
+  created_at: '2026-08-12T00:00:00Z',
+  updated_at: '2026-08-12T00:00:00Z',
+}
+
+beforeEach(() => {
+  apiMock.get.mockReset()
+  apiMock.post.mockReset()
+  apiMock.put.mockReset()
+  apiMock.delete.mockReset()
+})
+
+describe('continuityPlansApi', () => {
+  it('creates a strict-sequential plan', async () => {
+    apiMock.post.mockResolvedValueOnce(basePlan)
+
+    await expect(continuityPlansApi.create({
+      name: 'Kirby lane',
+      ordering_mode: 'strict_sequential',
+      lanes: basePlan.lanes,
+      nodes: basePlan.nodes,
+    })).resolves.toEqual(basePlan)
+
+    expect(apiMock.post).toHaveBeenCalledWith('/v1/continuity-plans/', {
+      name: 'Kirby lane',
+      ordering_mode: 'strict_sequential',
+      lanes: basePlan.lanes,
+      nodes: basePlan.nodes,
+    })
+  })
+
+  it('loads a plan by id', async () => {
+    apiMock.get.mockResolvedValueOnce(basePlan)
+
+    await expect(continuityPlansApi.get(12)).resolves.toEqual(basePlan)
+
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/continuity-plans/12')
+  })
+
+  it('replaces a plan with a full ordered payload', async () => {
+    apiMock.put.mockResolvedValueOnce(basePlan)
+
+    await expect(continuityPlansApi.update(12, {
+      name: 'Kirby lane',
+      ordering_mode: 'strict_sequential',
+      lanes: basePlan.lanes,
+      nodes: basePlan.nodes,
+    })).resolves.toEqual(basePlan)
+
+    expect(apiMock.put).toHaveBeenCalledWith('/v1/continuity-plans/12', {
+      name: 'Kirby lane',
+      ordering_mode: 'strict_sequential',
+      lanes: basePlan.lanes,
+      nodes: basePlan.nodes,
+    })
+  })
+})


### PR DESCRIPTION
Closes #925.

## Summary
- add a mobile-friendly sequential continuity planning workspace
- reuse the shared comic series and issue selectors and existing crossover identities
- create, reopen, reorder, remove, save, and cancel explicit single-lane plans
- surface unsaved, saving, saved, validation-error, and rule-conflict states
- persist strict sequential intent through the existing continuity-plan API

## Validation
- focused component coverage added for create and cancel behavior
- configured CI is the executable validation boundary for this connector-backed branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Continuity Planner for creating, editing, ordering, and saving continuity plans.
  - Added navigation links and protected routes for continuity planning.
  - Plans can be reopened, renamed, cancelled, and updated with issues and crossovers.
  - Added clear validation, loading, conflict, cycle, and error messages.

- **Bug Fixes**
  - Improved handling of pagination, duplicate items, unavailable data, and stale requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->