### PR TITLE
Fix Chromium snooze auth-recovery route

### DIFF
--- a/frontend/src/test/roll-auth-recovery.spec.ts
+++ b/frontend/src/test/roll-auth-recovery.spec.ts
@@ -16,7 +16,7 @@ async function openPendingThread(page: import('@playwright/test').Page): Promise
 
 async function injectExpiredMutationOnce(
   page: import('@playwright/test').Page,
-  endpoint: '/api/v1/rate/' | '/api/snooze/',
+  endpoint: '/api/v1/rate/' | '/api/v1/snooze/',
 ): Promise<() => { attempts: number; committedAttempts: number }> {
   let attempts = 0;
   let committedAttempts = 0;
@@ -65,7 +65,7 @@ test.describe('Roll mutation authentication recovery', () => {
     authenticatedWithThreadsPage,
   }) => {
     await openPendingThread(authenticatedWithThreadsPage);
-    const getCounts = await injectExpiredMutationOnce(authenticatedWithThreadsPage, '/api/snooze/');
+    const getCounts = await injectExpiredMutationOnce(authenticatedWithThreadsPage, '/api/v1/snooze/');
 
     await authenticatedWithThreadsPage.click(SELECTORS.rate.snoozeButton);
 


### PR DESCRIPTION
## Summary
- intercept the current versioned snooze mutation route in Chromium auth-recovery coverage
- preserve the exact retry assertion: two attempts and one committed mutation
- classify the old discovery failure as stale test infrastructure rather than a product regression

## Evidence
Discovery run 31532277131, shard 5 job 93915417340, observed zero snooze interceptions on the initial run and both retries because the spec watched `/api/snooze/` while the product posts to `/api/v1/snooze/`.

## Validation
This connector runtime has no usable local checkout, so exact-head CI is the executable validation boundary. No skips, forced actions, or weakened assertions were added.

Closes #1166