### PR TITLE
Restore fixed-model entry dispatch after concurrency fence

### DIFF
--- a/.github/scripts/validate-free-model-factories.py
+++ b/.github/scripts/validate-free-model-factories.py
@@ -129,11 +129,8 @@ def main() -> None:
     assert 'uses: ./.github/workflows/free-model-factory-run.yml' in entry_text
     assert 'worker: ${{ inputs.worker }}' in entry_text
     assert 'secrets: inherit' in entry_text
-    assert 'group: fixed-model-factory-${{ inputs.worker }}' in entry_text, (
-        'each fixed-model worker must have its own concurrency lane'
-    )
-    assert 'cancel-in-progress: true' in entry_text, (
-        'duplicate fixed-model runs for one worker must cancel the older run'
+    assert 'concurrency:' not in entry_text, (
+        'entry wrapper must not compete with the reusable runner for the same concurrency group'
     )
     for permission in ENTRY_PERMISSIONS:
         assert permission in entry_text
@@ -145,6 +142,12 @@ def main() -> None:
     worker = Path('.github/scripts/free-model-factory-worker.sh')
     assert runner.exists() and worker.exists()
     runner_text = runner.read_text(encoding='utf-8')
+    assert 'group: fixed-model-factory-${{ inputs.worker }}' in runner_text, (
+        'reusable runner must serialize each fixed-model worker lane'
+    )
+    assert 'cancel-in-progress: false' in runner_text, (
+        'same-worker sessions should serialize; factory-runtime deploys cancel stale revisions explicitly'
+    )
     assert 'opencode-free)' in runner_text
     assert 'runtime_model="opencode/${model}"' in runner_text
     assert "branch_suffix='opencode-free'" in runner_text

--- a/.github/workflows/free-model-factory-entry.yml
+++ b/.github/workflows/free-model-factory-entry.yml
@@ -8,10 +8,6 @@ on:
         required: true
         type: string
 
-concurrency:
-  group: fixed-model-factory-${{ inputs.worker }}
-  cancel-in-progress: true
-
 permissions:
   contents: write
   issues: write


### PR DESCRIPTION
Closes #1196.

Runtime follow-up to #1195.

The immediate post-merge smoke exposed that workers 6, 32, and 39 all failed before creating a job. Root cause: the reusable runner already owned the per-worker concurrency group, while #1195 added the same group to the caller wrapper. The caller and called workflow were therefore competing for the same lane.

This repair:
- restores the entry wrapper to its previously proven minimal reusable-workflow caller shape
- keeps the existing per-worker serialization in `free-model-factory-run.yml`
- keeps #1195's deploy-time cancellation of old factory-runtime revisions
- updates the deterministic validator so this caller/runner concurrency collision cannot return

No model roster, provider routing, lease-selection logic, worker script, or product code changes.