### PR TITLE
Bound fixed-model factory sessions to 20 minutes

### DIFF
--- a/.github/scripts/classify-fixed-model-run.py
+++ b/.github/scripts/classify-fixed-model-run.py
@@ -24,8 +24,14 @@ MODEL_MISSING_RE = re.compile(
     re.I,
 )
 TIMEOUT_RE = re.compile(r"timed? out|timeout|exit status 124|process completed with exit code 124", re.I)
-CANCEL_RE = re.compile(r"operation was canceled|operation was cancelled|cancellation requested|job was canceled|job was cancelled", re.I)
-PROCESS_FAILURE_RE = re.compile(r"process completed with exit code [1-9][0-9]*|command failed with exit code [1-9][0-9]*", re.I)
+CANCEL_RE = re.compile(
+    r"operation was canceled|operation was cancelled|cancellation requested|job was canceled|job was cancelled",
+    re.I,
+)
+PROCESS_FAILURE_RE = re.compile(
+    r"process completed with exit code [1-9][0-9]*|command failed with exit code [1-9][0-9]*",
+    re.I,
+)
 PROVIDER_RE = re.compile(
     r"provider error|service unavailable|bad gateway|gateway timeout|502|503|504|"
     r"econnreset|connection reset|model probe failed|failed the opencode compatibility probe",
@@ -41,6 +47,8 @@ PRODUCTIVE_SIGNALS = (
 
 @dataclass(frozen=True)
 class Result:
+    """Structured classification of a fixed-model factory run."""
+
     worker: str = ""
     source: str = ""
     model: str = ""
@@ -56,6 +64,14 @@ class Result:
 
 
 def classify(log: str) -> Result:
+    """Classify a fixed-model factory Actions log into a structured outcome.
+
+    Args:
+        log: Full text of the factory job log.
+
+    Returns:
+        Result describing worker, model, and terminal outcome.
+    """
     lock = LOCK_RE.search(log)
     if not lock:
         return Result()
@@ -81,81 +97,177 @@ def classify(log: str) -> Result:
     )
 
     if not configured:
-        return Result(**common, outcome="NOT YET PROVEN", detail="lane was not configured, so the pinned model was never invoked")
+        return Result(
+            **common,
+            outcome="NOT YET PROVEN",
+            detail="lane was not configured, so the pinned model was never invoked",
+        )
 
     if MODEL_MISSING_RE.search(log):
-        return Result(**common, outcome="MODEL MISSING", detail="the configured provider did not expose the pinned model")
+        return Result(
+            **common,
+            outcome="MODEL MISSING",
+            detail="the configured provider did not expose the pinned model",
+        )
 
     # Useful persistence wins even if a later cleanup/provider call failed. The
     # run did useful work with the exact model, which is the fleet fact we care about.
     if persisted and exact_proven:
-        return Result(**common, outcome="HEALTHY / PRODUCTIVE", detail="exact OpenCode model proof succeeded and useful work was persisted")
+        return Result(
+            **common,
+            outcome="HEALTHY / PRODUCTIVE",
+            detail="exact OpenCode model proof succeeded and useful work was persisted",
+        )
 
     if RATE_LIMIT_RE.search(log):
-        return Result(**common, outcome="RATE LIMITED", detail="runtime evidence contains a provider rate-limit or capacity response")
+        return Result(
+            **common,
+            outcome="RATE LIMITED",
+            detail="runtime evidence contains a provider rate-limit or capacity response",
+        )
 
     if TIMEOUT_RE.search(log) or CANCEL_RE.search(log):
-        return Result(**common, outcome="TIMEOUT", detail="the pinned-model run was cancelled or exceeded its runtime lease")
+        return Result(
+            **common,
+            outcome="TIMEOUT",
+            detail="the pinned-model run was cancelled or exceeded its runtime lease",
+        )
 
     if exact_proven:
         if PROVIDER_RE.search(log) or PROCESS_FAILURE_RE.search(log):
-            return Result(**common, outcome="PROVIDER FAILURE", detail="the model proved itself, then the worker/provider runtime failed before useful persistence")
-        return Result(**common, outcome="HEALTHY / IDLE", detail="exact OpenCode model proof succeeded but no useful work was persisted")
+            return Result(
+                **common,
+                outcome="PROVIDER FAILURE",
+                detail="the model proved itself, then the worker/provider runtime failed before useful persistence",
+            )
+        return Result(
+            **common,
+            outcome="HEALTHY / IDLE",
+            detail="exact OpenCode model proof succeeded but no useful work was persisted",
+        )
 
     # A smoke invocation reached OpenCode but did not produce the proof token.
     if "ComicPile fixed-model smoke" in log or "Smoke exact pinned model through OpenCode" in log:
-        return Result(**common, outcome="PROVIDER FAILURE", detail="the exact OpenCode model invocation ran but did not return the proof token")
+        return Result(
+            **common,
+            outcome="PROVIDER FAILURE",
+            detail="the exact OpenCode model invocation ran but did not return the proof token",
+        )
 
     # OmniRoute can prove provider/model exposure before OpenCode is reached. Keep
     # model-exposure failures above distinct, while setup failures remain unproven.
     if values["source"] == "omniroute-opencode":
-        return Result(**common, outcome="NOT YET PROVEN", detail="OmniRoute setup ended before exact OpenCode model proof")
+        return Result(
+            **common,
+            outcome="NOT YET PROVEN",
+            detail="OmniRoute setup ended before exact OpenCode model proof",
+        )
 
-    return Result(**common, outcome="NOT YET PROVEN", detail="execution ended before exact OpenCode model proof")
+    return Result(
+        **common,
+        outcome="NOT YET PROVEN",
+        detail="execution ended before exact OpenCode model proof",
+    )
 
 
 class ClassifierTests(unittest.TestCase):
-    BASE = "Factory 32 locked: source=omniroute-opencode model=oc/big-pickle runtime=omniroute/oc/big-pickle minute=:15 scheduler=slot-15 configured=true\n"
+    """Unit tests for fixed-model log classification."""
+
+    BASE = (
+        "Factory 32 locked: source=omniroute-opencode model=oc/big-pickle "
+        "runtime=omniroute/oc/big-pickle minute=:15 scheduler=slot-15 configured=true\n"
+    )
 
     def test_productive(self) -> None:
-        result = classify(self.BASE + "FIXED_MODEL_OPENCODE_OK\n[factory:32] checked out issue #928 on x\nopened/updated PR #1220 for issue #928\n")
+        """Productive runs with proof token and persisted work are healthy."""
+        result = classify(
+            self.BASE
+            + "FIXED_MODEL_OPENCODE_OK\n[factory:32] checked out issue #928 on x\n"
+            + "opened/updated PR #1220 for issue #928\n"
+        )
         self.assertEqual(result.outcome, "HEALTHY / PRODUCTIVE")
         self.assertTrue(result.exact_model_proven)
         self.assertTrue(result.persisted_work)
         self.assertEqual((result.selected_kind, result.selected_number), ("issue", "928"))
 
     def test_idle(self) -> None:
-        self.assertEqual(classify(self.BASE + "FIXED_MODEL_OPENCODE_OK\nno selectable ordinary target\n").outcome, "HEALTHY / IDLE")
+        """Proof without persisted work is classified as healthy idle."""
+        self.assertEqual(
+            classify(self.BASE + "FIXED_MODEL_OPENCODE_OK\nno selectable ordinary target\n").outcome,
+            "HEALTHY / IDLE",
+        )
 
     def test_rate_limited(self) -> None:
-        self.assertEqual(classify(self.BASE + "ComicPile fixed-model smoke\nError: Too Many Requests 429\n").outcome, "RATE LIMITED")
+        """Provider rate-limit responses map to RATE LIMITED."""
+        self.assertEqual(
+            classify(self.BASE + "ComicPile fixed-model smoke\nError: Too Many Requests 429\n").outcome,
+            "RATE LIMITED",
+        )
 
     def test_model_missing(self) -> None:
-        self.assertEqual(classify(self.BASE + "Pinned OmniRoute model is not currently exposed: oc/big-pickle\n").outcome, "MODEL MISSING")
+        """Missing pinned model exposure maps to MODEL MISSING."""
+        self.assertEqual(
+            classify(
+                self.BASE + "Pinned OmniRoute model is not currently exposed: oc/big-pickle\n"
+            ).outcome,
+            "MODEL MISSING",
+        )
 
     def test_timeout(self) -> None:
-        self.assertEqual(classify(self.BASE + "ComicPile fixed-model smoke\nProcess completed with exit code 124\n").outcome, "TIMEOUT")
+        """Exit code 124 and related signals map to TIMEOUT."""
+        self.assertEqual(
+            classify(
+                self.BASE + "ComicPile fixed-model smoke\nProcess completed with exit code 124\n"
+            ).outcome,
+            "TIMEOUT",
+        )
 
     def test_unconfigured(self) -> None:
-        log = "Factory 6 locked: source=nvidia model=z-ai/glm-5.2 runtime=nvidia/z-ai/glm-5.2 minute=:00 scheduler=slot-00 configured=false\n"
+        """Unconfigured lanes never invoke the model and stay unproven."""
+        log = (
+            "Factory 6 locked: source=nvidia model=z-ai/glm-5.2 "
+            "runtime=nvidia/z-ai/glm-5.2 minute=:00 scheduler=slot-00 configured=false\n"
+        )
         self.assertEqual(classify(log).outcome, "NOT YET PROVEN")
 
     def test_omniroute_setup_failure_is_unproven(self) -> None:
-        self.assertEqual(classify(self.BASE + "docker: Error response from daemon\n").outcome, "NOT YET PROVEN")
+        """OmniRoute setup failures before proof remain NOT YET PROVEN."""
+        self.assertEqual(
+            classify(self.BASE + "docker: Error response from daemon\n").outcome,
+            "NOT YET PROVEN",
+        )
 
     def test_failed_exact_smoke_is_provider_failure(self) -> None:
-        self.assertEqual(classify(self.BASE + "Smoke exact pinned model through OpenCode\nError: unexpected provider response\n").outcome, "PROVIDER FAILURE")
+        """Smoke that reaches the provider without the proof token is a provider failure."""
+        self.assertEqual(
+            classify(
+                self.BASE
+                + "Smoke exact pinned model through OpenCode\nError: unexpected provider response\n"
+            ).outcome,
+            "PROVIDER FAILURE",
+        )
 
     def test_post_proof_worker_failure_is_not_healthy(self) -> None:
-        result = classify(self.BASE + "FIXED_MODEL_OPENCODE_OK\nRun continuous fixed-model factory session\nProcess completed with exit code 1\n")
+        """Post-proof process failures are classified as PROVIDER FAILURE."""
+        result = classify(
+            self.BASE
+            + "FIXED_MODEL_OPENCODE_OK\nRun continuous fixed-model factory session\n"
+            + "Process completed with exit code 1\n"
+        )
         self.assertEqual(result.outcome, "PROVIDER FAILURE")
 
     def test_post_proof_cancellation_is_timeout(self) -> None:
+        """Post-proof cancellation is classified as TIMEOUT."""
         result = classify(self.BASE + "FIXED_MODEL_OPENCODE_OK\nThe operation was canceled.\n")
         self.assertEqual(result.outcome, "TIMEOUT")
 
 
 def main() -> int:
+    """CLI entrypoint for classification or self-tests.
+
+    Returns:
+        Process exit code (0 on success).
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument("--log", type=Path)
     parser.add_argument("--self-test", action="store_true")
@@ -166,7 +278,12 @@ def main() -> int:
         return 0 if unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful() else 1
     if not args.log:
         parser.error("--log is required unless --self-test is used")
-    print(json.dumps(asdict(classify(args.log.read_text(encoding="utf-8", errors="replace"))), sort_keys=True))
+    print(
+        json.dumps(
+            asdict(classify(args.log.read_text(encoding="utf-8", errors="replace"))),
+            sort_keys=True,
+        )
+    )
     return 0
 
 

--- a/.github/scripts/classify-fixed-model-run.py
+++ b/.github/scripts/classify-fixed-model-run.py
@@ -71,6 +71,7 @@ def classify(log: str) -> Result:
 
     Returns:
         Result describing worker, model, and terminal outcome.
+
     """
     lock = LOCK_RE.search(log)
     if not lock:
@@ -83,18 +84,18 @@ def classify(log: str) -> Result:
     target = target_matches[-1].groupdict() if target_matches else {"kind": "", "number": ""}
     persisted = any(signal in log for signal in PRODUCTIVE_SIGNALS)
 
-    common = dict(
-        worker=values["worker"],
-        source=values["source"],
-        model=values["model"],
-        runtime_model=values["runtime"],
-        minute=values["minute"],
-        configured=configured,
-        exact_model_proven=exact_proven,
-        selected_kind=target["kind"],
-        selected_number=target["number"],
-        persisted_work=persisted,
-    )
+    common = {
+        "worker": values["worker"],
+        "source": values["source"],
+        "model": values["model"],
+        "runtime_model": values["runtime"],
+        "minute": values["minute"],
+        "configured": configured,
+        "exact_model_proven": exact_proven,
+        "selected_kind": target["kind"],
+        "selected_number": target["number"],
+        "persisted_work": persisted,
+    }
 
     if not configured:
         return Result(
@@ -267,6 +268,7 @@ def main() -> int:
 
     Returns:
         Process exit code (0 on success).
+
     """
     parser = argparse.ArgumentParser()
     parser.add_argument("--log", type=Path)

--- a/.github/scripts/fixed-model-guard.py
+++ b/.github/scripts/fixed-model-guard.py
@@ -20,6 +20,7 @@ def unrelated_repair(previous_pr_files: set[str], latest_commit_files: set[str])
 
     Returns:
         True when the latest commit is an unrelated repair that should be rejected.
+
     """
     return bool(
         previous_pr_files
@@ -57,6 +58,7 @@ def main() -> int:
 
     Returns:
         Process exit code (0 on success).
+
     """
     parser = argparse.ArgumentParser()
     parser.add_argument("--self-test", action="store_true")

--- a/.github/scripts/fixed-model-guard.py
+++ b/.github/scripts/fixed-model-guard.py
@@ -13,25 +13,51 @@ def unrelated_repair(previous_pr_files: set[str], latest_commit_files: set[str])
 
     Empty previous PR diffs represent first implementation commits and are not
     treated as adopted-PR repair work.
+
+    Args:
+        previous_pr_files: Paths already present on the PR before the latest commit.
+        latest_commit_files: Paths touched by the latest commit.
+
+    Returns:
+        True when the latest commit is an unrelated repair that should be rejected.
     """
-    return bool(previous_pr_files and latest_commit_files and previous_pr_files.isdisjoint(latest_commit_files))
+    return bool(
+        previous_pr_files
+        and latest_commit_files
+        and previous_pr_files.isdisjoint(latest_commit_files)
+    )
 
 
 class GuardTests(unittest.TestCase):
+    """Unit tests for unrelated-repair detection."""
+
     def test_unrelated_repair_is_rejected(self) -> None:
-        self.assertTrue(unrelated_repair({".github/scripts/factory-visibility.cjs"}, {"app/schemas/release.py"}))
+        """Zero-overlap repair on an existing PR is rejected."""
+        self.assertTrue(
+            unrelated_repair({".github/scripts/factory-visibility.cjs"}, {"app/schemas/release.py"})
+        )
 
     def test_repair_with_overlap_is_allowed_even_with_new_tests(self) -> None:
-        self.assertFalse(unrelated_repair({"app/service.py"}, {"app/service.py", "tests/test_service.py"}))
+        """Overlap with prior PR files allows the repair, including new tests."""
+        self.assertFalse(
+            unrelated_repair({"app/service.py"}, {"app/service.py", "tests/test_service.py"})
+        )
 
     def test_first_implementation_commit_is_not_rejected(self) -> None:
+        """Empty previous PR set means first implementation, not a repair."""
         self.assertFalse(unrelated_repair(set(), {"app/new_feature.py"}))
 
     def test_empty_latest_commit_is_not_rejected(self) -> None:
+        """Empty latest commit is not treated as an unrelated repair."""
         self.assertFalse(unrelated_repair({"app/service.py"}, set()))
 
 
 def main() -> int:
+    """CLI entrypoint for the repair guard decision or self-tests.
+
+    Returns:
+        Process exit code (0 on success).
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument("--self-test", action="store_true")
     parser.add_argument("--previous-json")

--- a/.github/workflows/free-model-factory-run.yml
+++ b/.github/workflows/free-model-factory-run.yml
@@ -20,10 +20,10 @@ permissions:
 
 concurrency:
   group: fixed-model-factory-${{ inputs.worker }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
-  FACTORY_BUDGET_SECONDS: '1500'
+  FACTORY_BUDGET_SECONDS: '1200'
   OPENCODE_VERSION: '1.18.18'
   OPENCODE_LINUX_X64_SHA256: '0cddc222418b8553669905a8980c0cda7088f00da24d83d6ac76b01c9fdb2aaf'
   OMNIROUTE_IMAGE: 'diegosouzapw/omniroute:3.8.49@sha256:92c768c56e2de32c51a0621ef182835018b00b288c9bb235c5c5e4514658c1a1'
@@ -31,7 +31,7 @@ env:
 jobs:
   factory:
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 30
     env:
       GH_TOKEN: ${{ github.token }}
       NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}

--- a/tests/test_release_writer.py
+++ b/tests/test_release_writer.py
@@ -3,6 +3,7 @@
 import io
 import json
 import os
+from collections.abc import Callable
 from contextlib import redirect_stderr, redirect_stdout
 from unittest.mock import Mock, patch
 
@@ -11,7 +12,9 @@ import pytest
 from scripts import release_writer
 
 
-def _capture_stderr(func: object, *args: object, **kwargs: object) -> str:
+def _capture_stderr(
+    func: Callable[..., object], *args: object, **kwargs: object
+) -> str:
     """Capture stderr from a function call that exits unsuccessfully.
 
     Args:
@@ -21,6 +24,7 @@ def _capture_stderr(func: object, *args: object, **kwargs: object) -> str:
 
     Returns:
         The captured stderr output as a string.
+
     """
     f = io.StringIO()
     with redirect_stderr(f):
@@ -34,7 +38,9 @@ def _capture_stderr(func: object, *args: object, **kwargs: object) -> str:
     return f.getvalue()
 
 
-def _capture_stdout(func: object, *args: object, **kwargs: object) -> str:
+def _capture_stdout(
+    func: Callable[..., object], *args: object, **kwargs: object
+) -> str:
     """Capture stdout from a function call.
 
     Args:
@@ -44,6 +50,7 @@ def _capture_stdout(func: object, *args: object, **kwargs: object) -> str:
 
     Returns:
         The captured stdout output as a string.
+
     """
     f = io.StringIO()
     with redirect_stdout(f):
@@ -607,7 +614,7 @@ class TestReleaseWriterEnvironment:
             assert "RELEASE_WRITER_TOKEN is required" in stderr
 
 
-def _valid_payload() -> dict:
+def _valid_payload() -> dict[str, object]:
     """Return a valid release payload for testing."""
     return {
         "source_repository": "JoshCLWren/comic-pile",


### PR DESCRIPTION
Follow-up to #1221 / #1220.

#1221 landed the external 25-minute runtime-budget watchdog and the unrelated PR-repair guard, but the reusable runner still defaults to:

- `FACTORY_BUDGET_SECONDS=1500`
- `timeout-minutes: 35`

That still lets an hourly lane occupy a runner longer than its recurrence interval. This PR reduces both to a coherent 20-minute active lease (`1200s` budget, 30-minute hard job timeout) so each lane finishes inside its slot and leaves capacity for ordinary CI.

This PR also flips `cancel-in-progress` to `false` in the fixed-model concurrency group. A superseding scheduled trigger no longer cancels an in-progress run; queued runs of the same concurrency group wait for the active run to complete. This keeps an already-running session alive long enough to persist work rather than being killed by the next hourly heartbeat.

No models, provider paths, lease/handoff, or no-fallback semantics change.