### PR TITLE
Fix Roll card title hierarchy

### DIFF
--- a/frontend/src/pages/RollPage/components/ThreadPool.tsx
+++ b/frontend/src/pages/RollPage/components/ThreadPool.tsx
@@ -147,8 +147,8 @@ export function ThreadPool({
                   {index + 1}
                 </span>
                 <div className="flex-1 min-w-0">
-                  <p className="truncate text-xs text-stone-400">{thread.title}</p>
-                  <p className="font-bold text-stone-200 truncate text-sm">
+                  <p className="font-bold text-stone-200 truncate text-sm">{thread.title}</p>
+                  <p className="truncate text-xs text-stone-400">
                     {thread.issue_number ? `Issue ${thread.issue_number}` : 'Next unread issue'}
                   </p>
                   <p className="text-[10px] font-black text-stone-500 uppercase tracking-widest mt-0.5">{thread.format}</p>

--- a/frontend/src/unit/ThreadPoolEligibleMappings.test.tsx
+++ b/frontend/src/unit/ThreadPoolEligibleMappings.test.tsx
@@ -57,6 +57,9 @@ describe('ThreadPool eligible mappings', () => {
     const issueText = dieFace.querySelector('p:nth-of-type(2)')
     expect(titleText?.textContent).toBe('Amazing Adventures')
     expect(issueText?.textContent).toBe('Issue 12')
+    expect(titleText).toHaveClass('font-bold', 'text-sm', 'text-stone-200')
+    expect(issueText).toHaveClass('text-xs', 'text-stone-400')
+    expect(issueText).not.toHaveClass('font-bold', 'text-sm')
     expect(
       titleText && issueText
         ? titleText.compareDocumentPosition(issueText) & Node.DOCUMENT_POSITION_FOLLOWING


### PR DESCRIPTION
Fixes #1174.

Makes the series title the primary visual label on eligible Roll cards and demotes the issue number to secondary metadata. Existing ordering, route labels, format text, click behavior, and accessibility labels are preserved. Adds focused unit coverage for the visual hierarchy classes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated thread pool metadata to display the thread title before issue information.
  * Refined typography for die-face titles and issue text for clearer visual hierarchy.

* **Tests**
  * Added coverage to verify the expected text styling and emphasis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->