### PR TITLE
Add experimental OpenCode NVIDIA Factory 6

### DIFF
--- a/.github/workflows/nvidia-factory-6.yml
+++ b/.github/workflows/nvidia-factory-6.yml
@@ -1,0 +1,280 @@
+name: NVIDIA Factory 6
+
+on:
+  schedule:
+    - cron: "37 */2 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: nvidia-factory-6
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  actions: read
+  checks: read
+
+jobs:
+  factory:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      GH_TOKEN: ${{ github.token }}
+      NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+      FACTORY_OWNER: factory:6
+      FACTORY_WORKER_ID: opencode-nvidia-factory-6
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Configure git identity
+        run: |
+          git config user.name "opencode-nvidia-factory-6[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Install pinned OpenCode and NVIDIA model discovery
+        run: |
+          npm install --global --ignore-scripts opencode-ai@1.15.2 free-coding-models@0.5.69
+          opencode --version
+
+      - name: Select a healthy NVIDIA model
+        id: model
+        run: |
+          fcm_output="$(free-coding-models \
+            --json \
+            --origin nvidia \
+            --hide-unconfigured \
+            --best \
+            --no-telemetry)"
+          candidates="$(printf '%s\n' "$fcm_output" | python scripts/select_fcm_nvidia_model.py)"
+          selected_model=""
+          while IFS= read -r candidate; do
+            [[ -n "$candidate" ]] || continue
+            echo "Probing $candidate"
+            provider_model="${candidate#nvidia/}"
+            request="$(jq -nc \
+              --arg model "$provider_model" \
+              '{model:$model,messages:[{role:"user",content:"Reply with exactly: FCM_NVIDIA_MODEL_OK"}],max_tokens:32}')"
+            response="$(curl --silent --show-error --fail-with-body \
+              --header "Authorization: Bearer $NVIDIA_API_KEY" \
+              --header 'Content-Type: application/json' \
+              --data "$request" \
+              https://integrate.api.nvidia.com/v1/chat/completions || true)"
+            if jq -e '.choices[0].message.content | strings | contains("FCM_NVIDIA_MODEL_OK")' \
+              >/dev/null 2>&1 <<< "$response"; then
+              selected_model="$candidate"
+              break
+            fi
+          done <<< "$candidates"
+          if [[ -z "$selected_model" ]]; then
+            echo "No compatible NVIDIA model is currently healthy" >&2
+            exit 1
+          fi
+          echo "Selected $selected_model"
+          echo "model=$selected_model" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure Factory 6 owner label exists
+        run: |
+          if ! gh api "repos/${GITHUB_REPOSITORY}/labels/factory%3A6" >/dev/null 2>&1; then
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/labels" \
+              -f name='factory:6' \
+              -f color='5319e7' \
+              -f description='Owned by OpenCode NVIDIA Factory 6' >/dev/null
+          fi
+
+      - name: Select and claim work
+        id: target
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          owner_re='^factory:(unowned|local|[1-6])$'
+          stage_re='^factory:(building|review|changes-requested|ci|ready|blocked)$'
+
+          # Resume this factory's existing PR before claiming anything new.
+          pr_json="$(gh pr list --state open --label "$FACTORY_OWNER" --limit 100 \
+            --json number,headRefName,updatedAt,title | jq 'sort_by(.updatedAt) | first // empty')"
+          if [[ -n "$pr_json" ]]; then
+            number="$(jq -r .number <<< "$pr_json")"
+            branch="$(jq -r .headRefName <<< "$pr_json")"
+            echo "mode=pr" >> "$GITHUB_OUTPUT"
+            echo "number=$number" >> "$GITHUB_OUTPUT"
+            echo "branch=$branch" >> "$GITHUB_OUTPUT"
+            echo "has_target=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          choose_issue() {
+            local labels=("$@")
+            local args=(issue list --state open --limit 200 --json number,title,labels,createdAt)
+            for label in "${labels[@]}"; do
+              args+=(--label "$label")
+            done
+            gh "${args[@]}" | jq -r --arg owner_re "$owner_re" '
+              map(select(.number != 679))
+              | map(select(
+                  ([.labels[].name | select(test($owner_re))] | length) == 0
+                  or ([.labels[].name | select(. == "factory:unowned")] | length) == 1
+                ))
+              | sort_by(.createdAt) | reverse | first | .number // empty
+            '
+          }
+
+          # Product-first deterministic tiers. User-reported bugs always win.
+          number="$(choose_issue user-reported bug)"
+          [[ -n "$number" ]] || number="$(choose_issue bug)"
+          [[ -n "$number" ]] || number="$(choose_issue)"
+
+          if [[ -z "$number" ]]; then
+            echo "No executable unclaimed issue found."
+            echo "has_target=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          labels="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${number}/labels?per_page=100" --jq '[.[].name]')"
+          if jq -e --arg owner_re "$owner_re" '
+            [.[] | select(test($owner_re) and . != "factory:unowned")] | length > 0
+          ' >/dev/null <<< "$labels"; then
+            echo "Issue #$number was claimed during selection; leaving it alone."
+            echo "has_target=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          target_labels="$(jq -c --arg owner_re "$owner_re" --arg stage_re "$stage_re" '
+            map(select((test($owner_re) | not) and (test($stage_re) | not) and . != "factory"))
+            + ["factory", "factory:6", "factory:building"]
+            | unique
+          ' <<< "$labels")"
+          gh api --method PUT "repos/${GITHUB_REPOSITORY}/issues/${number}/labels" \
+            --input - <<< "{\"labels\":${target_labels}}" >/dev/null
+
+          branch="factory/6-${number}-nvidia"
+          echo "mode=issue" >> "$GITHUB_OUTPUT"
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "has_target=true" >> "$GITHUB_OUTPUT"
+
+      - name: Check out factory branch
+        if: steps.target.outputs.has_target == 'true'
+        env:
+          MODE: ${{ steps.target.outputs.mode }}
+          BRANCH: ${{ steps.target.outputs.branch }}
+        run: |
+          git fetch --prune origin
+          if [[ "$MODE" == "pr" ]]; then
+            git fetch origin "$BRANCH:$BRANCH"
+            git switch "$BRANCH"
+          elif git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            git fetch origin "$BRANCH:$BRANCH"
+            git switch "$BRANCH"
+          else
+            git switch -c "$BRANCH" origin/main
+          fi
+
+      - name: Build factory prompt
+        if: steps.target.outputs.has_target == 'true'
+        env:
+          MODE: ${{ steps.target.outputs.mode }}
+          NUMBER: ${{ steps.target.outputs.number }}
+          MODEL: ${{ steps.model.outputs.model }}
+        run: |
+          if [[ "$MODE" == "pr" ]]; then
+            target="pull request #${NUMBER}"
+            mission="Resume this existing Factory 6 implementation PR. Inspect the exact current head, current CI, review submissions, and inline review threads. Fix only actionable closure-critical defects or missing acceptance-criteria work, run focused validation, commit and push substantive repairs. If it is already green and review-clear, do not add optional polish and do not merge it; leave it ready for the supervising merge path."
+          else
+            target="issue #${NUMBER}"
+            mission="Implement this issue's complete acceptance contract in one coherent non-draft PR. Inspect the issue and relevant surrounding code first. Make closure-critical code and test changes, run focused validation, commit and push the implementation."
+          fi
+
+          cat > /tmp/factory-prompt.md <<EOF
+          Act as OpenCode NVIDIA Factory 6 for JoshCLWren/comic-pile.
+          Durable worker ID: \`$FACTORY_WORKER_ID\`.
+          Model: \`$MODEL\`.
+          Your assigned target is $target. Do not select a different issue or PR during this run.
+
+          Read current-main AGENTS.md, docs/ISSUE_EXECUTION_PROTOCOL.md, docs/AUTONOMOUS_FACTORY_POLICY.md, and docs/FACTORY_GITHUB_VISIBILITY.md before changing code. Follow their product-safety and validation rules. This experimental worker is deliberately narrower than the general policy: it may implement, test, commit, push, update GitHub labels/comments, and open/update a non-draft PR, but it MUST NOT merge, enable auto-merge, push to main, mutate automation schedules, or access production databases.
+
+          $mission
+
+          Product work outranks test plumbing, documentation, release-note repair, CI cosmetics, and optional cleanup. Never create or repair docs/changelog.d or /changelog.md as ordinary implementation work. Do not weaken tests or checks to make a branch green.
+
+          Use gh CLI when GitHub context is needed. Never print or expose credentials. Before ending with unfinished work, create or update a concise \`<!-- factory-resume:v1 -->\` comment on the managed issue or PR with the exact head, hypothesis, files touched, checks, next narrow verification, remaining blocker/action, and this durable worker ID.
+
+          Finish the assigned target as far as safely possible within this run. Do not merely summarize what someone else should do.
+          EOF
+
+      - name: Run OpenCode NVIDIA factory
+        if: steps.target.outputs.has_target == 'true'
+        env:
+          MODEL: ${{ steps.model.outputs.model }}
+        run: |
+          opencode run \
+            --dangerously-skip-permissions \
+            --model "$MODEL" \
+            --agent build \
+            --dir "$GITHUB_WORKSPACE" \
+            --title "ComicPile NVIDIA Factory 6" \
+            "$(cat /tmp/factory-prompt.md)" | tee /tmp/opencode-factory.log
+
+      - name: Persist implementation branch
+        if: steps.target.outputs.has_target == 'true'
+        env:
+          BRANCH: ${{ steps.target.outputs.branch }}
+          NUMBER: ${{ steps.target.outputs.number }}
+          MODEL: ${{ steps.model.outputs.model }}
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git add -A
+            git commit -m "factory: advance #${NUMBER} with NVIDIA OpenCode"
+          fi
+          if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
+            git push --set-upstream origin "$BRANCH"
+          fi
+
+          pr_number="$(gh pr list --state open --head "$BRANCH" --json number --jq '.[0].number // empty')"
+          if [[ -z "$pr_number" && "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
+            title="$(gh issue view "$NUMBER" --json title --jq .title 2>/dev/null || printf 'Factory 6 implementation')"
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "$title" \
+              --body "Implements #${NUMBER}.\n\nModel: ${MODEL}\nWorker: ${FACTORY_WORKER_ID}\n\nThis PR was produced by the experimental OpenCode NVIDIA Factory 6 and intentionally requires the normal supervising merge gates."
+            pr_number="$(gh pr list --state open --head "$BRANCH" --json number --jq '.[0].number // empty')"
+          fi
+
+          if [[ -n "$pr_number" ]]; then
+            current_labels="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr_number}/labels?per_page=100" --jq '[.[].name]')"
+            target_labels="$(jq -c '
+              map(select(
+                (test("^factory:(building|review|changes-requested|ci|ready|blocked)$") | not) and
+                (test("^factory:(unowned|local|[1-6])$") | not) and
+                . != "factory"
+              )) + ["factory", "factory:6", "factory:review"] | unique
+            ' <<< "$current_labels")"
+            gh api --method PUT "repos/${GITHUB_REPOSITORY}/issues/${pr_number}/labels" \
+              --input - <<< "{\"labels\":${target_labels}}" >/dev/null
+          fi
+
+      - name: Release empty issue claim
+        if: steps.target.outputs.has_target == 'true' && steps.target.outputs.mode == 'issue'
+        env:
+          NUMBER: ${{ steps.target.outputs.number }}
+          BRANCH: ${{ steps.target.outputs.branch }}
+        run: |
+          if ! git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            labels="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${NUMBER}/labels?per_page=100" --jq '[.[].name]')"
+            target_labels="$(jq -c '
+              map(select(
+                (test("^factory:(building|review|changes-requested|ci|ready|blocked)$") | not) and
+                (test("^factory:(unowned|local|[1-6])$") | not) and
+                . != "factory"
+              )) + ["factory", "factory:unowned", "factory:blocked"] | unique
+            ' <<< "$labels")"
+            gh api --method PUT "repos/${GITHUB_REPOSITORY}/issues/${NUMBER}/labels" \
+              --input - <<< "{\"labels\":${target_labels}}" >/dev/null
+          fi

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -57,12 +57,12 @@ jobs:
             "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels?per_page=100" \
             --jq '[.[].name]')"
           owner="$(jq -r '
-            map(select(test("^factory:(unowned|local|[1-5])$"))) | first // "factory:unowned"
+            map(select(test("^factory:(unowned|local|[1-6])$"))) | first // "factory:unowned"
           ' <<< "$current_labels")"
           target_labels="$(jq -c --arg owner "$owner" '
             map(select(
               (test("^factory:(building|review|changes-requested|ci|ready|blocked)$") | not) and
-              (test("^factory:(unowned|local|[1-5])$") | not) and
+              (test("^factory:(unowned|local|[1-6])$") | not) and
               . != "factory"
             )) + ["factory", $owner, "factory:review"] | unique
           ' <<< "$current_labels")"
@@ -157,12 +157,12 @@ jobs:
             "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels?per_page=100" \
             --jq '[.[].name]')"
           owner="$(jq -r '
-            map(select(test("^factory:(unowned|local|[1-5])$"))) | first // "factory:unowned"
+            map(select(test("^factory:(unowned|local|[1-6])$"))) | first // "factory:unowned"
           ' <<< "$current_labels")"
           target_labels="$(jq -c --arg owner "$owner" --arg stage "$target_stage" '
             map(select(
               (test("^factory:(building|review|changes-requested|ci|ready|blocked)$") | not) and
-              (test("^factory:(unowned|local|[1-5])$") | not) and
+              (test("^factory:(unowned|local|[1-6])$") | not) and
               . != "factory"
             )) + ["factory", $owner, $stage] | unique
           ' <<< "$current_labels")"


### PR DESCRIPTION
Adds an experimental scheduled OpenCode/NVIDIA implementation worker as `factory:6`.

Key behavior:
- Runs every 2 hours at :37 plus manual dispatch.
- Reuses the existing NVIDIA/FMC model-selection path and `NVIDIA_API_KEY` secret.
- Deterministically prioritizes unclaimed `user-reported` + `bug` work, then other bugs, then remaining executable issues, excluding #679 while ordinary work exists.
- Resumes its own open PR before claiming new work.
- Uses a dedicated `factory:6` owner label and factory branch namespace.
- Can inspect, edit, test, commit, push, comment, and open/update non-draft PRs.
- Explicitly cannot merge, enable auto-merge, push to main, mutate schedules, or access production databases.
- Keeps the existing OpenCode PR reviewer from stripping `factory:6` ownership.

This is intentionally a single-worker experiment before adding additional NVIDIA factories.