### PR TITLE
Anchor free-model factories to proven watchdog schedule

### DIFF
--- a/.github/free-model-factories.tsv
+++ b/.github/free-model-factories.tsv
@@ -1,42 +1,42 @@
 # worker	source	model	minute	scheduler	display_name
-6	nvidia	z-ai/glm-5.2	7	dispatcher	GLM 5.2
-7	nvidia	moonshotai/kimi-k2.6	22	dispatcher	Kimi K2.6
-8	nvidia	deepseek-ai/deepseek-v4-flash-0731	37	dispatcher	DeepSeek V4 Flash
-9	nvidia	stepfun-ai/step-3.7-flash	52	dispatcher	Step 3.7 Flash
-10	nvidia	nvidia/nemotron-3-ultra-550b-a55b	7	dispatcher	Nemotron 3 Ultra
-11	nvidia	poolside/laguna-xs-2.1	22	dispatcher	Laguna XS 2.1
-12	nvidia	openai/gpt-oss-120b	37	dispatcher	GPT OSS 120B
-13	nvidia	mistralai/mistral-medium-3.5-128b	52	dispatcher	Mistral Medium 3.5
-14	nvidia	minimaxai/minimax-m3	7	dispatcher	MiniMax M3
-15	nvidia	mistralai/mistral-nemotron	22	dispatcher	Mistral Nemotron
-16	nvidia	nvidia/nemotron-3-super-120b-a12b	37	dispatcher	Nemotron 3 Super
-17	nvidia	nvidia/nemotron-3-nano-omni-30b-a3b-reasoning	52	dispatcher	Nemotron 3 Omni
-18	nvidia	nvidia/llama-3.3-nemotron-super-49b-v1.5	7	dispatcher	Llama 3.3 Nemotron Super 49B
-19	nvidia	nvidia/nemotron-3-nano-30b-a3b	22	dispatcher	Nemotron Nano 30B
-20	nvidia	openai/gpt-oss-20b	37	dispatcher	GPT OSS 20B
-21	nvidia	google/gemma-4-31b-it	52	dispatcher	Gemma 4 31B
-22	nvidia	mistralai/mistral-large-2-instruct	7	dispatcher	Mistral Large 2
-23	nvidia	nvidia/nvidia-nemotron-nano-9b-v2	22	dispatcher	Nemotron Nano 9B v2
-24	nvidia	meta/llama-3.3-70b-instruct	37	dispatcher	Llama 3.3 70B
-25	nvidia	deepseek-ai/deepseek-coder-6.7b-instruct	52	dispatcher	DeepSeek Coder 6.7B
-26	nvidia	meta/codellama-70b	7	dispatcher	CodeLlama 70B
-27	nvidia	mistralai/codestral-22b-instruct-v0.1	22	dispatcher	Codestral 22B
-28	nvidia	ibm/granite-34b-code-instruct	37	dispatcher	Granite 34B Code
-29	nvidia	thinkingmachines/inkling	52	dispatcher	Inkling
-30	nvidia	meta/llama-3.2-11b-vision-instruct	7	dispatcher	Llama 3.2 11B Vision
-31	nvidia	nvidia/nemotron-mini-4b-instruct	22	dispatcher	Nemotron Mini 4B
-32	omniroute-opencode	oc/big-pickle	37	dispatcher	OmniRoute Big Pickle
-33	omniroute-opencode	oc/deepseek-v4-flash-free	52	dispatcher	OmniRoute DeepSeek V4 Flash Free
-34	omniroute-opencode	oc/mimo-v2.5-free	7	dispatcher	OmniRoute MiMo V2.5 Free
-35	omniroute-opencode	oc/nemotron-3-ultra-free	22	dispatcher	OmniRoute Nemotron 3 Ultra Free
-36	omniroute-opencode	oc/laguna-s-2.1-free	37	dispatcher	OmniRoute Laguna S 2.1 Free
-37	omniroute-opencode	oc/hy3-free	52	dispatcher	OmniRoute Tencent Hy3 Free
-38	omniroute-opencode	oc/nemotron-3.5-lightning-free	7	dispatcher	OmniRoute Nemotron 3.5 Lightning Free
-39	zen	big-pickle	22	dispatcher	OpenCode Big Pickle
-40	zen	deepseek-v4-flash-free	37	dispatcher	OpenCode DeepSeek V4 Flash Free
-41	zen	mimo-v2.5-free	52	dispatcher	OpenCode MiMo V2.5 Free
-42	zen	nemotron-3-ultra-free	7	dispatcher	OpenCode Nemotron 3 Ultra Free
-43	zen	laguna-s-2.1-free	22	dispatcher	OpenCode Laguna S 2.1 Free
-44	zen	hy3-free	37	dispatcher	OpenCode Tencent Hy3 Free
-45	zen	nemotron-3.5-lightning-free	52	dispatcher	OpenCode Nemotron 3.5 Lightning Free
-46	zen	ling-3.0-tiny-free	7	dispatcher	OpenCode Ling 3.0 Tiny Free
+6	nvidia	z-ai/glm-5.2	0	watchdog	GLM 5.2
+7	nvidia	moonshotai/kimi-k2.6	15	watchdog	Kimi K2.6
+8	nvidia	deepseek-ai/deepseek-v4-flash-0731	30	watchdog	DeepSeek V4 Flash
+9	nvidia	stepfun-ai/step-3.7-flash	45	watchdog	Step 3.7 Flash
+10	nvidia	nvidia/nemotron-3-ultra-550b-a55b	0	watchdog	Nemotron 3 Ultra
+11	nvidia	poolside/laguna-xs-2.1	15	watchdog	Laguna XS 2.1
+12	nvidia	openai/gpt-oss-120b	30	watchdog	GPT OSS 120B
+13	nvidia	mistralai/mistral-medium-3.5-128b	45	watchdog	Mistral Medium 3.5
+14	nvidia	minimaxai/minimax-m3	0	watchdog	MiniMax M3
+15	nvidia	mistralai/mistral-nemotron	15	watchdog	Mistral Nemotron
+16	nvidia	nvidia/nemotron-3-super-120b-a12b	30	watchdog	Nemotron 3 Super
+17	nvidia	nvidia/nemotron-3-nano-omni-30b-a3b-reasoning	45	watchdog	Nemotron 3 Omni
+18	nvidia	nvidia/llama-3.3-nemotron-super-49b-v1.5	0	watchdog	Llama 3.3 Nemotron Super 49B
+19	nvidia	nvidia/nemotron-3-nano-30b-a3b	15	watchdog	Nemotron Nano 30B
+20	nvidia	openai/gpt-oss-20b	30	watchdog	GPT OSS 20B
+21	nvidia	google/gemma-4-31b-it	45	watchdog	Gemma 4 31B
+22	nvidia	mistralai/mistral-large-2-instruct	0	watchdog	Mistral Large 2
+23	nvidia	nvidia/nvidia-nemotron-nano-9b-v2	15	watchdog	Nemotron Nano 9B v2
+24	nvidia	meta/llama-3.3-70b-instruct	30	watchdog	Llama 3.3 70B
+25	nvidia	deepseek-ai/deepseek-coder-6.7b-instruct	45	watchdog	DeepSeek Coder 6.7B
+26	nvidia	meta/codellama-70b	0	watchdog	CodeLlama 70B
+27	nvidia	mistralai/codestral-22b-instruct-v0.1	15	watchdog	Codestral 22B
+28	nvidia	ibm/granite-34b-code-instruct	30	watchdog	Granite 34B Code
+29	nvidia	thinkingmachines/inkling	45	watchdog	Inkling
+30	nvidia	meta/llama-3.2-11b-vision-instruct	0	watchdog	Llama 3.2 11B Vision
+31	nvidia	nvidia/nemotron-mini-4b-instruct	15	watchdog	Nemotron Mini 4B
+32	omniroute-opencode	oc/big-pickle	30	watchdog	OmniRoute Big Pickle
+33	omniroute-opencode	oc/deepseek-v4-flash-free	45	watchdog	OmniRoute DeepSeek V4 Flash Free
+34	omniroute-opencode	oc/mimo-v2.5-free	0	watchdog	OmniRoute MiMo V2.5 Free
+35	omniroute-opencode	oc/nemotron-3-ultra-free	15	watchdog	OmniRoute Nemotron 3 Ultra Free
+36	omniroute-opencode	oc/laguna-s-2.1-free	30	watchdog	OmniRoute Laguna S 2.1 Free
+37	omniroute-opencode	oc/hy3-free	45	watchdog	OmniRoute Tencent Hy3 Free
+38	omniroute-opencode	oc/nemotron-3.5-lightning-free	0	watchdog	OmniRoute Nemotron 3.5 Lightning Free
+39	zen	big-pickle	15	watchdog	OpenCode Big Pickle
+40	zen	deepseek-v4-flash-free	30	watchdog	OpenCode DeepSeek V4 Flash Free
+41	zen	mimo-v2.5-free	45	watchdog	OpenCode MiMo V2.5 Free
+42	zen	nemotron-3-ultra-free	0	watchdog	OpenCode Nemotron 3 Ultra Free
+43	zen	laguna-s-2.1-free	15	watchdog	OpenCode Laguna S 2.1 Free
+44	zen	hy3-free	30	watchdog	OpenCode Tencent Hy3 Free
+45	zen	nemotron-3.5-lightning-free	45	watchdog	OpenCode Nemotron 3.5 Lightning Free
+46	zen	ling-3.0-tiny-free	0	watchdog	OpenCode Ling 3.0 Tiny Free

--- a/.github/scripts/validate-free-model-factories.py
+++ b/.github/scripts/validate-free-model-factories.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
-"""Validate the deterministic free-model factory roster and dispatcher wiring."""
+"""Validate the deterministic free-model factory roster and watchdog-backed dispatcher."""
 
 from __future__ import annotations
 
 import csv
-import re
 from collections import Counter
 from pathlib import Path
 
 MANIFEST = Path('.github/free-model-factories.tsv')
 DISPATCHER = Path('.github/workflows/free-model-factory-dispatch.yml')
 ENTRY = Path('.github/workflows/free-model-factory-entry.yml')
+WATCHDOG = Path('.github/workflows/factory-heartbeat-watchdog.yml')
 EXPECTED_WORKERS = set(range(6, 47))
 EXPECTED_SOURCE_COUNTS = {
     'nvidia': 26,
@@ -27,7 +27,7 @@ EXPECTED_ZEN_MODELS = {
     'nemotron-3-ultra-free',
     'nemotron-3.5-lightning-free',
 }
-DISPATCH_MINUTES = (7, 22, 37, 52)
+BATCH_MINUTES = (0, 15, 30, 45)
 RETIRED_SCHEDULERS = (
     Path('.github/workflows/nvidia-factory-6.yml'),
     Path('.github/workflows/omniroute-factory-16.yml'),
@@ -48,7 +48,7 @@ ENTRY_PERMISSIONS = (
 
 
 def main() -> None:
-    """Validate roster completeness, fixed assignments, and dispatcher invariants."""
+    """Validate roster completeness, fixed assignments, and trigger invariants."""
     with MANIFEST.open(newline='', encoding='utf-8') as handle:
         rows = list(csv.DictReader(
             (line for line in handle if not line.startswith('# worker')),
@@ -57,18 +57,12 @@ def main() -> None:
         ))
 
     assert len(rows) == 41, f'expected 41 fixed model lanes, got {len(rows)}'
-
     workers = [int(row['worker']) for row in rows]
-    assert set(workers) == EXPECTED_WORKERS, (
-        f'worker roster mismatch: missing={sorted(EXPECTED_WORKERS - set(workers))} '
-        f'extra={sorted(set(workers) - EXPECTED_WORKERS)}'
-    )
-    assert len(workers) == len(set(workers)), 'duplicate worker IDs in fixed-model manifest'
+    assert set(workers) == EXPECTED_WORKERS
+    assert len(workers) == len(set(workers)), 'duplicate worker IDs'
 
     source_counts = Counter(row['source'] for row in rows)
-    assert source_counts == EXPECTED_SOURCE_COUNTS, (
-        f'source counts changed unexpectedly: {dict(source_counts)}'
-    )
+    assert source_counts == EXPECTED_SOURCE_COUNTS, f'unexpected source counts: {dict(source_counts)}'
 
     zen_models = {row['model'] for row in rows if row['source'] == 'zen'}
     assert zen_models == EXPECTED_ZEN_MODELS, (
@@ -78,44 +72,38 @@ def main() -> None:
 
     source_models = [(row['source'], row['model']) for row in rows]
     assert len(source_models) == len(set(source_models)), 'duplicate model inside the same source'
-
     assert not any(
         row['source'] == 'nvidia' and row['model'] == 'deepseek-ai/deepseek-v4-pro'
         for row in rows
-    ), 'page-only NVIDIA DeepSeek V4 Pro must not be scheduled as an API factory'
+    )
 
-    expected_batch_counts = Counter({7: 11, 22: 10, 37: 10, 52: 10})
+    expected_batch_counts = Counter({0: 11, 15: 10, 30: 10, 45: 10})
     actual_batch_counts: Counter[int] = Counter()
     for row in rows:
         worker = int(row['worker'])
         minute = int(row['minute'])
-        assert row['scheduler'] == 'dispatcher', f'worker {worker}: stale scheduler {row["scheduler"]!r}'
-        expected_minute = DISPATCH_MINUTES[(worker - 6) % len(DISPATCH_MINUTES)]
-        assert minute == expected_minute, (
-            f'worker {worker}: expected :{expected_minute:02d}, got :{minute:02d}'
-        )
+        assert row['scheduler'] == 'watchdog', f'worker {worker}: stale scheduler {row["scheduler"]!r}'
+        expected_minute = BATCH_MINUTES[(worker - 6) % len(BATCH_MINUTES)]
+        assert minute == expected_minute, f'worker {worker}: expected {expected_minute}, got {minute}'
         actual_batch_counts[minute] += 1
-        assert row['model'], f'worker {worker}: model is empty'
-        assert row['display_name'], f'worker {worker}: display name is empty'
-    assert actual_batch_counts == expected_batch_counts, (
-        f'dispatch batch counts changed: {dict(actual_batch_counts)}'
-    )
+        assert row['model'] and row['display_name']
+    assert actual_batch_counts == expected_batch_counts
 
-    assert DISPATCHER.exists(), 'single fixed-model dispatcher is missing'
+    assert WATCHDOG.exists(), 'heartbeat watchdog is missing'
+    watchdog_text = WATCHDOG.read_text(encoding='utf-8')
+    assert "cron: '*/15 * * * *'" in watchdog_text, 'watchdog must remain on proven 15-minute clock'
+
+    assert DISPATCHER.exists(), 'fixed-model dispatcher is missing'
     dispatcher_text = DISPATCHER.read_text(encoding='utf-8')
-    actual_crons = {
-        int(match.group(1))
-        for match in re.finditer(r"cron:\s*['\"](\d+) \* \* \* \*['\"]", dispatcher_text)
-    }
-    assert actual_crons == set(DISPATCH_MINUTES), (
-        f'dispatcher cron mismatch: expected={list(DISPATCH_MINUTES)} actual={sorted(actual_crons)}'
-    )
-    assert 'workers=\'["6","32","39"]\'' in dispatcher_text, (
-        'dispatcher must retain immediate NVIDIA/OmniRoute/OpenCode post-merge smoke'
-    )
+    assert 'workflow_run:' in dispatcher_text
+    assert "workflows: ['Factory heartbeat watchdog']" in dispatcher_text
+    assert 'schedule:' not in dispatcher_text, 'dispatcher must not own an independent cron clock'
+    assert 'WATCHDOG_RUN_NUMBER' in dispatcher_text
+    assert 'slots=(0 15 30 45)' in dispatcher_text
+    assert 'workers=\'["6","32","39"]\'' in dispatcher_text
     assert 'contents: read' in dispatcher_text and 'actions: write' in dispatcher_text
     assert 'gh workflow run free-model-factory-entry.yml' in dispatcher_text
-    assert 'matrix:' not in dispatcher_text, 'dispatcher must not dynamically matrix-call reusable workflows'
+    assert 'matrix:' not in dispatcher_text
 
     assert ENTRY.exists(), 'dispatchable fixed-model entry workflow is missing'
     entry_text = ENTRY.read_text(encoding='utf-8')
@@ -124,21 +112,20 @@ def main() -> None:
     assert 'worker: ${{ inputs.worker }}' in entry_text
     assert 'secrets: inherit' in entry_text
     for permission in ENTRY_PERMISSIONS:
-        assert permission in entry_text, f'entry workflow missing permission {permission!r}'
+        assert permission in entry_text
 
     for retired in RETIRED_SCHEDULERS:
         assert not retired.exists(), f'obsolete scheduler still exists: {retired}'
 
     runner = Path('.github/workflows/free-model-factory-run.yml')
     worker = Path('.github/scripts/free-model-factory-worker.sh')
-    assert runner.exists(), 'reusable fixed-model runner is missing'
-    assert worker.exists(), 'fixed-model worker script is missing'
+    assert runner.exists() and worker.exists()
     worker_text = worker.read_text(encoding='utf-8')
-    assert 'rotate_model' not in worker_text, 'fixed-model worker must never rotate models'
-    assert 'Do not switch models' in worker_text, 'fixed-model no-fallback contract is missing'
+    assert 'rotate_model' not in worker_text
+    assert 'Do not switch models' in worker_text
 
-    print('Validated 41 fixed model factories through dispatchable four-batch scheduler.')
-    for minute in DISPATCH_MINUTES:
+    print('Validated 41 fixed model factories on the proven 15-minute watchdog clock.')
+    for minute in BATCH_MINUTES:
         print(f'  :{minute:02d} -> {actual_batch_counts[minute]} workers')
     for source, count in EXPECTED_SOURCE_COUNTS.items():
         print(f'  {source}: {count}')

--- a/.github/workflows/free-model-factory-dispatch.yml
+++ b/.github/workflows/free-model-factory-dispatch.yml
@@ -1,11 +1,9 @@
 name: Fixed Model Factory Dispatcher
 
 on:
-  schedule:
-    - cron: '7 * * * *'
-    - cron: '22 * * * *'
-    - cron: '37 * * * *'
-    - cron: '52 * * * *'
+  workflow_run:
+    workflows: ['Factory heartbeat watchdog']
+    types: [completed]
   workflow_dispatch:
     inputs:
       worker:
@@ -26,6 +24,7 @@ permissions:
 
 jobs:
   dispatch:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -36,7 +35,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
-          SCHEDULE: ${{ github.event.schedule }}
+          WATCHDOG_RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
           DISPATCH_WORKER: ${{ inputs.worker }}
         run: |
           set -Eeuo pipefail
@@ -45,9 +44,12 @@ jobs:
           if [[ "$EVENT_NAME" == workflow_dispatch && -n "${DISPATCH_WORKER:-}" ]]; then
             awk -F '\t' -v worker="$DISPATCH_WORKER" '$1 == worker {found=1} END {exit !found}' "$manifest"
             workers="$(jq -nc --arg worker "$DISPATCH_WORKER" '[$worker]')"
-          elif [[ "$EVENT_NAME" == schedule ]]; then
-            minute="${SCHEDULE%% *}"
+          elif [[ "$EVENT_NAME" == workflow_run ]]; then
+            slots=(0 15 30 45)
+            index=$((WATCHDOG_RUN_NUMBER % 4))
+            minute="${slots[$index]}"
             workers="$(awk -F '\t' -v minute="$minute" '$4 == minute {print $1}' "$manifest" | jq -Rsc 'split("\n") | map(select(length > 0))')"
+            echo "Watchdog run ${WATCHDOG_RUN_NUMBER} selected :$(printf '%02d' "$minute") batch"
           else
             # Immediate post-merge/manual smoke: NVIDIA, OmniRoute, OpenCode.
             workers='["6","32","39"]'


### PR DESCRIPTION
The fixed-model dispatcher now works end-to-end on push and can launch real NVIDIA/OmniRoute/OpenCode worker entries, but its independent GitHub cron has still produced zero scheduled events. The existing Factory heartbeat watchdog has a proven `*/15` schedule with dozens of successful scheduled runs.

This change removes the dispatcher's independent cron and instead triggers it from completed `Factory heartbeat watchdog` runs. Each watchdog completion selects one of four batches by watchdog run number, so all 41 external fixed-model factories still receive one run per four watchdog ticks (about hourly).

- keep all Factory 6-46 model identities unchanged;
- align manifest slots to :00/:15/:30/:45 batch labels;
- listen to the proven watchdog via `workflow_run`;
- keep manual dispatch and merge smoke behavior;
- enforce in CI that the dispatcher owns no independent `schedule:` and that the watchdog remains `*/15`.

No product-code changes.