### PR TITLE
Recover public release-schema privacy work

### DIFF
--- a/app/api/releases.py
+++ b/app/api/releases.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.schemas.release import (
+    PublicReleaseResponse,
     ReleaseListResponse,
     ReleaseResponse,
     ReleaseSourceResponse,
@@ -125,13 +126,13 @@ async def list_releases(
 
 @router.get(
     "/{release_id}",
-    response_model=ReleaseResponse,
+    response_model=PublicReleaseResponse,
     description="Fetch one public published release.",
 )
 async def get_release(
     release_id: int,
     db: AsyncSession = Depends(get_db),
-) -> ReleaseResponse:
+) -> PublicReleaseResponse:
     """Fetch one public published release.
 
     Args:
@@ -147,7 +148,7 @@ async def get_release(
     release = await get_published_release(db, release_id)
     if release is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Release not found")
-    return ReleaseResponse.model_validate(release)
+    return PublicReleaseResponse.model_validate(release)
 
 
 @router.put(

--- a/app/schemas/release.py
+++ b/app/schemas/release.py
@@ -45,6 +45,29 @@ class ReleaseUpsertRequest(BaseModel):
 
 
 class ReleaseResponse(BaseModel):
+    """One complete release ledger record returned to trusted automation."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    source_repository: str
+    source_pr_number: int | None
+    source_merge_sha: str | None
+    merged_at: datetime | None
+    released_at: datetime
+    category: str
+    title: str
+    summary: str
+    body: str | None
+    visibility: ReleaseVisibility
+    status: ReleaseStatus
+    sort_order: int
+    provenance_json: dict[str, object]
+    created_at: datetime
+    updated_at: datetime
+
+
+class PublicReleaseResponse(BaseModel):
     """One release ledger record returned by public-facing endpoints."""
 
     model_config = ConfigDict(from_attributes=True)
@@ -63,7 +86,7 @@ class ReleaseResponse(BaseModel):
 class ReleaseListResponse(BaseModel):
     """Paginated published releases for What's New."""
 
-    releases: list[ReleaseResponse]
+    releases: list[PublicReleaseResponse]
     total: int
     limit: int
     offset: int

--- a/app/schemas/release.py
+++ b/app/schemas/release.py
@@ -9,38 +9,6 @@ ReleaseVisibility = Literal["public", "internal"]
 ReleaseStatus = Literal["draft", "published", "retracted"]
 
 
-class ReleaseResponse(BaseModel):
-    """One release ledger record returned by the API."""
-
-    model_config = ConfigDict(from_attributes=True)
-
-    id: int
-    source_repository: str
-    source_pr_number: int | None
-    source_merge_sha: str | None
-    merged_at: datetime | None
-    released_at: datetime
-    category: str
-    title: str
-    summary: str
-    body: str | None
-    visibility: ReleaseVisibility
-    status: ReleaseStatus
-    sort_order: int
-    provenance_json: dict[str, object]
-    created_at: datetime
-    updated_at: datetime
-
-
-class ReleaseListResponse(BaseModel):
-    """Paginated published releases for What's New."""
-
-    releases: list[ReleaseResponse]
-    total: int
-    limit: int
-    offset: int
-
-
 class ReleaseUpsertRequest(BaseModel):
     """Idempotent release publication payload from trusted automation."""
 
@@ -74,6 +42,31 @@ class ReleaseUpsertRequest(BaseModel):
         if self.source_pr_number is None and self.source_merge_sha is None:
             raise ValueError("source_pr_number or source_merge_sha is required")
         return self
+
+
+class ReleaseResponse(BaseModel):
+    """One release ledger record returned by public-facing endpoints."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    released_at: datetime
+    category: str
+    title: str
+    summary: str
+    body: str | None
+    sort_order: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class ReleaseListResponse(BaseModel):
+    """Paginated published releases for What's New."""
+
+    releases: list[ReleaseResponse]
+    total: int
+    limit: int
+    offset: int
 
 
 class ReleaseSourceResponse(BaseModel):

--- a/frontend/src/generated/openapi.json
+++ b/frontend/src/generated/openapi.json
@@ -2497,7 +2497,7 @@
         "type": "object"
       },
       "ReleaseResponse": {
-        "description": "One release ledger record returned by the API.",
+        "description": "One release ledger record returned by public-facing endpoints.",
         "properties": {
           "body": {
             "anyOf": [
@@ -2523,23 +2523,6 @@
             "title": "Id",
             "type": "integer"
           },
-          "merged_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Merged At"
-          },
-          "provenance_json": {
-            "additionalProperties": true,
-            "title": "Provenance Json",
-            "type": "object"
-          },
           "released_at": {
             "format": "date-time",
             "title": "Released At",
@@ -2548,41 +2531,6 @@
           "sort_order": {
             "title": "Sort Order",
             "type": "integer"
-          },
-          "source_merge_sha": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source Merge Sha"
-          },
-          "source_pr_number": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source Pr Number"
-          },
-          "source_repository": {
-            "title": "Source Repository",
-            "type": "string"
-          },
-          "status": {
-            "enum": [
-              "draft",
-              "published",
-              "retracted"
-            ],
-            "title": "Status",
-            "type": "string"
           },
           "summary": {
             "title": "Summary",
@@ -2596,31 +2544,16 @@
             "format": "date-time",
             "title": "Updated At",
             "type": "string"
-          },
-          "visibility": {
-            "enum": [
-              "public",
-              "internal"
-            ],
-            "title": "Visibility",
-            "type": "string"
           }
         },
         "required": [
           "id",
-          "source_repository",
-          "source_pr_number",
-          "source_merge_sha",
-          "merged_at",
           "released_at",
           "category",
           "title",
           "summary",
           "body",
-          "visibility",
-          "status",
           "sort_order",
-          "provenance_json",
           "created_at",
           "updated_at"
         ],

--- a/frontend/src/generated/openapi.json
+++ b/frontend/src/generated/openapi.json
@@ -2175,6 +2175,70 @@
         "title": "PositionRequest",
         "type": "object"
       },
+      "PublicReleaseResponse": {
+        "description": "One release ledger record returned by public-facing endpoints.",
+        "properties": {
+          "body": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Body"
+          },
+          "category": {
+            "title": "Category",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "released_at": {
+            "format": "date-time",
+            "title": "Released At",
+            "type": "string"
+          },
+          "sort_order": {
+            "title": "Sort Order",
+            "type": "integer"
+          },
+          "summary": {
+            "title": "Summary",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "released_at",
+          "category",
+          "title",
+          "summary",
+          "body",
+          "sort_order",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "PublicReleaseResponse",
+        "type": "object"
+      },
       "QueueThreadListItem": {
         "description": "Schema for a single thread in the list/queue view.\n\nA deliberate subset of ThreadResponse. The list view does not need\ndetail-only fields like last_rating, is_test, or reading_progress,\nwhich reduces payload size for large lists.",
         "properties": {
@@ -2477,7 +2541,7 @@
           },
           "releases": {
             "items": {
-              "$ref": "#/components/schemas/ReleaseResponse"
+              "$ref": "#/components/schemas/PublicReleaseResponse"
             },
             "title": "Releases",
             "type": "array"
@@ -2497,7 +2561,7 @@
         "type": "object"
       },
       "ReleaseResponse": {
-        "description": "One release ledger record returned by public-facing endpoints.",
+        "description": "One complete release ledger record returned to trusted automation.",
         "properties": {
           "body": {
             "anyOf": [
@@ -2523,6 +2587,23 @@
             "title": "Id",
             "type": "integer"
           },
+          "merged_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Merged At"
+          },
+          "provenance_json": {
+            "additionalProperties": true,
+            "title": "Provenance Json",
+            "type": "object"
+          },
           "released_at": {
             "format": "date-time",
             "title": "Released At",
@@ -2531,6 +2612,41 @@
           "sort_order": {
             "title": "Sort Order",
             "type": "integer"
+          },
+          "source_merge_sha": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Merge Sha"
+          },
+          "source_pr_number": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Pr Number"
+          },
+          "source_repository": {
+            "title": "Source Repository",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "draft",
+              "published",
+              "retracted"
+            ],
+            "title": "Status",
+            "type": "string"
           },
           "summary": {
             "title": "Summary",
@@ -2544,16 +2660,31 @@
             "format": "date-time",
             "title": "Updated At",
             "type": "string"
+          },
+          "visibility": {
+            "enum": [
+              "public",
+              "internal"
+            ],
+            "title": "Visibility",
+            "type": "string"
           }
         },
         "required": [
           "id",
+          "source_repository",
+          "source_pr_number",
+          "source_merge_sha",
+          "merged_at",
           "released_at",
           "category",
           "title",
           "summary",
           "body",
+          "visibility",
+          "status",
           "sort_order",
+          "provenance_json",
           "created_at",
           "updated_at"
         ],
@@ -8445,7 +8576,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ReleaseResponse"
+                  "$ref": "#/components/schemas/PublicReleaseResponse"
                 }
               }
             },

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -4383,6 +4383,39 @@ export interface components {
             new_position: number;
         };
         /**
+         * PublicReleaseResponse
+         * @description One release ledger record returned by public-facing endpoints.
+         */
+        PublicReleaseResponse: {
+            /** Body */
+            body: string | null;
+            /** Category */
+            category: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Id */
+            id: number;
+            /**
+             * Released At
+             * Format: date-time
+             */
+            released_at: string;
+            /** Sort Order */
+            sort_order: number;
+            /** Summary */
+            summary: string;
+            /** Title */
+            title: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+        };
+        /**
          * QueueThreadListItem
          * @description Schema for a single thread in the list/queue view.
          *
@@ -4523,13 +4556,13 @@ export interface components {
             /** Offset */
             offset: number;
             /** Releases */
-            releases: components["schemas"]["ReleaseResponse"][];
+            releases: components["schemas"]["PublicReleaseResponse"][];
             /** Total */
             total: number;
         };
         /**
          * ReleaseResponse
-         * @description One release ledger record returned by public-facing endpoints.
+         * @description One complete release ledger record returned to trusted automation.
          */
         ReleaseResponse: {
             /** Body */
@@ -4543,6 +4576,12 @@ export interface components {
             created_at: string;
             /** Id */
             id: number;
+            /** Merged At */
+            merged_at: string | null;
+            /** Provenance Json */
+            provenance_json: {
+                [key: string]: unknown;
+            };
             /**
              * Released At
              * Format: date-time
@@ -4550,6 +4589,17 @@ export interface components {
             released_at: string;
             /** Sort Order */
             sort_order: number;
+            /** Source Merge Sha */
+            source_merge_sha: string | null;
+            /** Source Pr Number */
+            source_pr_number: number | null;
+            /** Source Repository */
+            source_repository: string;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "draft" | "published" | "retracted";
             /** Summary */
             summary: string;
             /** Title */
@@ -4559,6 +4609,11 @@ export interface components {
              * Format: date-time
              */
             updated_at: string;
+            /**
+             * Visibility
+             * @enum {string}
+             */
+            visibility: "public" | "internal";
         };
         /**
          * ReleaseSourceResponse
@@ -7864,7 +7919,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ReleaseResponse"];
+                    "application/json": components["schemas"]["PublicReleaseResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/generated/openapi.ts
+++ b/frontend/src/generated/openapi.ts
@@ -4529,7 +4529,7 @@ export interface components {
         };
         /**
          * ReleaseResponse
-         * @description One release ledger record returned by the API.
+         * @description One release ledger record returned by public-facing endpoints.
          */
         ReleaseResponse: {
             /** Body */
@@ -4543,12 +4543,6 @@ export interface components {
             created_at: string;
             /** Id */
             id: number;
-            /** Merged At */
-            merged_at: string | null;
-            /** Provenance Json */
-            provenance_json: {
-                [key: string]: unknown;
-            };
             /**
              * Released At
              * Format: date-time
@@ -4556,17 +4550,6 @@ export interface components {
             released_at: string;
             /** Sort Order */
             sort_order: number;
-            /** Source Merge Sha */
-            source_merge_sha: string | null;
-            /** Source Pr Number */
-            source_pr_number: number | null;
-            /** Source Repository */
-            source_repository: string;
-            /**
-             * Status
-             * @enum {string}
-             */
-            status: "draft" | "published" | "retracted";
             /** Summary */
             summary: string;
             /** Title */
@@ -4576,11 +4559,6 @@ export interface components {
              * Format: date-time
              */
             updated_at: string;
-            /**
-             * Visibility
-             * @enum {string}
-             */
-            visibility: "public" | "internal";
         };
         /**
          * ReleaseSourceResponse

--- a/frontend/src/services/api-releases.ts
+++ b/frontend/src/services/api-releases.ts
@@ -1,7 +1,7 @@
 import type { components } from '../generated/openapi'
 import api from './api'
 
-export type Release = components['schemas']['ReleaseResponse']
+export type Release = components['schemas']['PublicReleaseResponse']
 export type ReleaseListResponse = components['schemas']['ReleaseListResponse']
 
 export const releasesApi = {

--- a/frontend/src/unit/WhatsNewPage.test.tsx
+++ b/frontend/src/unit/WhatsNewPage.test.tsx
@@ -98,7 +98,7 @@ describe('WhatsNewPage', () => {
 
   it('renders structured public fields without exposing PR or provenance metadata', async () => {
     api.list.mockResolvedValue({
-      releases: [release({ id: 10, title: 'PR release' })],
+      releases: [release({ id: 10 })],
       total: 1,
       limit: RELEASE_PAGE_SIZE,
       offset: 0,

--- a/frontend/src/unit/WhatsNewPage.test.tsx
+++ b/frontend/src/unit/WhatsNewPage.test.tsx
@@ -62,9 +62,9 @@ describe('release ordering helpers', () => {
 
   it('groups historical and PR-backed releases by localized release day', () => {
     const days = groupReleasesByDay([
-      release({ id: 3, source_pr_number: 1096, released_at: '2026-08-11T20:00:00Z' }),
-      release({ id: 2, source_pr_number: null, released_at: '2026-08-11T10:00:00Z' }),
-      release({ id: 1, source_pr_number: null, released_at: '2026-08-10T20:00:00Z' }),
+      release({ id: 3, released_at: '2026-08-11T20:00:00Z' }),
+      release({ id: 2, released_at: '2026-08-11T10:00:00Z' }),
+      release({ id: 1, released_at: '2026-08-10T20:00:00Z' }),
     ], 'UTC')
 
     expect(days).toHaveLength(2)

--- a/frontend/src/unit/WhatsNewPage.test.tsx
+++ b/frontend/src/unit/WhatsNewPage.test.tsx
@@ -19,19 +19,12 @@ const api = vi.mocked(releasesApi)
 function release(overrides: Partial<Release> = {}): Release {
   return {
     id: 1,
-    source_repository: 'JoshCLWren/comic-pile',
-    source_pr_number: null,
-    source_merge_sha: null,
-    merged_at: null,
     released_at: '2026-08-11T20:00:00Z',
     category: 'Queue',
     title: 'Queue cards open details',
     summary: 'Selecting a Queue card now opens its thread details reliably.',
     body: null,
-    visibility: 'public',
-    status: 'published',
     sort_order: 0,
-    provenance_json: {},
     created_at: '2026-08-11T20:00:00Z',
     updated_at: '2026-08-11T20:00:00Z',
     ...overrides,
@@ -105,7 +98,7 @@ describe('WhatsNewPage', () => {
 
   it('renders structured public fields without exposing PR or provenance metadata', async () => {
     api.list.mockResolvedValue({
-      releases: [release({ source_pr_number: 1096, provenance_json: { importer: 'release-import-v1' } })],
+      releases: [release({ id: 10, title: 'PR release' })],
       total: 1,
       limit: RELEASE_PAGE_SIZE,
       offset: 0,

--- a/tests/test_release_api.py
+++ b/tests/test_release_api.py
@@ -170,14 +170,17 @@ async def test_public_release_list_filters_and_orders(
     assert response.status_code == 200
     body = response.json()
     assert body["total"] == 3
-    assert [item["source_pr_number"] for item in body["releases"]] == [1207, 1206]
+    assert [item["title"] for item in body["releases"]] == ["Release 1207", "Release 1206"]
+    assert all("source_pr_number" not in item for item in body["releases"])
+    assert all("source_merge_sha" not in item for item in body["releases"])
+    assert all("provenance_json" not in item for item in body["releases"])
 
     second_page = await auth_client.get(
         "/api/v1/releases/",
         params={"limit": 2, "offset": 2},
     )
     assert second_page.status_code == 200
-    assert [item["source_pr_number"] for item in second_page.json()["releases"]] == [1205]
+    assert [item["title"] for item in second_page.json()["releases"]] == ["Release 1205"]
 
 
 def _release_payload(*, pr_number: int, merge_sha: str) -> dict[str, object]:


### PR DESCRIPTION
Recovered local factory work that was interrupted before normal delivery. This branch narrows the public release response schema so public What's New data does not expose internal source/provenance fields, with matching frontend test updates.

This PR exists to preserve and review recovered work. If the change is obsolete, duplicated, or unsafe against current main, close it with that disposition rather than leaving the branch stranded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated public release responses to show only information intended for public-facing endpoints.
  * Removed internal source, merge, visibility, status, and provenance details from release data.
  * Updated “What’s New” coverage to reflect the streamlined release information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->