### PR TITLE
Remove the Roll screen’s successful-readiness card

### DIFF
--- a/frontend/src/pages/RollPage/components/ContinuityReadinessSummary.tsx
+++ b/frontend/src/pages/RollPage/components/ContinuityReadinessSummary.tsx
@@ -62,24 +62,7 @@ export function ContinuityReadinessSummary({ issueId }: ContinuityReadinessSumma
     )
   }
 
-  if (readiness.is_readable) {
-    return (
-      <section
-        aria-labelledby="readiness-heading"
-        className="rounded-2xl border border-emerald-700/30 bg-emerald-950/20 p-3"
-      >
-        <div className="flex items-center gap-2">
-          <span aria-hidden="true" className="text-emerald-400">✓</span>
-          <h3 id="readiness-heading" className="text-xs font-black text-emerald-300">
-            Ready to read
-          </h3>
-        </div>
-        <p className="mt-1 text-[11px] leading-relaxed text-stone-400">
-          All known direct continuity prerequisites for this exact issue are satisfied.
-        </p>
-      </section>
-    )
-  }
+  if (readiness.is_readable) return null
 
   return (
     <section

--- a/frontend/src/unit/ContinuityReadinessSummary.test.tsx
+++ b/frontend/src/unit/ContinuityReadinessSummary.test.tsx
@@ -40,13 +40,13 @@ describe('ContinuityReadinessSummary', () => {
     expect(refetch).toHaveBeenCalledOnce()
   })
 
-  it('renders readable, blocked, and unexplained blocked states', () => {
+  it('hides successful readiness while preserving blocked states', () => {
     mocks.useContinuityReadiness.mockReturnValue({
       readiness: { node_type: 'issue', node_id: 7, is_readable: true, evaluated_issue_id: 7, blockers: [] },
       isLoading: false, error: null, refetch,
     })
     const { rerender } = render(<ContinuityReadinessSummary issueId={7} />)
-    expect(screen.getByRole('heading', { name: 'Ready to read' })).toBeVisible()
+    expect(screen.queryByRole('heading', { name: 'Ready to read' })).not.toBeInTheDocument()
 
     mocks.useContinuityReadiness.mockReturnValue({
       readiness: {


### PR DESCRIPTION
Closes #1137.

## Summary
- hide the positive continuity-readiness card when the selected issue is readable
- keep missing identity, loading, verification failure, and continuity-blocker warnings intact
- update focused unit coverage for the quieter success state

## Validation
- focused regression coverage updated in `ContinuityReadinessSummary.test.tsx`
- connector-backed branch has no local checkout; exact-head CI is the executable validation boundary