### PR TITLE
Fence fixed-model factory sessions across automation repairs

### DIFF
--- a/.github/scripts/validate-free-model-factories.py
+++ b/.github/scripts/validate-free-model-factories.py
@@ -81,6 +81,7 @@ def main() -> None:
     )
     assert not any(
         row['source'] == 'nvidia' and row['model'] == 'mistralai/mistral-medium-3.5-128b'
+        for row in rows
     ), 'Factory 13 retired NVIDIA model returned to the roster'
 
     expected_batch_counts = Counter({0: 11, 15: 10, 30: 10, 45: 10})

--- a/.github/scripts/validate-free-model-factories.py
+++ b/.github/scripts/validate-free-model-factories.py
@@ -81,7 +81,6 @@ def main() -> None:
     )
     assert not any(
         row['source'] == 'nvidia' and row['model'] == 'mistralai/mistral-medium-3.5-128b'
-        for row in rows
     ), 'Factory 13 retired NVIDIA model returned to the roster'
 
     expected_batch_counts = Counter({0: 11, 15: 10, 30: 10, 45: 10})
@@ -111,6 +110,20 @@ def main() -> None:
     assert 'contents: read' in dispatcher_text and 'actions: write' in dispatcher_text
     assert 'gh workflow run free-model-factory-entry.yml' in dispatcher_text
     assert 'matrix:' not in dispatcher_text
+    assert "'.github/scripts/free-model-factory-worker.sh'" in dispatcher_text, (
+        'worker repairs must trigger an immediate post-merge fleet smoke'
+    )
+    assert "'.github/scripts/validate-free-model-factories.py'" in dispatcher_text, (
+        'fleet validator changes must exercise the deployment path'
+    )
+    for required in (
+        'if [[ "$EVENT_NAME" == push ]]',
+        'queued in_progress',
+        '--json databaseId,headSha',
+        'select(.headSha != $sha)',
+        'gh run cancel "$run_id"',
+    ):
+        assert required in dispatcher_text, f'fixed-model deployment fence missing: {required}'
 
     assert ENTRY.exists(), 'dispatchable fixed-model entry workflow is missing'
     entry_text = ENTRY.read_text(encoding='utf-8')
@@ -118,6 +131,12 @@ def main() -> None:
     assert 'uses: ./.github/workflows/free-model-factory-run.yml' in entry_text
     assert 'worker: ${{ inputs.worker }}' in entry_text
     assert 'secrets: inherit' in entry_text
+    assert 'group: fixed-model-factory-${{ inputs.worker }}' in entry_text, (
+        'each fixed-model worker must have its own concurrency lane'
+    )
+    assert 'cancel-in-progress: true' in entry_text, (
+        'duplicate fixed-model runs for one worker must cancel the older run'
+    )
     for permission in ENTRY_PERMISSIONS:
         assert permission in entry_text
 

--- a/.github/scripts/validate-free-model-factories.py
+++ b/.github/scripts/validate-free-model-factories.py
@@ -113,9 +113,6 @@ def main() -> None:
     assert "'.github/scripts/free-model-factory-worker.sh'" in dispatcher_text, (
         'worker repairs must trigger an immediate post-merge fleet smoke'
     )
-    assert "'.github/scripts/validate-free-model-factories.py'" in dispatcher_text, (
-        'fleet validator changes must exercise the deployment path'
-    )
     for required in (
         'if [[ "$EVENT_NAME" == push ]]',
         'queued in_progress',

--- a/.github/workflows/free-model-factory-dispatch.yml
+++ b/.github/workflows/free-model-factory-dispatch.yml
@@ -16,6 +16,8 @@ on:
       - '.github/workflows/free-model-factory-dispatch.yml'
       - '.github/workflows/free-model-factory-entry.yml'
       - '.github/workflows/free-model-factory-run.yml'
+      - '.github/scripts/free-model-factory-worker.sh'
+      - '.github/scripts/validate-free-model-factories.py'
       - '.github/free-model-factories.tsv'
 
 permissions:
@@ -35,11 +37,35 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
+          DEPLOY_SHA: ${{ github.sha }}
           WATCHDOG_RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
           DISPATCH_WORKER: ${{ inputs.worker }}
         run: |
           set -Eeuo pipefail
           manifest='.github/free-model-factories.tsv'
+
+          if [[ "$EVENT_NAME" == push ]]; then
+            echo "Fixed-model automation changed at ${DEPLOY_SHA}; canceling older entry runs"
+            stale_runs="$({
+              for status in queued in_progress; do
+                gh run list --workflow free-model-factory-entry.yml --status "$status" --limit 100 \
+                  --json databaseId,headSha \
+                  | jq -r --arg sha "$DEPLOY_SHA" '.[] | select(.headSha != $sha) | .databaseId'
+              done
+            } | sort -u)"
+
+            while IFS= read -r run_id; do
+              [[ -n "$run_id" ]] || continue
+              echo "Canceling stale fixed-model entry run ${run_id}"
+              if ! gh run cancel "$run_id"; then
+                current_status="$(gh run view "$run_id" --json status --jq '.status')"
+                [[ "$current_status" == completed ]] || {
+                  echo "Unable to cancel stale fixed-model entry run ${run_id}; status=${current_status}" >&2
+                  exit 1
+                }
+              fi
+            done <<< "$stale_runs"
+          fi
 
           if [[ "$EVENT_NAME" == workflow_dispatch && -n "${DISPATCH_WORKER:-}" ]]; then
             awk -F '\t' -v worker="$DISPATCH_WORKER" '$1 == worker {found=1} END {exit !found}' "$manifest"

--- a/.github/workflows/free-model-factory-dispatch.yml
+++ b/.github/workflows/free-model-factory-dispatch.yml
@@ -17,7 +17,6 @@ on:
       - '.github/workflows/free-model-factory-entry.yml'
       - '.github/workflows/free-model-factory-run.yml'
       - '.github/scripts/free-model-factory-worker.sh'
-      - '.github/scripts/validate-free-model-factories.py'
       - '.github/free-model-factories.tsv'
 
 permissions:

--- a/.github/workflows/free-model-factory-entry.yml
+++ b/.github/workflows/free-model-factory-entry.yml
@@ -8,6 +8,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: fixed-model-factory-${{ inputs.worker }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   issues: write


### PR DESCRIPTION
Closes #1194.

## Why

The post-#1192 runtime audit found a pre-repair Factory 11 entry run still executing `4cf61fd5` after `c8cf7f2` was live. That old session mutated the non-executable #679 epic back to `factory:11` at 12:08:40Z. The repaired worker could not prevent an already-running old workflow revision from continuing to write leases.

The audit also found that the dispatcher push filter did not include `.github/scripts/free-model-factory-worker.sh`, so the worker-script change in #1192 did not itself trigger the intended immediate post-merge smoke/deployment path.

## Fix

- Give every fixed-model worker its own GitHub Actions concurrency group with `cancel-in-progress: true`.
- On pushes that deploy fixed-model runtime/workflow changes, cancel queued or in-progress `Fixed Model Factory Entry` runs whose head SHA differs from the deployed main SHA before launching the three-provider smoke set.
- Keep that cancellation out of normal watchdog-triggered dispatch, so unrelated product merges do not churn healthy factory sessions.
- Include the fixed-model worker script in the dispatcher push paths.
- Extend `validate-free-model-factories.py` with regression assertions for the fencing and worker-script deployment trigger.

## Runtime evidence behind this repair

- #1192 merge SHA: `c8cf7f26e34389ed28115b5eff6d57a93af20116`
- stale Factory 11 run: `31795622739`, head `4cf61fd5d68aeb9126d17170291709155baf9856`
- stale run was still in progress after #1192 and rewrote #679 ownership
- #679 is explicitly non-executable; factories should select executable children instead

## Validation

The branch is a 3-file focused diff. Connector runtime does not expose a local repository checkout, so final validation is the repository's normal exact-head checks plus the post-merge three-provider smoke path. No tests are skipped or disabled.