### PR TITLE
Keep NVIDIA Factory 6 on executable product work

### DIFF
--- a/.github/workflows/nvidia-factory-6.yml
+++ b/.github/workflows/nvidia-factory-6.yml
@@ -101,13 +101,16 @@ jobs:
             local labels=("$@")
             local args=(issue list --state open --limit 200 --json number,labels,createdAt)
             for label in "${labels[@]}"; do args+=(--label "$label"); done
-            gh "${args[@]}" | jq -r --arg owner_re "$owner_re" 'map(select(.number != 679)) | map(select((([.labels[].name | select(test($owner_re))] | length) == 0) or (([.labels[].name | select(. == "factory:unowned")] | length) == 1))) | sort_by(.createdAt) | reverse | first | .number // empty'
+            gh "${args[@]}" | jq -r --arg owner_re "$owner_re" '
+              map(select(.number != 679 and .number != 1093 and .number != 1109))
+              | map(select((([.labels[].name | select(test($owner_re))] | length) == 0) or (([.labels[].name | select(. == "factory:unowned")] | length) == 1)))
+              | sort_by(.createdAt) | reverse | first | .number // empty'
           }
           number="$(choose_issue user-reported bug)"
           [[ -n "$number" ]] || number="$(choose_issue bug)"
-          [[ -n "$number" ]] || number="$(choose_issue)"
+          [[ -n "$number" ]] || number="$(choose_issue ralph-task)"
           if [[ -z "$number" ]]; then
-            echo "No unclaimed executable work found"
+            echo "No unclaimed executable product work found"
             echo "has_target=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi


### PR DESCRIPTION
Prevents Factory 6 from claiming the heartbeat registry/alert or arbitrary operational issues when real product work is already owned. Fallback selection is now restricted to unclaimed `ralph-task` issues, with #679, #1093, and #1109 explicitly excluded. This keeps the NVIDIA worker product-focused while retaining user-reported bug priority.