### PR TITLE
Guard fixed-model PR repairs and runner leases

### DIFF
--- a/.github/scripts/fixed-model-guard.py
+++ b/.github/scripts/fixed-model-guard.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Pure decision helpers for fixed-model fleet safety guards."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import unittest
+
+MAX_RUN_SECONDS = 2400
+
+
+def unrelated_repair(previous_pr_files: set[str], latest_commit_files: set[str]) -> bool:
+    """Reject only an existing-PR repair whose latest commit has zero overlap.
+
+    Empty previous PR diffs represent first implementation commits and are not
+    treated as adopted-PR repair work.
+    """
+    return bool(previous_pr_files and latest_commit_files and previous_pr_files.isdisjoint(latest_commit_files))
+
+
+def over_runtime_budget(age_seconds: int, status: str) -> bool:
+    return status == "in_progress" and age_seconds >= MAX_RUN_SECONDS
+
+
+class GuardTests(unittest.TestCase):
+    def test_unrelated_repair_is_rejected(self) -> None:
+        self.assertTrue(unrelated_repair({".github/scripts/factory-visibility.cjs"}, {"app/schemas/release.py"}))
+
+    def test_repair_with_overlap_is_allowed_even_with_new_tests(self) -> None:
+        self.assertFalse(unrelated_repair({"app/service.py"}, {"app/service.py", "tests/test_service.py"}))
+
+    def test_first_implementation_commit_is_not_rejected(self) -> None:
+        self.assertFalse(unrelated_repair(set(), {"app/new_feature.py"}))
+
+    def test_empty_latest_commit_is_not_rejected(self) -> None:
+        self.assertFalse(unrelated_repair({"app/service.py"}, set()))
+
+    def test_runtime_budget(self) -> None:
+        self.assertFalse(over_runtime_budget(2399, "in_progress"))
+        self.assertTrue(over_runtime_budget(2400, "in_progress"))
+        self.assertFalse(over_runtime_budget(9999, "completed"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--previous-json")
+    parser.add_argument("--latest-json")
+    parser.add_argument("--age-seconds", type=int)
+    parser.add_argument("--status", default="in_progress")
+    args = parser.parse_args()
+
+    if args.self_test:
+        suite = unittest.defaultTestLoader.loadTestsFromTestCase(GuardTests)
+        return 0 if unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful() else 1
+
+    if args.age_seconds is not None:
+        print(json.dumps({"cancel": over_runtime_budget(args.age_seconds, args.status), "max_seconds": MAX_RUN_SECONDS}))
+        return 0
+
+    previous = set(json.loads(args.previous_json or "[]"))
+    latest = set(json.loads(args.latest_json or "[]"))
+    print(json.dumps({"reject": unrelated_repair(previous, latest)}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/fixed-model-guard.py
+++ b/.github/scripts/fixed-model-guard.py
@@ -7,7 +7,7 @@ import argparse
 import json
 import unittest
 
-MAX_RUN_SECONDS = 2400
+MAX_RUN_SECONDS = 1500
 
 
 def unrelated_repair(previous_pr_files: set[str], latest_commit_files: set[str]) -> bool:
@@ -37,8 +37,8 @@ class GuardTests(unittest.TestCase):
         self.assertFalse(unrelated_repair({"app/service.py"}, set()))
 
     def test_runtime_budget(self) -> None:
-        self.assertFalse(over_runtime_budget(2399, "in_progress"))
-        self.assertTrue(over_runtime_budget(2400, "in_progress"))
+        self.assertFalse(over_runtime_budget(1499, "in_progress"))
+        self.assertTrue(over_runtime_budget(1500, "in_progress"))
         self.assertFalse(over_runtime_budget(9999, "completed"))
 
 

--- a/.github/workflows/fixed-model-pr-repair-guard.yml
+++ b/.github/workflows/fixed-model-pr-repair-guard.yml
@@ -6,8 +6,6 @@ on:
       - opened
       - reopened
       - synchronize
-    paths-ignore:
-      - docs/**
 
 permissions:
   contents: write

--- a/.github/workflows/fixed-model-pr-repair-guard.yml
+++ b/.github/workflows/fixed-model-pr-repair-guard.yml
@@ -1,0 +1,75 @@
+name: Fixed Model PR Repair Guard
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths-ignore:
+      - docs/**
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  guard-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Test fleet guard decisions
+        run: python .github/scripts/fixed-model-guard.py --self-test
+
+  reject-unrelated-repair:
+    if: >-
+      github.event.action == 'synchronize' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+
+      - name: Reject unrelated fixed-model repair commit
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          commit="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}")"
+          author="$(jq -r '.commit.author.name // ""' <<< "$commit")"
+          if ! [[ "$author" =~ ^opencode-free-model-factory-[0-9]+\[bot\]$ ]]; then
+            echo "Latest commit is not from a fixed-model factory: ${author:-unknown}"
+            exit 0
+          fi
+
+          parent="$(jq -r '.parents[0].sha // empty' <<< "$commit")"
+          [[ -n "$parent" ]] || exit 0
+          latest_files="$(jq -c '[.files[]?.filename] | unique' <<< "$commit")"
+          previous_files="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${BASE_SHA}...${parent}" \
+            --jq '[.files[]?.filename] | unique')"
+
+          decision="$(python .github/scripts/fixed-model-guard.py \
+            --previous-json "$previous_files" --latest-json "$latest_files")"
+          if [[ "$(jq -r .reject <<< "$decision")" != true ]]; then
+            echo 'Fixed-model repair overlaps the existing PR diff; allowing it.'
+            exit 0
+          fi
+
+          echo "Rejecting unrelated fixed-model repair ${HEAD_SHA}; restoring ${parent}."
+          gh api --method PATCH "repos/${GITHUB_REPOSITORY}/git/refs/heads/${HEAD_BRANCH}" \
+            -f sha="$parent" -F force=true >/dev/null
+
+          labels="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels?per_page=100" --jq '[.[].name]')"
+          target="$(jq -c '
+            map(select((test("^factory:(unowned|local|[1-9][0-9]*|building|review|changes-requested|ci|ready|blocked)$") | not) and . != "factory"))
+            + ["factory", "factory:unowned", "factory:review"] | unique' <<< "$labels")"
+          gh api --method PUT "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" \
+            --input - <<< "{\"labels\":${target}}" >/dev/null
+          gh pr comment "$PR_NUMBER" --body "Rejected fixed-model repair commit \`${HEAD_SHA}\`: its changed files had zero overlap with the PR's existing diff. The branch was restored to \`${parent}\` and released to \`factory:unowned\`." >/dev/null

--- a/.github/workflows/fixed-model-runtime-budget.yml
+++ b/.github/workflows/fixed-model-runtime-budget.yml
@@ -1,0 +1,51 @@
+name: Fixed Model Runtime Budget
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/scripts/fixed-model-guard.py
+      - .github/workflows/fixed-model-runtime-budget.yml
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  guard-tests:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Test fleet guard decisions
+        run: python .github/scripts/fixed-model-guard.py --self-test
+
+  enforce-budget:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+
+      - name: Cancel fixed-model runs beyond the lease budget
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          now="$(date +%s)"
+          runs="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/workflows/free-model-factory-entry.yml/runs?status=in_progress&per_page=100" | jq -s 'add | .workflow_runs')"
+          jq -c '.[]' <<< "$runs" | while IFS= read -r run; do
+            id="$(jq -r .id <<< "$run")"
+            started="$(jq -r '.run_started_at // .created_at' <<< "$run")"
+            started_epoch="$(date -d "$started" +%s)"
+            age=$((now - started_epoch))
+            decision="$(python .github/scripts/fixed-model-guard.py --age-seconds "$age" --status in_progress)"
+            if [[ "$(jq -r .cancel <<< "$decision")" == true ]]; then
+              echo "Cancelling fixed-model run ${id} after ${age}s; lease budget is $(jq -r .max_seconds <<< "$decision")s."
+              gh api --method POST "repos/${GITHUB_REPOSITORY}/actions/runs/${id}/cancel" >/dev/null || true
+            fi
+          done


### PR DESCRIPTION
Closes #1220.

Live fleet validation exposed two control-plane failures: fixed-model PR repair workers could push edits with zero relation to the PR they adopted, and 100-minute factory sessions were crowding normal CI.

This adds two external safety rails without changing any of the 41 factory schedules or model routes:

- a synchronize-time fixed-model repair guard that detects commits authored by `opencode-free-model-factory-N[bot]`, compares the latest commit's files to the PR diff that existed before that commit, and restores the parent/release state when there is zero overlap;
- a five-minute runtime-budget watchdog that cancels Fixed Model Factory Entry runs once their runner lease reaches 25 minutes.

The shared pure decision helper has focused tests for unrelated repairs, legitimate overlapping repairs plus new tests, first implementation commits, and the runtime boundary.