### PR TITLE
Recover NVIDIA OpenCode model-discovery work

### DIFF
--- a/.github/workflows/factory-policy.yml
+++ b/.github/workflows/factory-policy.yml
@@ -11,6 +11,7 @@ on:
       - scripts/comic-pile-opencode-factory-overnight.sh
       - scripts/opencode-model-manifest.sh
       - scripts/opencode-model-scout.sh
+      - scripts/select_fcm_nvidia_model.py
       - scripts/install-git-hooks.sh
       - .githooks/prepare-commit-msg
       - scripts/check-autonomous-factory-policy.py
@@ -18,6 +19,8 @@ on:
       - scripts/tests/test_install_git_hooks.py
       - scripts/tests/test_opencode_model_tools.py
       - scripts/tests/test_opencode_provider_rotation.py
+      - scripts/tests/test_select_fcm_nvidia_model.py
+      - .github/workflows/opencode.yml
       - scripts/tests/test_overnight_factory_cli.py
       - .github/workflows/factory-policy.yml
   push:
@@ -32,6 +35,7 @@ on:
       - scripts/comic-pile-opencode-factory-overnight.sh
       - scripts/opencode-model-manifest.sh
       - scripts/opencode-model-scout.sh
+      - scripts/select_fcm_nvidia_model.py
       - scripts/install-git-hooks.sh
       - .githooks/prepare-commit-msg
       - scripts/check-autonomous-factory-policy.py
@@ -39,6 +43,8 @@ on:
       - scripts/tests/test_install_git_hooks.py
       - scripts/tests/test_opencode_model_tools.py
       - scripts/tests/test_opencode_provider_rotation.py
+      - scripts/tests/test_select_fcm_nvidia_model.py
+      - .github/workflows/opencode.yml
       - scripts/tests/test_overnight_factory_cli.py
       - .github/workflows/factory-policy.yml
 
@@ -67,6 +73,7 @@ jobs:
             scripts/tests/test_install_git_hooks.py \
             scripts/tests/test_opencode_model_tools.py \
             scripts/tests/test_opencode_provider_rotation.py \
+            scripts/tests/test_select_fcm_nvidia_model.py \
             scripts/tests/test_overnight_factory_cli.py
       - name: Check canonical factory invariants
         run: python scripts/check-autonomous-factory-policy.py
@@ -79,5 +86,6 @@ jobs:
           python -m unittest
           scripts/tests/test_opencode_model_tools.py
           scripts/tests/test_opencode_provider_rotation.py
+          scripts/tests/test_select_fcm_nvidia_model.py
       - name: Test overnight factory CLI
         run: python -m unittest scripts/tests/test_overnight_factory_cli.py

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,6 +1,7 @@
 name: opencode
 
 on:
+  workflow_dispatch:
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -9,10 +10,16 @@ on:
 jobs:
   opencode:
     if: |
-      contains(github.event.comment.body, ' /oc') ||
-      startsWith(github.event.comment.body, '/oc') ||
-      contains(github.event.comment.body, ' /opencode') ||
-      startsWith(github.event.comment.body, '/opencode')
+      github.event_name == 'workflow_dispatch' ||
+      (
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+        (
+          contains(github.event.comment.body, ' /oc') ||
+          startsWith(github.event.comment.body, '/oc') ||
+          contains(github.event.comment.body, ' /opencode') ||
+          startsWith(github.event.comment.body, '/opencode')
+        )
+      )
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -25,9 +32,59 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Run opencode
-        uses: anomalyco/opencode/github@latest
+      - name: Install pinned FCM discovery CLI
+        run: npm install --global --ignore-scripts free-coding-models@0.5.69
+
+      - name: Select a healthy NVIDIA model
+        id: model
         env:
-          ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+        run: |
+          fcm_output="$(free-coding-models \
+            --json \
+            --origin nvidia \
+            --hide-unconfigured \
+            --best \
+            --no-telemetry)"
+          candidates="$(printf '%s\n' "$fcm_output" | \
+            python scripts/select_fcm_nvidia_model.py)"
+          selected_model=""
+          while IFS= read -r candidate; do
+            echo "Probing $candidate through NVIDIA chat completions"
+            provider_model="${candidate#nvidia/}"
+            request="$(jq -nc \
+              --arg model "$provider_model" \
+              '{model:$model,messages:[{role:"user",content:"Reply with exactly: FCM_NVIDIA_MODEL_OK"}],max_tokens:32}')"
+            response="$(curl --silent --show-error --fail-with-body \
+              --header "Authorization: Bearer $NVIDIA_API_KEY" \
+              --header 'Content-Type: application/json' \
+              --data "$request" \
+              https://integrate.api.nvidia.com/v1/chat/completions || true)"
+            if jq -e \
+              '.choices[0].message.content | strings | contains("FCM_NVIDIA_MODEL_OK")' \
+              >/dev/null 2>&1 <<< "$response"; then
+              selected_model="$candidate"
+              break
+            fi
+            echo "Candidate did not produce a compatible response"
+          done <<< "$candidates"
+          if [[ -z "$selected_model" ]]; then
+            echo "No FCM candidate completed the OpenCode compatibility probe" >&2
+            exit 1
+          fi
+          echo "Selected $selected_model"
+          echo "model=$selected_model" >> "$GITHUB_OUTPUT"
+
+      - name: Verify NVIDIA through OpenCode
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+        run: echo "FCM_NVIDIA_GITHUB_OK (${{ steps.model.outputs.model }})"
+
+      - name: Run OpenCode PR agent
+        if: github.event_name != 'workflow_dispatch'
+        uses: anomalyco/opencode/github@77fc88c8ade8e5a620ebbe1197f3a572d29ae91a
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
         with:
-          model: zai-coding-plan/glm-5.1
+          model: ${{ steps.model.outputs.model }}

--- a/docs/changelog.d/2026-08-09-1004.md
+++ b/docs/changelog.d/2026-08-09-1004.md
@@ -1,0 +1,5 @@
+## 2026-08-09
+
+### Factory automation
+
+- [PR #1004](https://github.com/JoshCLWren/comic-pile/pull/1004) lets the GitHub OpenCode agent discover and verify a currently responsive NVIDIA coding model instead of depending on one volatile NIM model identifier.

--- a/docs/changelog.d/2026-08-09-1004.md
+++ b/docs/changelog.d/2026-08-09-1004.md
@@ -2,4 +2,4 @@
 
 ### Factory automation
 
-- [PR #1004](https://github.com/JoshCLWren/comic-pile/pull/1004) lets the GitHub OpenCode agent discover and verify a currently responsive NVIDIA coding model instead of depending on one volatile NIM model identifier.
+- [#1004](https://github.com/JoshCLWren/comic-pile/pull/1004) lets the GitHub OpenCode agent discover and verify a currently responsive NVIDIA coding model instead of depending on one volatile NIM model identifier.

--- a/scripts/select_fcm_nvidia_model.py
+++ b/scripts/select_fcm_nvidia_model.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Select a healthy NVIDIA chat model from free-coding-models JSON output."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass
+
+
+EXCLUDED_MODEL_TERMS = (
+    "embed",
+    "image",
+    "rerank",
+    "safety",
+    "vision",
+)
+TIER_RANK = {"S+": 4, "S": 3, "A+": 2, "A": 1}
+MODEL_ID_PATTERN = re.compile(r"^[A-Za-z0-9._/-]+$")
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """A healthy NVIDIA model that OpenCode can invoke."""
+
+    model_id: str
+    tier: str
+    stability: float
+    uptime: float
+    latency: float
+
+    @property
+    def opencode_model(self) -> str:
+        """Return the provider-qualified OpenCode model identifier."""
+        return f"nvidia/{self.model_id}"
+
+    @property
+    def sort_key(self) -> tuple[float, float, float, float, str]:
+        """Return a deterministic best-first ranking key."""
+        return (
+            -float(TIER_RANK.get(self.tier, 0)),
+            -self.stability,
+            -self.uptime,
+            self.latency,
+            self.model_id,
+        )
+
+
+def _number(value: object, default: float) -> float:
+    """Convert a JSON number to float without accepting booleans or strings."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return default
+    return float(value)
+
+
+def _candidate(value: object) -> Candidate | None:
+    """Convert one FCM result into a candidate when it is safe to select."""
+    if not isinstance(value, dict):
+        return None
+
+    provider = value.get("provider")
+    status = value.get("status")
+    model_id = value.get("modelId")
+    tier = value.get("tier")
+    if provider != "nvidia" or status != "up":
+        return None
+    if not isinstance(model_id, str) or not isinstance(tier, str):
+        return None
+    if not MODEL_ID_PATTERN.fullmatch(model_id):
+        return None
+
+    normalized_id = model_id.lower()
+    if any(term in normalized_id for term in EXCLUDED_MODEL_TERMS):
+        return None
+    if tier not in TIER_RANK:
+        return None
+
+    return Candidate(
+        model_id=model_id,
+        tier=tier,
+        stability=_number(value.get("stability"), 0),
+        uptime=_number(value.get("uptime"), 0),
+        latency=_number(value.get("latestPing"), float("inf")),
+    )
+
+
+def select_models(raw_output: str) -> list[str]:
+    """Rank NVIDIA models from possibly banner-prefixed FCM output.
+
+    Args:
+        raw_output: Complete stdout emitted by ``free-coding-models --json``.
+
+    Returns:
+        Provider-qualified model identifiers ordered best-first for OpenCode.
+
+    Raises:
+        ValueError: When the output is malformed or has no healthy candidate.
+    """
+    payload_start = raw_output.find("[")
+    if payload_start < 0:
+        raise ValueError("FCM output did not contain a JSON array")
+
+    payload: object = json.loads(raw_output[payload_start:])
+    if not isinstance(payload, list):
+        raise ValueError("FCM JSON payload was not an array")
+
+    candidates = [candidate for item in payload if (candidate := _candidate(item))]
+    if not candidates:
+        raise ValueError("FCM found no healthy S- or A-tier NVIDIA chat model")
+    return [candidate.opencode_model for candidate in sorted(candidates, key=lambda item: item.sort_key)]
+
+
+def select_model(raw_output: str) -> str:
+    """Return the highest-ranked NVIDIA model from FCM output.
+
+    Args:
+        raw_output: Complete stdout emitted by ``free-coding-models --json``.
+
+    Returns:
+        The first provider-qualified model identifier.
+    """
+    return select_models(raw_output)[0]
+
+
+def main() -> int:
+    """Read FCM output from stdin and print one selected OpenCode model."""
+    try:
+        print("\n".join(select_models(sys.stdin.read())))
+    except (json.JSONDecodeError, ValueError) as error:
+        print(f"Unable to select NVIDIA model: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_select_fcm_nvidia_model.py
+++ b/scripts/tests/test_select_fcm_nvidia_model.py
@@ -1,0 +1,148 @@
+"""Tests for the defensive FCM NVIDIA model selector."""
+
+from __future__ import annotations
+
+import json
+import unittest
+
+from scripts.select_fcm_nvidia_model import select_model, select_models
+
+
+class SelectFcmNvidiaModelTests(unittest.TestCase):
+    """Verify FCM output is sanitized and ranked before use."""
+
+    def test_ignores_banner_other_providers_and_non_chat_models(self) -> None:
+        """Only healthy NVIDIA chat models should be eligible."""
+        payload = [
+            {
+                "provider": "groq",
+                "status": "up",
+                "modelId": "qwen/better-ranked",
+                "tier": "S+",
+                "stability": 100,
+                "uptime": 100,
+                "latestPing": 10,
+            },
+            {
+                "provider": "nvidia",
+                "status": "up",
+                "modelId": "nvidia/nemotron-embed-1b",
+                "tier": "S+",
+                "stability": 100,
+                "uptime": 100,
+                "latestPing": 10,
+            },
+            {
+                "provider": "nvidia",
+                "status": "timeout",
+                "modelId": "qwen/unavailable",
+                "tier": "S+",
+                "stability": 100,
+                "uptime": 100,
+                "latestPing": 10,
+            },
+            {
+                "provider": "nvidia",
+                "status": "up",
+                "modelId": "openai/gpt-oss-20b",
+                "tier": "S",
+                "stability": 98,
+                "uptime": 100,
+                "latestPing": 500,
+            },
+        ]
+
+        selected = select_model(f"  Pinging models...\n\n{json.dumps(payload)}")
+
+        self.assertEqual(selected, "nvidia/openai/gpt-oss-20b")
+
+    def test_prefers_tier_then_stability_uptime_and_latency(self) -> None:
+        """Selection should remain deterministic as live model order changes."""
+        payload = [
+            {
+                "provider": "nvidia",
+                "status": "up",
+                "modelId": "vendor/fast-a",
+                "tier": "A+",
+                "stability": 100,
+                "uptime": 100,
+                "latestPing": 1,
+            },
+            {
+                "provider": "nvidia",
+                "status": "up",
+                "modelId": "vendor/stable-s",
+                "tier": "S",
+                "stability": 99,
+                "uptime": 100,
+                "latestPing": 900,
+            },
+            {
+                "provider": "nvidia",
+                "status": "up",
+                "modelId": "vendor/less-stable-s",
+                "tier": "S",
+                "stability": 90,
+                "uptime": 100,
+                "latestPing": 100,
+            },
+        ]
+
+        selected = select_model(json.dumps(payload))
+
+        self.assertEqual(selected, "nvidia/vendor/stable-s")
+
+    def test_rejects_output_without_a_healthy_candidate(self) -> None:
+        """An unavailable review model should fail explicitly."""
+        payload = [
+            {
+                "provider": "nvidia",
+                "status": "timeout",
+                "modelId": "vendor/down",
+                "tier": "S",
+            }
+        ]
+
+        with self.assertRaisesRegex(ValueError, "no healthy"):
+            select_model(json.dumps(payload))
+
+    def test_returns_all_candidates_in_fallback_order(self) -> None:
+        """The workflow should be able to probe later candidates after an empty response."""
+        payload = [
+            {
+                "provider": "nvidia",
+                "status": "up",
+                "modelId": "vendor/second",
+                "tier": "S",
+                "stability": 90,
+                "uptime": 100,
+                "latestPing": 100,
+            },
+            {
+                "provider": "nvidia",
+                "status": "up",
+                "modelId": "vendor/first",
+                "tier": "S+",
+                "stability": 80,
+                "uptime": 100,
+                "latestPing": 200,
+            },
+            {
+                "provider": "nvidia",
+                "status": "up",
+                "modelId": "vendor/invalid model",
+                "tier": "S+",
+                "stability": 100,
+                "uptime": 100,
+                "latestPing": 1,
+            },
+        ]
+
+        self.assertEqual(
+            select_models(json.dumps(payload)),
+            ["nvidia/vendor/first", "nvidia/vendor/second"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Recovered local factory work for the GitHub OpenCode/NVIDIA model-selection path. It adds pinned FCM discovery, healthy NVIDIA model selection/probing, workflow-dispatch validation, policy coverage, and related tests.

This PR exists to preserve and review recovered work. If current main already supersedes it, close it explicitly as duplicated/obsolete instead of leaving the branch stranded.