### PR TITLE
Fix keyless OpenCode Free factory lanes

### DIFF
--- a/.github/free-model-factories.tsv
+++ b/.github/free-model-factories.tsv
@@ -6,7 +6,7 @@
 10	nvidia	nvidia/nemotron-3-ultra-550b-a55b	0	watchdog	Nemotron 3 Ultra
 11	nvidia	poolside/laguna-xs-2.1	15	watchdog	Laguna XS 2.1
 12	nvidia	openai/gpt-oss-120b	30	watchdog	GPT OSS 120B
-13	nvidia	mistralai/mistral-medium-3.5-128b	45	watchdog	Mistral Medium 3.5
+13	nvidia	mistralai/mistral-small-4-119b-2603	45	watchdog	Mistral Small 4 119B
 14	nvidia	minimaxai/minimax-m3	0	watchdog	MiniMax M3
 15	nvidia	mistralai/mistral-nemotron	15	watchdog	Mistral Nemotron
 16	nvidia	nvidia/nemotron-3-super-120b-a12b	30	watchdog	Nemotron 3 Super
@@ -32,11 +32,11 @@
 36	omniroute-opencode	oc/laguna-s-2.1-free	30	watchdog	OmniRoute Laguna S 2.1 Free
 37	omniroute-opencode	oc/hy3-free	45	watchdog	OmniRoute Tencent Hy3 Free
 38	omniroute-opencode	oc/nemotron-3.5-lightning-free	0	watchdog	OmniRoute Nemotron 3.5 Lightning Free
-39	zen	big-pickle	15	watchdog	OpenCode Big Pickle
-40	zen	deepseek-v4-flash-free	30	watchdog	OpenCode DeepSeek V4 Flash Free
-41	zen	mimo-v2.5-free	45	watchdog	OpenCode MiMo V2.5 Free
-42	zen	nemotron-3-ultra-free	0	watchdog	OpenCode Nemotron 3 Ultra Free
-43	zen	laguna-s-2.1-free	15	watchdog	OpenCode Laguna S 2.1 Free
-44	zen	hy3-free	30	watchdog	OpenCode Tencent Hy3 Free
-45	zen	nemotron-3.5-lightning-free	45	watchdog	OpenCode Nemotron 3.5 Lightning Free
-46	zen	ling-3.0-tiny-free	0	watchdog	OpenCode Ling 3.0 Tiny Free
+39	opencode-free	big-pickle	15	watchdog	OpenCode Big Pickle
+40	opencode-free	deepseek-v4-flash-free	30	watchdog	OpenCode DeepSeek V4 Flash Free
+41	opencode-free	mimo-v2.5-free	45	watchdog	OpenCode MiMo V2.5 Free
+42	opencode-free	nemotron-3-ultra-free	0	watchdog	OpenCode Nemotron 3 Ultra Free
+43	opencode-free	laguna-s-2.1-free	15	watchdog	OpenCode Laguna S 2.1 Free
+44	opencode-free	hy3-free	30	watchdog	OpenCode Tencent Hy3 Free
+45	opencode-free	nemotron-3.5-lightning-free	45	watchdog	OpenCode Nemotron 3.5 Lightning Free
+46	opencode-free	ling-3.0-tiny-free	0	watchdog	OpenCode Ling 3.0 Tiny Free

--- a/.github/scripts/validate-free-model-factories.py
+++ b/.github/scripts/validate-free-model-factories.py
@@ -15,9 +15,9 @@ EXPECTED_WORKERS = set(range(6, 47))
 EXPECTED_SOURCE_COUNTS = {
     'nvidia': 26,
     'omniroute-opencode': 7,
-    'zen': 8,
+    'opencode-free': 8,
 }
-EXPECTED_ZEN_MODELS = {
+EXPECTED_OPENCODE_FREE_MODELS = {
     'big-pickle',
     'deepseek-v4-flash-free',
     'hy3-free',
@@ -64,10 +64,13 @@ def main() -> None:
     source_counts = Counter(row['source'] for row in rows)
     assert source_counts == EXPECTED_SOURCE_COUNTS, f'unexpected source counts: {dict(source_counts)}'
 
-    zen_models = {row['model'] for row in rows if row['source'] == 'zen'}
-    assert zen_models == EXPECTED_ZEN_MODELS, (
-        f'OpenCode free roster changed: missing={sorted(EXPECTED_ZEN_MODELS - zen_models)} '
-        f'extra={sorted(zen_models - EXPECTED_ZEN_MODELS)}'
+    opencode_free_models = {row['model'] for row in rows if row['source'] == 'opencode-free'}
+    assert opencode_free_models == EXPECTED_OPENCODE_FREE_MODELS, (
+        f'OpenCode free roster changed: missing={sorted(EXPECTED_OPENCODE_FREE_MODELS - opencode_free_models)} '
+        f'extra={sorted(opencode_free_models - EXPECTED_OPENCODE_FREE_MODELS)}'
+    )
+    assert not any(row['source'] in {'zen', 'kilo', 'llm7', 'ovhcloud'} for row in rows), (
+        'retired or unrelated provider source returned to the fixed-model roster'
     )
 
     source_models = [(row['source'], row['model']) for row in rows]
@@ -76,6 +79,10 @@ def main() -> None:
         row['source'] == 'nvidia' and row['model'] == 'deepseek-ai/deepseek-v4-pro'
         for row in rows
     )
+    assert not any(
+        row['source'] == 'nvidia' and row['model'] == 'mistralai/mistral-medium-3.5-128b'
+        for row in rows
+    ), 'Factory 13 retired NVIDIA model returned to the roster'
 
     expected_batch_counts = Counter({0: 11, 15: 10, 30: 10, 45: 10})
     actual_batch_counts: Counter[int] = Counter()
@@ -120,6 +127,12 @@ def main() -> None:
     runner = Path('.github/workflows/free-model-factory-run.yml')
     worker = Path('.github/scripts/free-model-factory-worker.sh')
     assert runner.exists() and worker.exists()
+    runner_text = runner.read_text(encoding='utf-8')
+    assert 'opencode-free)' in runner_text
+    assert 'runtime_model="opencode/${model}"' in runner_text
+    assert "branch_suffix='opencode-free'" in runner_text
+    assert 'OPENCODE_API_KEY' not in runner_text, 'direct OpenCode Free must remain keyless'
+    assert all(source not in runner_text for source in ('kilo)', 'llm7)', 'ovhcloud)', 'zen)'))
     worker_text = worker.read_text(encoding='utf-8')
     assert 'rotate_model' not in worker_text
     assert 'Do not switch models' in worker_text

--- a/.github/workflows/free-model-factory-run.yml
+++ b/.github/workflows/free-model-factory-run.yml
@@ -10,8 +10,6 @@ on:
     secrets:
       NVIDIA_API_KEY:
         required: false
-      OPENCODE_API_KEY:
-        required: false
 
 permissions:
   contents: write
@@ -37,7 +35,6 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
-      OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v6
@@ -70,28 +67,11 @@ jobs:
               configured=true
               reason='configured'
               ;;
-            zen)
+            opencode-free)
               runtime_model="opencode/${model}"
-              branch_suffix='zen'
-              if [[ -n "${OPENCODE_API_KEY:-}" ]]; then configured=true; reason='configured'; else configured=false; reason='missing-OPENCODE_API_KEY'; fi
-              ;;
-            kilo)
-              runtime_model="kilo/${model}"
-              branch_suffix='kilo'
+              branch_suffix='opencode-free'
               configured=true
-              reason='configured'
-              ;;
-            llm7)
-              runtime_model="llm7/${model}"
-              branch_suffix='llm7'
-              configured=true
-              reason='configured'
-              ;;
-            ovhcloud)
-              runtime_model="ovhcloud/${model}"
-              branch_suffix='ovh'
-              configured=true
-              reason='configured'
+              reason='configured-keyless'
               ;;
             *)
               echo "Unsupported factory source: ${source}" >&2
@@ -188,33 +168,6 @@ jobs:
           test -x "$bin_dir/opencode"
           echo "$bin_dir" >> "$GITHUB_PATH"
           "$bin_dir/opencode" --version
-
-      - name: Configure keyless OpenAI-compatible provider
-        if: steps.lane.outputs.configured == 'true' && (steps.lane.outputs.source == 'kilo' || steps.lane.outputs.source == 'llm7' || steps.lane.outputs.source == 'ovhcloud')
-        shell: bash
-        env:
-          SOURCE: ${{ steps.lane.outputs.source }}
-          MODEL: ${{ steps.lane.outputs.model }}
-        run: |
-          set -Eeuo pipefail
-          mkdir -p "$HOME/.config/opencode"
-          case "$SOURCE" in
-            kilo) base_url='https://api.kilo.ai/api/gateway' ;;
-            llm7) base_url='https://api.llm7.io/v1' ;;
-            ovhcloud) base_url='https://oai.endpoints.kepler.ai.cloud.ovh.net/v1' ;;
-            *) echo "Unsupported keyless provider ${SOURCE}" >&2; exit 2 ;;
-          esac
-          jq -n --arg provider "$SOURCE" --arg model "$MODEL" --arg base "$base_url" '{
-            provider: {
-              ($provider): {
-                npm: "@ai-sdk/openai-compatible",
-                name: ($provider + " free lane"),
-                options: {baseURL: $base},
-                models: {($model): {name: $model}}
-              }
-            }
-          }' > "$HOME/.config/opencode/opencode.json"
-          chmod 600 "$HOME/.config/opencode/opencode.json"
 
       - name: Create ephemeral OmniRoute runtime secrets
         if: steps.lane.outputs.configured == 'true' && steps.lane.outputs.source == 'omniroute-opencode'


### PR DESCRIPTION
Fix the external fixed-model fleet without changing the proven watchdog scheduler architecture.

- rename direct lanes from `zen` to `opencode-free`
- remove `OPENCODE_API_KEY` gating and stale unrelated provider cases
- keep direct runtime IDs exactly `opencode/<model>` for Factories 39–46
- replace Factory 13's retired NVIDIA model with fixed `mistralai/mistral-small-4-119b-2603`
- strengthen roster validation so the intended 26 NVIDIA / 7 OmniRoute / 8 OpenCode Free split cannot silently regress

Post-merge validation still requires a real watchdog/dispatcher/entry run proving a direct OpenCode Free model executes keylessly. No model fallback or independent cron is introduced.