### PR TITLE
Make NVIDIA factory ownership visible and drain unowned PRs

### DIFF
--- a/.github/scripts/nvidia-factory-worker.sh
+++ b/.github/scripts/nvidia-factory-worker.sh
@@ -30,16 +30,26 @@ replace_labels() {
   gh api --method PUT "repos/${GITHUB_REPOSITORY}/issues/${number}/labels" --input - <<< "{\"labels\":${target}}" >/dev/null
 }
 
-ensure_label() {
-  if ! gh api "repos/${GITHUB_REPOSITORY}/labels/factory%3A${WORKER}" >/dev/null 2>&1; then
-    gh api --method POST "repos/${GITHUB_REPOSITORY}/labels" \
-      -f name="$OWNER" -f color='5319e7' -f description="Owned by OpenCode NVIDIA Factory ${WORKER}" >/dev/null
-  fi
+ensure_fleet_labels() {
+  local worker label
+  for worker in 6 7 8 9 10; do
+    label="factory:${worker}"
+    if ! gh api "repos/${GITHUB_REPOSITORY}/labels/factory%3A${worker}" >/dev/null 2>&1; then
+      gh api --method POST "repos/${GITHUB_REPOSITORY}/labels" \
+        -f name="$label" -f color='5319e7' -f description="Owned by OpenCode NVIDIA Factory ${worker}" >/dev/null
+      log "created ${label}"
+    fi
+  done
 }
 
 choose_existing_pr() {
   gh pr list --state open --limit 200 --json number,headRefName,updatedAt | jq -r --arg prefix "factory/${WORKER}-" '
     map(select(.headRefName | startswith($prefix))) | sort_by(.updatedAt) | .[].number'
+}
+
+choose_unowned_pr() {
+  gh pr list --state open --limit 200 --label 'factory:unowned' --json number,isDraft,updatedAt | jq -r '
+    map(select(.isDraft == false)) | sort_by(.updatedAt) | .[].number'
 }
 
 choose_issue() {
@@ -63,6 +73,27 @@ claim_issue() {
     map(select((test($owner_re)|not) and (test($stage_re)|not) and . != "factory"))
     + ["factory", $owner, "factory:building"] | unique' <<< "$labels")"
   gh api --method PUT "repos/${GITHUB_REPOSITORY}/issues/${number}/labels" --input - <<< "{\"labels\":${target}}" >/dev/null
+}
+
+claim_unowned_pr() {
+  local number="$1" labels owner_count
+  labels="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${number}/labels?per_page=100" --jq '[.[].name]')"
+  jq -e 'index("factory:unowned") != null' >/dev/null <<< "$labels" || return 1
+  owner_count="$(jq -r --arg owner_re "$OWNER_RE" '[.[] | select(test($owner_re) and . != "factory:unowned")] | length' <<< "$labels")"
+  [[ "$owner_count" == "0" ]] || return 1
+
+  replace_labels "$number" "$OWNER" 'factory:review'
+
+  # Verify we still own it after the write. Staggering makes races unlikely, but
+  # this prevents two workers from proceeding if another worker won a late race.
+  labels="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${number}/labels?per_page=100" --jq '[.[].name]')"
+  jq -e --arg owner "$OWNER" 'index($owner) != null' >/dev/null <<< "$labels" || return 1
+
+  # Branch identity cannot encode the adopting worker for an existing PR. Leave a
+  # durable marker so the post-review reconciler can restore ownership if another
+  # workflow rewrites factory labels.
+  gh issue comment "$number" --body "<!-- nvidia-factory-owner:${WORKER} -->\nFactory ${WORKER} adopted this previously unowned PR for the next actionable step." >/dev/null
+  return 0
 }
 
 checkout_target() {
@@ -146,7 +177,9 @@ persist_pr_changes() {
   return 0
 }
 
-ensure_label
+# Bootstrap all five durable owner labels immediately. Visibility should not wait
+# for four separate future schedule slots to happen to execute successfully.
+ensure_fleet_labels
 log "starting with model ${MODEL}; budget ${BUDGET_SECONDS}s"
 
 while (( $(remaining) > 480 )); do
@@ -162,6 +195,23 @@ while (( $(remaining) > 480 )); do
     BRANCH="$(gh pr view "$NUMBER" --json headRefName --jq .headRefName)"
     break
   done < <(choose_existing_pr)
+
+  # Existing unowned PRs are executable work too. Adopt them before opening fresh
+  # issue branches so the fleet drains stranded review/CI work instead of piling
+  # new PRs on top of it.
+  if [[ -z "$NUMBER" ]]; then
+    while IFS= read -r candidate; do
+      [[ -n "$candidate" ]] || continue
+      contains_skip_pr "$candidate" && continue
+      if claim_unowned_pr "$candidate"; then
+        NUMBER="$candidate"
+        MODE='pr'
+        BRANCH="$(gh pr view "$NUMBER" --json headRefName --jq .headRefName)"
+        log "adopted unowned PR #${NUMBER} on ${BRANCH}"
+        break
+      fi
+    done < <(choose_unowned_pr)
+  fi
 
   if [[ -z "$NUMBER" ]]; then
     for selector in 'user-reported bug' 'bug' 'ralph-task'; do

--- a/.github/workflows/factory-heartbeat-watchdog.yml
+++ b/.github/workflows/factory-heartbeat-watchdog.yml
@@ -34,6 +34,11 @@ jobs:
               ["chatgpt-factory-3", { name: "Starman", slot: ":04" }],
               ["chatgpt-factory-4", { name: "Mister Miracle", slot: ":16" }],
               ["chatgpt-factory-5", { name: "Death's Head", slot: ":28" }],
+              ["opencode-nvidia-factory-6", { name: "NVIDIA 6", slot: ":07", staleMinutes: 90, runningMinutes: 65 }],
+              ["opencode-nvidia-factory-7", { name: "NVIDIA 7", slot: ":19", staleMinutes: 90, runningMinutes: 65 }],
+              ["opencode-nvidia-factory-8", { name: "NVIDIA 8", slot: ":31", staleMinutes: 90, runningMinutes: 65 }],
+              ["opencode-nvidia-factory-9", { name: "NVIDIA 9", slot: ":43", staleMinutes: 90, runningMinutes: 65 }],
+              ["opencode-nvidia-factory-10", { name: "NVIDIA 10", slot: ":55", staleMinutes: 90, runningMinutes: 65 }],
             ]);
             const marker = "<!-- factory-heartbeat-alert:v1 -->";
             const now = new Date();
@@ -70,9 +75,11 @@ jobs:
                 (now - new Date(comment.updated_at)) / 60000,
               );
               const running = /^Outcome:\s*running\s*$/im.test(comment.body ?? "");
+              const workerStaleMinutes = metadata.staleMinutes ?? staleMinutes;
+              const workerRunningMinutes = metadata.runningMinutes ?? runningMinutes;
               const unhealthy =
-                ageMinutes > staleMinutes ||
-                (running && ageMinutes > runningMinutes);
+                ageMinutes > workerStaleMinutes ||
+                (running && ageMinutes > workerRunningMinutes);
               const status = unhealthy
                 ? running
                   ? "🔴 stuck running"
@@ -98,7 +105,7 @@ jobs:
               "",
               stale.length
                 ? "The external watchdog detected missing or stuck factory heartbeats."
-                : "All five scheduled factories are reporting normally.",
+                : "All ten scheduled factories are reporting normally.",
               "",
               "| Worker | Call sign | Slot (America/Chicago) | Age | Status |",
               "|---|---|---:|---:|---|",
@@ -108,7 +115,7 @@ jobs:
               `Checked: ${now.toISOString()}`,
               "",
               stale.length
-                ? "Open ChatGPT Scheduled to determine whether the task paused, exhausted usage, or needs action. Do not assign this alert to a factory."
+                ? "Check ChatGPT Scheduled for factories 1-5 and GitHub Actions for NVIDIA factories 6-10. Do not assign this alert to a factory."
                 : "This alert closed automatically after every worker recovered.",
             ].join("\n");
 
@@ -158,11 +165,11 @@ jobs:
               });
               await core.summary
                 .addHeading("Factory heartbeat recovery")
-                .addRaw("All five factories are reporting normally.")
+                .addRaw("All ten factories are reporting normally.")
                 .write();
             } else {
               await core.summary
                 .addHeading("Factory heartbeats healthy")
-                .addRaw("All five factories are reporting normally.")
+                .addRaw("All ten factories are reporting normally.")
                 .write();
             }

--- a/.github/workflows/nvidia-factory-6.yml
+++ b/.github/workflows/nvidia-factory-6.yml
@@ -1,6 +1,12 @@
 name: NVIDIA Factory Fleet 6-10
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/nvidia-factory-6.yml'
+      - '.github/scripts/nvidia-factory-worker.sh'
+      - '.github/workflows/nvidia-factory-owner-reconcile.yml'
   schedule:
     - cron: "7 * * * *"
     - cron: "19 * * * *"
@@ -28,7 +34,30 @@ permissions:
   checks: read
 
 jobs:
+  bootstrap:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Create and verify all durable fleet owner labels
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          for worker in 6 7 8 9 10; do
+            if ! gh api "repos/${GITHUB_REPOSITORY}/labels/factory%3A${worker}" >/dev/null 2>&1; then
+              gh api --method POST "repos/${GITHUB_REPOSITORY}/labels" \
+                -f name="factory:${worker}" \
+                -f color='5319e7' \
+                -f description="Owned by OpenCode NVIDIA Factory ${worker}" >/dev/null
+              echo "Created factory:${worker}"
+            fi
+            gh api "repos/${GITHUB_REPOSITORY}/labels/factory%3A${worker}" --jq '.name'
+          done
+          echo 'NVIDIA fleet ownership labels 6-10 are visible.'
+
   factory:
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 58
     env:

--- a/.github/workflows/nvidia-factory-6.yml
+++ b/.github/workflows/nvidia-factory-6.yml
@@ -59,6 +59,20 @@ jobs:
           echo "worker=$worker" >> "$GITHUB_OUTPUT"
           echo "Factory $worker selected"
 
+      - name: Bootstrap fleet owner labels
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          for worker in 6 7 8 9 10; do
+            if ! gh api "repos/${GITHUB_REPOSITORY}/labels/factory%3A${worker}" >/dev/null 2>&1; then
+              gh api --method POST "repos/${GITHUB_REPOSITORY}/labels" \
+                -f name="factory:${worker}" \
+                -f color='5319e7' \
+                -f description="Owned by OpenCode NVIDIA Factory ${worker}" >/dev/null
+              echo "Created factory:${worker}"
+            fi
+          done
+
       - name: Checkout main
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/nvidia-factory-6.yml
+++ b/.github/workflows/nvidia-factory-6.yml
@@ -7,6 +7,7 @@ on:
       - '.github/workflows/nvidia-factory-6.yml'
       - '.github/scripts/nvidia-factory-worker.sh'
       - '.github/workflows/nvidia-factory-owner-reconcile.yml'
+      - '.github/workflows/factory-heartbeat-watchdog.yml'
   schedule:
     - cron: "7 * * * *"
     - cron: "19 * * * *"
@@ -102,6 +103,25 @@ jobs:
             fi
           done
 
+      - name: Report running heartbeat
+        env:
+          WORKER: ${{ steps.worker.outputs.worker }}
+          SCHEDULE: ${{ github.event.schedule }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          marker="<!-- factory-heartbeat:v1 worker=opencode-nvidia-factory-${WORKER} -->"
+          now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          body="$(printf '%s\nWorker: opencode-nvidia-factory-%s\nSlot: %s\nOutcome: running\nUpdated: %s\nRun: %s' \
+            "$marker" "$WORKER" "${SCHEDULE:-dispatch}" "$now" "$GITHUB_RUN_ID")"
+          comment_id="$(gh api "repos/${GITHUB_REPOSITORY}/issues/1093/comments?per_page=100" \
+            | jq -r --arg marker "$marker" '[.[] | select(.body | contains($marker)) | .id] | last // empty')"
+          if [[ -n "$comment_id" ]]; then
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" -f body="$body" >/dev/null
+          else
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/1093/comments" -f body="$body" >/dev/null
+          fi
+
       - name: Checkout main
         uses: actions/checkout@v6
         with:
@@ -163,3 +183,25 @@ jobs:
           WORKER: ${{ steps.worker.outputs.worker }}
           MODEL: ${{ steps.model.outputs.model }}
         run: bash .github/scripts/nvidia-factory-worker.sh "$WORKER" "$MODEL"
+
+      - name: Report terminal heartbeat
+        if: always()
+        env:
+          WORKER: ${{ steps.worker.outputs.worker }}
+          SCHEDULE: ${{ github.event.schedule }}
+          OUTCOME: ${{ job.status }}
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          [[ -n "${WORKER:-}" ]] || exit 0
+          marker="<!-- factory-heartbeat:v1 worker=opencode-nvidia-factory-${WORKER} -->"
+          now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          body="$(printf '%s\nWorker: opencode-nvidia-factory-%s\nSlot: %s\nOutcome: %s\nUpdated: %s\nRun: %s' \
+            "$marker" "$WORKER" "${SCHEDULE:-dispatch}" "$OUTCOME" "$now" "$GITHUB_RUN_ID")"
+          comment_id="$(gh api "repos/${GITHUB_REPOSITORY}/issues/1093/comments?per_page=100" \
+            | jq -r --arg marker "$marker" '[.[] | select(.body | contains($marker)) | .id] | last // empty')"
+          if [[ -n "$comment_id" ]]; then
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" -f body="$body" >/dev/null
+          else
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/1093/comments" -f body="$body" >/dev/null
+          fi

--- a/.github/workflows/nvidia-factory-owner-reconcile.yml
+++ b/.github/workflows/nvidia-factory-owner-reconcile.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - name: Restore NVIDIA owner from branch identity
+      - name: Restore NVIDIA owner from branch identity or adoption marker
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_ID: ${{ github.event.workflow_run.id }}
@@ -24,11 +24,18 @@ jobs:
           pr="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}" --jq '.pull_requests[0].number // empty')"
           [[ -n "$pr" ]] || exit 0
           branch="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr}" --jq .head.ref)"
+          worker=""
           if [[ "$branch" =~ ^factory/([6-9]|10)- ]]; then
             worker="${BASH_REMATCH[1]}"
           else
-            exit 0
+            # Existing unowned PRs keep their original branch name when adopted.
+            # The worker writes a durable marker comment so reconciliation can
+            # restore ownership after the independent reviewer rewrites labels.
+            worker="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments?per_page=100" \
+              --jq '[.[] | .body | capture("<!-- nvidia-factory-owner:(?<worker>([6-9]|10)) -->")?.worker] | map(select(. != null)) | last // empty' 2>/dev/null || true)"
           fi
+          [[ "$worker" =~ ^([6-9]|10)$ ]] || exit 0
+
           labels="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr}/labels?per_page=100" --jq '[.[].name]')"
           stage="$(jq -r '[.[] | select(test("^factory:(building|review|changes-requested|ci|ready|blocked)$"))] | first // "factory:review"' <<< "$labels")"
           target="$(jq -c --arg owner "factory:${worker}" --arg stage "$stage" '


### PR DESCRIPTION
## Summary

- bootstrap `factory:6` through `factory:10` labels immediately when fleet infrastructure lands on `main`, before any NVIDIA/OpenCode dependency can fail
- verify all five durable labels in a lightweight push-time bootstrap job, so fleet visibility does not wait for future cron slots
- let Factories 6-10 claim existing `factory:unowned` pull requests before opening fresh issue work
- leave a durable NVIDIA owner marker on adopted PRs and restore ownership after independent review reconciliation
- publish permanent running/terminal heartbeat comments for NVIDIA Factories 6-10 on the existing #1093 registry
- extend the 15-minute heartbeat watchdog to all ten factories, with tighter 90-minute stale and 65-minute stuck-running thresholds for the NVIDIA workers

## Why

The fleet was merged, but only `factory:6` existed, existing unowned PRs were not eligible for takeover, and no post-merge fleet schedule had fired yet. That made the fleet look active on paper without giving us immediate proof of ownership visibility.

This changes the invariant: fleet infrastructure creates/verifies all owner labels immediately on deployment, every NVIDIA run reports externally before model setup and again on completion, and the watchdog alerts if a worker never reports or gets stuck. We should discover a dead or missing NVIDIA worker from GitHub telemetry instead of Josh noticing absent labels manually.