### PR TITLE
Scale NVIDIA OpenCode to autonomous Factory 6-10 fleet

### DIFF
--- a/.github/scripts/nvidia-factory-worker.sh
+++ b/.github/scripts/nvidia-factory-worker.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+WORKER="${1:?worker number required}"
+MODEL="${2:?model required}"
+OWNER="factory:${WORKER}"
+WORKER_ID="opencode-nvidia-factory-${WORKER}"
+BUDGET_SECONDS="${FACTORY_BUDGET_SECONDS:-3000}"
+STARTED="$(date +%s)"
+DEADLINE=$((STARTED + BUDGET_SECONDS))
+OWNER_RE='^factory:(unowned|local|([1-9]|10))$'
+STAGE_RE='^factory:(building|review|changes-requested|ci|ready|blocked)$'
+SKIP_PRS=()
+
+log() { printf '[factory:%s] %s\n' "$WORKER" "$*"; }
+remaining() { echo $((DEADLINE - $(date +%s))); }
+contains_skip_pr() {
+  local needle="$1" item
+  for item in "${SKIP_PRS[@]:-}"; do [[ "$item" == "$needle" ]] && return 0; done
+  return 1
+}
+
+replace_labels() {
+  local number="$1" owner="$2" stage="$3"
+  local labels target
+  labels="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${number}/labels?per_page=100" --jq '[.[].name]')"
+  target="$(jq -c --arg owner "$owner" --arg stage "$stage" --arg owner_re "$OWNER_RE" --arg stage_re "$STAGE_RE" '
+    map(select((test($owner_re)|not) and (test($stage_re)|not) and . != "factory"))
+    + ["factory", $owner, $stage] | unique' <<< "$labels")"
+  gh api --method PUT "repos/${GITHUB_REPOSITORY}/issues/${number}/labels" --input - <<< "{\"labels\":${target}}" >/dev/null
+}
+
+ensure_label() {
+  if ! gh api "repos/${GITHUB_REPOSITORY}/labels/factory%3A${WORKER}" >/dev/null 2>&1; then
+    gh api --method POST "repos/${GITHUB_REPOSITORY}/labels" \
+      -f name="$OWNER" -f color='5319e7' -f description="Owned by OpenCode NVIDIA Factory ${WORKER}" >/dev/null
+  fi
+}
+
+choose_existing_pr() {
+  gh pr list --state open --limit 200 --json number,headRefName,updatedAt | jq -r --arg prefix "factory/${WORKER}-" '
+    map(select(.headRefName | startswith($prefix))) | sort_by(.updatedAt) | .[].number'
+}
+
+choose_issue() {
+  local labels=("$@")
+  local args=(issue list --state open --limit 300 --json number,labels,createdAt)
+  local label
+  for label in "${labels[@]}"; do args+=(--label "$label"); done
+  gh "${args[@]}" | jq -r --arg owner_re "$OWNER_RE" '
+    map(select(.number != 679 and .number != 1093 and .number != 1109))
+    | map(select((([.labels[].name | select(test($owner_re) and . != "factory:unowned")] | length) == 0)))
+    | sort_by(.createdAt) | reverse | .[].number'
+}
+
+claim_issue() {
+  local number="$1" labels target
+  labels="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${number}/labels?per_page=100" --jq '[.[].name]')"
+  if jq -e --arg owner_re "$OWNER_RE" '[.[] | select(test($owner_re) and . != "factory:unowned")] | length > 0' >/dev/null <<< "$labels"; then
+    return 1
+  fi
+  target="$(jq -c --arg owner "$OWNER" --arg owner_re "$OWNER_RE" --arg stage_re "$STAGE_RE" '
+    map(select((test($owner_re)|not) and (test($stage_re)|not) and . != "factory"))
+    + ["factory", $owner, "factory:building"] | unique' <<< "$labels")"
+  gh api --method PUT "repos/${GITHUB_REPOSITORY}/issues/${number}/labels" --input - <<< "{\"labels\":${target}}" >/dev/null
+}
+
+checkout_target() {
+  local mode="$1" number="$2" branch="$3"
+  git fetch --prune origin
+  git switch --detach origin/main >/dev/null 2>&1 || true
+  git reset --hard origin/main >/dev/null
+  git clean -fd >/dev/null
+  if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+    git fetch origin "$branch:$branch" --force
+    git switch "$branch"
+    git reset --hard "origin/$branch" >/dev/null
+  else
+    git switch -C "$branch" origin/main
+  fi
+  log "checked out ${mode} #${number} on ${branch}"
+}
+
+current_head_review_blockers() {
+  local pr="$1" head="$2"
+  local changes unresolved
+  changes="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${pr}/reviews?per_page=100" | jq -s --arg head "$head" '[.[][] | select(.state == "CHANGES_REQUESTED" and .commit_id == $head)] | length')"
+  [[ "$changes" == "0" ]] || return 1
+  unresolved="$(gh api graphql -F owner='JoshCLWren' -F name='comic-pile' -F number="$pr" -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100){nodes{isResolved}}}}}' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')"
+  [[ "$unresolved" == "0" ]]
+}
+
+machine_merge_gates_pass() {
+  local pr="$1" expected_head="$2" info head
+  info="$(gh pr view "$pr" --json state,isDraft,mergeable,headRefOid)"
+  [[ "$(jq -r .state <<< "$info")" == "OPEN" ]] || return 1
+  [[ "$(jq -r .isDraft <<< "$info")" == "false" ]] || return 1
+  [[ "$(jq -r .mergeable <<< "$info")" == "MERGEABLE" ]] || return 1
+  head="$(jq -r .headRefOid <<< "$info")"
+  [[ "$head" == "$expected_head" ]] || return 1
+  gh pr checks "$pr" --required >/tmp/factory-required-checks 2>&1 || return 1
+  current_head_review_blockers "$pr" "$head" || return 1
+}
+
+run_agent() {
+  local mode="$1" number="$2" timeout_seconds="$3"
+  local target mission prompt status=0
+  if [[ "$mode" == "pr" ]]; then
+    target="pull request #${number}"
+    mission="Resume this PR. Inspect the exact current head, required CI, review submissions, and every inline review thread. Fix closure-critical defects and resolve or concretely rebut actionable threads. If no edits are required, decide whether the PR fully completes its declared scope and is safe to merge. End your final response with FACTORY_GATE_READY only when no semantic blocker remains; otherwise end with FACTORY_GATE_NOT_READY."
+  else
+    target="issue #${number}"
+    mission="Implement the full closure-critical acceptance contract for this issue with code and focused tests. Do not stop at planning or optional polish."
+  fi
+  prompt="You are OpenCode NVIDIA Factory ${WORKER} for JoshCLWren/comic-pile. Durable worker ID: ${WORKER_ID}. Model: ${MODEL}. Assigned target: ${target}. Read AGENTS.md, docs/ISSUE_EXECUTION_PROTOCOL.md, docs/AUTONOMOUS_FACTORY_POLICY.md, docs/CHATGPT_FACTORY_PROMPT.md, and docs/FACTORY_GITHUB_VISIBILITY.md first. Josh directly requires product-first V22 behavior: user-reported product bugs outrank unrelated CI/E2E/test plumbing, and a run is a work session rather than a one-ticket punch. ${mission} Work only on the assigned target during this agent invocation. Edit the checked-out branch, run focused validation, and use gh/GitHub when needed for review context. Do not commit or push; the wrapper persists changes. Do not enable auto-merge, push main, touch production databases, or alter automation schedules."
+  set +e
+  timeout --signal=TERM --kill-after=30s "${timeout_seconds}s" opencode run -m "$MODEL" --agent build --auto --dir "$GITHUB_WORKSPACE" --title "ComicPile NVIDIA Factory ${WORKER}" "$prompt" | tee "/tmp/opencode-factory-${WORKER}.log"
+  status=${PIPESTATUS[0]}
+  set -e
+  return "$status"
+}
+
+persist_issue_pr() {
+  local number="$1" branch="$2" pr title
+  if [[ -z "$(git status --porcelain)" ]]; then return 1; fi
+  git add -A
+  git commit -m "factory: advance #${number} with NVIDIA OpenCode"
+  git push --set-upstream origin "$branch"
+  pr="$(gh pr list --state open --head "$branch" --json number --jq '.[0].number // empty')"
+  if [[ -z "$pr" ]]; then
+    title="$(gh issue view "$number" --json title --jq .title)"
+    gh pr create --base main --head "$branch" --title "$title" --body "Closes #${number}.\n\nModel: ${MODEL}\nWorker: ${WORKER_ID}\n\nProduced by OpenCode NVIDIA Factory ${WORKER}. Normal exact-head factory merge gates apply." >/tmp/factory-pr-url
+    pr="$(gh pr list --state open --head "$branch" --json number --jq '.[0].number')"
+  fi
+  replace_labels "$pr" "$OWNER" 'factory:review'
+  echo "$pr"
+}
+
+persist_pr_changes() {
+  local pr="$1" branch="$2"
+  if [[ -z "$(git status --porcelain)" ]]; then return 1; fi
+  git add -A
+  git commit -m "factory: advance PR #${pr} with NVIDIA OpenCode"
+  git push origin "$branch"
+  replace_labels "$pr" "$OWNER" 'factory:review'
+  return 0
+}
+
+ensure_label
+log "starting with model ${MODEL}; budget ${BUDGET_SECONDS}s"
+
+while (( $(remaining) > 480 )); do
+  MODE=''
+  NUMBER=''
+  BRANCH=''
+
+  while IFS= read -r candidate; do
+    [[ -n "$candidate" ]] || continue
+    contains_skip_pr "$candidate" && continue
+    NUMBER="$candidate"
+    MODE='pr'
+    BRANCH="$(gh pr view "$NUMBER" --json headRefName --jq .headRefName)"
+    break
+  done < <(choose_existing_pr)
+
+  if [[ -z "$NUMBER" ]]; then
+    for selector in 'user-reported bug' 'bug' 'ralph-task'; do
+      read -r -a labels <<< "$selector"
+      while IFS= read -r candidate; do
+        [[ -n "$candidate" ]] || continue
+        if claim_issue "$candidate"; then
+          NUMBER="$candidate"
+          MODE='issue'
+          BRANCH="factory/${WORKER}-${NUMBER}-nvidia"
+          break 2
+        fi
+      done < <(choose_issue "${labels[@]}")
+    done
+  fi
+
+  if [[ -z "$NUMBER" ]]; then
+    log 'no unclaimed executable product work found; ending this session cleanly'
+    break
+  fi
+
+  checkout_target "$MODE" "$NUMBER" "$BRANCH"
+  before="$(git rev-parse HEAD)"
+  available="$(remaining)"
+  agent_timeout=$((available - 240))
+  (( agent_timeout > 1500 )) && agent_timeout=1500
+  (( agent_timeout < 300 )) && break
+
+  set +e
+  run_agent "$MODE" "$NUMBER" "$agent_timeout"
+  agent_status=$?
+  set -e
+  log "agent exit status ${agent_status} for ${MODE} #${NUMBER}"
+
+  if [[ "$MODE" == 'issue' ]]; then
+    if pr="$(persist_issue_pr "$NUMBER" "$BRANCH")"; then
+      log "opened/updated PR #${pr} for issue #${NUMBER}"
+      SKIP_PRS+=("$pr")
+    else
+      log "issue #${NUMBER} produced no changes; releasing as blocked/unowned"
+      replace_labels "$NUMBER" 'factory:unowned' 'factory:blocked'
+    fi
+    continue
+  fi
+
+  if persist_pr_changes "$NUMBER" "$BRANCH"; then
+    log "pushed repairs to PR #${NUMBER}; review/CI must refresh"
+    SKIP_PRS+=("$NUMBER")
+    continue
+  fi
+
+  current="$(git rev-parse HEAD)"
+  if grep -q 'FACTORY_GATE_READY' "/tmp/opencode-factory-${WORKER}.log" && machine_merge_gates_pass "$NUMBER" "$current"; then
+    log "all exact-head gates passed for PR #${NUMBER}; merging ${current}"
+    gh pr merge "$NUMBER" --merge --match-head-commit "$current" --delete-branch
+    issue_number="$(sed -nE "s#^factory/${WORKER}-([0-9]+)-nvidia$#\\1#p" <<< "$BRANCH")"
+    if [[ -n "$issue_number" ]]; then
+      state="$(gh issue view "$issue_number" --json state --jq .state 2>/dev/null || true)"
+      if [[ "$state" == 'OPEN' ]]; then gh issue close "$issue_number" --reason completed --comment "Closed after Factory ${WORKER} merged PR #${NUMBER} through the exact-head gates."; fi
+    fi
+    continue
+  fi
+
+  log "PR #${NUMBER} is not merge-eligible now; releasing this cycle and selecting other work"
+  SKIP_PRS+=("$NUMBER")
+done
+
+log "session complete; remaining budget $(remaining)s"

--- a/.github/workflows/nvidia-factory-6.yml
+++ b/.github/workflows/nvidia-factory-6.yml
@@ -1,17 +1,24 @@
-name: NVIDIA Factory 6
+name: NVIDIA Factory Fleet 6-10
 
 on:
   schedule:
-    - cron: "37 */2 * * *"
+    - cron: "7 * * * *"
+    - cron: "19 * * * *"
+    - cron: "31 * * * *"
+    - cron: "43 * * * *"
+    - cron: "55 * * * *"
   workflow_dispatch:
-  push:
-    branches: [main]
-    paths:
-      - .github/workflows/nvidia-factory-6.yml
+    inputs:
+      worker:
+        description: NVIDIA factory worker to run
+        required: true
+        default: "6"
+        type: choice
+        options: ["6", "7", "8", "9", "10"]
 
 concurrency:
-  group: nvidia-factory-6
-  cancel-in-progress: true
+  group: nvidia-factory-${{ github.event.schedule || inputs.worker || github.run_id }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -23,13 +30,35 @@ permissions:
 jobs:
   factory:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 58
     env:
       GH_TOKEN: ${{ github.token }}
       NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
-      FACTORY_OWNER: factory:6
-      FACTORY_WORKER_ID: opencode-nvidia-factory-6
+      FACTORY_BUDGET_SECONDS: "3000"
     steps:
+      - name: Resolve durable worker
+        id: worker
+        shell: bash
+        env:
+          DISPATCH_WORKER: ${{ inputs.worker }}
+          SCHEDULE: ${{ github.event.schedule }}
+        run: |
+          set -Eeuo pipefail
+          if [[ -n "${DISPATCH_WORKER:-}" ]]; then
+            worker="$DISPATCH_WORKER"
+          else
+            case "$SCHEDULE" in
+              "7 * * * *") worker=6 ;;
+              "19 * * * *") worker=7 ;;
+              "31 * * * *") worker=8 ;;
+              "43 * * * *") worker=9 ;;
+              "55 * * * *") worker=10 ;;
+              *) echo "Unknown schedule: $SCHEDULE" >&2; exit 1 ;;
+            esac
+          fi
+          echo "worker=$worker" >> "$GITHUB_OUTPUT"
+          echo "Factory $worker selected"
+
       - name: Checkout main
         uses: actions/checkout@v6
         with:
@@ -37,8 +66,10 @@ jobs:
           persist-credentials: true
 
       - name: Configure git identity
+        env:
+          WORKER: ${{ steps.worker.outputs.worker }}
         run: |
-          git config user.name "opencode-nvidia-factory-6[bot]"
+          git config user.name "opencode-nvidia-factory-${WORKER}[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Install OpenCode CLI
@@ -50,17 +81,25 @@ jobs:
       - name: Install pinned FCM discovery CLI
         run: npm install --global --ignore-scripts free-coding-models@0.5.69
 
-      - name: Select a healthy NVIDIA model
+      - name: Select a healthy NVIDIA model with fleet rotation
         id: model
         shell: bash
+        env:
+          WORKER: ${{ steps.worker.outputs.worker }}
         run: |
           set -Eeuo pipefail
           fcm_output="$(free-coding-models --json --origin nvidia --hide-unconfigured --best --no-telemetry)"
-          candidates="$(printf '%s\n' "$fcm_output" | python scripts/select_fcm_nvidia_model.py)"
+          mapfile -t candidates < <(printf '%s\n' "$fcm_output" | python scripts/select_fcm_nvidia_model.py | sed '/^$/d')
+          if (( ${#candidates[@]} == 0 )); then
+            echo "No NVIDIA candidates returned by FCM" >&2
+            exit 1
+          fi
+          start=$(( (WORKER - 6) % ${#candidates[@]} ))
           selected_model=""
-          while IFS= read -r candidate; do
-            [[ -n "$candidate" ]] || continue
-            echo "Probing $candidate"
+          for ((offset=0; offset<${#candidates[@]}; offset++)); do
+            idx=$(( (start + offset) % ${#candidates[@]} ))
+            candidate="${candidates[$idx]}"
+            echo "Factory ${WORKER} probing ${candidate}"
             provider_model="${candidate#nvidia/}"
             request="$(jq -nc --arg model "$provider_model" '{model:$model,messages:[{role:"user",content:"Reply with exactly: FCM_NVIDIA_MODEL_OK"}],max_tokens:32}')"
             response="$(curl --silent --show-error --fail-with-body --header "Authorization: Bearer $NVIDIA_API_KEY" --header 'Content-Type: application/json' --data "$request" https://integrate.api.nvidia.com/v1/chat/completions || true)"
@@ -68,131 +107,16 @@ jobs:
               selected_model="$candidate"
               break
             fi
-          done <<< "$candidates"
+          done
           if [[ -z "$selected_model" ]]; then
             echo "No compatible NVIDIA model is currently healthy" >&2
             exit 1
           fi
-          echo "Selected $selected_model"
+          echo "Selected $selected_model for Factory $WORKER"
           echo "model=$selected_model" >> "$GITHUB_OUTPUT"
 
-      - name: Ensure Factory 6 label exists
-        run: |
-          if ! gh api "repos/${GITHUB_REPOSITORY}/labels/factory%3A6" >/dev/null 2>&1; then
-            gh api --method POST "repos/${GITHUB_REPOSITORY}/labels" -f name='factory:6' -f color='5319e7' -f description='Owned by OpenCode NVIDIA Factory 6' >/dev/null
-          fi
-
-      - name: Select and claim product work
-        id: target
-        shell: bash
-        run: |
-          set -Eeuo pipefail
-          owner_re='^factory:(unowned|local|[1-6])$'
-          stage_re='^factory:(building|review|changes-requested|ci|ready|blocked)$'
-          existing_pr="$(gh pr list --state open --label "$FACTORY_OWNER" --limit 100 --json number,headRefName,updatedAt | jq 'sort_by(.updatedAt) | first // empty')"
-          if [[ -n "$existing_pr" ]]; then
-            echo "mode=pr" >> "$GITHUB_OUTPUT"
-            echo "number=$(jq -r .number <<< "$existing_pr")" >> "$GITHUB_OUTPUT"
-            echo "branch=$(jq -r .headRefName <<< "$existing_pr")" >> "$GITHUB_OUTPUT"
-            echo "has_target=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          choose_issue() {
-            local labels=("$@")
-            local args=(issue list --state open --limit 200 --json number,labels,createdAt)
-            for label in "${labels[@]}"; do args+=(--label "$label"); done
-            gh "${args[@]}" | jq -r --arg owner_re "$owner_re" '
-              map(select(.number != 679 and .number != 1093 and .number != 1109))
-              | map(select((([.labels[].name | select(test($owner_re))] | length) == 0) or (([.labels[].name | select(. == "factory:unowned")] | length) == 1)))
-              | sort_by(.createdAt) | reverse | first | .number // empty'
-          }
-          number="$(choose_issue user-reported bug)"
-          [[ -n "$number" ]] || number="$(choose_issue bug)"
-          [[ -n "$number" ]] || number="$(choose_issue ralph-task)"
-          if [[ -z "$number" ]]; then
-            echo "No unclaimed executable product work found"
-            echo "has_target=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          labels="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${number}/labels?per_page=100" --jq '[.[].name]')"
-          if jq -e --arg owner_re "$owner_re" '[.[] | select(test($owner_re) and . != "factory:unowned")] | length > 0' >/dev/null <<< "$labels"; then
-            echo "Issue #$number was claimed during selection"
-            echo "has_target=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          target_labels="$(jq -c --arg owner_re "$owner_re" --arg stage_re "$stage_re" 'map(select((test($owner_re)|not) and (test($stage_re)|not) and . != "factory")) + ["factory","factory:6","factory:building"] | unique' <<< "$labels")"
-          gh api --method PUT "repos/${GITHUB_REPOSITORY}/issues/${number}/labels" --input - <<< "{\"labels\":${target_labels}}" >/dev/null
-          echo "mode=issue" >> "$GITHUB_OUTPUT"
-          echo "number=$number" >> "$GITHUB_OUTPUT"
-          echo "branch=factory/6-${number}-nvidia" >> "$GITHUB_OUTPUT"
-          echo "has_target=true" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout factory branch
-        if: steps.target.outputs.has_target == 'true'
+      - name: Run continuous NVIDIA factory work session
         env:
-          MODE: ${{ steps.target.outputs.mode }}
-          BRANCH: ${{ steps.target.outputs.branch }}
-        run: |
-          git fetch --prune origin
-          if [[ "$MODE" == "pr" ]]; then
-            git fetch origin "$BRANCH:$BRANCH"
-            git switch "$BRANCH"
-          elif git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-            git fetch origin "$BRANCH:$BRANCH"
-            git switch "$BRANCH"
-          else
-            git switch -c "$BRANCH" origin/main
-          fi
-
-      - name: Run OpenCode NVIDIA factory
-        if: steps.target.outputs.has_target == 'true'
-        env:
+          WORKER: ${{ steps.worker.outputs.worker }}
           MODEL: ${{ steps.model.outputs.model }}
-          MODE: ${{ steps.target.outputs.mode }}
-          NUMBER: ${{ steps.target.outputs.number }}
-        shell: bash
-        run: |
-          set -Eeuo pipefail
-          if [[ "$MODE" == "pr" ]]; then
-            target="pull request #${NUMBER}"
-            mission="Resume this Factory 6 PR. Inspect current CI and actionable review feedback, repair only closure-critical defects, and run focused validation."
-          else
-            target="issue #${NUMBER}"
-            mission="Implement the full closure-critical acceptance contract for this issue with code and focused tests."
-          fi
-          prompt="You are OpenCode NVIDIA Factory 6 for JoshCLWren/comic-pile. Durable worker ID: ${FACTORY_WORKER_ID}. Model: ${MODEL}. Assigned target: ${target}. Read AGENTS.md, docs/ISSUE_EXECUTION_PROTOCOL.md, docs/AUTONOMOUS_FACTORY_POLICY.md, and docs/FACTORY_GITHUB_VISIBILITY.md first. ${mission} Work only on the assigned target. Product bugs outrank test plumbing, docs, changelog work, CI cosmetics, and optional cleanup. Edit the checked-out branch and run focused validation. Do not commit or push; the workflow will persist your changes. Do not merely summarize. Do not merge, enable auto-merge, push main, touch production databases, or alter automation schedules."
-          opencode run -m "$MODEL" --agent build --auto --dir "$GITHUB_WORKSPACE" --title "ComicPile NVIDIA Factory 6" "$prompt" | tee /tmp/opencode-factory.log
-
-      - name: Persist implementation and open PR
-        if: steps.target.outputs.has_target == 'true'
-        env:
-          MODE: ${{ steps.target.outputs.mode }}
-          BRANCH: ${{ steps.target.outputs.branch }}
-          NUMBER: ${{ steps.target.outputs.number }}
-          MODEL: ${{ steps.model.outputs.model }}
-        shell: bash
-        run: |
-          set -Eeuo pipefail
-          if [[ -n "$(git status --porcelain)" ]]; then
-            git add -A
-            git commit -m "factory: advance #${NUMBER} with NVIDIA OpenCode"
-          fi
-
-          if [[ "$(git rev-parse HEAD)" == "$(git rev-parse origin/main)" ]]; then
-            if [[ "$MODE" == "issue" ]]; then
-              labels="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${NUMBER}/labels?per_page=100" --jq '[.[].name]')"
-              target_labels="$(jq -c 'map(select((test("^factory:(building|review|changes-requested|ci|ready|blocked)$")|not) and (test("^factory:(unowned|local|[1-6])$")|not) and . != "factory")) + ["factory","factory:unowned","factory:blocked"] | unique' <<< "$labels")"
-              gh api --method PUT "repos/${GITHUB_REPOSITORY}/issues/${NUMBER}/labels" --input - <<< "{\"labels\":${target_labels}}" >/dev/null
-            fi
-            echo "Factory produced no branch changes"
-            exit 0
-          fi
-
-          git push --set-upstream origin "$BRANCH"
-          if [[ "$MODE" == "issue" ]]; then
-            pr_number="$(gh pr list --state open --head "$BRANCH" --json number --jq '.[0].number // empty')"
-            if [[ -z "$pr_number" ]]; then
-              title="$(gh issue view "$NUMBER" --json title --jq .title)"
-              gh pr create --base main --head "$BRANCH" --title "$title" --body "Implements #${NUMBER}.\n\nModel: ${MODEL}\nWorker: ${FACTORY_WORKER_ID}\n\nProduced by OpenCode NVIDIA Factory 6. Normal merge gates still apply."
-            fi
-          fi
+        run: bash .github/scripts/nvidia-factory-worker.sh "$WORKER" "$MODEL"

--- a/.github/workflows/nvidia-factory-owner-reconcile.yml
+++ b/.github/workflows/nvidia-factory-owner-reconcile.yml
@@ -1,0 +1,38 @@
+name: NVIDIA Factory Owner Reconcile
+
+on:
+  workflow_run:
+    workflows: [opencode]
+    types: [completed]
+
+permissions:
+  pull-requests: read
+  issues: write
+
+jobs:
+  reconcile:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Restore NVIDIA owner from branch identity
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          pr="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}" --jq '.pull_requests[0].number // empty')"
+          [[ -n "$pr" ]] || exit 0
+          branch="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr}" --jq .head.ref)"
+          if [[ "$branch" =~ ^factory/([6-9]|10)- ]]; then
+            worker="${BASH_REMATCH[1]}"
+          else
+            exit 0
+          fi
+          labels="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr}/labels?per_page=100" --jq '[.[].name]')"
+          stage="$(jq -r '[.[] | select(test("^factory:(building|review|changes-requested|ci|ready|blocked)$"))] | first // "factory:review"' <<< "$labels")"
+          target="$(jq -c --arg owner "factory:${worker}" --arg stage "$stage" '
+            map(select((test("^factory:(building|review|changes-requested|ci|ready|blocked)$")|not) and (test("^factory:(unowned|local|([1-9]|10))$")|not) and . != "factory"))
+            + ["factory", $owner, $stage] | unique' <<< "$labels")"
+          gh api --method PUT "repos/${GITHUB_REPOSITORY}/issues/${pr}/labels" --input - <<< "{\"labels\":${target}}" >/dev/null
+          echo "Restored factory:${worker} on PR #${pr} with ${stage}"


### PR DESCRIPTION
## Summary

- scale the proven NVIDIA/OpenCode worker into five durable factories, `factory:6` through `factory:10`
- stagger workers every 12 minutes across each hour so the fleet continuously feeds the backlog without five simultaneous cold starts
- rotate healthy NVIDIA model selection across workers instead of hammering the same first candidate
- turn each invocation into a 50-minute work session that can open multiple PRs, repair existing PRs, and keep selecting work rather than stopping after one ticket
- allow exact-head autonomous merges only after the agent reports semantic readiness, the PR is open/non-draft/mergeable, required checks pass, current-head change requests are absent, and all inline review threads are resolved
- use `--match-head-commit` on merge so a moved branch cannot be merged accidentally
- preserve NVIDIA ownership after the existing OpenCode reviewer reconciles review state
- keep production DB access, main pushes, auto-merge, and schedule mutation forbidden

This supersedes #1121's single-worker hourly cadence change. The fleet is hourly per worker, but staggered at :07, :19, :31, :43, and :55 for Factories 6-10.

## Throughput model

Each worker has a 50-minute productive budget inside a 58-minute job timeout. Same-worker runs queue instead of cancelling productive work. Within a session, workers skip PRs that are waiting for fresh review/CI and immediately select other executable product work.

## Merge safety

The worker may merge a PR it owns only when the exact current head passes the repository's required checks and review gates and the OpenCode implementation agent explicitly emits `FACTORY_GATE_READY` without making another edit. Any push invalidates readiness and sends that PR back through review/CI before a later merge attempt.