### PR TITLE
Fix reusable free-model runner YAML

### DIFF
--- a/.github/workflows/free-model-factory-config.yml
+++ b/.github/workflows/free-model-factory-config.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Validate fixed-model roster and schedules
         run: python .github/scripts/validate-free-model-factories.py
+      - name: Parse fixed-model workflow YAML
+        run: ruby -e 'require "yaml"; ARGV.each { |f| YAML.parse_file(f) }' .github/workflows/free-model-factory-*.yml
       - name: Check JavaScript helper syntax
         run: node --check .github/scripts/fixed-model-owner-normalize.cjs
       - name: Check shell worker syntax

--- a/.github/workflows/free-model-factory-run.yml
+++ b/.github/workflows/free-model-factory-run.yml
@@ -169,7 +169,8 @@ jobs:
         env:
           REASON: ${{ steps.lane.outputs.reason }}
           DISPLAY: ${{ steps.lane.outputs.display }}
-        run: echo "${DISPLAY} lane is installed but inactive: ${REASON}"
+        run: |
+          echo "${DISPLAY} lane is installed but inactive: ${REASON}"
 
       - name: Install pinned OpenCode release
         if: steps.lane.outputs.configured == 'true'


### PR DESCRIPTION
The fixed-model dispatcher is now reaching the Actions dispatch API correctly, but the static entry workflow exposed a latent YAML syntax error in the reusable runner at the unconfigured-lane echo step.

This is a narrow two-file fix:
- make the runner's unconfigured echo a YAML block scalar so the colon in the message is valid;
- add a YAML parse step to `Fixed Model Factory Config` for all `free-model-factory-*.yml` workflows so this class of failure is caught before merge.

No model roster, schedule, or product-code changes.