### PR TITLE
Correct free-model factory scope to NVIDIA, OmniRoute, and OpenCode

### DIFF
--- a/.github/free-model-factories.tsv
+++ b/.github/free-model-factories.tsv
@@ -32,24 +32,11 @@
 36	omniroute-opencode	oc/laguna-s-2.1-free	30	A	OmniRoute Laguna S 2.1 Free
 37	omniroute-opencode	oc/hy3-free	31	B	OmniRoute Tencent Hy3 Free
 38	omniroute-opencode	oc/nemotron-3.5-lightning-free	32	C	OmniRoute Nemotron 3.5 Lightning Free
-39	zen	big-pickle	33	D	Zen Big Pickle
-40	zen	deepseek-v4-flash-free	34	E	Zen DeepSeek V4 Flash Free
-41	zen	mimo-v2.5-free	35	A	Zen MiMo V2.5 Free
-42	zen	nemotron-3-ultra-free	36	B	Zen Nemotron 3 Ultra Free
-43	zen	laguna-s-2.1-free	37	C	Zen Laguna S 2.1 Free
-44	zen	hy3-free	38	D	Zen Tencent Hy3 Free
-45	zen	nemotron-3.5-lightning-free	39	E	Zen Nemotron 3.5 Lightning Free
-46	kilo	kilo-auto/free	40	A	Kilo Auto Free
-47	kilo	kilo-auto/small	41	B	Kilo Auto Small
-48	llm7	minimax-m2.7	42	C	LLM7 MiniMax M2.7
-49	llm7	gemini-3.1-flash-lite	43	D	LLM7 Gemini 3.1 Flash Lite
-50	llm7	gpt-oss:20b	44	E	LLM7 GPT OSS 20B
-51	llm7	mistral-Nemo-Instruct-2407	45	A	LLM7 Mistral Nemo 12B
-52	llm7	codestral-latest	46	B	LLM7 Codestral Latest
-53	ovhcloud	Qwen3.5-397B-A17B	47	C	OVH Qwen3.5 397B MoE
-54	ovhcloud	Qwen3.6-27B	48	D	OVH Qwen3.6 27B
-55	ovhcloud	gpt-oss-120b	49	E	OVH GPT OSS 120B
-56	ovhcloud	gpt-oss-20b	50	A	OVH GPT OSS 20B
-57	ovhcloud	Meta-Llama-3_3-70B-Instruct	51	B	OVH Llama 3.3 70B
-58	ovhcloud	Qwen3.5-9B	52	C	OVH Qwen3.5 9B
-59	ovhcloud	Qwen2.5-VL-72B-Instruct	53	D	OVH Qwen2.5 VL 72B
+39	zen	big-pickle	33	D	OpenCode Big Pickle
+40	zen	deepseek-v4-flash-free	34	E	OpenCode DeepSeek V4 Flash Free
+41	zen	mimo-v2.5-free	35	A	OpenCode MiMo V2.5 Free
+42	zen	nemotron-3-ultra-free	36	B	OpenCode Nemotron 3 Ultra Free
+43	zen	laguna-s-2.1-free	37	C	OpenCode Laguna S 2.1 Free
+44	zen	hy3-free	38	D	OpenCode Tencent Hy3 Free
+45	zen	nemotron-3.5-lightning-free	39	E	OpenCode Nemotron 3.5 Lightning Free
+46	zen	ling-3.0-tiny-free	40	A	OpenCode Ling 3.0 Tiny Free

--- a/.github/scripts/validate-free-model-factories.py
+++ b/.github/scripts/validate-free-model-factories.py
@@ -9,14 +9,21 @@ from collections import Counter, defaultdict
 from pathlib import Path
 
 MANIFEST = Path('.github/free-model-factories.tsv')
-EXPECTED_WORKERS = set(range(6, 60))
+EXPECTED_WORKERS = set(range(6, 47))
 EXPECTED_SOURCE_COUNTS = {
     'nvidia': 26,
     'omniroute-opencode': 7,
-    'zen': 7,
-    'kilo': 2,
-    'llm7': 5,
-    'ovhcloud': 7,
+    'zen': 8,
+}
+EXPECTED_ZEN_MODELS = {
+    'big-pickle',
+    'deepseek-v4-flash-free',
+    'hy3-free',
+    'laguna-s-2.1-free',
+    'ling-3.0-tiny-free',
+    'mimo-v2.5-free',
+    'nemotron-3-ultra-free',
+    'nemotron-3.5-lightning-free',
 }
 EXPECTED_SCHEDULERS = {'A', 'B', 'C', 'D', 'E'}
 RETIRED_SCHEDULERS = (
@@ -42,7 +49,7 @@ def main() -> None:
             delimiter='\t',
         ))
 
-    assert len(rows) == 54, f'expected 54 fixed model/route lanes, got {len(rows)}'
+    assert len(rows) == 41, f'expected 41 fixed model lanes, got {len(rows)}'
 
     workers = [int(row['worker']) for row in rows]
     assert set(workers) == EXPECTED_WORKERS, (
@@ -54,6 +61,12 @@ def main() -> None:
     source_counts = Counter(row['source'] for row in rows)
     assert source_counts == EXPECTED_SOURCE_COUNTS, (
         f'source counts changed unexpectedly: {dict(source_counts)}'
+    )
+
+    zen_models = {row['model'] for row in rows if row['source'] == 'zen'}
+    assert zen_models == EXPECTED_ZEN_MODELS, (
+        f'OpenCode free roster changed: missing={sorted(EXPECTED_ZEN_MODELS - zen_models)} '
+        f'extra={sorted(zen_models - EXPECTED_ZEN_MODELS)}'
     )
 
     source_models = [(row['source'], row['model']) for row in rows]
@@ -118,7 +131,7 @@ def main() -> None:
     assert 'rotate_model' not in worker_text, 'fixed-model worker must never rotate models'
     assert 'Do not switch models' in worker_text, 'fixed-model no-fallback contract is missing'
 
-    print('Validated 54 fixed model/route factory lanes across schedulers A-E.')
+    print('Validated 41 fixed model factory lanes across schedulers A-E.')
     for source, count in EXPECTED_SOURCE_COUNTS.items():
         print(f'  {source}: {count}')
 

--- a/.github/workflows/free-model-factory-a.yml
+++ b/.github/workflows/free-model-factory-a.yml
@@ -11,15 +11,13 @@ on:
     - cron: '30 * * * *'
     - cron: '35 * * * *'
     - cron: '40 * * * *'
-    - cron: '45 * * * *'
-    - cron: '50 * * * *'
   workflow_dispatch:
     inputs:
       worker:
         description: Factory worker from scheduler A
         required: true
         type: choice
-        options: ['6','11','16','21','26','31','36','41','46','51','56']
+        options: ['6','11','16','21','26','31','36','41','46']
 
 permissions:
   contents: write

--- a/.github/workflows/free-model-factory-b.yml
+++ b/.github/workflows/free-model-factory-b.yml
@@ -10,16 +10,13 @@ on:
     - cron: '26 * * * *'
     - cron: '31 * * * *'
     - cron: '36 * * * *'
-    - cron: '41 * * * *'
-    - cron: '46 * * * *'
-    - cron: '51 * * * *'
   workflow_dispatch:
     inputs:
       worker:
         description: Factory worker from scheduler B
         required: true
         type: choice
-        options: ['7','12','17','22','27','32','37','42','47','52','57']
+        options: ['7','12','17','22','27','32','37','42']
 
 permissions:
   contents: write

--- a/.github/workflows/free-model-factory-c.yml
+++ b/.github/workflows/free-model-factory-c.yml
@@ -10,16 +10,13 @@ on:
     - cron: '27 * * * *'
     - cron: '32 * * * *'
     - cron: '37 * * * *'
-    - cron: '42 * * * *'
-    - cron: '47 * * * *'
-    - cron: '52 * * * *'
   workflow_dispatch:
     inputs:
       worker:
         description: Factory worker from scheduler C
         required: true
         type: choice
-        options: ['8','13','18','23','28','33','38','43','48','53','58']
+        options: ['8','13','18','23','28','33','38','43']
 
 permissions:
   contents: write

--- a/.github/workflows/free-model-factory-d.yml
+++ b/.github/workflows/free-model-factory-d.yml
@@ -10,16 +10,13 @@ on:
     - cron: '28 * * * *'
     - cron: '33 * * * *'
     - cron: '38 * * * *'
-    - cron: '43 * * * *'
-    - cron: '48 * * * *'
-    - cron: '53 * * * *'
   workflow_dispatch:
     inputs:
       worker:
         description: Factory worker from scheduler D
         required: true
         type: choice
-        options: ['9','14','19','24','29','34','39','44','49','54','59']
+        options: ['9','14','19','24','29','34','39','44']
 
 permissions:
   contents: write

--- a/.github/workflows/free-model-factory-e.yml
+++ b/.github/workflows/free-model-factory-e.yml
@@ -10,15 +10,13 @@ on:
     - cron: '29 * * * *'
     - cron: '34 * * * *'
     - cron: '39 * * * *'
-    - cron: '44 * * * *'
-    - cron: '49 * * * *'
   workflow_dispatch:
     inputs:
       worker:
         description: Factory worker from scheduler E
         required: true
         type: choice
-        options: ['10','15','20','25','30','35','40','45','50','55']
+        options: ['10','15','20','25','30','35','40','45']
 
 permissions:
   contents: write


### PR DESCRIPTION
Corrects the just-merged free-model bake-off to match the intended scope.

- Keep 26 fixed NVIDIA lanes.
- Keep 7 fixed OmniRoute/OpenCode-free lanes.
- Keep exactly the 8 user-specified OpenCode free models:
  - opencode/big-pickle
  - opencode/deepseek-v4-flash-free
  - opencode/hy3-free
  - opencode/laguna-s-2.1-free
  - opencode/ling-3.0-tiny-free
  - opencode/mimo-v2.5-free
  - opencode/nemotron-3-ultra-free
  - opencode/nemotron-3.5-lightning-free
- Remove Kilo, LLM7, and OVHcloud from the active factory manifest and schedules.
- Repurpose Factory 46 as OpenCode Ling 3.0 Tiny Free.
- Reduce the external fleet from 54 to 41 lanes, Factories 6-46, scheduled from :00 through :40 hourly.
- Enforce the exact 8-model OpenCode free roster in the validator so drift fails CI.

This is intentionally a narrow correction to PR #1180, not a broader factory rewrite.