### PR TITLE
Fix fixed-model dispatcher runtime

### DIFF
--- a/.github/scripts/validate-free-model-factories.py
+++ b/.github/scripts/validate-free-model-factories.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 MANIFEST = Path('.github/free-model-factories.tsv')
 DISPATCHER = Path('.github/workflows/free-model-factory-dispatch.yml')
+ENTRY = Path('.github/workflows/free-model-factory-entry.yml')
 EXPECTED_WORKERS = set(range(6, 47))
 EXPECTED_SOURCE_COUNTS = {
     'nvidia': 26,
@@ -37,7 +38,7 @@ RETIRED_SCHEDULERS = (
     Path('.github/workflows/free-model-factory-d.yml'),
     Path('.github/workflows/free-model-factory-e.yml'),
 )
-REQUIRED_CALLER_PERMISSIONS = (
+ENTRY_PERMISSIONS = (
     'contents: write',
     'issues: write',
     'pull-requests: write',
@@ -112,10 +113,18 @@ def main() -> None:
     assert 'workers=\'["6","32","39"]\'' in dispatcher_text, (
         'dispatcher must retain immediate NVIDIA/OmniRoute/OpenCode post-merge smoke'
     )
-    assert 'matrix:' in dispatcher_text and 'fromJSON(needs.resolve.outputs.workers)' in dispatcher_text
-    assert 'secrets: inherit' in dispatcher_text
-    for permission in REQUIRED_CALLER_PERMISSIONS:
-        assert permission in dispatcher_text, f'dispatcher missing permission {permission!r}'
+    assert 'contents: read' in dispatcher_text and 'actions: write' in dispatcher_text
+    assert 'gh workflow run free-model-factory-entry.yml' in dispatcher_text
+    assert 'matrix:' not in dispatcher_text, 'dispatcher must not dynamically matrix-call reusable workflows'
+
+    assert ENTRY.exists(), 'dispatchable fixed-model entry workflow is missing'
+    entry_text = ENTRY.read_text(encoding='utf-8')
+    assert 'workflow_dispatch:' in entry_text
+    assert 'uses: ./.github/workflows/free-model-factory-run.yml' in entry_text
+    assert 'worker: ${{ inputs.worker }}' in entry_text
+    assert 'secrets: inherit' in entry_text
+    for permission in ENTRY_PERMISSIONS:
+        assert permission in entry_text, f'entry workflow missing permission {permission!r}'
 
     for retired in RETIRED_SCHEDULERS:
         assert not retired.exists(), f'obsolete scheduler still exists: {retired}'
@@ -128,7 +137,7 @@ def main() -> None:
     assert 'rotate_model' not in worker_text, 'fixed-model worker must never rotate models'
     assert 'Do not switch models' in worker_text, 'fixed-model no-fallback contract is missing'
 
-    print('Validated 41 fixed model factories through one four-batch dispatcher.')
+    print('Validated 41 fixed model factories through dispatchable four-batch scheduler.')
     for minute in DISPATCH_MINUTES:
         print(f'  :{minute:02d} -> {actual_batch_counts[minute]} workers')
     for source, count in EXPECTED_SOURCE_COUNTS.items():

--- a/.github/workflows/free-model-factory-dispatch.yml
+++ b/.github/workflows/free-model-factory-dispatch.yml
@@ -16,28 +16,25 @@ on:
     branches: [main]
     paths:
       - '.github/workflows/free-model-factory-dispatch.yml'
+      - '.github/workflows/free-model-factory-entry.yml'
       - '.github/workflows/free-model-factory-run.yml'
       - '.github/free-model-factories.tsv'
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
-  actions: read
-  checks: read
+  contents: read
+  actions: write
 
 jobs:
-  resolve:
+  dispatch:
     runs-on: ubuntu-latest
-    outputs:
-      workers: ${{ steps.resolve.outputs.workers }}
     steps:
       - uses: actions/checkout@v6
         with:
           ref: main
-      - id: resolve
+      - name: Resolve and dispatch fixed workers
         shell: bash
         env:
+          GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
           SCHEDULE: ${{ github.event.schedule }}
           DISPATCH_WORKER: ${{ inputs.worker }}
@@ -57,16 +54,9 @@ jobs:
           fi
 
           [[ "$workers" != '[]' ]] || { echo 'Dispatcher resolved no workers' >&2; exit 1; }
-          echo "workers=$workers" >> "$GITHUB_OUTPUT"
           echo "Dispatching workers: $workers"
 
-  run:
-    needs: resolve
-    strategy:
-      fail-fast: false
-      matrix:
-        worker: ${{ fromJSON(needs.resolve.outputs.workers) }}
-    uses: ./.github/workflows/free-model-factory-run.yml
-    with:
-      worker: ${{ matrix.worker }}
-    secrets: inherit
+          while IFS= read -r worker; do
+            echo "Starting Factory ${worker}"
+            gh workflow run free-model-factory-entry.yml --ref main -f worker="$worker"
+          done < <(jq -r '.[]' <<< "$workers")

--- a/.github/workflows/free-model-factory-entry.yml
+++ b/.github/workflows/free-model-factory-entry.yml
@@ -1,0 +1,23 @@
+name: Fixed Model Factory Entry
+
+on:
+  workflow_dispatch:
+    inputs:
+      worker:
+        description: Fixed-model Factory number (6-46)
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  actions: read
+  checks: read
+
+jobs:
+  run:
+    uses: ./.github/workflows/free-model-factory-run.yml
+    with:
+      worker: ${{ inputs.worker }}
+    secrets: inherit


### PR DESCRIPTION
Follow-up to #1184. The unified dispatcher now triggers correctly on push, but its dynamic matrix/reusable-workflow call fails during workflow graph construction before any job is created.

This replaces that fragile graph with an explicit Actions dispatch path:
- add `free-model-factory-entry.yml`, a static `workflow_dispatch` wrapper around the existing reusable runner;
- have the scheduler run as a normal job with `actions: write` and dispatch each fixed worker via `gh workflow run`;
- keep the same four hourly batches and the same Factory 6-46 model assignments;
- keep the post-merge smoke set of Factory 6 (NVIDIA), 32 (OmniRoute), and 39 (OpenCode);
- make the validator reject the failed dynamic-matrix architecture.

No product code or model roster changes.