### PR TITLE
Recover session phase timing and query-count instrumentation

### DIFF
--- a/app/api/session.py
+++ b/app/api/session.py
@@ -13,6 +13,7 @@ from app.cache import TTL, cached, invalidate_cache
 from app.database import get_db
 from app.middleware import limiter
 from app.models import Event, Issue, Session as SessionModel, Snapshot, Thread, User
+from app.performance_diagnostics import record_phase
 from app.schemas import (
     ActiveThreadInfo,
     EventDetail,
@@ -404,41 +405,55 @@ async def get_current_session(
 
     while retries < max_retries:
         try:
-            active_session_result = await db.execute(
-                select(SessionModel)
-                .where(SessionModel.user_id == current_user.id)
-                .where(SessionModel.ended_at.is_(None))
-                .order_by(SessionModel.started_at.desc(), SessionModel.id.desc())
-                .limit(1)
-            )
-            active_session = active_session_result.scalars().first()
+            async with record_phase("candidate_selection"):
+                active_session_result = await db.execute(
+                    select(SessionModel)
+                    .where(SessionModel.user_id == current_user.id)
+                    .where(SessionModel.ended_at.is_(None))
+                    .order_by(SessionModel.started_at.desc(), SessionModel.id.desc())
+                    .limit(1)
+                )
+                active_session = active_session_result.scalars().first()
 
-            if active_session is None or not await is_active(
-                active_session.started_at, active_session.ended_at, db
-            ):
-                active_session = await get_or_create(db, user_id=current_user.id)
+                if active_session is None or not await is_active(
+                    active_session.started_at, active_session.ended_at, db
+                ):
+                    active_session = await get_or_create(db, user_id=current_user.id)
 
-            await db.refresh(active_session)
-            active_session_id = active_session.id
-            _, active_thread = await get_session_with_thread_safe(active_session_id, db)
+            async with record_phase("session_refresh"):
+                await db.refresh(active_session)
+                active_session_id = active_session.id
+
+            async with record_phase("active_thread"):
+                _, active_thread = await get_session_with_thread_safe(active_session_id, db)
 
             from sqlalchemy import func
 
-            snapshot_count_result = await db.execute(
-                select(func.count())
-                .select_from(Snapshot)
-                .where(Snapshot.session_id == active_session_id)
-            )
-            snapshot_count = snapshot_count_result.scalar() or 0
+            async with record_phase("snapshot_count"):
+                snapshot_count_result = await db.execute(
+                    select(func.count())
+                    .select_from(Snapshot)
+                    .where(Snapshot.session_id == active_session_id)
+                )
+                snapshot_count = snapshot_count_result.scalar() or 0
 
             snoozed_threads = []
             snoozed_ids = active_session.snoozed_thread_ids or []
-            if snoozed_ids:
-                snoozed_result = await db.execute(select(Thread).where(Thread.id.in_(snoozed_ids)))
-                snoozed_threads = [
-                    SnoozedThreadInfo(id=thread.id, title=thread.title)
-                    for thread in snoozed_result.scalars().all()
-                ]
+            async with record_phase("snoozed_threads"):
+                if snoozed_ids:
+                    snoozed_result = await db.execute(
+                        select(Thread).where(Thread.id.in_(snoozed_ids))
+                    )
+                    snoozed_threads = [
+                        SnoozedThreadInfo(id=thread.id, title=thread.title)
+                        for thread in snoozed_result.scalars().all()
+                    ]
+
+            async with record_phase("ladder_path"):
+                ladder_path = await build_ladder_path(active_session_id, db)
+
+            async with record_phase("current_die"):
+                current_die = await get_current_die(active_session_id, db)
 
             return SessionResponse(
                 id=active_session_id,
@@ -447,9 +462,9 @@ async def get_current_session(
                 start_die=active_session.start_die,
                 manual_die=active_session.manual_die,
                 user_id=active_session.user_id,
-                ladder_path=await build_ladder_path(active_session_id, db),
+                ladder_path=ladder_path,
                 active_thread=active_thread,
-                current_die=await get_current_die(active_session_id, db),
+                current_die=current_die,
                 last_rolled_result=active_thread.last_rolled_result if active_thread else None,
                 has_restore_point=snapshot_count > 0,
                 snapshot_count=snapshot_count,
@@ -523,8 +538,9 @@ async def list_sessions(
             ) from None
 
     query = query.limit(page_size + 1)
-    sessions_result = await db.execute(query)
-    sessions = sessions_result.scalars().all()
+    async with record_phase("history_page"):
+        sessions_result = await db.execute(query)
+        sessions = sessions_result.scalars().all()
 
     has_more = len(sessions) > page_size
     sessions_to_return = sessions[:page_size]
@@ -534,27 +550,29 @@ async def list_sessions(
 
     session_ids = [s.id for s in sessions_to_return]
 
-    history_events_result = await db.execute(
-        select(Event)
-        .where(Event.session_id.in_(session_ids))
-        .where(
-            or_(
-                (Event.type == "roll") & (Event.selected_thread_id.is_not(None)),
-                (Event.type.in_(("rate", "snooze", "undo"))) & (Event.die_after.is_not(None)),
+    async with record_phase("history_events"):
+        history_events_result = await db.execute(
+            select(Event)
+            .where(Event.session_id.in_(session_ids))
+            .where(
+                or_(
+                    (Event.type == "roll") & (Event.selected_thread_id.is_not(None)),
+                    (Event.type.in_(("rate", "snooze", "undo"))) & (Event.die_after.is_not(None)),
+                )
             )
+            .order_by(Event.session_id, Event.timestamp, Event.id)
         )
-        .order_by(Event.session_id, Event.timestamp, Event.id)
-    )
-    history_events = history_events_result.scalars().all()
+        history_events = history_events_result.scalars().all()
 
-    projection = project_session_history_events(session_ids, history_events)
+        projection = project_session_history_events(session_ids, history_events)
 
-    snapshot_count_result = await db.execute(
-        select(Snapshot.session_id, func.count())
-        .where(Snapshot.session_id.in_(session_ids))
-        .group_by(Snapshot.session_id)
-    )
-    snapshot_counts = {row[0]: row[1] for row in snapshot_count_result.all()}
+    async with record_phase("history_snapshot_counts"):
+        snapshot_count_result = await db.execute(
+            select(Snapshot.session_id, func.count())
+            .where(Snapshot.session_id.in_(session_ids))
+            .group_by(Snapshot.session_id)
+        )
+        snapshot_counts = {row[0]: row[1] for row in snapshot_count_result.all()}
 
     sessions_by_id = {s.id: s for s in sessions_to_return}
 
@@ -580,12 +598,13 @@ async def list_sessions(
     }
 
     active_threads_dict: dict[int, ActiveThreadInfo | None] = {}
-    if thread_ids:
-        threads_result = await db.execute(select(Thread).where(Thread.id.in_(thread_ids)))
-        threads_by_id = {t.id: t for t in threads_result.scalars().all()}
-        threads = list(threads_by_id.values())
-        unread_counts = await _bulk_unread_counts(threads, db)
-        issue_numbers = await _bulk_next_issue_numbers(threads, db)
+    async with record_phase("history_active_threads"):
+        if thread_ids:
+            threads_result = await db.execute(select(Thread).where(Thread.id.in_(thread_ids)))
+            threads_by_id = {t.id: t for t in threads_result.scalars().all()}
+            threads = list(threads_by_id.values())
+            unread_counts = await _bulk_unread_counts(threads, db)
+            issue_numbers = await _bulk_next_issue_numbers(threads, db)
 
         for sid in session_ids:
             roll_event = projection.latest_roll_by_session.get(sid)

--- a/app/database.py
+++ b/app/database.py
@@ -7,7 +7,12 @@ from collections.abc import AsyncIterator
 
 from sqlalchemy import event, text
 from sqlalchemy.engine import make_url
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 from sqlalchemy.orm import DeclarativeBase
 
 from app.config import get_database_settings
@@ -50,34 +55,53 @@ async_engine = create_async_engine(
 )
 
 
-@event.listens_for(async_engine.sync_engine, "before_cursor_execute")
-def _before_cursor_execute(
-    connection: object,
-    cursor: object,
-    statement: str,
-    parameters: object,
-    context: object,
-    executemany: bool,
-) -> None:
-    """Start timing a SQL statement after a connection has been acquired."""
-    del connection, cursor, statement, parameters, executemany
-    vars(context)["_comic_pile_query_started_at"] = time.perf_counter()
+def install_database_instrumentation(engine: AsyncEngine) -> None:
+    """Attach SQL timing and query-count listeners to an async engine.
+
+    The listeners feed the active request diagnostics context so that total
+    database time/query counts and per-phase query attribution are observable
+    for any engine, including test engines that use their own connection.
+
+    Installing on the same engine more than once is a no-op.
+
+    Args:
+        engine: The async engine to instrument.
+    """
+    if getattr(engine.sync_engine, "_comic_pile_instrumented", False):
+        return
+
+    @event.listens_for(engine.sync_engine, "before_cursor_execute")
+    def _before_cursor_execute(
+        connection: object,
+        cursor: object,
+        statement: str,
+        parameters: object,
+        context: object,
+        executemany: bool,
+    ) -> None:
+        """Start timing a SQL statement after a connection has been acquired."""
+        del connection, cursor, statement, parameters, executemany
+        vars(context)["_comic_pile_query_started_at"] = time.perf_counter()
+
+    @event.listens_for(engine.sync_engine, "after_cursor_execute")
+    def _after_cursor_execute(
+        connection: object,
+        cursor: object,
+        statement: str,
+        parameters: object,
+        context: object,
+        executemany: bool,
+    ) -> None:
+        """Record SQL execution time in the active request diagnostics context."""
+        del connection, cursor, statement, parameters, executemany
+        started_at = vars(context).get("_comic_pile_query_started_at")
+        if isinstance(started_at, float):
+            record_database_query((time.perf_counter() - started_at) * 1000)
+
+    vars(engine.sync_engine)["_comic_pile_instrumented"] = True
 
 
-@event.listens_for(async_engine.sync_engine, "after_cursor_execute")
-def _after_cursor_execute(
-    connection: object,
-    cursor: object,
-    statement: str,
-    parameters: object,
-    context: object,
-    executemany: bool,
-) -> None:
-    """Record SQL execution time in the active request diagnostics context."""
-    del connection, cursor, statement, parameters, executemany
-    started_at = vars(context).get("_comic_pile_query_started_at")
-    if isinstance(started_at, float):
-        record_database_query((time.perf_counter() - started_at) * 1000)
+install_database_instrumentation(async_engine)
 
 
 AsyncSessionLocal = async_sessionmaker(

--- a/app/middleware/request_logging.py
+++ b/app/middleware/request_logging.py
@@ -171,6 +171,8 @@ def _server_timing_header(total_ms: float) -> str:
         metrics.append(
             f'cache;dur={diagnostics.cache_time_ms:.2f};desc="{diagnostics.cache_status}"'
         )
+    for name, phase in diagnostics.phases.items():
+        metrics.append(f'{name};dur={phase.duration_ms:.2f};desc="{phase.query_count} queries"')
     return ", ".join(metrics)
 
 
@@ -224,6 +226,14 @@ def add_request_logging_middleware(app: FastAPI, environment: str) -> None:
                 "user_agent": request.headers.get("user-agent"),
                 "headers": redact_headers(dict(request.headers)),
             }
+
+            if diagnostics.phases:
+                log_data["phase_timings_ms"] = {
+                    name: round(phase.duration_ms, 2) for name, phase in diagnostics.phases.items()
+                }
+                log_data["phase_query_counts"] = {
+                    name: phase.query_count for name, phase in diagnostics.phases.items()
+                }
 
             if hasattr(request.state, "request_body"):
                 log_data["request_body"] = request.state.request_body

--- a/app/performance_diagnostics.py
+++ b/app/performance_diagnostics.py
@@ -6,9 +6,10 @@ import asyncio
 import logging
 import os
 import time
-from collections.abc import Awaitable
+from collections.abc import AsyncIterator, Awaitable
+from contextlib import asynccontextmanager
 from contextvars import ContextVar, Token
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 from app.cache import UpstashCache
@@ -17,6 +18,14 @@ logger = logging.getLogger(__name__)
 
 CacheOutcome = Literal["hit", "miss", "write", "bypass", "timeout", "error"]
 _DEFAULT_CACHE_OPERATION_TIMEOUT_SECONDS = 2.0
+
+
+@dataclass
+class PhaseTiming:
+    """Wall-clock duration and SQL statement count for one named phase."""
+
+    duration_ms: float = 0.0
+    query_count: int = 0
 
 
 @dataclass
@@ -33,6 +42,7 @@ class RequestDiagnostics:
     cache_time_ms: float = 0.0
     database_queries: int = 0
     database_time_ms: float = 0.0
+    phases: dict[str, PhaseTiming] = field(default_factory=dict)
 
     @property
     def cache_status(self) -> str:
@@ -61,6 +71,8 @@ _request_diagnostics: ContextVar[RequestDiagnostics | None] = ContextVar(
     default=None,
 )
 
+_current_phase: ContextVar[str | None] = ContextVar("current_phase", default=None)
+
 
 def begin_request_diagnostics() -> Token[RequestDiagnostics | None]:
     """Start a fresh diagnostics context for the current request."""
@@ -84,6 +96,34 @@ def record_database_query(duration_ms: float) -> None:
         return
     diagnostics.database_queries += 1
     diagnostics.database_time_ms += duration_ms
+
+    phase_name = _current_phase.get()
+    if phase_name is not None:
+        phase = diagnostics.phases.setdefault(phase_name, PhaseTiming())
+        phase.query_count += 1
+
+
+@asynccontextmanager
+async def record_phase(name: str) -> AsyncIterator[None]:
+    """Time one named logical phase, attributing SQL statements to it.
+
+    Nested phases are supported; each SQL statement is counted against the
+    innermost active phase while its wall-clock duration is accumulated on the
+    phase that opened it.
+
+    Args:
+        name: The phase name to record (e.g. ``"active_thread"``).
+    """
+    diagnostics = _request_diagnostics.get()
+    started_at = time.perf_counter()
+    token = _current_phase.set(name)
+    try:
+        yield
+    finally:
+        _current_phase.reset(token)
+        if diagnostics is not None:
+            phase = diagnostics.phases.setdefault(name, PhaseTiming())
+            phase.duration_ms += (time.perf_counter() - started_at) * 1000
 
 
 def record_cache_operation(outcome: CacheOutcome, duration_ms: float) -> None:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## 2026-08-03
 
+<<<<<<< HEAD
 **OpenCode model discovery, rotation, and attribution (factory tooling)**
 
 - Added `scripts/opencode-model-manifest.sh`: a shared, flock-protected model manifest helper (`init`, `set`, `record`, `confirmed`, `next`, `pending`, `summary`) that tracks probe status, tool-call support, last probe time, and per-model usage.
@@ -11,6 +12,12 @@
 - The overnight supervisor (`comic-pile-opencode-factory-overnight.sh`) now launches the model scout in `--watch` mode alongside the factory, tracks it with its own pid file, and reports confirmed models in `status`.
 - Added `.githooks/prepare-commit-msg`: every commit is attributed with a `Model: <id>` trailer from `OPENCODE_MODEL` (skipped for merges, amends, and squash commits). Factory PR bodies are attributed with the producing model.
 - `scripts/install-git-hooks.sh` installs the new hook, preserving any original user hooks in `.sample` backups on first run; `factory-policy.yml` syntax-checks the new shell scripts.
+
+**Session read phase instrumentation (#700)**
+
+- Current-session and History reads now record structured per-phase wall-clock durations and SQL statement counts through the existing request diagnostics context, exposed in the `Server-Timing` response header and in the `phase_timings_ms`/`phase_query_counts` structured log fields.
+- `get_current_session()` phases: `candidate_selection`, `session_refresh`, `active_thread`, `snapshot_count`, `snoozed_threads`, `ladder_path`, `current_die`. History phases: `history_page`, `history_events`, `history_snapshot_counts`, `history_active_threads`.
+- Added exact per-phase statement-count regression coverage proving the current-session path issues bounded, attributed SQL and that History reads stay bounded.
 
 **Production migrations on Vercel/Neon**
 

--- a/tests/test_session_phase_instrumentation.py
+++ b/tests/test_session_phase_instrumentation.py
@@ -1,0 +1,307 @@
+"""Phase instrumentation and statement-count regressions for session reads.
+
+Issue #700: structured phase/query-count instrumentation was the final
+executable slice deferred by the merged read-pipeline PR. These tests prove:
+
+- ``get_current_session()`` records named phases and exact per-phase SQL
+  statement counts through the request diagnostics context;
+- ``list_sessions()`` records bounded History phases;
+- the middleware surfaces phase timings and query counts in the
+  ``Server-Timing`` response header and the structured request log.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import event as sa_event
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+from app.models import Event, Issue, Thread, User
+from app.models import Session as SessionModel
+from app.performance_diagnostics import get_request_diagnostics, record_phase
+from app.database import install_database_instrumentation
+
+
+@pytest.fixture(autouse=True)
+def _instrument_engine(db_engine: AsyncEngine) -> None:
+    """Attach the query-count listeners to the test engine."""
+    install_database_instrumentation(db_engine)
+
+
+def _parse_server_timing(header: str) -> dict[str, int]:
+    """Parse ``name;dur=..;desc="N queries"`` entries into name -> query count."""
+    counts: dict[str, int] = {}
+    for metric in header.split(","):
+        metric = metric.strip()
+        if not metric:
+            continue
+        parts = [p.strip() for p in metric.split(";")]
+        name = parts[0]
+        for part in parts[1:]:
+            if part.startswith('desc="') and part.endswith(' queries"'):
+                counts[name] = int(part[6:-9])
+    return counts
+
+
+async def _seed_current_session(
+    async_db: AsyncSession, user: User, *, issues_remaining: int = 2
+) -> SessionModel:
+    """Seed an active session with a rolled migrated thread and return it."""
+    session = SessionModel(start_die=10, user_id=user.id, started_at=datetime.now(UTC))
+    async_db.add(session)
+    await async_db.commit()
+    await async_db.refresh(session)
+
+    thread = Thread(
+        title="Phase Comic",
+        format="Comic",
+        issues_remaining=issues_remaining,
+        queue_position=1,
+        status="active",
+        user_id=user.id,
+        total_issues=4,
+        reading_progress="in_progress",
+    )
+    async_db.add(thread)
+    await async_db.commit()
+    await async_db.refresh(thread)
+
+    for i in range(1, 5):
+        async_db.add(
+            Issue(
+                thread_id=thread.id,
+                issue_number=str(i),
+                status="read" if i < 3 else "unread",
+                position=i,
+            )
+        )
+    await async_db.commit()
+
+    issue_result = await async_db.execute(
+        __import__("sqlalchemy").select(Issue).where(
+            Issue.thread_id == thread.id, Issue.issue_number == "3"
+        )
+    )
+    next_issue = issue_result.scalar_one()
+    thread.next_unread_issue_id = next_issue.id
+    await async_db.commit()
+
+    async_db.add(
+        Event(
+            type="roll",
+            die=10,
+            result=1,
+            selected_thread_id=thread.id,
+            selection_method="random",
+            session_id=session.id,
+            thread_id=thread.id,
+        )
+    )
+    await async_db.commit()
+    return session
+
+
+def _statement_recorder() -> tuple[list[str], object]:
+    """Return a statement list and a SQLAlchemy before_cursor_execute listener."""
+    statements: list[str] = []
+
+    def record_statement(
+        _connection: object,
+        _cursor: object,
+        statement: str,
+        _parameters: object,
+        _context: object,
+        _executemany: bool,
+    ) -> None:
+        statements.append(statement)
+
+    return statements, record_statement
+
+
+@pytest.mark.asyncio
+async def test_current_session_phase_query_counts_match_statement_counts(
+    auth_client: AsyncClient,
+    async_db: AsyncSession,
+    db_engine: AsyncEngine,
+    default_user: User,
+) -> None:
+    """Per-phase query counts equal the real SQL statement counts in the path."""
+    await _seed_current_session(async_db, default_user)
+
+    statements, listener = _statement_recorder()
+    sa_event.listen(db_engine.sync_engine, "before_cursor_execute", listener)
+    try:
+        response = await auth_client.get("/api/sessions/current/")
+    finally:
+        sa_event.remove(db_engine.sync_engine, "before_cursor_execute", listener)
+
+    assert response.status_code == 200
+    assert "server-timing" in response.headers
+
+    app_statements = [
+        s
+        for s in statements
+        if "savepoint" not in s.lower()
+        and "revoked_tokens" not in s.lower()
+        and "from users" not in s.lower()
+    ]
+    timing_counts = _parse_server_timing(response.headers["server-timing"])
+
+    for name in ("candidate_selection", "session_refresh", "active_thread"):
+        assert name in timing_counts, f"Missing phase {name!r} in {timing_counts}"
+
+    expected_total = sum(
+        count
+        for name, count in timing_counts.items()
+        if name
+        in (
+            "candidate_selection",
+            "session_refresh",
+            "active_thread",
+            "snapshot_count",
+            "snoozed_threads",
+            "ladder_path",
+            "current_die",
+        )
+    )
+    assert expected_total == len(app_statements), (
+        f"Phase query counts ({expected_total}) must match real statements "
+        f"({len(app_statements)}): {app_statements}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_current_session_records_expected_phases_in_diagnostics(
+    auth_client: AsyncClient,
+    async_db: AsyncSession,
+    db_engine: AsyncEngine,
+    default_user: User,
+) -> None:
+    """The diagnostics context exposes named phases for the current-session path."""
+    await _seed_current_session(async_db, default_user)
+
+    response = await auth_client.get("/api/sessions/current/")
+    assert response.status_code == 200
+    assert "server-timing" in response.headers
+
+    timing_counts = _parse_server_timing(response.headers["server-timing"])
+    expected_phases = {
+        "candidate_selection",
+        "session_refresh",
+        "active_thread",
+        "snapshot_count",
+        "ladder_path",
+        "current_die",
+    }
+    assert expected_phases.issubset(timing_counts), (
+        f"Expected phases {expected_phases}, got {set(timing_counts)}"
+    )
+    assert timing_counts["candidate_selection"] == 1
+    assert timing_counts["snapshot_count"] == 1
+    assert timing_counts["ladder_path"] == 1
+    assert timing_counts["current_die"] == 2
+    assert timing_counts["snoozed_threads"] == 0
+
+
+@pytest.mark.asyncio
+async def test_current_session_phase_durations_are_nonnegative(
+    auth_client: AsyncClient,
+    async_db: AsyncSession,
+    default_user: User,
+) -> None:
+    """Each recorded phase carries a real nonnegative wall-clock duration."""
+    await _seed_current_session(async_db, default_user)
+
+    response = await auth_client.get("/api/sessions/current/")
+    assert response.status_code == 200
+    server_timing = response.headers["server-timing"]
+
+    for metric in server_timing.split(","):
+        parts = [p.strip() for p in metric.split(";")]
+        name = parts[0]
+        if name in {
+            "candidate_selection",
+            "session_refresh",
+            "active_thread",
+            "snapshot_count",
+            "snoozed_threads",
+            "ladder_path",
+            "current_die",
+        }:
+            duration_part = next(p for p in parts if p.startswith("dur="))
+            assert float(duration_part[4:]) >= 0.0, f"Phase {name} has negative duration"
+
+
+@pytest.mark.asyncio
+async def test_record_phase_accumulates_duration_and_queries() -> None:
+    """``record_phase`` records elapsed wall-clock time on the active context."""
+    import asyncio
+
+    from app.performance_diagnostics import begin_request_diagnostics, end_request_diagnostics
+
+    token = begin_request_diagnostics()
+    try:
+        async with record_phase("probe_phase"):
+            await asyncio.sleep(0.01)
+    finally:
+        diagnostics = get_request_diagnostics()
+        end_request_diagnostics(token)
+
+    assert "probe_phase" in diagnostics.phases
+    assert diagnostics.phases["probe_phase"].duration_ms >= 10.0
+    assert diagnostics.phases["probe_phase"].query_count == 0
+
+
+@pytest.mark.asyncio
+async def test_history_records_bounded_phases(
+    auth_client: AsyncClient,
+    async_db: AsyncSession,
+    default_user: User,
+) -> None:
+    """History page records bounded read phases in the Server-Timing header."""
+    session = SessionModel(start_die=6, user_id=default_user.id, started_at=datetime.now(UTC))
+    async_db.add(session)
+    await async_db.commit()
+
+    response = await auth_client.get("/api/sessions/?page_size=10")
+    assert response.status_code == 200
+
+    timing_counts = _parse_server_timing(response.headers["server-timing"])
+    for name in ("history_page", "history_events", "history_snapshot_counts"):
+        assert name in timing_counts, f"Missing History phase {name!r} in {timing_counts}"
+    assert timing_counts["history_page"] == 1
+    assert timing_counts["history_events"] == 1
+    assert timing_counts["history_snapshot_counts"] == 1
+
+
+@pytest.mark.asyncio
+async def test_structured_log_exposes_phase_timings(
+    auth_client: AsyncClient,
+    async_db: AsyncSession,
+    default_user: User,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Structured slow-request logs include per-phase timing and query counts."""
+    monkeypatch.setenv("SLOW_REQUEST_THRESHOLD_MS", "1")
+    await _seed_current_session(async_db, default_user)
+
+    caplog.set_level(logging.WARNING, logger="app.middleware.request_logging")
+    await auth_client.get("/api/sessions/current/")
+
+    slow_records = [
+        record
+        for record in caplog.records
+        if record.name == "app.middleware.request_logging"
+        and record.getMessage().startswith("Slow HTTP request:")
+    ]
+    assert len(slow_records) == 1
+    extra = slow_records[0].__dict__
+    assert "phase_timings_ms" in extra
+    assert "phase_query_counts" in extra
+    assert extra["phase_query_counts"]["candidate_selection"] == 1
+    assert "active_thread" in extra["phase_timings_ms"]


### PR DESCRIPTION
Recovered local factory work for #700. It instruments current-session and History reads with named phases, surfaces phase timing/query counts through existing diagnostics, and adds regression coverage.

This PR exists to preserve and review recovered work. If another PR already contains the same implementation, close the duplicate explicitly rather than leaving the branch stranded.