### PR TITLE
Make NVIDIA factories recover from transient model failures

### DIFF
--- a/.github/scripts/nvidia-factory-worker.sh
+++ b/.github/scripts/nvidia-factory-worker.sh
@@ -6,17 +6,25 @@ MODEL="${2:?model required}"
 OWNER="factory:${WORKER}"
 WORKER_ID="opencode-nvidia-factory-${WORKER}"
 BUDGET_SECONDS="${FACTORY_BUDGET_SECONDS:-3000}"
+MAX_AGENT_ATTEMPTS="${NVIDIA_AGENT_MAX_ATTEMPTS:-2}"
+TRANSIENT_BACKOFF_SECONDS="${NVIDIA_TRANSIENT_BACKOFF_SECONDS:-20}"
 STARTED="$(date +%s)"
 DEADLINE=$((STARTED + BUDGET_SECONDS))
 OWNER_RE='^factory:(unowned|local|([1-9]|10))$'
 STAGE_RE='^factory:(building|review|changes-requested|ci|ready|blocked)$'
 SKIP_PRS=()
+COOLED_MODELS=()
 
 log() { printf '[factory:%s] %s\n' "$WORKER" "$*"; }
 remaining() { echo $((DEADLINE - $(date +%s))); }
 contains_skip_pr() {
   local needle="$1" item
   for item in "${SKIP_PRS[@]:-}"; do [[ "$item" == "$needle" ]] && return 0; done
+  return 1
+}
+contains_cooled_model() {
+  local needle="$1" item
+  for item in "${COOLED_MODELS[@]:-}"; do [[ "$item" == "$needle" ]] && return 0; done
   return 1
 }
 
@@ -133,6 +141,53 @@ machine_merge_gates_pass() {
   current_head_review_blockers "$pr" "$head" || return 1
 }
 
+is_transient_agent_failure() {
+  local status="$1"
+  [[ "$status" == "124" ]] && return 0
+  grep -Eiq '429|Too Many Requests|rate.?limit|overloaded|temporar(il)?y unavailable|bad gateway|gateway timeout|service unavailable|HTTP[^0-9]*(502|503|504)|ECONNRESET|ETIMEDOUT|connection reset' "/tmp/opencode-factory-${WORKER}.log"
+}
+
+probe_nvidia_model() {
+  local candidate="$1" provider_model request response http_code
+  provider_model="${candidate#nvidia/}"
+  request="$(jq -nc --arg model "$provider_model" '{model:$model,messages:[{role:"user",content:"Reply with exactly: FCM_NVIDIA_MODEL_OK"}],max_tokens:32}')"
+  response="$(mktemp)"
+  http_code="$(curl --silent --show-error --output "$response" --write-out '%{http_code}' \
+    --header "Authorization: Bearer $NVIDIA_API_KEY" \
+    --header 'Content-Type: application/json' \
+    --data "$request" https://integrate.api.nvidia.com/v1/chat/completions || true)"
+  if [[ "$http_code" =~ ^2[0-9][0-9]$ ]] && jq -e '.choices[0].message.content | strings | contains("FCM_NVIDIA_MODEL_OK")' >/dev/null 2>&1 <"$response"; then
+    rm -f "$response"
+    return 0
+  fi
+  rm -f "$response"
+  return 1
+}
+
+rotate_model() {
+  local fcm_output candidate start idx offset
+  local candidates=()
+  if ! fcm_output="$(free-coding-models --json --origin nvidia --hide-unconfigured --best --no-telemetry 2>/dev/null)"; then
+    return 1
+  fi
+  mapfile -t candidates < <(printf '%s\n' "$fcm_output" | python scripts/select_fcm_nvidia_model.py | sed '/^$/d')
+  ((${#candidates[@]} > 0)) || return 1
+  start=$(( (WORKER - 6 + 1) % ${#candidates[@]} ))
+  for ((offset=0; offset<${#candidates[@]}; offset++)); do
+    idx=$(( (start + offset) % ${#candidates[@]} ))
+    candidate="${candidates[$idx]}"
+    [[ "$candidate" == "$MODEL" ]] && continue
+    contains_cooled_model "$candidate" && continue
+    log "probing alternate model ${candidate} after transient failure"
+    if probe_nvidia_model "$candidate"; then
+      MODEL="$candidate"
+      log "rotated to healthy model ${MODEL}"
+      return 0
+    fi
+  done
+  return 1
+}
+
 run_agent() {
   local mode="$1" number="$2" timeout_seconds="$3"
   local target mission prompt status=0
@@ -144,10 +199,8 @@ run_agent() {
     mission="Implement the full closure-critical acceptance contract for this issue with code and focused tests. Do not stop at planning or optional polish."
   fi
   prompt="You are OpenCode NVIDIA Factory ${WORKER} for JoshCLWren/comic-pile. Durable worker ID: ${WORKER_ID}. Model: ${MODEL}. Assigned target: ${target}. Read AGENTS.md, docs/ISSUE_EXECUTION_PROTOCOL.md, docs/AUTONOMOUS_FACTORY_POLICY.md, docs/CHATGPT_FACTORY_PROMPT.md, and docs/FACTORY_GITHUB_VISIBILITY.md first. Josh directly requires product-first V22 behavior: user-reported product bugs outrank unrelated CI/E2E/test plumbing, and a run is a work session rather than a one-ticket punch. ${mission} Work only on the assigned target during this agent invocation. Edit the checked-out branch, run focused validation, and use gh/GitHub when needed for review context. Do not commit or push; the wrapper persists changes. Do not enable auto-merge, push main, touch production databases, or alter automation schedules."
-  set +e
   timeout --signal=TERM --kill-after=30s "${timeout_seconds}s" opencode run -m "$MODEL" --agent build --auto --dir "$GITHUB_WORKSPACE" --title "ComicPile NVIDIA Factory ${WORKER}" "$prompt" | tee "/tmp/opencode-factory-${WORKER}.log"
   status=${PIPESTATUS[0]}
-  set -e
   return "$status"
 }
 
@@ -240,16 +293,64 @@ while (( $(remaining) > 480 )); do
   (( agent_timeout > 1500 )) && agent_timeout=1500
   (( agent_timeout < 300 )) && break
 
-  set +e
-  run_agent "$MODE" "$NUMBER" "$agent_timeout"
-  agent_status=$?
-  set -e
-  log "agent exit status ${agent_status} for ${MODE} #${NUMBER}"
+  agent_attempt=1
+  agent_status=0
+  transient_failure=0
+  while :; do
+    set +e
+    run_agent "$MODE" "$NUMBER" "$agent_timeout"
+    agent_status=$?
+    set -e
+    log "agent exit status ${agent_status} for ${MODE} #${NUMBER} on ${MODEL}"
+
+    if (( agent_status == 0 )); then
+      transient_failure=0
+      break
+    fi
+    if ! is_transient_agent_failure "$agent_status"; then
+      transient_failure=0
+      break
+    fi
+
+    transient_failure=1
+    log "transient NVIDIA/OpenCode interruption on ${MODEL}; preserving this target instead of failing the heartbeat"
+
+    # A timeout after useful edits is productive partial work. Let the normal
+    # persistence path checkpoint it rather than throwing the work away or
+    # handing a half-edited tree to another model.
+    if [[ -n "$(git status --porcelain)" ]]; then
+      log 'transient interruption left edits in the worktree; checkpointing them before selecting more work'
+      break
+    fi
+
+    (( agent_attempt < MAX_AGENT_ATTEMPTS )) || break
+    (( $(remaining) > 600 )) || break
+
+    COOLED_MODELS+=("$MODEL")
+    sleep_for="$TRANSIENT_BACKOFF_SECONDS"
+    max_sleep=$(( $(remaining) - 540 ))
+    (( sleep_for > max_sleep )) && sleep_for="$max_sleep"
+    (( sleep_for > 0 )) && sleep "$sleep_for"
+
+    if ! rotate_model; then
+      log 'no alternate NVIDIA model became healthy during this recovery window'
+      break
+    fi
+
+    agent_attempt=$((agent_attempt + 1))
+    available="$(remaining)"
+    agent_timeout=$((available - 240))
+    (( agent_timeout > 1500 )) && agent_timeout=1500
+    (( agent_timeout >= 300 )) || break
+  done
 
   if [[ "$MODE" == 'issue' ]]; then
     if pr="$(persist_issue_pr "$NUMBER" "$BRANCH")"; then
       log "opened/updated PR #${pr} for issue #${NUMBER}"
       SKIP_PRS+=("$pr")
+    elif (( transient_failure == 1 )); then
+      log "issue #${NUMBER} produced no changes because of a transient provider/runtime interruption; releasing without marking the issue blocked"
+      replace_labels "$NUMBER" 'factory:unowned' 'factory:building'
     else
       log "issue #${NUMBER} produced no changes; releasing as blocked/unowned"
       replace_labels "$NUMBER" 'factory:unowned' 'factory:blocked'
@@ -275,7 +376,11 @@ while (( $(remaining) > 480 )); do
     continue
   fi
 
-  log "PR #${NUMBER} is not merge-eligible now; releasing this cycle and selecting other work"
+  if (( transient_failure == 1 )); then
+    log "PR #${NUMBER} was interrupted transiently with no persisted edits; preserving ownership state and selecting other work"
+  else
+    log "PR #${NUMBER} is not merge-eligible now; releasing this cycle and selecting other work"
+  fi
   SKIP_PRS+=("$NUMBER")
 done
 

--- a/.github/scripts/nvidia-factory-worker.sh
+++ b/.github/scripts/nvidia-factory-worker.sh
@@ -5,12 +5,12 @@ WORKER="${1:?worker number required}"
 MODEL="${2:?model required}"
 OWNER="factory:${WORKER}"
 WORKER_ID="opencode-nvidia-factory-${WORKER}"
-BUDGET_SECONDS="${FACTORY_BUDGET_SECONDS:-3000}"
+BUDGET_SECONDS="${FACTORY_BUDGET_SECONDS:-6000}"
 MAX_AGENT_ATTEMPTS="${NVIDIA_AGENT_MAX_ATTEMPTS:-2}"
 TRANSIENT_BACKOFF_SECONDS="${NVIDIA_TRANSIENT_BACKOFF_SECONDS:-20}"
 STARTED="$(date +%s)"
 DEADLINE=$((STARTED + BUDGET_SECONDS))
-OWNER_RE='^factory:(unowned|local|([1-9]|10))$'
+OWNER_RE='^factory:(unowned|local|([1-9]|1[0-5]))$'
 STAGE_RE='^factory:(building|review|changes-requested|ci|ready|blocked)$'
 SKIP_PRS=()
 COOLED_MODELS=()
@@ -40,7 +40,7 @@ replace_labels() {
 
 ensure_fleet_labels() {
   local worker label
-  for worker in 6 7 8 9 10; do
+  for worker in {6..15}; do
     label="factory:${worker}"
     if ! gh api "repos/${GITHUB_REPOSITORY}/labels/factory%3A${worker}" >/dev/null 2>&1; then
       gh api --method POST "repos/${GITHUB_REPOSITORY}/labels" \
@@ -92,14 +92,9 @@ claim_unowned_pr() {
 
   replace_labels "$number" "$OWNER" 'factory:review'
 
-  # Verify we still own it after the write. Staggering makes races unlikely, but
-  # this prevents two workers from proceeding if another worker won a late race.
   labels="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${number}/labels?per_page=100" --jq '[.[].name]')"
   jq -e --arg owner "$OWNER" 'index($owner) != null' >/dev/null <<< "$labels" || return 1
 
-  # Branch identity cannot encode the adopting worker for an existing PR. Leave a
-  # durable marker so the post-review reconciler can restore ownership if another
-  # workflow rewrites factory labels.
   gh issue comment "$number" --body "<!-- nvidia-factory-owner:${WORKER} -->\nFactory ${WORKER} adopted this previously unowned PR for the next actionable step." >/dev/null
   return 0
 }
@@ -153,6 +148,7 @@ probe_nvidia_model() {
   request="$(jq -nc --arg model "$provider_model" '{model:$model,messages:[{role:"user",content:"Reply with exactly: FCM_NVIDIA_MODEL_OK"}],max_tokens:32}')"
   response="$(mktemp)"
   http_code="$(curl --silent --show-error --output "$response" --write-out '%{http_code}' \
+    --connect-timeout 5 --max-time 20 \
     --header "Authorization: Bearer $NVIDIA_API_KEY" \
     --header 'Content-Type: application/json' \
     --data "$request" https://integrate.api.nvidia.com/v1/chat/completions || true)"
@@ -199,7 +195,7 @@ run_agent() {
     mission="Implement the full closure-critical acceptance contract for this issue with code and focused tests. Do not stop at planning or optional polish."
   fi
   prompt="You are OpenCode NVIDIA Factory ${WORKER} for JoshCLWren/comic-pile. Durable worker ID: ${WORKER_ID}. Model: ${MODEL}. Assigned target: ${target}. Read AGENTS.md, docs/ISSUE_EXECUTION_PROTOCOL.md, docs/AUTONOMOUS_FACTORY_POLICY.md, docs/CHATGPT_FACTORY_PROMPT.md, and docs/FACTORY_GITHUB_VISIBILITY.md first. Josh directly requires product-first V22 behavior: user-reported product bugs outrank unrelated CI/E2E/test plumbing, and a run is a work session rather than a one-ticket punch. ${mission} Work only on the assigned target during this agent invocation. Edit the checked-out branch, run focused validation, and use gh/GitHub when needed for review context. Do not commit or push; the wrapper persists changes. Do not enable auto-merge, push main, touch production databases, or alter automation schedules."
-  timeout --signal=TERM --kill-after=30s "${timeout_seconds}s" opencode run -m "$MODEL" --agent build --auto --dir "$GITHUB_WORKSPACE" --title "ComicPile NVIDIA Factory ${WORKER}" "$prompt" | tee "/tmp/opencode-factory-${WORKER}.log"
+  timeout --signal=TERM --kill-after=30s "${timeout_seconds}s" opencode run -m "$MODEL" --agent build --auto --dir "$GITHUB_WORKSPACE" --title "ComicPile NVIDIA Factory ${WORKER}" "$prompt" 2>&1 | tee "/tmp/opencode-factory-${WORKER}.log"
   status=${PIPESTATUS[0]}
   return "$status"
 }
@@ -230,8 +226,8 @@ persist_pr_changes() {
   return 0
 }
 
-# Bootstrap all five durable owner labels immediately. Visibility should not wait
-# for four separate future schedule slots to happen to execute successfully.
+# Bootstrap all ten durable owner labels immediately. Visibility should not wait
+# for future schedule slots to happen to execute successfully.
 ensure_fleet_labels
 log "starting with model ${MODEL}; budget ${BUDGET_SECONDS}s"
 
@@ -249,9 +245,6 @@ while (( $(remaining) > 480 )); do
     break
   done < <(choose_existing_pr)
 
-  # Existing unowned PRs are executable work too. Adopt them before opening fresh
-  # issue branches so the fleet drains stranded review/CI work instead of piling
-  # new PRs on top of it.
   if [[ -z "$NUMBER" ]]; then
     while IFS= read -r candidate; do
       [[ -n "$candidate" ]] || continue
@@ -290,7 +283,7 @@ while (( $(remaining) > 480 )); do
   before="$(git rev-parse HEAD)"
   available="$(remaining)"
   agent_timeout=$((available - 240))
-  (( agent_timeout > 1500 )) && agent_timeout=1500
+  (( agent_timeout > 3000 )) && agent_timeout=3000
   (( agent_timeout < 300 )) && break
 
   agent_attempt=1
@@ -315,9 +308,6 @@ while (( $(remaining) > 480 )); do
     transient_failure=1
     log "transient NVIDIA/OpenCode interruption on ${MODEL}; preserving this target instead of failing the heartbeat"
 
-    # A timeout after useful edits is productive partial work. Let the normal
-    # persistence path checkpoint it rather than throwing the work away or
-    # handing a half-edited tree to another model.
     if [[ -n "$(git status --porcelain)" ]]; then
       log 'transient interruption left edits in the worktree; checkpointing them before selecting more work'
       break
@@ -340,7 +330,7 @@ while (( $(remaining) > 480 )); do
     agent_attempt=$((agent_attempt + 1))
     available="$(remaining)"
     agent_timeout=$((available - 240))
-    (( agent_timeout > 1500 )) && agent_timeout=1500
+    (( agent_timeout > 3000 )) && agent_timeout=3000
     (( agent_timeout >= 300 )) || break
   done
 

--- a/.github/workflows/factory-heartbeat-watchdog.yml
+++ b/.github/workflows/factory-heartbeat-watchdog.yml
@@ -34,11 +34,16 @@ jobs:
               ["chatgpt-factory-3", { name: "Starman", slot: ":04" }],
               ["chatgpt-factory-4", { name: "Mister Miracle", slot: ":16" }],
               ["chatgpt-factory-5", { name: "Death's Head", slot: ":28" }],
-              ["opencode-nvidia-factory-6", { name: "NVIDIA 6", slot: ":07", staleMinutes: 90, runningMinutes: 65 }],
-              ["opencode-nvidia-factory-7", { name: "NVIDIA 7", slot: ":19", staleMinutes: 90, runningMinutes: 65 }],
-              ["opencode-nvidia-factory-8", { name: "NVIDIA 8", slot: ":31", staleMinutes: 90, runningMinutes: 65 }],
-              ["opencode-nvidia-factory-9", { name: "NVIDIA 9", slot: ":43", staleMinutes: 90, runningMinutes: 65 }],
-              ["opencode-nvidia-factory-10", { name: "NVIDIA 10", slot: ":55", staleMinutes: 90, runningMinutes: 65 }],
+              ["opencode-nvidia-factory-6", { name: "NVIDIA 6", slot: ":07", staleMinutes: 150, runningMinutes: 125 }],
+              ["opencode-nvidia-factory-7", { name: "NVIDIA 7", slot: ":19", staleMinutes: 150, runningMinutes: 125 }],
+              ["opencode-nvidia-factory-8", { name: "NVIDIA 8", slot: ":31", staleMinutes: 150, runningMinutes: 125 }],
+              ["opencode-nvidia-factory-9", { name: "NVIDIA 9", slot: ":43", staleMinutes: 150, runningMinutes: 125 }],
+              ["opencode-nvidia-factory-10", { name: "NVIDIA 10", slot: ":55", staleMinutes: 150, runningMinutes: 125 }],
+              ["opencode-nvidia-factory-11", { name: "NVIDIA 11", slot: ":01", staleMinutes: 150, runningMinutes: 125 }],
+              ["opencode-nvidia-factory-12", { name: "NVIDIA 12", slot: ":13", staleMinutes: 150, runningMinutes: 125 }],
+              ["opencode-nvidia-factory-13", { name: "NVIDIA 13", slot: ":25", staleMinutes: 150, runningMinutes: 125 }],
+              ["opencode-nvidia-factory-14", { name: "NVIDIA 14", slot: ":37", staleMinutes: 150, runningMinutes: 125 }],
+              ["opencode-nvidia-factory-15", { name: "NVIDIA 15", slot: ":49", staleMinutes: 150, runningMinutes: 125 }],
             ]);
             const marker = "<!-- factory-heartbeat-alert:v1 -->";
             const now = new Date();
@@ -105,7 +110,7 @@ jobs:
               "",
               stale.length
                 ? "The external watchdog detected missing or stuck factory heartbeats."
-                : "All ten scheduled factories are reporting normally.",
+                : "All fifteen scheduled factories are reporting normally.",
               "",
               "| Worker | Call sign | Slot (America/Chicago) | Age | Status |",
               "|---|---|---:|---:|---|",
@@ -115,7 +120,7 @@ jobs:
               `Checked: ${now.toISOString()}`,
               "",
               stale.length
-                ? "Check ChatGPT Scheduled for factories 1-5 and GitHub Actions for NVIDIA factories 6-10. Do not assign this alert to a factory."
+                ? "Check ChatGPT Scheduled for factories 1-5 and GitHub Actions for NVIDIA factories 6-15. Do not assign this alert to a factory."
                 : "This alert closed automatically after every worker recovered.",
             ].join("\n");
 
@@ -165,11 +170,11 @@ jobs:
               });
               await core.summary
                 .addHeading("Factory heartbeat recovery")
-                .addRaw("All ten factories are reporting normally.")
+                .addRaw("All fifteen factories are reporting normally.")
                 .write();
             } else {
               await core.summary
                 .addHeading("Factory heartbeats healthy")
-                .addRaw("All ten factories are reporting normally.")
+                .addRaw("All fifteen factories are reporting normally.")
                 .write();
             }

--- a/.github/workflows/nvidia-factory-6.yml
+++ b/.github/workflows/nvidia-factory-6.yml
@@ -1,4 +1,4 @@
-name: NVIDIA Factory Fleet 6-10
+name: NVIDIA Factory Fleet 6-15
 
 on:
   push:
@@ -9,10 +9,15 @@ on:
       - '.github/workflows/nvidia-factory-owner-reconcile.yml'
       - '.github/workflows/factory-heartbeat-watchdog.yml'
   schedule:
+    - cron: "1 * * * *"
     - cron: "7 * * * *"
+    - cron: "13 * * * *"
     - cron: "19 * * * *"
+    - cron: "25 * * * *"
     - cron: "31 * * * *"
+    - cron: "37 * * * *"
     - cron: "43 * * * *"
+    - cron: "49 * * * *"
     - cron: "55 * * * *"
   workflow_dispatch:
     inputs:
@@ -21,7 +26,7 @@ on:
         required: true
         default: "6"
         type: choice
-        options: ["6", "7", "8", "9", "10"]
+        options: ["6", "7", "8", "9", "10", "11", "12", "13", "14", "15"]
 
 concurrency:
   group: nvidia-factory-${{ github.event.schedule || inputs.worker || github.run_id }}
@@ -45,7 +50,7 @@ jobs:
         shell: bash
         run: |
           set -Eeuo pipefail
-          for worker in 6 7 8 9 10; do
+          for worker in {6..15}; do
             if ! gh api "repos/${GITHUB_REPOSITORY}/labels/factory%3A${worker}" >/dev/null 2>&1; then
               gh api --method POST "repos/${GITHUB_REPOSITORY}/labels" \
                 -f name="factory:${worker}" \
@@ -55,16 +60,16 @@ jobs:
             fi
             gh api "repos/${GITHUB_REPOSITORY}/labels/factory%3A${worker}" --jq '.name'
           done
-          echo 'NVIDIA fleet ownership labels 6-10 are visible.'
+          echo 'NVIDIA fleet ownership labels 6-15 are visible.'
 
   factory:
     if: github.event_name != 'push'
     runs-on: ubuntu-latest
-    timeout-minutes: 58
+    timeout-minutes: 116
     env:
       GH_TOKEN: ${{ github.token }}
       NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
-      FACTORY_BUDGET_SECONDS: "3000"
+      FACTORY_BUDGET_SECONDS: "6000"
     steps:
       - name: Resolve durable worker
         id: worker
@@ -83,6 +88,11 @@ jobs:
               "31 * * * *") worker=8 ;;
               "43 * * * *") worker=9 ;;
               "55 * * * *") worker=10 ;;
+              "1 * * * *") worker=11 ;;
+              "13 * * * *") worker=12 ;;
+              "25 * * * *") worker=13 ;;
+              "37 * * * *") worker=14 ;;
+              "49 * * * *") worker=15 ;;
               *) echo "Unknown schedule: $SCHEDULE" >&2; exit 1 ;;
             esac
           fi
@@ -93,7 +103,7 @@ jobs:
         shell: bash
         run: |
           set -Eeuo pipefail
-          for worker in 6 7 8 9 10; do
+          for worker in {6..15}; do
             if ! gh api "repos/${GITHUB_REPOSITORY}/labels/factory%3A${worker}" >/dev/null 2>&1; then
               gh api --method POST "repos/${GITHUB_REPOSITORY}/labels" \
                 -f name="factory:${worker}" \
@@ -165,7 +175,7 @@ jobs:
             echo "Factory ${WORKER} probing ${candidate}"
             provider_model="${candidate#nvidia/}"
             request="$(jq -nc --arg model "$provider_model" '{model:$model,messages:[{role:"user",content:"Reply with exactly: FCM_NVIDIA_MODEL_OK"}],max_tokens:32}')"
-            response="$(curl --silent --show-error --fail-with-body --header "Authorization: Bearer $NVIDIA_API_KEY" --header 'Content-Type: application/json' --data "$request" https://integrate.api.nvidia.com/v1/chat/completions || true)"
+            response="$(curl --silent --show-error --fail-with-body --connect-timeout 5 --max-time 20 --header "Authorization: Bearer $NVIDIA_API_KEY" --header 'Content-Type: application/json' --data "$request" https://integrate.api.nvidia.com/v1/chat/completions || true)"
             if jq -e '.choices[0].message.content | strings | contains("FCM_NVIDIA_MODEL_OK")' >/dev/null 2>&1 <<< "$response"; then
               selected_model="$candidate"
               break

--- a/.github/workflows/nvidia-factory-owner-reconcile.yml
+++ b/.github/workflows/nvidia-factory-owner-reconcile.yml
@@ -25,21 +25,21 @@ jobs:
           [[ -n "$pr" ]] || exit 0
           branch="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr}" --jq .head.ref)"
           worker=""
-          if [[ "$branch" =~ ^factory/([6-9]|10)- ]]; then
+          if [[ "$branch" =~ ^factory/([6-9]|1[0-5])- ]]; then
             worker="${BASH_REMATCH[1]}"
           else
             # Existing unowned PRs keep their original branch name when adopted.
             # The worker writes a durable marker comment so reconciliation can
             # restore ownership after the independent reviewer rewrites labels.
             worker="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments?per_page=100" \
-              --jq '[.[] | .body | capture("<!-- nvidia-factory-owner:(?<worker>([6-9]|10)) -->")?.worker] | map(select(. != null)) | last // empty' 2>/dev/null || true)"
+              --jq '[.[] | .body | capture("<!-- nvidia-factory-owner:(?<worker>([6-9]|1[0-5])) -->")?.worker] | map(select(. != null)) | last // empty' 2>/dev/null || true)"
           fi
-          [[ "$worker" =~ ^([6-9]|10)$ ]] || exit 0
+          [[ "$worker" =~ ^([6-9]|1[0-5])$ ]] || exit 0
 
           labels="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr}/labels?per_page=100" --jq '[.[].name]')"
           stage="$(jq -r '[.[] | select(test("^factory:(building|review|changes-requested|ci|ready|blocked)$"))] | first // "factory:review"' <<< "$labels")"
           target="$(jq -c --arg owner "factory:${worker}" --arg stage "$stage" '
-            map(select((test("^factory:(building|review|changes-requested|ci|ready|blocked)$")|not) and (test("^factory:(unowned|local|([1-9]|10))$")|not) and . != "factory"))
+            map(select((test("^factory:(building|review|changes-requested|ci|ready|blocked)$")|not) and (test("^factory:(unowned|local|([1-9]|1[0-5]))$")|not) and . != "factory"))
             + ["factory", $owner, $stage] | unique' <<< "$labels")"
           gh api --method PUT "repos/${GITHUB_REPOSITORY}/issues/${pr}/labels" --input - <<< "{\"labels\":${target}}" >/dev/null
           echo "Restored factory:${worker} on PR #${pr} with ${stage}"


### PR DESCRIPTION
## Summary
- stop OpenCode timeout exit 124 from leaking through `errexit` and killing the whole factory job
- classify 429s, provider overload/5xx/network resets, and agent timeouts as transient interruptions
- cool down the affected model, probe another healthy NVIDIA model, and retry the same target once when the worktree is still clean and budget remains
- checkpoint useful partial edits after a timeout instead of throwing the session away
- release transiently interrupted issues as unowned/in-progress rather than falsely marking the product issue blocked

## Why
The 6–10 fleet is successfully reaching NVIDIA, but individual runs have been turning red for conditions the worker should absorb. Factory 9 hit a 429 after model selection, while Factory 7 worked for roughly 25 minutes and then the wrapper itself exited 124 because `run_agent` re-enabled `errexit` before returning the timeout status. These should be scheduling/recovery signals, not fatal fleet verdicts.

## Recovery policy
A transient failure now gets bounded accommodation rather than an infinite retry loop: preserve useful edits first, otherwise cool the current model for the rest of the run, wait briefly, rotate to another probed NVIDIA model, and retry only while enough session budget remains. Genuine semantic failures still follow the existing blocked/review paths.

This intentionally adapts the resilience philosophy from the old `fix/factory-transient-failure-rotation` experiment to the current GitHub-hosted NVIDIA fleet without reviving that stale branch wholesale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from temporary NVIDIA and OpenCode interruptions.
  * Added automatic model health checks and fallback rotation when a model is unavailable.
  * Added cooldowns, backoff, and bounded retries to reduce repeated failures.
  * Preserved partial edits after interrupted work.
  * Improved handling of interrupted tasks and pull request outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->