### PR TITLE
Fix frozen What's New release pipeline

### DIFF
--- a/.github/workflows/release-writer.yml
+++ b/.github/workflows/release-writer.yml
@@ -33,6 +33,27 @@ jobs:
           ref: main
           persist-credentials: false
 
+      - name: Validate release-writer credentials
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          if [[ -z "$RELEASE_WRITER_TOKEN" ]]; then
+            echo '::error::RELEASE_WRITER_TOKEN is not configured in GitHub Actions secrets.'
+            exit 1
+          fi
+          if [[ -z "$NVIDIA_API_KEY" ]]; then
+            echo '::error::NVIDIA_API_KEY is not configured in GitHub Actions secrets.'
+            exit 1
+          fi
+
+      - name: Install OpenCode CLI
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          curl -fsSL https://opencode.ai/install | bash
+          echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
+          "$HOME/.opencode/bin/opencode" --version
+
       - name: Install pinned FCM discovery CLI
         run: npm install --global --ignore-scripts free-coding-models@0.5.69
 
@@ -65,14 +86,11 @@ jobs:
           printf 'prompt=%s\n' "$prompt" >> "$GITHUB_OUTPUT"
 
       - name: Run dedicated release writer
-        uses: anomalyco/opencode/github@77fc88c8ade8e5a620ebbe1197f3a572d29ae91a
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
-          RELEASE_API_URL: ${{ env.RELEASE_API_URL }}
-          RELEASE_WRITER_TOKEN: ${{ secrets.RELEASE_WRITER_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          MODEL: ${{ steps.model.outputs.model }}
           PROMPT: ${{ steps.prompt.outputs.prompt }}
-        with:
-          model: ${{ steps.model.outputs.model }}
-          agent: release-writer
-          use_github_token: true
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          opencode run -m "$MODEL" --agent release-writer --auto --dir "$GITHUB_WORKSPACE" --title "ComicPile release writer" "$PROMPT"

--- a/frontend/src/pages/WhatsNewPage.tsx
+++ b/frontend/src/pages/WhatsNewPage.tsx
@@ -19,6 +19,13 @@ function releasedAtTimestamp(release: Release) {
   return Number.isNaN(parsed) ? Number.NEGATIVE_INFINITY : parsed
 }
 
+export function releaseDisplayText(text: string) {
+  return text
+    .replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+    .trim()
+}
+
 export function sortReleasesNewestFirst(releases: Release[]): Release[] {
   return [...releases].sort((left, right) => {
     const timestampDifference = releasedAtTimestamp(right) - releasedAtTimestamp(left)
@@ -79,13 +86,18 @@ export function groupReleasesByDay(releases: Release[], timeZone?: string): Rele
 }
 
 function ReleaseCard({ release }: { release: Release }) {
+  const title = releaseDisplayText(release.title)
+  const summary = releaseDisplayText(release.summary)
+
   return (
     <article className="rounded-xl border border-stone-800 bg-stone-900/50 p-4">
       <p className="text-xs font-bold uppercase tracking-[0.18em] text-amber-400">
         {release.category}
       </p>
-      <h3 className="mt-1 text-lg font-bold text-stone-100">{release.title}</h3>
-      <p className="mt-2 leading-7 text-stone-300">{release.summary}</p>
+      <h3 className="mt-1 text-lg font-bold text-stone-100">{title}</h3>
+      {summary !== title && (
+        <p className="mt-2 leading-7 text-stone-300">{summary}</p>
+      )}
     </article>
   )
 }


### PR DESCRIPTION
Repairs the release-note pipeline that has never completed successfully since the database-backed What's New cutover.

## Fixes
- run the dedicated release writer through the direct OpenCode CLI instead of the GitHub interaction wrapper, avoiding pull-request reaction/comment permission failures
- pass the constructed reconciliation prompt directly to OpenCode for merge, manual, and scheduled runs
- fail immediately with a clear error when `RELEASE_WRITER_TOKEN` or `NVIDIA_API_KEY` is missing
- keep GitHub permissions read-only for the release writer
- clean imported Markdown link syntax from public What's New cards
- suppress duplicated summary text when historical title and summary normalize to the same content

## Manual production step still required
GitHub Actions currently has no `RELEASE_WRITER_TOKEN` secret. After this merges, configure the same strong token in GitHub Actions and the Vercel production environment, then manually dispatch **Release writer** with the PR number blank to reconcile the recent merged PRs.

The current missing window is within the workflow's 50-PR reconciliation bound.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved release note presentation by removing Markdown links and inline-code formatting from displayed titles and summaries.
  * Automatically hides redundant summaries when they repeat the release title.

* **Chores**
  * Updated release generation to validate credentials, use the configured model and agent, and verify the release-writing tool before execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->