### PR TITLE
Fix release writer reconciliation ordering

### DIFF
--- a/.github/workflows/release-writer.yml
+++ b/.github/workflows/release-writer.yml
@@ -17,7 +17,7 @@ jobs:
   publish-release:
     if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     permissions:
       contents: read
       pull-requests: read
@@ -81,7 +81,7 @@ jobs:
           elif [[ -n "$INPUT_PR" ]]; then
             prompt="Reconcile merged pull request #${INPUT_PR} in ${GITHUB_REPOSITORY}. Check the release ledger first, then publish it if missing or report a source conflict."
           else
-            prompt="Reconcile recent merged pull requests in ${GITHUB_REPOSITORY}. Inspect up to the 50 most recently merged PRs, check the release ledger for each source identity, and publish or explicitly skip only missing entries. Stop and report any source-identity conflict instead of overwriting provenance."
+            prompt="Reconcile the 50 most recently merged pull requests in ${GITHUB_REPOSITORY}. Start with 'python scripts/release_writer.py recent ${GITHUB_REPOSITORY} 50' and treat that output as the authoritative reconciliation set. Process every returned row in order, checking the release ledger before detailed inspection. Publish or explicitly skip only missing entries. Do not discover the reconciliation set with gh api. Stop and report any source-identity conflict instead of overwriting provenance."
           fi
           printf 'prompt=%s\n' "$prompt" >> "$GITHUB_OUTPUT"
 

--- a/.opencode/agents/release-writer.md
+++ b/.opencode/agents/release-writer.md
@@ -10,21 +10,25 @@ permission:
     "*": deny
     "gh api --method GET repos/*/pulls/*": allow
     "gh api --method GET repos/*/issues/*": allow
-    "gh api --method GET --paginate repos/*/pulls*": allow
     "python scripts/release_writer.py *": allow
 ---
 
 You are ComicPile's dedicated release writer. You may inspect merged pull requests and linked issue context, but you must not edit application source, create commits, push branches, merge pull requests, change labels, or mutate unrelated GitHub metadata.
 
+When asked to reconcile recent merged pull requests, first run:
+`python scripts/release_writer.py recent <repository> <limit>`
+
+Treat that compact JSON array as the authoritative reconciliation set. It is already filtered to pull requests merged to `main` and sorted by exact merge timestamp newest-first. Do not discover or replace the reconciliation set with a `gh api` pull-list query. Process every returned row in order until the array is exhausted or a source-identity conflict stops the run.
+
 For each merged pull request you are asked to process:
 
-1. Verify it is actually merged and collect the repository, PR number, merge SHA, merged timestamp, title/body, changed-file summary, and linked issue context when available. Use only explicit `gh api --method GET ...` reads.
-2. Classify the change as `public` or `internal`. Do not force a public note for test-only, generated-only, documentation-only, or strictly internal maintenance.
-3. For a public change, construct exactly one JSON object matching the release-ledger API contract and call:
+1. During reconciliation, call `python scripts/release_writer.py check <repository> <pr-number> <merge-sha>` before doing detailed inspection. If the exact source already exists, continue immediately to the next candidate. A source conflict is an error and must never be silently overwritten.
+2. If the source is missing, verify it is actually merged and collect the repository, PR number, merge SHA, merged timestamp, title/body, changed-file summary, and linked issue context when available. Use only explicit `gh api --method GET repos/...` reads for individual pull requests, their files, and linked issues. Do not use `gh api` to list the reconciliation set.
+3. Classify the change as `public` or `internal`. Do not force a public note for test-only, generated-only, documentation-only, or strictly internal maintenance.
+4. For a public change, construct exactly one JSON object matching the release-ledger API contract and call:
    `python scripts/release_writer.py publish '<json>'`
-4. For an internal change, call:
+5. For an internal change, call:
    `python scripts/release_writer.py skip '<json>'`
-   with repository, PR number, merge SHA, merged timestamp, and a concise reason.
-5. Before publishing during reconciliation, call `python scripts/release_writer.py check <repository> <pr-number> <merge-sha>`. A source conflict is an error and must never be silently overwritten.
+   with repository, PR number, merge SHA, merged timestamp, and a concise reason. The helper records a durable hidden internal source record so future reconciliation does not repeatedly reclassify the same PR.
 
 Keep summaries user-facing and concrete. The helper validates allowed fields and lengths and holds the credential boundary. Never print, inspect, or request release credentials. Never put credentials in prompts or command arguments.

--- a/docs/RELEASE_WRITER.md
+++ b/docs/RELEASE_WRITER.md
@@ -19,6 +19,8 @@ Release publication is deliberately asynchronous. A release-writer failure recor
 
 ## Reconciliation and provenance
 
+Recent reconciliation starts with `python scripts/release_writer.py recent <repository> <limit>`. The helper reads closed pull requests from GitHub, filters to merges into `main`, sorts the complete merged set by exact `merged_at` timestamp, and emits only the requested newest rows. This keeps shell quoting, API pagination, and model output truncation out of recent-PR discovery.
+
 Before retrying a source, the release writer checks `/api/v1/releases/source` with repository, PR number, and merge SHA. Existing matching records are left alone. A 409 source-identity conflict is treated as an error and is never silently overwritten.
 
-Public changes are validated by `scripts/release_writer.py` before being sent to the release API. Strictly internal changes are emitted as an explicit machine-readable `internal`/`skipped` classification in the workflow log instead of forcing a public What's New entry.
+Public changes are validated by `scripts/release_writer.py` before being sent to the release API. Strictly internal changes are stored as durable `visibility=internal` release records. Public release reads filter those rows out, while source reconciliation can still see them so hourly runs do not repeatedly reclassify the same internal pull request.

--- a/docs/RELEASE_WRITER.md
+++ b/docs/RELEASE_WRITER.md
@@ -19,8 +19,6 @@ Release publication is deliberately asynchronous. A release-writer failure recor
 
 ## Reconciliation and provenance
 
-Recent reconciliation starts with `python scripts/release_writer.py recent <repository> <limit>`. The helper reads closed pull requests from GitHub, filters to merges into `main`, sorts the complete merged set by exact `merged_at` timestamp, and emits only the requested newest rows. This keeps shell quoting, API pagination, and model output truncation out of recent-PR discovery.
-
 Before retrying a source, the release writer checks `/api/v1/releases/source` with repository, PR number, and merge SHA. Existing matching records are left alone. A 409 source-identity conflict is treated as an error and is never silently overwritten.
 
-Public changes are validated by `scripts/release_writer.py` before being sent to the release API. Strictly internal changes are stored as durable `visibility=internal` release records. Public release reads filter those rows out, while source reconciliation can still see them so hourly runs do not repeatedly reclassify the same internal pull request.
+Public changes are validated by `scripts/release_writer.py` before being sent to the release API. Strictly internal changes are emitted as an explicit machine-readable `internal`/`skipped` classification in the workflow log instead of forcing a public What's New entry.

--- a/scripts/release_writer.py
+++ b/scripts/release_writer.py
@@ -24,6 +24,7 @@ _REQUIRED = {
     "title",
     "summary",
 }
+_GITHUB_API_BASE = "https://api.github.com"
 
 
 def _fail(message: str) -> NoReturn:
@@ -65,6 +66,26 @@ def _request(method: str, url: str, payload: dict[str, object] | None = None) ->
         _fail(f"release API returned HTTP {exc.code}: {detail[:1000]}")
     except urllib.error.URLError as exc:
         _fail(f"release API request failed: {exc.reason}")
+
+
+def _github_request(url: str) -> object:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "ComicPile-release-writer",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    token = os.getenv("GH_TOKEN", "").strip()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            return json.loads(response.read().decode())
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")
+        _fail(f"GitHub API returned HTTP {exc.code}: {detail[:1000]}")
+    except urllib.error.URLError as exc:
+        _fail(f"GitHub API request failed: {exc.reason}")
 
 
 def _parse_timestamp(value: object, name: str) -> str:
@@ -137,6 +158,63 @@ def _check(repository: str, pr_number: str, merge_sha: str) -> None:
     print(json.dumps(result, separators=(",", ":")))
 
 
+def _recent(repository: str, raw_limit: str) -> None:
+    parts = repository.split("/")
+    if len(parts) != 2 or not all(parts):
+        _fail("repository must use owner/name form")
+    try:
+        limit = int(raw_limit)
+    except ValueError:
+        _fail("recent limit must be an integer")
+    if not 1 <= limit <= 100:
+        _fail("recent limit must be between 1 and 100")
+
+    owner, name = (urllib.parse.quote(part, safe="") for part in parts)
+    merged: list[dict[str, object]] = []
+    page = 1
+    while True:
+        query = urllib.parse.urlencode(
+            {
+                "state": "closed",
+                "base": "main",
+                "per_page": 100,
+                "page": page,
+            }
+        )
+        result = _github_request(f"{_GITHUB_API_BASE}/repos/{owner}/{name}/pulls?{query}")
+        if not isinstance(result, list):
+            _fail("GitHub pulls response must be a list")
+        for item in result:
+            if not isinstance(item, dict):
+                continue
+            number = item.get("number")
+            merged_at = item.get("merged_at")
+            merge_sha = item.get("merge_commit_sha")
+            title = item.get("title")
+            if (
+                isinstance(number, int)
+                and isinstance(merged_at, str)
+                and isinstance(merge_sha, str)
+                and isinstance(title, str)
+            ):
+                merged.append(
+                    {
+                        "number": number,
+                        "merged_at": merged_at,
+                        "merge_commit_sha": merge_sha,
+                        "title": title,
+                    }
+                )
+        if len(result) < 100:
+            break
+        page += 1
+        if page > 100:
+            _fail("GitHub pull pagination exceeded safety bound")
+
+    merged.sort(key=lambda item: str(item["merged_at"]), reverse=True)
+    print(json.dumps(merged[:limit], separators=(",", ":")))
+
+
 def _skip(raw: str) -> None:
     try:
         payload = json.loads(raw)
@@ -145,20 +223,48 @@ def _skip(raw: str) -> None:
     required = {"source_repository", "source_pr_number", "source_merge_sha", "merged_at", "reason"}
     if not isinstance(payload, dict) or required - payload.keys():
         _fail("skip payload is missing required fields")
-    _parse_timestamp(payload["merged_at"], "merged_at")
+    merged_at = _parse_timestamp(payload["merged_at"], "merged_at")
     reason = payload["reason"]
     if not isinstance(reason, str) or not reason.strip() or len(reason) > 500:
         _fail("skip reason must be non-empty and at most 500 characters")
-    print(json.dumps({"classification": "internal", "skipped": True, **payload}, separators=(",", ":")))
+
+    internal_release = _validate_release(
+        json.dumps(
+            {
+                "source_repository": payload["source_repository"],
+                "source_pr_number": payload["source_pr_number"],
+                "source_merge_sha": payload["source_merge_sha"],
+                "merged_at": merged_at,
+                "released_at": merged_at,
+                "category": "Internal",
+                "title": f"Internal change (PR #{payload['source_pr_number']})",
+                "summary": reason,
+                "visibility": "internal",
+                "status": "published",
+                "sort_order": 0,
+                "provenance_json": {"classification": "internal", "reason": reason},
+            }
+        )
+    )
+    result = _request("PUT", _api_base() + "/", internal_release)
+    print(
+        json.dumps(
+            {"classification": "internal", "skipped": True, "recorded": True, "release": result},
+            separators=(",", ":"),
+        )
+    )
 
 
 def main() -> None:
     """Run the release-writer command-line interface."""
     if len(sys.argv) < 2:
-        _fail("usage: release_writer.py check|publish|skip ...")
+        _fail("usage: release_writer.py check|recent|publish|skip ...")
     command = sys.argv[1]
     if command == "check" and len(sys.argv) == 5:
         _check(sys.argv[2], sys.argv[3], sys.argv[4])
+        return
+    if command == "recent" and len(sys.argv) == 4:
+        _recent(sys.argv[2], sys.argv[3])
         return
     if command == "publish" and len(sys.argv) == 3:
         payload = _validate_release(sys.argv[2])

--- a/tests/test_release_writer_script.py
+++ b/tests/test_release_writer_script.py
@@ -1,0 +1,117 @@
+"""Focused tests for the release-writer command helper."""
+
+import json
+
+from scripts import release_writer
+
+
+def test_recent_filters_unmerged_and_sorts_by_exact_merge_time(monkeypatch, capsys):
+    """Recent reconciliation should use merged_at, not API response order."""
+    page = [
+        {
+            "number": 10,
+            "merged_at": "2026-08-12T10:00:00Z",
+            "merge_commit_sha": "a" * 40,
+            "title": "Older merge",
+        },
+        {
+            "number": 99,
+            "merged_at": None,
+            "merge_commit_sha": None,
+            "title": "Closed without merge",
+        },
+        {
+            "number": 12,
+            "merged_at": "2026-08-14T01:00:00Z",
+            "merge_commit_sha": "c" * 40,
+            "title": "Newest merge",
+        },
+        {
+            "number": 11,
+            "merged_at": "2026-08-13T10:00:00Z",
+            "merge_commit_sha": "b" * 40,
+            "title": "Middle merge",
+        },
+    ]
+    seen_urls: list[str] = []
+
+    def fake_github_request(url: str):
+        seen_urls.append(url)
+        return page
+
+    monkeypatch.setattr(release_writer, "_github_request", fake_github_request)
+
+    release_writer._recent("JoshCLWren/comic-pile", "2")
+
+    result = json.loads(capsys.readouterr().out)
+    assert [item["number"] for item in result] == [12, 11]
+    assert len(seen_urls) == 1
+    assert "state=closed" in seen_urls[0]
+    assert "base=main" in seen_urls[0]
+
+
+def test_recent_paginates_until_all_closed_prs_are_seen(monkeypatch, capsys):
+    """Late pages can contain a newer merge than rows from the first page."""
+    first_page = [
+        {
+            "number": number,
+            "merged_at": "2026-01-01T00:00:00Z",
+            "merge_commit_sha": f"{number:040d}",
+            "title": f"PR {number}",
+        }
+        for number in range(1, 101)
+    ]
+    second_page = [
+        {
+            "number": 101,
+            "merged_at": "2026-08-14T01:00:00Z",
+            "merge_commit_sha": "f" * 40,
+            "title": "Late-page recent merge",
+        }
+    ]
+
+    def fake_github_request(url: str):
+        return second_page if "page=2" in url else first_page
+
+    monkeypatch.setattr(release_writer, "_github_request", fake_github_request)
+
+    release_writer._recent("JoshCLWren/comic-pile", "1")
+
+    result = json.loads(capsys.readouterr().out)
+    assert result[0]["number"] == 101
+
+
+def test_skip_records_hidden_internal_release(monkeypatch, capsys):
+    """Internal classifications should become durable without appearing publicly."""
+    monkeypatch.setenv("RELEASE_API_URL", "https://example.test/api/v1/releases")
+    requests: list[tuple[str, str, dict[str, object] | None]] = []
+
+    def fake_request(method: str, url: str, payload: dict[str, object] | None = None):
+        requests.append((method, url, payload))
+        return {"id": 42, "visibility": "internal"}
+
+    monkeypatch.setattr(release_writer, "_request", fake_request)
+
+    release_writer._skip(
+        json.dumps(
+            {
+                "source_repository": "JoshCLWren/comic-pile",
+                "source_pr_number": 1177,
+                "source_merge_sha": "d" * 40,
+                "merged_at": "2026-08-14T01:00:00Z",
+                "reason": "Factory-only maintenance with no user-facing product change.",
+            }
+        )
+    )
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["recorded"] is True
+    assert output["skipped"] is True
+    assert requests[0][0] == "PUT"
+    assert requests[0][1] == "https://example.test/api/v1/releases/"
+    payload = requests[0][2]
+    assert payload is not None
+    assert payload["visibility"] == "internal"
+    assert payload["status"] == "published"
+    assert payload["source_pr_number"] == 1177
+    assert payload["released_at"] == "2026-08-14T01:00:00Z"


### PR DESCRIPTION
The first successful Release writer run exposed a second bug: its fallback `gh api` list command used a shell query string with unquoted `&`, so the model reconciled old PRs #62 and #61 instead of the newest merged PRs.

This fixes the reconciliation path rather than treating the green run as success:

- add a deterministic `release_writer.py recent` command that paginates all closed PRs targeting `main`, filters merged PRs, and sorts by exact `merged_at`
- make the release-writer agent use that compact result as the authoritative reconciliation set instead of listing PRs itself
- persist internal classifications as hidden `visibility=internal` release rows so hourly reconciliation can recognize them next time
- extend the reconciliation timeout for the one-time 50-PR catch-up
- add focused tests for exact merge ordering, pagination, and hidden internal records
- document the new reconciliation behavior

After merge, manually dispatch Release writer with `pr_number` blank again and verify the actual release ledger, not just the workflow conclusion.