### PR TITLE
Split factory push PAT from GITHUB_TOKEN API access

### DIFF
--- a/.github/scripts/validate-free-model-factories.py
+++ b/.github/scripts/validate-free-model-factories.py
@@ -180,8 +180,12 @@ def main() -> None:
     assert 'secrets.PR_REBASE_TOKEN' in runner_text, (
         'factory pushes must use PR_REBASE_TOKEN so pull_request workflows are not stuck in action_required'
     )
-    assert 'GH_TOKEN: ${{ github.token }}' not in runner_text, (
-        'GITHUB_TOKEN pushes attribute to github-actions[bot] and block the repair guard'
+    assert 'PR_REBASE_TOKEN: ${{ secrets.PR_REBASE_TOKEN }}' in runner_text
+    assert 'GH_TOKEN: ${{ github.token }}' in runner_text, (
+        'gh API/labels must keep using GITHUB_TOKEN; PR_REBASE_TOKEN is push-only'
+    )
+    assert 'x-access-token:${PR_REBASE_TOKEN}' in runner_text, (
+        'git remote must authenticate pushes with PR_REBASE_TOKEN'
     )
 
     worker_text = worker.read_text(encoding='utf-8')

--- a/.github/workflows/free-model-factory-run.yml
+++ b/.github/workflows/free-model-factory-run.yml
@@ -35,18 +35,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      # Dedicated PAT/App token so factory pushes trigger normal PR workflows.
-      # GITHUB_TOKEN pushes are attributed to github-actions[bot] and leave
-      # pull_request workflows (including the repair guard) stuck in
-      # action_required until a human approves them.
-      GH_TOKEN: ${{ secrets.PR_REBASE_TOKEN }}
+      # Workflow token for labels/comments/API. A dedicated PAT is used only for
+      # git fetch/push so pull_request workflows (including the repair guard) are
+      # attributed to a trusted actor instead of github-actions[bot].
+      GH_TOKEN: ${{ github.token }}
+      PR_REBASE_TOKEN: ${{ secrets.PR_REBASE_TOKEN }}
       NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
     steps:
       - name: Require trusted push credential
         shell: bash
         run: |
           set -Eeuo pipefail
-          if [[ -z "${GH_TOKEN:-}" ]]; then
+          if [[ -z "${PR_REBASE_TOKEN:-}" ]]; then
             echo '::error::PR_REBASE_TOKEN is required so fixed-model factory pushes trigger PR workflows without action_required.'
             exit 1
           fi
@@ -63,7 +63,7 @@ jobs:
         shell: bash
         run: |
           set -Eeuo pipefail
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://x-access-token:${PR_REBASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
       - name: Resolve fixed lane
         id: lane


### PR DESCRIPTION
## Summary
- Keep `GH_TOKEN=${{ github.token }}` for labels/comments/API.
- Use `PR_REBASE_TOKEN` only for checkout + `git remote` / push so PR workflows still avoid `action_required`.

## Why
Post-merge fleet smoke failed at the heartbeat step: `PR_REBASE_TOKEN` can push, but cannot comment on issue #1093.

## Test plan
- [ ] Merge and re-dispatch factories 6–46
- [ ] Confirm heartbeat + pinned-model smoke succeed for healthy lanes
- [ ] Confirm a factory push triggers Fixed Model PR Repair Guard without `action_required`


Made with [Cursor](https://cursor.com)