### PR TITLE
Fix migration dialog clicks from queue edit modal

### DIFF
--- a/frontend/src/components/MigrationDialog.tsx
+++ b/frontend/src/components/MigrationDialog.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import type { Thread } from '../types'
 import axios from 'axios'
 import { migrationApi } from '../services/api'
+import OverlayPortal from './OverlayPortal'
 import './MigrationDialog.css'
 
 interface MigrationDialogProps {
@@ -151,8 +152,9 @@ export default function MigrationDialog({ thread, onComplete, onSkip, onClose }:
   }
 
   return (
-    <div
-      className="migration-dialog__overlay"
+    <OverlayPortal layer="dialog">
+      <div
+        className="migration-dialog__overlay"
       onClick={handleBackdropClick}
       role="dialog"
       aria-modal="true"
@@ -281,7 +283,8 @@ export default function MigrationDialog({ thread, onComplete, onSkip, onClose }:
             </div>
           </div>
         )}
+        </div>
       </div>
-    </div>
+    </OverlayPortal>
   )
 }


### PR DESCRIPTION
## Summary
- render `MigrationDialog` through the shared dialog overlay portal
- keep the migration dialog above the queue edit modal that launched it
- restore clickable **Start Tracking** and validation controls in that flow

## Evidence
Chromium E2E run 31532277131, shard 4/6, repeatedly reported the underlying edit-modal overlay intercepting pointer events for both migration-from-edit-modal scenarios.

## Validation
The existing `frontend/src/test/migration.spec.ts` scenarios cover successful submission and empty-input validation from the edit modal. CI should rerun them against this branch.

Closes #1161