### PR TITLE
Prevent fixed-model PR contamination and unblock repair guard

### DIFF
--- a/.github/scripts/classify-fixed-model-run.py
+++ b/.github/scripts/classify-fixed-model-run.py
@@ -20,7 +20,7 @@ LOCK_RE = re.compile(
 TARGET_RE = re.compile(r"checked out (?P<kind>issue|pr) #(?P<number>\d+) on ")
 RATE_LIMIT_RE = re.compile(r"429|too many requests|rate.?limit|quota|throttl|capacity", re.I)
 MODEL_MISSING_RE = re.compile(
-    r"pinned .*model is not currently exposed|unknown model|model .*not found|model .*does not exist",
+    r"pinned .*model is not currently (?:exposed|invokable)|unknown model|model .*not found|model .*does not exist",
     re.I,
 )
 TIMEOUT_RE = re.compile(r"timed? out|timeout|exit status 124|process completed with exit code 124", re.I)

--- a/.github/scripts/classify-fixed-model-run.py
+++ b/.github/scripts/classify-fixed-model-run.py
@@ -214,6 +214,16 @@ class ClassifierTests(unittest.TestCase):
             "MODEL MISSING",
         )
 
+    def test_nvidia_model_not_invokable_is_missing(self) -> None:
+        """NVIDIA catalog entries that return 404 on invoke map to MODEL MISSING."""
+        self.assertEqual(
+            classify(
+                self.BASE
+                + "Pinned NVIDIA model is not currently invokable for this account: moonshotai/kimi-k2.6\n"
+            ).outcome,
+            "MODEL MISSING",
+        )
+
     def test_timeout(self) -> None:
         """Exit code 124 and related signals map to TIMEOUT."""
         self.assertEqual(

--- a/.github/scripts/fixed-model-guard.py
+++ b/.github/scripts/fixed-model-guard.py
@@ -7,6 +7,46 @@ import argparse
 import json
 import unittest
 
+FACTORY_CONTROL_PREFIXES: tuple[str, ...] = (
+    ".github/workflows/fixed-model-",
+    ".github/workflows/free-model-factory-",
+    ".github/scripts/fixed-model-",
+    ".github/scripts/free-model-factory-",
+    ".github/scripts/classify-fixed-model-run.py",
+    ".github/scripts/validate-free-model-factories.py",
+    ".github/free-model-factories.tsv",
+)
+
+FACTORY_TASK_NEEDLES: tuple[str, ...] = (
+    "fixed-model",
+    "free-model-factory",
+    "factory fleet",
+    "factory worker",
+    "factory lease",
+    "factory contamination",
+    "factory guard",
+    "factory dispatcher",
+    "factory runner",
+    "opencode-free-model-factory",
+)
+
+
+def is_factory_control_path(path: str) -> bool:
+    """Return True when a path is fixed-model factory control infrastructure."""
+    normalized = path.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return any(
+        normalized == prefix.rstrip("/") or normalized.startswith(prefix)
+        for prefix in FACTORY_CONTROL_PREFIXES
+    )
+
+
+def task_allows_factory_control(title: str, body: str) -> bool:
+    """Return True when the selected task explicitly concerns factory infrastructure."""
+    text = f"{title}\n{body}".lower()
+    return any(needle in text for needle in FACTORY_TASK_NEEDLES)
+
 
 def unrelated_repair(previous_pr_files: set[str], latest_commit_files: set[str]) -> bool:
     """Reject only an existing-PR repair whose latest commit has zero overlap.
@@ -29,28 +69,148 @@ def unrelated_repair(previous_pr_files: set[str], latest_commit_files: set[str])
     )
 
 
+def reject_decision(
+    previous_pr_files: set[str],
+    latest_commit_files: set[str],
+    *,
+    title: str = "",
+    body: str = "",
+) -> dict[str, object]:
+    """Decide whether a factory persistence attempt must be rejected.
+
+    Rejection is fail-closed and deterministic:
+    1. Zero overlap with an existing PR diff is rejected.
+    2. Factory-control paths are rejected unless the selected task is about
+       fixed-model factory infrastructure.
+
+    Args:
+        previous_pr_files: Paths already on the PR before local changes.
+        latest_commit_files: Paths in the staged/uncommitted factory diff.
+        title: Selected issue or PR title used for scope checks.
+        body: Selected issue or PR body used for scope checks.
+
+    Returns:
+        JSON-serializable decision with reject flag and reason.
+
+    """
+    latest = set()
+    for path in latest_commit_files:
+        if not path:
+            continue
+        normalized = path.replace("\\", "/")
+        while normalized.startswith("./"):
+            normalized = normalized[2:]
+        latest.add(normalized)
+    previous = set()
+    for path in previous_pr_files:
+        if not path:
+            continue
+        normalized = path.replace("\\", "/")
+        while normalized.startswith("./"):
+            normalized = normalized[2:]
+        previous.add(normalized)
+
+    if unrelated_repair(previous, latest):
+        return {
+            "reject": True,
+            "reason": "zero-overlap-with-existing-pr-diff",
+            "factory_control_files": sorted(path for path in latest if is_factory_control_path(path)),
+        }
+
+    control_files = sorted(path for path in latest if is_factory_control_path(path))
+    if control_files and not task_allows_factory_control(title, body):
+        return {
+            "reject": True,
+            "reason": "factory-control-out-of-scope",
+            "factory_control_files": control_files,
+        }
+
+    return {
+        "reject": False,
+        "reason": "allowed",
+        "factory_control_files": control_files,
+    }
+
+
 class GuardTests(unittest.TestCase):
-    """Unit tests for unrelated-repair detection."""
+    """Unit tests for unrelated-repair and factory-control detection."""
 
     def test_unrelated_repair_is_rejected(self) -> None:
         """Zero-overlap repair on an existing PR is rejected."""
-        self.assertTrue(
-            unrelated_repair({".github/scripts/factory-visibility.cjs"}, {"app/schemas/release.py"})
+        decision = reject_decision(
+            {".github/scripts/factory-visibility.cjs"},
+            {"app/schemas/release.py"},
+            title="After rating two d4s appear?",
+            body="Duplicate dice on the roll screen.",
         )
+        self.assertTrue(decision["reject"])
+        self.assertEqual(decision["reason"], "zero-overlap-with-existing-pr-diff")
 
     def test_repair_with_overlap_is_allowed_even_with_new_tests(self) -> None:
         """Overlap with prior PR files allows the repair, including new tests."""
-        self.assertFalse(
-            unrelated_repair({"app/service.py"}, {"app/service.py", "tests/test_service.py"})
+        decision = reject_decision(
+            {"app/service.py"},
+            {"app/service.py", "tests/test_service.py"},
+            title="Fix service bug",
+            body="Product bug",
         )
+        self.assertFalse(decision["reject"])
 
     def test_first_implementation_commit_is_not_rejected(self) -> None:
         """Empty previous PR set means first implementation, not a repair."""
-        self.assertFalse(unrelated_repair(set(), {"app/new_feature.py"}))
+        decision = reject_decision(
+            set(),
+            {"app/new_feature.py"},
+            title="Add feature",
+            body="Product feature",
+        )
+        self.assertFalse(decision["reject"])
 
     def test_empty_latest_commit_is_not_rejected(self) -> None:
         """Empty latest commit is not treated as an unrelated repair."""
-        self.assertFalse(unrelated_repair({"app/service.py"}, set()))
+        decision = reject_decision(
+            {"app/service.py"},
+            set(),
+            title="Fix service bug",
+            body="Product bug",
+        )
+        self.assertFalse(decision["reject"])
+
+    def test_mixed_factory_control_on_product_pr_is_rejected(self) -> None:
+        """Factory control edits are rejected even when mixed with product overlap."""
+        decision = reject_decision(
+            {
+                "frontend/src/components/Dice3D.tsx",
+                "frontend/src/test/issue-1182-header-die-size.spec.ts",
+            },
+            {
+                "frontend/src/test/issue-1182-header-die-size.spec.ts",
+                ".github/scripts/classify-fixed-model-run.py",
+                ".github/scripts/fixed-model-guard.py",
+            },
+            title="After raiting two d4s appear?",
+            body="They're both rotating on the dice selection screen.",
+        )
+        self.assertTrue(decision["reject"])
+        self.assertEqual(decision["reason"], "factory-control-out-of-scope")
+        self.assertIn(".github/scripts/classify-fixed-model-run.py", decision["factory_control_files"])
+
+    def test_factory_infra_task_may_edit_factory_control(self) -> None:
+        """Tasks about the fixed-model fleet may touch factory control paths."""
+        decision = reject_decision(
+            {".github/scripts/fixed-model-guard.py"},
+            {".github/scripts/fixed-model-guard.py", ".github/free-model-factories.tsv"},
+            title="Guard fixed-model PR repairs and runner leases",
+            body="Prevent fixed-model factory contamination across the factory fleet.",
+        )
+        self.assertFalse(decision["reject"])
+
+    def test_legacy_unrelated_repair_helper_still_matches(self) -> None:
+        """Preserve the original zero-overlap helper behavior."""
+        self.assertTrue(
+            unrelated_repair({".github/scripts/factory-visibility.cjs"}, {"app/schemas/release.py"})
+        )
+        self.assertFalse(unrelated_repair({"app/service.py"}, {"app/service.py", "tests/test_service.py"}))
 
 
 def main() -> int:
@@ -64,6 +224,8 @@ def main() -> int:
     parser.add_argument("--self-test", action="store_true")
     parser.add_argument("--previous-json")
     parser.add_argument("--latest-json")
+    parser.add_argument("--title", default="")
+    parser.add_argument("--body", default="")
     args = parser.parse_args()
 
     if args.self_test:
@@ -72,7 +234,7 @@ def main() -> int:
 
     previous = set(json.loads(args.previous_json or "[]"))
     latest = set(json.loads(args.latest_json or "[]"))
-    print(json.dumps({"reject": unrelated_repair(previous, latest)}))
+    print(json.dumps(reject_decision(previous, latest, title=args.title, body=args.body)))
     return 0
 
 

--- a/.github/scripts/free-model-factory-worker.sh
+++ b/.github/scripts/free-model-factory-worker.sh
@@ -255,9 +255,62 @@ run_agent() {
   return "$status"
 }
 
+target_scope_text() {
+  local mode="$1" number="$2" issue title body
+  if [[ "$mode" == 'issue' ]]; then
+    gh issue view "$number" --json title,body --jq '{title,body}'
+    return 0
+  fi
+  title="$(gh pr view "$number" --json title --jq .title)"
+  body="$(gh pr view "$number" --json body --jq .body)"
+  issue="$(linked_issue_from_branch "$(gh pr view "$number" --json headRefName --jq .headRefName)")"
+  if [[ -n "$issue" ]]; then
+    title="$(gh issue view "$issue" --json title --jq .title)"
+    body="$(gh issue view "$issue" --json body --jq .body)"
+  fi
+  jq -nc --arg title "$title" --arg body "$body" '{title:$title,body:$body}'
+}
+
+changed_paths_json() {
+  local base_ref="$1"
+  {
+    git diff --name-only --relative "$base_ref"
+    git ls-files --others --exclude-standard
+  } | jq -R -s 'split("\n") | map(select(length > 0)) | unique'
+}
+
+reject_out_of_scope_diff() {
+  local mode="$1" number="$2" base_ref="$3" scope previous latest decision reason
+  scope="$(target_scope_text "$mode" "$number")"
+  if [[ "$mode" == 'pr' ]]; then
+    previous="$(gh api "repos/${GITHUB_REPOSITORY}/compare/$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${number}" --jq .base.sha)...${base_ref}" \
+      --jq '[.files[]?.filename] | unique')"
+  else
+    previous='[]'
+  fi
+  latest="$(changed_paths_json "$base_ref")"
+  decision="$(python3 .github/scripts/fixed-model-guard.py \
+    --previous-json "$previous" \
+    --latest-json "$latest" \
+    --title "$(jq -r .title <<< "$scope")" \
+    --body "$(jq -r .body <<< "$scope")")"
+  if [[ "$(jq -r .reject <<< "$decision")" != true ]]; then
+    return 0
+  fi
+  reason="$(jq -r .reason <<< "$decision")"
+  log "rejecting out-of-scope ${mode} #${number} diff before push (${reason}): $(jq -c .factory_control_files <<< "$decision")"
+  git reset --hard "$base_ref" >/dev/null
+  git clean -fd >/dev/null
+  return 1
+}
+
 persist_issue_pr() {
-  local number="$1" branch="$2" pr title body
+  local number="$1" branch="$2" pr title body base_ref
   [[ -n "$(git status --porcelain)" ]] || return 1
+  base_ref="$(git rev-parse HEAD)"
+  if ! reject_out_of_scope_diff 'issue' "$number" "$base_ref"; then
+    return 1
+  fi
   git add -A >&2
   git commit -m "factory: advance #${number} with ${DISPLAY}" >&2
   git push --set-upstream origin "$branch" >&2
@@ -274,8 +327,12 @@ persist_issue_pr() {
 }
 
 persist_pr_changes() {
-  local pr="$1" branch="$2"
+  local pr="$1" branch="$2" base_ref
   [[ -n "$(git status --porcelain)" ]] || return 1
+  base_ref="$(git rev-parse HEAD)"
+  if ! reject_out_of_scope_diff 'pr' "$pr" "$base_ref"; then
+    return 1
+  fi
   git add -A
   git commit -m "factory: advance PR #${pr} with ${DISPLAY}"
   git push origin "$branch"

--- a/.github/scripts/validate-free-model-factories.py
+++ b/.github/scripts/validate-free-model-factories.py
@@ -177,10 +177,28 @@ def main() -> None:
     assert "branch_suffix='opencode-free'" in runner_text
     assert 'OPENCODE_API_KEY' not in runner_text, 'direct OpenCode Free must remain keyless'
     assert all(source not in runner_text for source in ('kilo)', 'llm7)', 'ovhcloud)', 'zen)'))
+    assert 'secrets.PR_REBASE_TOKEN' in runner_text, (
+        'factory pushes must use PR_REBASE_TOKEN so pull_request workflows are not stuck in action_required'
+    )
+    assert 'GH_TOKEN: ${{ github.token }}' not in runner_text, (
+        'GITHUB_TOKEN pushes attribute to github-actions[bot] and block the repair guard'
+    )
 
     worker_text = worker.read_text(encoding='utf-8')
     assert 'rotate_model' not in worker_text
     assert 'Do not switch models' in worker_text
+    assert 'reject_out_of_scope_diff' in worker_text, (
+        'factories must fail closed on out-of-scope diffs before push'
+    )
+    assert 'fixed-model-guard.py' in worker_text, (
+        'pre-push scope enforcement must use the deterministic fixed-model guard'
+    )
+
+    guard = Path('.github/scripts/fixed-model-guard.py')
+    assert guard.exists()
+    guard_text = guard.read_text(encoding='utf-8')
+    assert 'factory-control-out-of-scope' in guard_text
+    assert 'is_factory_control_path' in guard_text
 
     # Ownership is a next-action lease, never a permanent reservation. A worker
     # must hand its claims back when a scheduled session ends so another lane can

--- a/.github/workflows/fixed-model-pr-repair-guard.yml
+++ b/.github/workflows/fixed-model-pr-repair-guard.yml
@@ -53,14 +53,28 @@ jobs:
           previous_files="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${BASE_SHA}...${parent}" \
             --jq '[.files[]?.filename] | unique')"
 
+          branch_issue=""
+          if [[ "$HEAD_BRANCH" =~ ^factory/[0-9]+-([0-9]+)- ]]; then
+            branch_issue="${BASH_REMATCH[1]}"
+          fi
+          if [[ -n "$branch_issue" ]]; then
+            scope="$(gh issue view "$branch_issue" --json title,body)"
+          else
+            scope="$(gh pr view "$PR_NUMBER" --json title,body)"
+          fi
+
           decision="$(python .github/scripts/fixed-model-guard.py \
-            --previous-json "$previous_files" --latest-json "$latest_files")"
+            --previous-json "$previous_files" \
+            --latest-json "$latest_files" \
+            --title "$(jq -r .title <<< "$scope")" \
+            --body "$(jq -r .body <<< "$scope")")"
           if [[ "$(jq -r .reject <<< "$decision")" != true ]]; then
-            echo 'Fixed-model repair overlaps the existing PR diff; allowing it.'
+            echo 'Fixed-model repair is in scope; allowing it.'
             exit 0
           fi
 
-          echo "Rejecting unrelated fixed-model repair ${HEAD_SHA}; restoring ${parent}."
+          reason="$(jq -r .reason <<< "$decision")"
+          echo "Rejecting unrelated fixed-model repair ${HEAD_SHA} (${reason}); restoring ${parent}."
           gh api --method PATCH "repos/${GITHUB_REPOSITORY}/git/refs/heads/${HEAD_BRANCH}" \
             -f sha="$parent" -F force=true >/dev/null
 
@@ -70,4 +84,4 @@ jobs:
             + ["factory", "factory:unowned", "factory:review"] | unique' <<< "$labels")"
           gh api --method PUT "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" \
             --input - <<< "{\"labels\":${target}}" >/dev/null
-          gh pr comment "$PR_NUMBER" --body "Rejected fixed-model repair commit \`${HEAD_SHA}\`: its changed files had zero overlap with the PR's existing diff. The branch was restored to \`${parent}\` and released to \`factory:unowned\`." >/dev/null
+          gh pr comment "$PR_NUMBER" --body "Rejected fixed-model repair commit \`${HEAD_SHA}\` (${reason}): the diff was out of scope for the selected task. The branch was restored to \`${parent}\` and released to \`factory:unowned\`." >/dev/null

--- a/.github/workflows/free-model-factory-run.yml
+++ b/.github/workflows/free-model-factory-run.yml
@@ -10,6 +10,8 @@ on:
     secrets:
       NVIDIA_API_KEY:
         required: false
+      PR_REBASE_TOKEN:
+        required: true
 
 permissions:
   contents: write
@@ -33,15 +35,35 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      GH_TOKEN: ${{ github.token }}
+      # Dedicated PAT/App token so factory pushes trigger normal PR workflows.
+      # GITHUB_TOKEN pushes are attributed to github-actions[bot] and leave
+      # pull_request workflows (including the repair guard) stuck in
+      # action_required until a human approves them.
+      GH_TOKEN: ${{ secrets.PR_REBASE_TOKEN }}
       NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
     steps:
+      - name: Require trusted push credential
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo '::error::PR_REBASE_TOKEN is required so fixed-model factory pushes trigger PR workflows without action_required.'
+            exit 1
+          fi
+
       - name: Checkout main
         uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
-          persist-credentials: true
+          persist-credentials: false
+          token: ${{ secrets.PR_REBASE_TOKEN }}
+
+      - name: Configure trusted git remote
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
       - name: Resolve fixed lane
         id: lane
@@ -272,6 +294,35 @@ jobs:
             }
           }' > "$HOME/.config/opencode/opencode.json"
           chmod 600 "$HOME/.config/opencode/opencode.json"
+
+      - name: Probe pinned NVIDIA model before OpenCode smoke
+        if: steps.lane.outputs.configured == 'true' && steps.lane.outputs.source == 'nvidia'
+        shell: bash
+        env:
+          MODEL: ${{ steps.lane.outputs.model }}
+        run: |
+          set -Eeuo pipefail
+          [[ -n "${NVIDIA_API_KEY:-}" ]] || { echo 'NVIDIA_API_KEY missing after lane configured=true' >&2; exit 1; }
+          request="$(jq -nc --arg model "$MODEL" '{model:$model,messages:[{role:"user",content:"Reply with exactly FIXED_MODEL_OK"}],max_tokens:16}')"
+          response="$RUNNER_TEMP/nvidia-probe.json"
+          code="$(curl --silent --show-error --output "$response" --write-out '%{http_code}' \
+            --connect-timeout 5 --max-time 120 \
+            --header "Authorization: Bearer ${NVIDIA_API_KEY}" \
+            --header 'Content-Type: application/json' \
+            --data "$request" \
+            https://integrate.api.nvidia.com/v1/chat/completions || true)"
+          if [[ "$code" == "404" ]]; then
+            echo "Pinned NVIDIA model is not currently invokable for this account: ${MODEL}" >&2
+            echo 'No fallback is allowed for a fixed-model lane.' >&2
+            cat "$response" >&2 || true
+            exit 1
+          fi
+          [[ "$code" =~ ^2 ]] || {
+            echo "Pinned NVIDIA model probe failed HTTP ${code}" >&2
+            cat "$response" >&2 || true
+            exit 1
+          }
+          echo "NVIDIA probe succeeded for ${MODEL}"
 
       - name: Smoke exact pinned model through OpenCode
         if: steps.lane.outputs.configured == 'true'


### PR DESCRIPTION
## Summary
- Fail closed in the fixed-model worker before push when a diff is zero-overlap or touches factory-control paths on a non-factory task (the Factory 39 → PR #1188 failure mode).
- Push factory branches with `PR_REBASE_TOKEN` instead of `GITHUB_TOKEN` so `pull_request` workflows (including Fixed Model PR Repair Guard) actually run instead of stalling in `action_required`.
- Probe NVIDIA chat-completions invokeability before OpenCode smoke so catalog-listed but non-invokable models are classified as MODEL MISSING.

## Test plan
- [x] `python3 .github/scripts/fixed-model-guard.py --self-test`
- [x] `python3 .github/scripts/validate-free-model-factories.py`
- [x] `python3 .github/scripts/classify-fixed-model-run.py --self-test`
- [x] Restored PR #1188 to `7aaae2b` (product Dice3D diff only)
- [ ] Merge to main, then exercise all four cohorts (`:00`, `:15`, `:30`, `:45`) and confirm:
  - pinned-model smoke/proof
  - no cross-factory contamination
  - repair guard runs without `action_required`
  - lease handoff still releases to `factory:unowned`


Made with [Cursor](https://cursor.com)