### PR TITLE
Fix external factory owner visibility

### DIFF
--- a/.github/scripts/factory-visibility.cjs
+++ b/.github/scripts/factory-visibility.cjs
@@ -1,10 +1,11 @@
+const WORKER_OWNER_LABELS = Array.from({ length: 16 }, (_, index) => `factory:${index + 1}`);
+
 const DEFINITIONS = {
   factory: ['5319E7', 'Work owned or produced by an autonomous ComicPile factory'],
-  'factory:1': ['0366D6', 'Current next-action owner is ComicPile Factory 1'],
-  'factory:2': ['0366D6', 'Current next-action owner is ComicPile Factory 2'],
-  'factory:3': ['0366D6', 'Current next-action owner is ComicPile Factory 3'],
-  'factory:4': ['0366D6', 'Current next-action owner is ComicPile Factory 4'],
-  'factory:5': ['0366D6', 'Current next-action owner is ComicPile Factory 5'],
+  ...Object.fromEntries(WORKER_OWNER_LABELS.map((name, index) => [
+    name,
+    ['0366D6', `Current next-action owner is ComicPile Factory ${index + 1}`],
+  ])),
   'factory:local': ['0366D6', 'Current next-action owner is the local OpenCode factory'],
   'factory:unowned': ['BFDADC', 'Factory work has no current next-action owner'],
   'factory:building': ['FBCA04', 'A factory is actively implementing or repairing this work'],
@@ -16,11 +17,7 @@ const DEFINITIONS = {
 };
 
 const OWNER_LABELS = [
-  'factory:1',
-  'factory:2',
-  'factory:3',
-  'factory:4',
-  'factory:5',
+  ...WORKER_OWNER_LABELS,
   'factory:local',
   'factory:unowned',
 ];
@@ -221,8 +218,16 @@ async function reconcile({ github, context }) {
     );
     if (!isFactory) return;
 
+    const current = await currentLabels(github, context, pullRequest.number);
+    const externalOwner = WORKER_OWNER_LABELS
+      .slice(5)
+      .find(label => current.has(label));
+
     await reconcileLabels(github, context, pullRequest.number, {
-      owner: await ownerFromLinkedIssue(github, context, pullRequest),
+      // External workers write their durable PR owner before review workflows
+      // refresh visibility. Preserve that stronger PR-local signal even when the
+      // linked issue has since been released for other work.
+      owner: externalOwner || await ownerFromLinkedIssue(github, context, pullRequest),
       stage: 'factory:review',
     });
     return;

--- a/.github/scripts/factory-visibility.test.cjs
+++ b/.github/scripts/factory-visibility.test.cjs
@@ -139,3 +139,52 @@ test('PR synchronize events refresh owner and stage from the linked issue', asyn
   assert.ok(!calls[0].labels.includes('factory:5'));
   assert.ok(!calls[0].labels.includes('factory:building'));
 });
+
+
+test('PR refresh preserves one external owner after the linked issue is released', async () => {
+  const calls = [];
+  const github = githubFor({
+    labels: [
+      'bug',
+      'factory',
+      'factory:13',
+      'factory:unowned',
+      'factory:review',
+    ],
+    comments: [{
+      author_association: 'OWNER',
+      body: '<!-- comic-pile-factory-claim-released-v3:issue-1149:chatgpt-factory-2:123 -->',
+      created_at: '2026-08-13T06:00:00Z',
+      user: { login: 'JoshCLWren' },
+    }],
+    setLabels: async input => calls.push(input),
+  });
+
+  await reconcile({
+    github,
+    context: contextFor('pull_request_target', {
+      action: 'synchronize',
+      repository: { full_name: 'JoshCLWren/comic-pile' },
+      pull_request: {
+        body: 'Closes #1149',
+        head: {
+          ref: 'factory/1149-omniroute',
+          repo: { full_name: 'JoshCLWren/comic-pile' },
+        },
+        labels: [
+          { name: 'factory' },
+          { name: 'factory:13' },
+          { name: 'factory:unowned' },
+        ],
+        number: 1155,
+      },
+    }),
+  });
+
+  assert.equal(calls.length, 1);
+  const owners = calls[0].labels.filter(label => (
+    /^factory:(?:unowned|local|[1-9]|1[0-6])$/.test(label)
+  ));
+  assert.deepEqual(owners, ['factory:13']);
+  assert.ok(calls[0].labels.includes('factory:review'));
+});


### PR DESCRIPTION
Closes #1157.

Factory visibility now recognizes every configured worker owner through Factory 16 and preserves an existing external PR owner during refresh events. This prevents contradictory `factory:unowned` plus external-owner states from making actively owned PRs selectable by another worker.

Tests: `node --test .github/scripts/factory-visibility.test.cjs` (6 passed).