### PR TITLE
Make Chromium session expiry deterministic

### DIFF
--- a/app/api/test_helpers.py
+++ b/app/api/test_helpers.py
@@ -1,7 +1,7 @@
 """Test API endpoints for E2E testing."""
 
 import os
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -42,8 +42,6 @@ async def expire_current_session(
             detail="This endpoint is only available in test environment",
         )
 
-    cutoff_time = datetime.now(UTC) - timedelta(hours=24)
-
     session_result = await db.execute(
         select(SessionModel)
         .where(SessionModel.user_id == current_user.id)
@@ -57,7 +55,7 @@ async def expire_current_session(
             detail="No active session found",
         )
 
-    session.started_at = cutoff_time
+    session.ended_at = datetime.now(UTC)
     await db.commit()
 
     return {"status": "success", "message": "Session expired"}

--- a/tests/test_test_helpers.py
+++ b/tests/test_test_helpers.py
@@ -1,0 +1,31 @@
+"""Regression tests for test-only browser helpers."""
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.test_helpers import expire_current_session
+
+
+@pytest.mark.asyncio
+async def test_expire_current_session_ends_active_session() -> None:
+    """The helper must expire sessions even when recent reading activity exists."""
+    session = SimpleNamespace(
+        started_at=datetime.now(UTC),
+        ended_at=None,
+        pending_thread_id=17,
+        pending_issue_id=42,
+    )
+    result = Mock()
+    result.scalar_one_or_none.return_value = session
+    db = AsyncMock(spec=AsyncSession)
+    db.execute.return_value = result
+
+    response = await expire_current_session(SimpleNamespace(id=1), db)
+
+    assert response == {"status": "success", "message": "Session expired"}
+    assert session.ended_at is not None
+    db.commit.assert_awaited_once()


### PR DESCRIPTION
Closes #1170.

The test-only session-expiry endpoint now explicitly ends the active session instead of only backdating its start time. This remains reliable after recent roll events or pending reading context became part of current-session resolution.

Adds focused backend regression coverage.

Local checks:
- `uv run ruff check app/api/test_helpers.py tests/test_test_helpers.py`
- `uv run ty check --error-on-warning`
- `uv run pytest tests/test_test_helpers.py --no-cov -q`
- `git diff --check`