### PR TITLE
Preserve fixed-model PR ownership through Factory 46

### DIFF
--- a/.github/scripts/factory-visibility.cjs
+++ b/.github/scripts/factory-visibility.cjs
@@ -1,4 +1,4 @@
-const WORKER_OWNER_LABELS = Array.from({ length: 16 }, (_, index) => `factory:${index + 1}`);
+const WORKER_OWNER_LABELS = Array.from({ length: 46 }, (_, index) => `factory:${index + 1}`);
 
 const DEFINITIONS = {
   factory: ['5319E7', 'Work owned or produced by an autonomous ComicPile factory'],
@@ -54,6 +54,13 @@ function workerFrom(body) {
 function ownerFor(worker) {
   const scheduled = worker?.match(/^chatgpt-factory-([1-5])$/);
   if (scheduled) return `factory:${scheduled[1]}`;
+
+  const fixedModel = worker?.match(/^opencode-(?:free-model|nvidia)-factory-(\d+)$/);
+  if (fixedModel) {
+    const number = Number(fixedModel[1]);
+    if (number >= 6 && number <= 46) return `factory:${number}`;
+  }
+
   if (worker === 'local' || worker === 'local-opencode' || worker?.startsWith('local-opencode-')) {
     return 'factory:local';
   }
@@ -154,11 +161,14 @@ async function ensureLabels(github, context) {
 }
 
 async function ownerFromLinkedIssue(github, context, pullRequest) {
-  const branch = pullRequest.head.ref.match(/^factory\/(\d+)(?:-|$)/);
   const closing = (pullRequest.body || '').match(
     /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/i,
   );
-  const issueNumber = Number(branch?.[1] || closing?.[1] || 0);
+  const fixedModelBranch = pullRequest.head.ref.match(
+    /^factory\/\d+-(\d+)-(?:nvidia|omni|opencode-free)(?:-|$)/,
+  );
+  const legacyBranch = pullRequest.head.ref.match(/^factory\/(\d+)(?:-|$)/);
+  const issueNumber = Number(closing?.[1] || fixedModelBranch?.[1] || legacyBranch?.[1] || 0);
   if (!issueNumber) return 'factory:unowned';
 
   const comments = await withRetry(() => github.paginate(github.rest.issues.listComments, {
@@ -224,7 +234,7 @@ async function reconcile({ github, context }) {
       .find(label => current.has(label));
 
     await reconcileLabels(github, context, pullRequest.number, {
-      // External workers write their durable PR owner before review workflows
+      // Fixed-model workers write their durable PR owner before review workflows
       // refresh visibility. Preserve that stronger PR-local signal even when the
       // linked issue has since been released for other work.
       owner: externalOwner || await ownerFromLinkedIssue(github, context, pullRequest),

--- a/.github/scripts/factory-visibility.cjs
+++ b/.github/scripts/factory-visibility.cjs
@@ -1,8 +1,9 @@
 const WORKER_OWNER_LABELS = Array.from({ length: 46 }, (_, index) => `factory:${index + 1}`);
+const VISIBILITY_MANAGED_OWNER_LABELS = WORKER_OWNER_LABELS.slice(0, 16);
 
 const DEFINITIONS = {
   factory: ['5319E7', 'Work owned or produced by an autonomous ComicPile factory'],
-  ...Object.fromEntries(WORKER_OWNER_LABELS.map((name, index) => [
+  ...Object.fromEntries(VISIBILITY_MANAGED_OWNER_LABELS.map((name, index) => [
     name,
     ['0366D6', `Current next-action owner is ComicPile Factory ${index + 1}`],
   ])),

--- a/.github/scripts/factory-visibility.test.cjs
+++ b/.github/scripts/factory-visibility.test.cjs
@@ -12,14 +12,16 @@ function contextFor(eventName, payload) {
   };
 }
 
-function githubFor({ labels = [], comments = [], setLabels } = {}) {
+function githubFor({ labels = [], comments = [], setLabels, commentIssueNumbers } = {}) {
+  const workerDefinitions = Object.fromEntries(
+    Array.from({ length: 46 }, (_, index) => [
+      `factory:${index + 1}`,
+      ['0366D6', `Current next-action owner is ComicPile Factory ${index + 1}`],
+    ]),
+  );
   const definitions = Object.entries({
     factory: ['5319E7', 'Work owned or produced by an autonomous ComicPile factory'],
-    'factory:1': ['0366D6', 'Current next-action owner is ComicPile Factory 1'],
-    'factory:2': ['0366D6', 'Current next-action owner is ComicPile Factory 2'],
-    'factory:3': ['0366D6', 'Current next-action owner is ComicPile Factory 3'],
-    'factory:4': ['0366D6', 'Current next-action owner is ComicPile Factory 4'],
-    'factory:5': ['0366D6', 'Current next-action owner is ComicPile Factory 5'],
+    ...workerDefinitions,
     'factory:local': ['0366D6', 'Current next-action owner is the local OpenCode factory'],
     'factory:unowned': ['BFDADC', 'Factory work has no current next-action owner'],
     'factory:building': ['FBCA04', 'A factory is actively implementing or repairing this work'],
@@ -38,9 +40,12 @@ function githubFor({ labels = [], comments = [], setLabels } = {}) {
     setLabels: setLabels || (async () => {}),
   };
   return {
-    paginate: async operation => {
+    paginate: async (operation, params = {}) => {
       if (operation === api.listLabelsForRepo) return definitions;
-      if (operation === api.listComments) return comments;
+      if (operation === api.listComments) {
+        if (commentIssueNumbers) commentIssueNumbers.push(params.issue_number);
+        return comments;
+      }
       return labels.map(name => ({ name }));
     },
     rest: { issues: api },
@@ -51,6 +56,13 @@ test('canonical local worker tokens map to the local owner', () => {
   assert.equal(ownerFor('local'), 'factory:local');
   assert.equal(ownerFor('local-opencode'), 'factory:local');
   assert.equal(ownerFor('local-opencode-debian'), 'factory:local');
+});
+
+test('fixed-model worker tokens map across the complete fleet range', () => {
+  assert.equal(ownerFor('opencode-nvidia-factory-6'), 'factory:6');
+  assert.equal(ownerFor('opencode-free-model-factory-32'), 'factory:32');
+  assert.equal(ownerFor('opencode-free-model-factory-46'), 'factory:46');
+  assert.equal(ownerFor('opencode-free-model-factory-47'), 'factory:unowned');
 });
 
 test('label reconciliation replaces both groups with one atomic call', async () => {
@@ -105,6 +117,28 @@ test('PR progress comments preserve an advanced review stage and local owner', a
   assert.ok(!calls[0].labels.includes('factory:unowned'));
 });
 
+test('fixed-model progress comments use the durable fixed owner', async () => {
+  const calls = [];
+  const github = githubFor({
+    labels: ['factory', 'factory:building', 'factory:unowned'],
+    setLabels: async input => calls.push(input),
+  });
+  await reconcile({
+    github,
+    context: contextFor('issue_comment', {
+      issue: { number: 1089 },
+      comment: {
+        author_association: 'OWNER',
+        user: { login: 'JoshCLWren' },
+        body: '<!-- comic-pile-factory-implement-progress-v3:issue-1089:opencode-free-model-factory-32:123 -->',
+      },
+    }),
+  });
+  assert.equal(calls.length, 1);
+  assert.ok(calls[0].labels.includes('factory:32'));
+  assert.ok(!calls[0].labels.includes('factory:unowned'));
+});
+
 test('PR synchronize events refresh owner and stage from the linked issue', async () => {
   const calls = [];
   const github = githubFor({
@@ -140,6 +174,84 @@ test('PR synchronize events refresh owner and stage from the linked issue', asyn
   assert.ok(!calls[0].labels.includes('factory:building'));
 });
 
+test('PR refresh preserves a Factory 32 PR-local owner', async () => {
+  const calls = [];
+  const github = githubFor({
+    labels: ['factory', 'factory:review', 'factory:32'],
+    comments: [{
+      author_association: 'OWNER',
+      body: '<!-- comic-pile-factory-claim-released-v3:issue-1089:opencode-free-model-factory-32:123 -->',
+      created_at: '2026-08-14T14:27:00Z',
+      user: { login: 'JoshCLWren' },
+    }],
+    setLabels: async input => calls.push(input),
+  });
+
+  await reconcile({
+    github,
+    context: contextFor('pull_request_target', {
+      action: 'synchronize',
+      repository: { full_name: 'JoshCLWren/comic-pile' },
+      pull_request: {
+        body: 'Closes #1089',
+        head: {
+          ref: 'factory/32-1089-omni',
+          repo: { full_name: 'JoshCLWren/comic-pile' },
+        },
+        labels: [{ name: 'factory' }, { name: 'factory:32' }],
+        number: 1202,
+      },
+    }),
+  });
+
+  assert.equal(calls.length, 1);
+  assert.ok(calls[0].labels.includes('factory:32'));
+  assert.ok(calls[0].labels.includes('factory:review'));
+  assert.ok(!calls[0].labels.includes('factory:unowned'));
+});
+
+test('released fixed-model PR resolves closing issue instead of worker branch number', async () => {
+  const calls = [];
+  const commentIssueNumbers = [];
+  const github = githubFor({
+    labels: ['factory', 'factory:review', 'factory:unowned'],
+    comments: [{
+      author_association: 'OWNER',
+      body: '<!-- comic-pile-factory-claim-released-v3:issue-1089:opencode-free-model-factory-32:123 -->',
+      created_at: '2026-08-14T14:27:00Z',
+      user: { login: 'JoshCLWren' },
+    }],
+    commentIssueNumbers,
+    setLabels: async input => calls.push(input),
+  });
+
+  await reconcile({
+    github,
+    context: contextFor('pull_request_target', {
+      action: 'synchronize',
+      repository: { full_name: 'JoshCLWren/comic-pile' },
+      pull_request: {
+        body: 'Closes #1089',
+        head: {
+          ref: 'factory/32-1089-omni',
+          repo: { full_name: 'JoshCLWren/comic-pile' },
+        },
+        labels: [{ name: 'factory' }, { name: 'factory:unowned' }],
+        number: 1202,
+      },
+    }),
+  });
+
+  assert.deepEqual(commentIssueNumbers, [1089]);
+  assert.equal(calls.length, 1);
+  const owners = calls[0].labels.filter(label => (
+    label === 'factory:unowned'
+    || label === 'factory:local'
+    || /^factory:(?:[1-9]|[1-3][0-9]|4[0-6])$/.test(label)
+  ));
+  assert.deepEqual(owners, ['factory:unowned']);
+  assert.ok(calls[0].labels.includes('factory:review'));
+});
 
 test('PR refresh preserves one external owner after the linked issue is released', async () => {
   const calls = [];
@@ -183,7 +295,9 @@ test('PR refresh preserves one external owner after the linked issue is released
 
   assert.equal(calls.length, 1);
   const owners = calls[0].labels.filter(label => (
-    /^factory:(?:unowned|local|[1-9]|1[0-6])$/.test(label)
+    label === 'factory:unowned'
+    || label === 'factory:local'
+    || /^factory:(?:[1-9]|[1-3][0-9]|4[0-6])$/.test(label)
   ));
   assert.deepEqual(owners, ['factory:13']);
   assert.ok(calls[0].labels.includes('factory:review'));

--- a/.github/scripts/factory-visibility.test.cjs
+++ b/.github/scripts/factory-visibility.test.cjs
@@ -12,31 +12,41 @@ function contextFor(eventName, payload) {
   };
 }
 
-function githubFor({ labels = [], comments = [], setLabels, commentIssueNumbers } = {}) {
+function githubFor({
+  labels = [],
+  comments = [],
+  setLabels,
+  updateLabel,
+  commentIssueNumbers,
+  extraDefinitions = [],
+} = {}) {
   const workerDefinitions = Object.fromEntries(
-    Array.from({ length: 46 }, (_, index) => [
+    Array.from({ length: 16 }, (_, index) => [
       `factory:${index + 1}`,
       ['0366D6', `Current next-action owner is ComicPile Factory ${index + 1}`],
     ]),
   );
-  const definitions = Object.entries({
-    factory: ['5319E7', 'Work owned or produced by an autonomous ComicPile factory'],
-    ...workerDefinitions,
-    'factory:local': ['0366D6', 'Current next-action owner is the local OpenCode factory'],
-    'factory:unowned': ['BFDADC', 'Factory work has no current next-action owner'],
-    'factory:building': ['FBCA04', 'A factory is actively implementing or repairing this work'],
-    'factory:review': ['D4C5F9', 'The exact current head needs review or re-review'],
-    'factory:changes-requested': ['D73A4A', 'Actionable review findings currently block progress'],
-    'factory:ci': ['1D76DB', 'Review passed and required exact-head checks are being verified'],
-    'factory:ready': ['0E8A16', 'All exact-head factory merge gates are satisfied'],
-    'factory:blocked': ['B60205', 'A genuine human, credential, or external blocker remains'],
-  }).map(([name, [color, description]]) => ({ name, color, description }));
+  const definitions = [
+    ...Object.entries({
+      factory: ['5319E7', 'Work owned or produced by an autonomous ComicPile factory'],
+      ...workerDefinitions,
+      'factory:local': ['0366D6', 'Current next-action owner is the local OpenCode factory'],
+      'factory:unowned': ['BFDADC', 'Factory work has no current next-action owner'],
+      'factory:building': ['FBCA04', 'A factory is actively implementing or repairing this work'],
+      'factory:review': ['D4C5F9', 'The exact current head needs review or re-review'],
+      'factory:changes-requested': ['D73A4A', 'Actionable review findings currently block progress'],
+      'factory:ci': ['1D76DB', 'Review passed and required exact-head checks are being verified'],
+      'factory:ready': ['0E8A16', 'All exact-head factory merge gates are satisfied'],
+      'factory:blocked': ['B60205', 'A genuine human, credential, or external blocker remains'],
+    }).map(([name, [color, description]]) => ({ name, color, description })),
+    ...extraDefinitions,
+  ];
   const api = {
     listLabelsForRepo() {},
     listLabelsOnIssue() {},
     listComments() {},
     createLabel: async () => {},
-    updateLabel: async () => {},
+    updateLabel: updateLabel || (async () => {}),
     setLabels: setLabels || (async () => {}),
   };
   return {
@@ -63,6 +73,22 @@ test('fixed-model worker tokens map across the complete fleet range', () => {
   assert.equal(ownerFor('opencode-free-model-factory-32'), 'factory:32');
   assert.equal(ownerFor('opencode-free-model-factory-46'), 'factory:46');
   assert.equal(ownerFor('opencode-free-model-factory-47'), 'factory:unowned');
+});
+
+test('fixed-model label metadata is recognized without being rewritten', async () => {
+  const updates = [];
+  const github = githubFor({
+    extraDefinitions: [{
+      name: 'factory:32',
+      color: '5319e7',
+      description: 'Fixed-model Factory 32: OmniRoute Big Pickle via omniroute-opencode',
+    }],
+    updateLabel: async input => updates.push(input),
+  });
+
+  await reconcile({ github, context: contextFor('workflow_dispatch', {}) });
+
+  assert.ok(!updates.some(update => update.name === 'factory:32'));
 });
 
 test('label reconciliation replaces both groups with one atomic call', async () => {


### PR DESCRIPTION
Closes #1209.

Live fleet validation exposed two stale assumptions in shared factory visibility reconciliation:

- durable owner labels stopped at `factory:16`, so PR refresh events could not reliably preserve Factories 17-46;
- fixed-model branches such as `factory/32-1089-omni` could be interpreted as linking to issue #32 instead of #1089.

This extends the shared owner vocabulary through Factory 46, maps trusted fixed-model worker markers back to their durable owner labels, and resolves fixed-model PR linkage from the explicit closing issue before branch fallback. Focused tests cover the exact Factory 32 / PR #1202 shape, including proving the reconciler queries issue #1089 rather than #32 and preserves released `factory:unowned` state.

No scheduler, model, worker selection, or lease acquisition behavior is changed.