### PR TITLE
Authenticate Chromium mobile containment coverage

### DIFF
--- a/frontend/src/test/mobile-form-containment.spec.ts
+++ b/frontend/src/test/mobile-form-containment.spec.ts
@@ -1,9 +1,9 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from './fixtures'
 
 const MOBILE_WIDTHS = [320, 375, 414] as const
 
 for (const width of MOBILE_WIDTHS) {
-  test(`mobile form controls remain contained at ${width}px`, async ({ page }) => {
+  test(`mobile form controls remain contained at ${width}px`, async ({ authenticatedPage: page }) => {
     await page.setViewportSize({ width, height: 812 })
     await page.goto('/queue')
     await expect(page.getByRole('heading', { name: 'Read Queue' })).toBeVisible()


### PR DESCRIPTION
## Summary
- run mobile form containment coverage with ComicPile's authenticated browser fixture
- preserve all three viewport widths and existing containment/font-size assertions
- classify the old missing Queue heading as test setup rather than a product layout failure

## Evidence
Discovery run 31532277131, shard 4 job 93915417284, failed at 320px, 375px, and 414px on the initial run and both retries because the base Playwright page opened the protected Queue without authentication.

## Validation
This connector runtime has no usable local checkout, so exact-head CI is the executable validation boundary. No assertions, widths, retries, or browser-health checks were weakened.

Closes #1168