### PR TITLE
Run NVIDIA Factory 6 hourly

### DIFF
--- a/.github/workflows/nvidia-factory-6.yml
+++ b/.github/workflows/nvidia-factory-6.yml
@@ -2,7 +2,7 @@ name: NVIDIA Factory 6
 
 on:
   schedule:
-    - cron: "37 */2 * * *"
+    - cron: "37 * * * *"
   workflow_dispatch:
   push:
     branches: [main]


### PR DESCRIPTION
Increase NVIDIA Factory 6 cadence from every 2 hours to hourly at :37.

The worker still has a 45-minute timeout and a single concurrency group, so this leaves a 15-minute buffer between scheduled starts while avoiding overlapping factory runs.