### PR TITLE
Execute fixed-model guard only from trusted main checkout

### DIFF
--- a/.github/scripts/fixed-model-guard.py
+++ b/.github/scripts/fixed-model-guard.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import unittest
+from typing import cast
 
 FACTORY_CONTROL_PREFIXES: tuple[str, ...] = (
     ".github/workflows/fixed-model-",
@@ -75,24 +76,65 @@ def reject_decision(
     *,
     title: str = "",
     body: str = "",
+    merge_in_progress: bool = False,
+    cherry_pick_in_progress: bool = False,
+    revert_in_progress: bool = False,
+    unmerged_entries: bool = False,
+    conflict_markers: bool = False,
+    head_changed: bool = False,
+    foreign_main_commits: bool = False,
 ) -> dict[str, object]:
     """Decide whether a factory persistence attempt must be rejected.
 
-    Rejection is fail-closed and deterministic:
-    1. Zero overlap with an existing PR diff is rejected.
-    2. Factory-control paths are rejected unless the selected task is about
-       fixed-model factory infrastructure.
+    Rejection is fail-closed and deterministic. Checks run in order:
+    1. Unclean git state is always rejected so the wrapper can never persist
+       a model-created merge, rebase, or conflict resolution. This covers an
+       in-progress merge/cherry-pick/revert, unmerged index entries, literal
+       conflict-marker text in changed files, a HEAD that moved away from the
+       checked-out target (a model-committed merge or rebase of main), and
+       commits from main folded into the branch.
+    2. Factory-control paths already present in the prior PR diff are rejected
+       for non-factory tasks, so an adopted PR branch carrying stale factory
+       contamination cannot be pushed further.
+    3. Zero overlap with an existing PR diff is rejected.
+    4. Factory-control paths in the latest diff are rejected unless the
+       selected task is about fixed-model factory infrastructure.
 
     Args:
         previous_pr_files: Paths already on the PR before local changes.
         latest_commit_files: Paths in the staged/uncommitted factory diff.
         title: Selected issue or PR title used for scope checks.
         body: Selected issue or PR body used for scope checks.
+        merge_in_progress: A git merge is under way (MERGE_HEAD exists).
+        cherry_pick_in_progress: A cherry-pick is under way.
+        revert_in_progress: A revert is under way.
+        unmerged_entries: The index has unmerged (conflicted) entries.
+        conflict_markers: Changed files contain literal git conflict markers.
+        head_changed: HEAD no longer equals the checked-out target head.
+        foreign_main_commits: The branch now contains commits from main that
+            were not reachable at checkout time.
 
     Returns:
         JSON-serializable decision with reject flag and reason.
 
     """
+    git_state = {
+        "merge_in_progress": merge_in_progress,
+        "cherry_pick_in_progress": cherry_pick_in_progress,
+        "revert_in_progress": revert_in_progress,
+        "unmerged_entries": unmerged_entries,
+        "conflict_markers": conflict_markers,
+        "head_changed": head_changed,
+        "foreign_main_commits": foreign_main_commits,
+    }
+    if any(git_state.values()):
+        return {
+            "reject": True,
+            "reason": "unclean-git-state",
+            "git_state": git_state,
+            "factory_control_files": [],
+        }
+
     latest = set()
     for path in latest_commit_files:
         if not path:
@@ -109,6 +151,14 @@ def reject_decision(
         while normalized.startswith("./"):
             normalized = normalized[2:]
         previous.add(normalized)
+
+    prior_control_files = sorted(path for path in previous if is_factory_control_path(path))
+    if prior_control_files and not task_allows_factory_control(title, body):
+        return {
+            "reject": True,
+            "reason": "factory-control-in-prior-pr-diff",
+            "factory_control_files": prior_control_files,
+        }
 
     if unrelated_repair(previous, latest):
         return {
@@ -205,6 +255,137 @@ class GuardTests(unittest.TestCase):
         )
         self.assertFalse(decision["reject"])
 
+    def test_merge_in_progress_is_rejected(self) -> None:
+        """An in-progress git merge (MERGE_HEAD) fails closed before any push."""
+        decision = reject_decision(
+            {"frontend/src/pages/RollPage/components/RatingView.tsx"},
+            {"frontend/src/pages/RollPage/components/RatingView.tsx"},
+            title="Continuity correction from the Roll screen",
+            body="Product feature",
+            merge_in_progress=True,
+        )
+        self.assertTrue(decision["reject"])
+        self.assertEqual(decision["reason"], "unclean-git-state")
+        self.assertTrue(cast(dict, decision["git_state"])["merge_in_progress"])
+
+    def test_conflict_markers_are_rejected(self) -> None:
+        """Literal git conflict-marker text in the diff fails closed."""
+        decision = reject_decision(
+            {"app/schemas/release.py"},
+            {"app/schemas/release.py"},
+            title="Release writer regression coverage",
+            body="Product work",
+            conflict_markers=True,
+        )
+        self.assertTrue(decision["reject"])
+        self.assertEqual(decision["reason"], "unclean-git-state")
+        self.assertTrue(cast(dict, decision["git_state"])["conflict_markers"])
+
+    def test_cherry_pick_and_revert_in_progress_are_rejected(self) -> None:
+        """Cherry-pick and revert heads fail closed exactly like MERGE_HEAD."""
+        for flag in ("cherry_pick_in_progress", "revert_in_progress"):
+            with self.subTest(flag=flag):
+                decision = reject_decision(
+                    {"app/service.py"},
+                    {"app/service.py"},
+                    title="Fix service bug",
+                    body="Product bug",
+                    **{flag: True},
+                )
+                self.assertTrue(decision["reject"])
+                self.assertEqual(decision["reason"], "unclean-git-state")
+
+    def test_unmerged_index_entries_are_rejected(self) -> None:
+        """Unmerged (conflicted) index entries fail closed."""
+        decision = reject_decision(
+            {"app/service.py"},
+            {"app/service.py"},
+            title="Fix service bug",
+            body="Product bug",
+            unmerged_entries=True,
+        )
+        self.assertTrue(decision["reject"])
+        self.assertEqual(decision["reason"], "unclean-git-state")
+
+    def test_head_changed_after_model_merge_is_rejected(self) -> None:
+        """A HEAD that moved from the checkout target blocks model merge/rebase."""
+        decision = reject_decision(
+            {"frontend/src/pages/RollPage/components/RatingView.tsx"},
+            {"frontend/src/pages/RollPage/components/RatingView.tsx"},
+            title="Continuity correction from the Roll screen",
+            body="Product feature",
+            head_changed=True,
+        )
+        self.assertTrue(decision["reject"])
+        self.assertEqual(decision["reason"], "unclean-git-state")
+        self.assertTrue(cast(dict, decision["git_state"])["head_changed"])
+
+    def test_foreign_main_commits_are_rejected(self) -> None:
+        """Main commits folded into the branch (rebase/merge) fail closed."""
+        decision = reject_decision(
+            {"frontend/src/pages/QueuePage.tsx"},
+            {"frontend/src/pages/QueuePage.tsx"},
+            title="Decompose QueuePage",
+            body="Product refactor",
+            foreign_main_commits=True,
+        )
+        self.assertTrue(decision["reject"])
+        self.assertEqual(decision["reason"], "unclean-git-state")
+
+    def test_stale_branch_guard_helper_cannot_weaken_trusted_guard(self) -> None:
+        """A stale branch guard helper cannot weaken the trusted guard.
+
+        The old branch helper only implemented zero-overlap detection; the
+        trusted guard copy still rejects factory control paths regardless of
+        the stale helper's presence in the prior or latest diff sets.
+        """
+        decision = reject_decision(
+            {
+                ".github/scripts/fixed-model-guard.py",
+                "frontend/src/components/ContinuityCorrectionDialog.tsx",
+                "frontend/src/pages/RollPage/components/RatingView.tsx",
+            },
+            {
+                "frontend/src/unit/ContinuityCorrectionDialog.test.tsx",
+                ".github/scripts/classify-fixed-model-run.py",
+                ".github/scripts/fixed-model-guard.py",
+            },
+            title="Add in-context continuity correction from the Roll rating screen",
+            body="Part of #852. Reader can open the ContinuityCorrectionDialog and add the current issue.",
+        )
+        self.assertTrue(decision["reject"])
+        self.assertIn(decision["reason"], ("factory-control-in-prior-pr-diff", "factory-control-out-of-scope"))
+        self.assertIn(".github/scripts/fixed-model-guard.py", decision["factory_control_files"])
+
+    def test_prior_pr_diff_factory_control_is_rejected_on_product_task(self) -> None:
+        """Factory control already in the PR diff blocks further pushes."""
+        decision = reject_decision(
+            {
+                ".github/scripts/classify-fixed-model-run.py",
+                ".github/scripts/fixed-model-guard.py",
+                "frontend/src/components/ContinuityCorrectionDialog.tsx",
+            },
+            {
+                "frontend/src/components/ContinuityCorrectionDialog.tsx",
+                "frontend/src/unit/ContinuityCorrectionDialog.test.tsx",
+            },
+            title="Add in-context continuity correction from the Roll rating screen",
+            body="Part of #852.",
+        )
+        self.assertTrue(decision["reject"])
+        self.assertEqual(decision["reason"], "factory-control-in-prior-pr-diff")
+        self.assertIn(".github/scripts/fixed-model-guard.py", decision["factory_control_files"])
+
+    def test_factory_task_allows_prior_factory_control_diff(self) -> None:
+        """Factory infrastructure tasks may carry prior factory-control diffs."""
+        decision = reject_decision(
+            {".github/scripts/fixed-model-guard.py"},
+            {".github/scripts/fixed-model-guard.py", ".github/free-model-factories.tsv"},
+            title="Guard fixed-model PR repairs and runner leases",
+            body="Prevent fixed-model factory contamination across the factory fleet.",
+        )
+        self.assertFalse(decision["reject"])
+
     def test_legacy_unrelated_repair_helper_still_matches(self) -> None:
         """Preserve the original zero-overlap helper behavior."""
         self.assertTrue(
@@ -224,6 +405,7 @@ def main() -> int:
     parser.add_argument("--self-test", action="store_true")
     parser.add_argument("--previous-json")
     parser.add_argument("--latest-json")
+    parser.add_argument("--git-state", default="{}")
     parser.add_argument("--title", default="")
     parser.add_argument("--body", default="")
     args = parser.parse_args()
@@ -234,7 +416,24 @@ def main() -> int:
 
     previous = set(json.loads(args.previous_json or "[]"))
     latest = set(json.loads(args.latest_json or "[]"))
-    print(json.dumps(reject_decision(previous, latest, title=args.title, body=args.body)))
+    git_state = json.loads(args.git_state or "{}")
+    print(
+        json.dumps(
+            reject_decision(
+                previous,
+                latest,
+                title=args.title,
+                body=args.body,
+                merge_in_progress=git_state.get("merge_in_progress", False),
+                cherry_pick_in_progress=git_state.get("cherry_pick_in_progress", False),
+                revert_in_progress=git_state.get("revert_in_progress", False),
+                unmerged_entries=git_state.get("unmerged_entries", False),
+                conflict_markers=git_state.get("conflict_markers", False),
+                head_changed=git_state.get("head_changed", False),
+                foreign_main_commits=git_state.get("foreign_main_commits", False),
+            )
+        )
+    )
     return 0
 
 

--- a/.github/scripts/free-model-factory-worker.sh
+++ b/.github/scripts/free-model-factory-worker.sh
@@ -28,6 +28,20 @@ contains_skip_pr() {
   return 1
 }
 
+stage_trusted_guard() {
+  # The worker starts on the trusted main checkout. Copy the guard to a
+  # stable location BEFORE any checkout_target switches onto an adopted PR
+  # branch, then invoke only this copy for pre-push decisions. A stale PR
+  # branch copy of fixed-model-guard.py can never downgrade the decision.
+  TRUSTED_GUARD="${TRUSTED_GUARD:-}"
+  if [[ -z "$TRUSTED_GUARD" ]]; then
+    TRUSTED_GUARD="$(mktemp /tmp/comic-pile-fixed-model-guard.XXXXXX.py)"
+  fi
+  cp .github/scripts/fixed-model-guard.py "$TRUSTED_GUARD"
+  chmod +x "$TRUSTED_GUARD"
+  python3 "$TRUSTED_GUARD" --self-test >/dev/null 2>&1
+}
+
 replace_labels() {
   local number="$1" owner="$2" stage="$3"
   local labels target
@@ -200,7 +214,8 @@ checkout_target() {
   else
     git switch -C "$branch" origin/main
   fi
-  log "checked out ${mode} #${number} on ${branch}"
+  EXPECTED_HEAD="$(git rev-parse HEAD)"
+  log "checked out ${mode} #${number} on ${branch} at ${EXPECTED_HEAD}"
 }
 
 current_head_review_blockers() {
@@ -279,8 +294,54 @@ changed_paths_json() {
   } | jq -R -s 'split("\n") | map(select(length > 0)) | unique'
 }
 
+conflict_markers_present() {
+  local file
+  while IFS= read -r file; do
+    [[ -n "$file" ]] || continue
+    [[ -f "$file" ]] || continue
+    if grep -qE '^(<<<<<<< |>>>>>>> |=======$)' "$file" 2>/dev/null; then
+      return 0
+    fi
+  done < <(git diff --name-only --diff-filter=ACMRTUXB HEAD; git ls-files --others --exclude-standard)
+  return 1
+}
+
+branch_folded_main_commits() {
+  local ours theirs shared
+  ours="$(git rev-list "$EXPECTED_HEAD"..HEAD 2>/dev/null || true)"
+  theirs="$(git rev-list "$EXPECTED_HEAD"..origin/main 2>/dev/null || true)"
+  [[ -n "$ours" && -n "$theirs" ]] || return 1
+  shared="$(comm -12 <(printf '%s\n' "$ours" | sort) <(printf '%s\n' "$theirs" | sort))"
+  [[ -n "$shared" ]]
+}
+
+unclean_git_state_json() {
+  local merge_head cherry_pick_head revert_head
+  local merge_in_progress=false cherry_pick_in_progress=false revert_in_progress=false
+  local unmerged_entries=false conflict_markers=false head_changed=false foreign_main_commits=false
+  merge_head="$(git rev-parse -q --verify MERGE_HEAD 2>/dev/null || true)"
+  [[ -z "$merge_head" ]] || merge_in_progress=true
+  cherry_pick_head="$(git rev-parse -q --verify CHERRY_PICK_HEAD 2>/dev/null || true)"
+  [[ -z "$cherry_pick_head" ]] || cherry_pick_in_progress=true
+  revert_head="$(git rev-parse -q --verify REVERT_HEAD 2>/dev/null || true)"
+  [[ -z "$revert_head" ]] || revert_in_progress=true
+  [[ -z "$(git ls-files -u)" ]] || unmerged_entries=true
+  if conflict_markers_present; then conflict_markers=true; fi
+  [[ "$(git rev-parse HEAD)" == "$EXPECTED_HEAD" ]] || head_changed=true
+  if branch_folded_main_commits; then foreign_main_commits=true; fi
+  jq -nc \
+    --argjson merge_in_progress "$merge_in_progress" \
+    --argjson cherry_pick_in_progress "$cherry_pick_in_progress" \
+    --argjson revert_in_progress "$revert_in_progress" \
+    --argjson unmerged_entries "$unmerged_entries" \
+    --argjson conflict_markers "$conflict_markers" \
+    --argjson head_changed "$head_changed" \
+    --argjson foreign_main_commits "$foreign_main_commits" \
+    '{merge_in_progress:$merge_in_progress,cherry_pick_in_progress:$cherry_pick_in_progress,revert_in_progress:$revert_in_progress,unmerged_entries:$unmerged_entries,conflict_markers:$conflict_markers,head_changed:$head_changed,foreign_main_commits:$foreign_main_commits}'
+}
+
 reject_out_of_scope_diff() {
-  local mode="$1" number="$2" base_ref="$3" scope previous latest decision reason
+  local mode="$1" number="$2" base_ref="$3" scope previous latest git_state decision reason
   scope="$(target_scope_text "$mode" "$number")"
   if [[ "$mode" == 'pr' ]]; then
     previous="$(gh api "repos/${GITHUB_REPOSITORY}/compare/$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${number}" --jq .base.sha)...${base_ref}" \
@@ -289,16 +350,18 @@ reject_out_of_scope_diff() {
     previous='[]'
   fi
   latest="$(changed_paths_json "$base_ref")"
-  decision="$(python3 .github/scripts/fixed-model-guard.py \
+  git_state="$(unclean_git_state_json)"
+  decision="$(python3 "$TRUSTED_GUARD" \
     --previous-json "$previous" \
     --latest-json "$latest" \
+    --git-state "$git_state" \
     --title "$(jq -r .title <<< "$scope")" \
     --body "$(jq -r .body <<< "$scope")")"
   if [[ "$(jq -r .reject <<< "$decision")" != true ]]; then
     return 0
   fi
   reason="$(jq -r .reason <<< "$decision")"
-  log "rejecting out-of-scope ${mode} #${number} diff before push (${reason}): $(jq -c .factory_control_files <<< "$decision")"
+  log "rejecting out-of-scope ${mode} #${number} diff before push (${reason}): git_state=$(jq -c .git_state <<< "$decision") factory_control_files=$(jq -c .factory_control_files <<< "$decision")"
   git reset --hard "$base_ref" >/dev/null
   git clean -fd >/dev/null
   return 1
@@ -307,7 +370,7 @@ reject_out_of_scope_diff() {
 persist_issue_pr() {
   local number="$1" branch="$2" pr title body base_ref
   [[ -n "$(git status --porcelain)" ]] || return 1
-  base_ref="$(git rev-parse HEAD)"
+  base_ref="$EXPECTED_HEAD"
   if ! reject_out_of_scope_diff 'issue' "$number" "$base_ref"; then
     return 1
   fi
@@ -329,7 +392,7 @@ persist_issue_pr() {
 persist_pr_changes() {
   local pr="$1" branch="$2" base_ref
   [[ -n "$(git status --porcelain)" ]] || return 1
-  base_ref="$(git rev-parse HEAD)"
+  base_ref="$EXPECTED_HEAD"
   if ! reject_out_of_scope_diff 'pr' "$pr" "$base_ref"; then
     return 1
   fi
@@ -340,6 +403,7 @@ persist_pr_changes() {
 }
 
 ensure_owner_label
+stage_trusted_guard
 release_owned_targets 'previous-run-stale-lease'
 trap 'release_owned_targets session-end-handoff || true' EXIT
 log "starting fixed-model session with runtime ${RUNTIME_MODEL}; budget ${BUDGET_SECONDS}s"

--- a/.github/scripts/nvidia-factory-worker.sh
+++ b/.github/scripts/nvidia-factory-worker.sh
@@ -112,7 +112,8 @@ checkout_target() {
   else
     git switch -C "$branch" origin/main
   fi
-  log "checked out ${mode} #${number} on ${branch}"
+  EXPECTED_HEAD="$(git rev-parse HEAD)"
+  log "checked out ${mode} #${number} on ${branch} at ${EXPECTED_HEAD}"
 }
 
 current_head_review_blockers() {
@@ -200,9 +201,38 @@ run_agent() {
   return "$status"
 }
 
+reject_unclean_git_state() {
+  # Fail closed before persistence: a model-created merge, rebase, cherry-pick,
+  # revert, or unresolved conflict must never be committed or pushed by the
+  # wrapper. The model is instructed not to commit; any HEAD movement away from
+  # the checked-out target means the model merged or rebased main.
+  local marker
+  marker="$(git rev-parse -q --verify MERGE_HEAD 2>/dev/null || true)"
+  [[ -z "$marker" ]] || { log 'rejecting persistence: merge in progress (MERGE_HEAD)'; return 1; }
+  marker="$(git rev-parse -q --verify CHERRY_PICK_HEAD 2>/dev/null || true)"
+  [[ -z "$marker" ]] || { log 'rejecting persistence: cherry-pick in progress'; return 1; }
+  marker="$(git rev-parse -q --verify REVERT_HEAD 2>/dev/null || true)"
+  [[ -z "$marker" ]] || { log 'rejecting persistence: revert in progress'; return 1; }
+  [[ -z "$(git ls-files -u)" ]] || { log 'rejecting persistence: unmerged index entries'; return 1; }
+  if git diff --name-only --diff-filter=ACMRTUXB HEAD | xargs -r grep -lE '^(<<<<<<< |>>>>>>> |=======$)' 2>/dev/null | grep -q .; then
+    log 'rejecting persistence: conflict markers in changed files'
+    return 1
+  fi
+  if [[ "$(git rev-parse HEAD)" != "$EXPECTED_HEAD" ]]; then
+    log 'rejecting persistence: HEAD moved away from the checked-out target (model merge/rebase/commit)'
+    return 1
+  fi
+  return 0
+}
+
 persist_issue_pr() {
   local number="$1" branch="$2" pr title
   if [[ -z "$(git status --porcelain)" ]]; then return 1; fi
+  if ! reject_unclean_git_state; then
+    git reset --hard "$EXPECTED_HEAD" >/dev/null
+    git clean -fd >/dev/null
+    return 1
+  fi
   git add -A
   git commit -m "factory: advance #${number} with NVIDIA OpenCode"
   git push --set-upstream origin "$branch"
@@ -219,6 +249,11 @@ persist_issue_pr() {
 persist_pr_changes() {
   local pr="$1" branch="$2"
   if [[ -z "$(git status --porcelain)" ]]; then return 1; fi
+  if ! reject_unclean_git_state; then
+    git reset --hard "$EXPECTED_HEAD" >/dev/null
+    git clean -fd >/dev/null
+    return 1
+  fi
   git add -A
   git commit -m "factory: advance PR #${pr} with NVIDIA OpenCode"
   git push origin "$branch"
@@ -280,7 +315,6 @@ while (( $(remaining) > 480 )); do
   fi
 
   checkout_target "$MODE" "$NUMBER" "$BRANCH"
-  before="$(git rev-parse HEAD)"
   available="$(remaining)"
   agent_timeout=$((available - 240))
   (( agent_timeout > 3000 )) && agent_timeout=3000

--- a/.github/scripts/omniroute-factory-worker.sh
+++ b/.github/scripts/omniroute-factory-worker.sh
@@ -116,7 +116,8 @@ checkout_target() {
   else
     git switch -C "$branch" origin/main
   fi
-  log "checked out ${mode} #${number} on ${branch}"
+  EXPECTED_HEAD="$(git rev-parse HEAD)"
+  log "checked out ${mode} #${number} on ${branch} at ${EXPECTED_HEAD}"
 }
 
 current_head_review_blockers() {
@@ -184,9 +185,38 @@ smoke_agent() {
   log 'OpenCode smoke succeeded without modifying the worktree'
 }
 
+reject_unclean_git_state() {
+  # Fail closed before persistence: a model-created merge, rebase, cherry-pick,
+  # revert, or unresolved conflict must never be committed or pushed by the
+  # wrapper. The model is instructed not to commit; any HEAD movement away from
+  # the checked-out target means the model merged or rebased main.
+  local marker
+  marker="$(git rev-parse -q --verify MERGE_HEAD 2>/dev/null || true)"
+  [[ -z "$marker" ]] || { log 'rejecting persistence: merge in progress (MERGE_HEAD)'; return 1; }
+  marker="$(git rev-parse -q --verify CHERRY_PICK_HEAD 2>/dev/null || true)"
+  [[ -z "$marker" ]] || { log 'rejecting persistence: cherry-pick in progress'; return 1; }
+  marker="$(git rev-parse -q --verify REVERT_HEAD 2>/dev/null || true)"
+  [[ -z "$marker" ]] || { log 'rejecting persistence: revert in progress'; return 1; }
+  [[ -z "$(git ls-files -u)" ]] || { log 'rejecting persistence: unmerged index entries'; return 1; }
+  if git diff --name-only --diff-filter=ACMRTUXB HEAD | xargs -r grep -lE '^(<<<<<<< |>>>>>>> |=======$)' 2>/dev/null | grep -q .; then
+    log 'rejecting persistence: conflict markers in changed files'
+    return 1
+  fi
+  if [[ "$(git rev-parse HEAD)" != "$EXPECTED_HEAD" ]]; then
+    log 'rejecting persistence: HEAD moved away from the checked-out target (model merge/rebase/commit)'
+    return 1
+  fi
+  return 0
+}
+
 persist_issue_pr() {
   local number="$1" branch="$2" pr title body
   [[ -n "$(git status --porcelain)" ]] || return 1
+  if ! reject_unclean_git_state; then
+    git reset --hard "$EXPECTED_HEAD" >/dev/null
+    git clean -fd >/dev/null
+    return 1
+  fi
   git add -A
   git commit -m "factory: advance #${number} with OmniRoute"
   git push --set-upstream origin "$branch"
@@ -205,6 +235,11 @@ persist_issue_pr() {
 persist_pr_changes() {
   local pr="$1" branch="$2"
   [[ -n "$(git status --porcelain)" ]] || return 1
+  if ! reject_unclean_git_state; then
+    git reset --hard "$EXPECTED_HEAD" >/dev/null
+    git clean -fd >/dev/null
+    return 1
+  fi
   git add -A
   git commit -m "factory: advance PR #${pr} with OmniRoute"
   git push origin "$branch"

--- a/.github/workflows/fixed-model-pr-repair-guard.yml
+++ b/.github/workflows/fixed-model-pr-repair-guard.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/checkout@v7
       - name: Test fleet guard decisions
         run: python .github/scripts/fixed-model-guard.py --self-test
+      - name: Test pre-push guard regressions
+        run: bash scripts/tests/test_free_model_worker_guard.sh
 
   reject-unrelated-repair:
     if: >-
@@ -49,32 +51,52 @@ jobs:
 
           parent="$(jq -r '.parents[0].sha // empty' <<< "$commit")"
           [[ -n "$parent" ]] || exit 0
+          parent_count="$(jq '.parents | length' <<< "$commit")"
           latest_files="$(jq -c '[.files[]?.filename] | unique' <<< "$commit")"
           previous_files="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${BASE_SHA}...${parent}" \
             --jq '[.files[]?.filename] | unique')"
 
-          branch_issue=""
-          if [[ "$HEAD_BRANCH" =~ ^factory/[0-9]+-([0-9]+)- ]]; then
-            branch_issue="${BASH_REMATCH[1]}"
-          fi
-          if [[ -n "$branch_issue" ]]; then
-            scope="$(gh issue view "$branch_issue" --json title,body)"
+          reason=""
+          if (( parent_count > 1 )); then
+            reason="merge-commit"
           else
-            scope="$(gh pr view "$PR_NUMBER" --json title,body)"
+            conflicted=""
+            while IFS= read -r file; do
+              [[ -n "$file" ]] || continue
+              encoded="$(gh api "repos/${GITHUB_REPOSITORY}/contents/$(jq -rn --arg p "$file" '$p | @uri')?ref=${HEAD_SHA}" --jq '.content // empty' 2>/dev/null || true)"
+              if [[ -n "$encoded" ]] && grep -qE '^(<<<<<<< |>>>>>>> |=======$)' <(base64 -d <<< "$encoded" 2>/dev/null || true); then
+                conflicted="$conflicted $file"
+              fi
+            done <<< "$(jq -r '.files[]?.filename' <<< "$commit")"
+            if [[ -n "$conflicted" ]]; then
+              reason="conflict-markers-in-${HEAD_SHA:0:12}:${conflicted}"
+            fi
           fi
 
-          decision="$(python .github/scripts/fixed-model-guard.py \
-            --previous-json "$previous_files" \
-            --latest-json "$latest_files" \
-            --title "$(jq -r .title <<< "$scope")" \
-            --body "$(jq -r .body <<< "$scope")")"
-          if [[ "$(jq -r .reject <<< "$decision")" != true ]]; then
-            echo 'Fixed-model repair is in scope; allowing it.'
-            exit 0
+          if [[ -z "$reason" ]]; then
+            branch_issue=""
+            if [[ "$HEAD_BRANCH" =~ ^factory/[0-9]+-([0-9]+)- ]]; then
+              branch_issue="${BASH_REMATCH[1]}"
+            fi
+            if [[ -n "$branch_issue" ]]; then
+              scope="$(gh issue view "$branch_issue" --json title,body)"
+            else
+              scope="$(gh pr view "$PR_NUMBER" --json title,body)"
+            fi
+
+            decision="$(python .github/scripts/fixed-model-guard.py \
+              --previous-json "$previous_files" \
+              --latest-json "$latest_files" \
+              --title "$(jq -r .title <<< "$scope")" \
+              --body "$(jq -r .body <<< "$scope")")"
+            if [[ "$(jq -r .reject <<< "$decision")" != true ]]; then
+              echo 'Fixed-model repair is in scope; allowing it.'
+              exit 0
+            fi
+            reason="$(jq -r .reason <<< "$decision")"
           fi
 
-          reason="$(jq -r .reason <<< "$decision")"
-          echo "Rejecting unrelated fixed-model repair ${HEAD_SHA} (${reason}); restoring ${parent}."
+          echo "Rejecting fixed-model repair ${HEAD_SHA} (${reason}); restoring ${parent}."
           gh api --method PATCH "repos/${GITHUB_REPOSITORY}/git/refs/heads/${HEAD_BRANCH}" \
             -f sha="$parent" -F force=true >/dev/null
 
@@ -84,4 +106,4 @@ jobs:
             + ["factory", "factory:unowned", "factory:review"] | unique' <<< "$labels")"
           gh api --method PUT "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" \
             --input - <<< "{\"labels\":${target}}" >/dev/null
-          gh pr comment "$PR_NUMBER" --body "Rejected fixed-model repair commit \`${HEAD_SHA}\` (${reason}): the diff was out of scope for the selected task. The branch was restored to \`${parent}\` and released to \`factory:unowned\`." >/dev/null
+          gh pr comment "$PR_NUMBER" --body "Rejected fixed-model repair commit \`${HEAD_SHA}\` (${reason}): the diff was out of scope for the selected task or carried an unclean merge/conflict state. The branch was restored to \`${parent}\` and released to \`factory:unowned\`." >/dev/null

--- a/scripts/tests/test_fixed_model_worker_output_contract.py
+++ b/scripts/tests/test_fixed_model_worker_output_contract.py
@@ -82,6 +82,21 @@ def test_trusted_guard_is_staged_before_checkout() -> None:
     assert guard_index < loop_index
 
 
+def test_stage_trusted_guard_keeps_tmp_fallback_in_production() -> None:
+    """Production keeps its /tmp mktemp fallback; tests set TRUSTED_GUARD.
+
+    The regression suite points TRUSTED_GUARD inside its own test workspace so
+    the CI review agent never needs external-directory permission. Production
+    must not be narrowed to satisfy the test: when TRUSTED_GUARD is unset the
+    worker still stages the guard under /tmp via mktemp.
+    """
+    body = _function_body('stage_trusted_guard')
+
+    assert re.search(r'TRUSTED_GUARD="\$\{TRUSTED_GUARD:-\}"', body)
+    assert re.search(r'mktemp /tmp/comic-pile-fixed-model-guard\.XXXXXX\.py', body)
+    assert 'cp .github/scripts/fixed-model-guard.py "$TRUSTED_GUARD"' in body
+
+
 def test_reject_out_of_scope_diff_uses_trusted_guard_and_git_state() -> None:
     """The pre-push decision must be made by the trusted guard with git state.
 

--- a/scripts/tests/test_fixed_model_worker_output_contract.py
+++ b/scripts/tests/test_fixed_model_worker_output_contract.py
@@ -41,6 +41,28 @@ def test_persist_issue_pr_stdout_is_reserved_for_pr_number() -> None:
     assert stdout_commands == ['echo "$pr"']
 
 
+def test_worker_config_environment_vars_remain_fail_fast() -> None:
+    """Production worker identity must fail fast, never default silently.
+
+    The worker must refuse to run when FACTORY_WORKER / FACTORY_SOURCE /
+    FACTORY_MODEL / FACTORY_RUNTIME_MODEL are unset. A default like
+    ``${FACTORY_WORKER:-test}`` would silently run an anonymous worker and is
+    prohibited. The bash regression suite supplies its own test environment
+    and must never require weakening this fail-fast property.
+    """
+    text = WORKER.read_text(encoding='utf-8')
+
+    assert 'WORKER="${FACTORY_WORKER:?FACTORY_WORKER is required}"' in text
+    assert 'SOURCE="${FACTORY_SOURCE:?FACTORY_SOURCE is required}"' in text
+    assert 'MODEL="${FACTORY_MODEL:?FACTORY_MODEL is required}"' in text
+    assert 'RUNTIME_MODEL="${FACTORY_RUNTIME_MODEL:?FACTORY_RUNTIME_MODEL is required}"' in text
+
+    for var in ('FACTORY_WORKER', 'FACTORY_SOURCE', 'FACTORY_MODEL', 'FACTORY_RUNTIME_MODEL'):
+        assert re.search(rf'{re.escape(var)}:-\$', text) is None, (
+            f'{var} must not be given a silent default'
+        )
+
+
 def test_trusted_guard_is_staged_before_checkout() -> None:
     """The guard must be copied from the main checkout before any branch switch.
 

--- a/scripts/tests/test_fixed_model_worker_output_contract.py
+++ b/scripts/tests/test_fixed_model_worker_output_contract.py
@@ -39,3 +39,70 @@ def test_persist_issue_pr_stdout_is_reserved_for_pr_number() -> None:
         and not line.rstrip().endswith('>&2')
     ]
     assert stdout_commands == ['echo "$pr"']
+
+
+def test_trusted_guard_is_staged_before_checkout() -> None:
+    """The guard must be copied from the main checkout before any branch switch.
+
+    This is the root-cause fix: an adopted PR branch carrying an older copy of
+    fixed-model-guard.py must never be the implementation the worker executes.
+    """
+    body = _function_body('stage_trusted_guard')
+
+    assert re.search(r'TRUSTED_GUARD="\$\{TRUSTED_GUARD:-\}"', body)
+    assert re.search(r'TRUSTED_GUARD="\$\{TRUSTED_GUARD:-\}"\n', body)
+    assert 'cp .github/scripts/fixed-model-guard.py "$TRUSTED_GUARD"' in body
+    assert 'python3 "$TRUSTED_GUARD" --self-test' in body
+
+    script = WORKER.read_text(encoding='utf-8')
+    guard_index = script.index('stage_trusted_guard')
+    loop_index = script.index('while ((')
+    assert guard_index < loop_index
+
+
+def test_reject_out_of_scope_diff_uses_trusted_guard_and_git_state() -> None:
+    """The pre-push decision must be made by the trusted guard with git state.
+
+    The worker must pass deterministic git-state flags (MERGE_HEAD, unmerged
+    index entries, conflict markers, HEAD movement) to the trusted guard so a
+    model-created merge/conflict is rejected before commit or push.
+    """
+    body = _function_body('reject_out_of_scope_diff')
+
+    assert 'python3 "$TRUSTED_GUARD"' in body
+    assert '.github/scripts/fixed-model-guard.py' not in body
+    assert '--git-state "$git_state"' in body
+    assert 'git_state="$(unclean_git_state_json)' in body
+
+    for marker in ('MERGE_HEAD', 'CHERRY_PICK_HEAD', 'REVERT_HEAD', 'git ls-files -u', 'conflict'):
+        assert marker in _function_body('unclean_git_state_json')
+
+
+def test_persist_uses_expected_head_not_current_head() -> None:
+    """Persistence must diff against and reset to the checked-out target head.
+
+    Using `git rev-parse HEAD` would let a model-committed merge be treated as
+    the base and then blindly persisted.
+    """
+    for fn in ('persist_issue_pr', 'persist_pr_changes'):
+        body = _function_body(fn)
+        assert 'base_ref="$EXPECTED_HEAD"' in body
+        assert 'base_ref="$(git rev-parse HEAD)"' not in body
+
+
+def test_checkout_target_records_expected_head() -> None:
+    """checkout_target must record the branch head for fail-closed detection."""
+    body = _function_body('checkout_target')
+    assert 'EXPECTED_HEAD="$(git rev-parse HEAD)"' in body
+
+
+def test_omniroute_and_nvidia_workers_reject_unclean_git_state() -> None:
+    """Every factory wrapper must fail closed on model-created merge state."""
+    for path in (Path('.github/scripts/omniroute-factory-worker.sh'), Path('.github/scripts/nvidia-factory-worker.sh')):
+        script = path.read_text(encoding='utf-8')
+        assert 'reject_unclean_git_state' in script
+        assert 'MERGE_HEAD' in script
+        assert 'CHERRY_PICK_HEAD' in script
+        assert 'REVERT_HEAD' in script
+        assert 'git ls-files -u' in script
+        assert 'git reset --hard "$EXPECTED_HEAD"' in script

--- a/scripts/tests/test_free_model_worker_guard.sh
+++ b/scripts/tests/test_free_model_worker_guard.sh
@@ -346,6 +346,20 @@ test_regression_model_committed_merge() {
   git reset -q --hard "$EXPECTED_HEAD"
 }
 
+test_worker_fail_fast_env() {
+  printf '\n--- test_worker_fail_fast_env ---\n'
+  # The worker must refuse to start when required identity env vars are
+  # missing. The test harness provides no factory env vars here on purpose;
+  # this proves fail-fast does not depend on weakened production defaults.
+  local output
+  output="$(env -i HOME="$HOME" PATH="$PATH" bash "$WORKER" 2>&1 || true)"
+  if grep -q 'FACTORY_WORKER is required' <<< "$output"; then
+    pass "worker fails fast on missing FACTORY_WORKER"
+  else
+    fail "worker did not fail fast on missing FACTORY_WORKER"
+  fi
+}
+
 test_worker_syntax() {
   printf '\n--- test_worker_syntax ---\n'
   bash -n "$WORKER" && pass "worker script has valid bash syntax" || fail "worker script has syntax errors"
@@ -354,6 +368,7 @@ test_worker_syntax() {
 }
 
 test_worker_syntax
+test_worker_fail_fast_env
 test_trusted_guard_staging
 test_regression_stale_branch_guard
 test_regression_merge_main_rejected

--- a/scripts/tests/test_free_model_worker_guard.sh
+++ b/scripts/tests/test_free_model_worker_guard.sh
@@ -1,0 +1,369 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# ===========================================================================
+# Test suite for the fixed-model free-model-factory-worker.sh pre-push guard.
+#
+# Regression 1: a target PR branch that carries an OLD copy of
+# fixed-model-guard.py (zero-overlap detection only) must not weaken the
+# pre-push decision. The worker must execute the trusted guard staged from the
+# main checkout and reject factory-control edits on a normal product task.
+#
+# Regression 2: a model that runs `git merge origin/main` and leaves
+# MERGE_HEAD / unmerged index entries / conflict-marker text must be rejected
+# and reset without commit or push.
+#
+# Regression 3: a model that completes a merge or rebase of main (moving HEAD
+# away from the checked-out target) must be rejected.
+# ===========================================================================
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WORKER="$ROOT/.github/scripts/free-model-factory-worker.sh"
+TRUSTED_GUARD_SRC="$ROOT/.github/scripts/fixed-model-guard.py"
+PASS=0
+FAIL=0
+TEST_TMPDIR=""
+
+cleanup() {
+  if [[ -n "${TEST_TMPDIR:-}" && -d "$TEST_TMPDIR" ]]; then
+    rm -rf "$TEST_TMPDIR"
+  fi
+  TEST_TMPDIR=""
+}
+trap cleanup EXIT
+
+fail() {
+  FAIL=$((FAIL + 1))
+  printf '  FAIL: %s\n' "$*" >&2
+}
+
+pass() {
+  PASS=$((PASS + 1))
+  printf '  PASS: %s\n' "$*"
+}
+
+assert_eq() {
+  local expected="$1" actual="$2" msg="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$msg"
+  else
+    fail "$msg — expected '$expected', got '$actual'"
+  fi
+}
+
+assert_true() {
+  local msg="$1"
+  shift
+  if "$@"; then
+    pass "$msg"
+  else
+    fail "$msg"
+  fi
+}
+
+assert_false() {
+  local msg="$1"
+  shift
+  if "$@"; then
+    fail "$msg"
+  else
+    pass "$msg"
+  fi
+}
+
+# Extract named function definitions from the worker script.
+extract_functions() {
+  local pattern=""
+  local name
+  for name in "$@"; do
+    [[ -z "$pattern" ]] || pattern="$pattern|"
+    pattern="$pattern^${name}\\(\\) \\{"
+  done
+  eval "$(awk -v re="$pattern" '
+    $0 ~ re {
+      in_func = 1
+      depth = 1
+      printf "%s\n", $0
+      next
+    }
+    in_func {
+      printf "%s\n", $0
+      for (i = 1; i <= length($0); i++) {
+        c = substr($0, i, 1)
+        if (c == "{") depth++
+        if (c == "}") depth--
+      }
+      if (depth <= 0) {
+        in_func = 0
+        printf "\n"
+      }
+    }
+  ' "$WORKER")"
+}
+
+# Minimal OLD guard implementation: zero-overlap detection only. This mirrors
+# the 8af84904-era helper that did not implement factory-control scope checks,
+# which is what let the contaminated PR downgrade the pre-push decision.
+write_stale_guard() {
+  local path="$1"
+  cat > "$path" <<'EOF'
+#!/usr/bin/env python3
+"""Stale helper: zero-overlap detection only (pre-factory-control-check)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+
+def unrelated_repair(previous_pr_files, latest_commit_files):
+    return bool(
+        previous_pr_files
+        and latest_commit_files
+        and previous_pr_files.isdisjoint(latest_commit_files)
+    )
+
+
+def reject_decision(previous_pr_files, latest_commit_files, *, title="", body=""):
+    previous = set(p for p in previous_pr_files if p)
+    latest = set(p for p in latest_commit_files if p)
+    if unrelated_repair(previous, latest):
+        return {"reject": True, "reason": "zero-overlap-with-existing-pr-diff"}
+    return {"reject": False, "reason": "allowed"}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--previous-json")
+    parser.add_argument("--latest-json")
+    parser.add_argument("--title", default="")
+    parser.add_argument("--body", default="")
+    args = parser.parse_args()
+    print(json.dumps(reject_decision(
+        set(json.loads(args.previous_json or "[]")),
+        set(json.loads(args.latest_json or "[]")),
+    )))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+EOF
+  chmod +x "$path"
+}
+
+new_work() {
+  # Fresh clone of a shared bare remote with a main branch.
+  cd /
+  cleanup
+  TEST_TMPDIR="$(mktemp -d)"
+  git init -q --bare "$TEST_TMPDIR/remote.git"
+  git clone -q "$TEST_TMPDIR/remote.git" "$TEST_TMPDIR/work"
+  git -C "$TEST_TMPDIR/work" config user.email "test@example.com"
+  git -C "$TEST_TMPDIR/work" config user.name "Test"
+  git -C "$TEST_TMPDIR/work" checkout -q -b main
+  git -C "$TEST_TMPDIR/work" config push.default current
+  echo "init" > "$TEST_TMPDIR/work/README.md"
+  git -C "$TEST_TMPDIR/work" add -A
+  git -C "$TEST_TMPDIR/work" commit -qm init
+  git -C "$TEST_TMPDIR/work" push -q -u origin main
+}
+
+stage_real_guard_on_main() {
+  # The trusted main checkout contains the current fixed-model-guard.py.
+  cd "$TEST_TMPDIR/work"
+  mkdir -p .github/scripts
+  cp "$TRUSTED_GUARD_SRC" .github/scripts/fixed-model-guard.py
+  git add -A && git commit -qm "add trusted guard"
+  git push -q origin main
+}
+
+# ===========================================================================
+# TEST: trusted guard is staged from the main checkout and self-tests.
+# ===========================================================================
+test_trusted_guard_staging() {
+  printf '\n--- test_trusted_guard_staging ---\n'
+  new_work
+  stage_real_guard_on_main
+  extract_functions stage_trusted_guard
+  stage_trusted_guard
+  assert_true "trusted guard copy exists in /tmp" test -f "${TRUSTED_GUARD:-}"
+  assert_true "trusted copy carries the new git-state logic" \
+    grep -q 'conflict_markers' "${TRUSTED_GUARD}"
+}
+
+# ===========================================================================
+# REGRESSION 1: stale branch guard helper must not weaken the trusted guard.
+# ===========================================================================
+test_regression_stale_branch_guard() {
+  printf '\n--- test_regression_stale_branch_guard ---\n'
+  new_work
+  stage_real_guard_on_main
+  extract_functions stage_trusted_guard
+  stage_trusted_guard
+
+  cd "$TEST_TMPDIR/work"
+  git checkout -q -b feature
+  git reset -q --hard origin/main
+  write_stale_guard .github/scripts/fixed-model-guard.py
+  mkdir -p frontend/src/pages/RollPage/components frontend/src/components frontend/src/unit
+  echo "product" > frontend/src/pages/RollPage/components/RatingView.tsx
+  git add -A && git commit -qm "product work with stale branch guard helper"
+  EXPECTED_HEAD="$(git rev-parse HEAD)"
+
+  # The stale branch helper is what the old buggy worker would have executed.
+  # The latest diff overlaps the prior product diff (real contamination had
+  # product overlap), so the stale zero-overlap-only helper passes it.
+  stale_decision="$(python3 .github/scripts/fixed-model-guard.py \
+    --previous-json '["frontend/src/components/ContinuityCorrectionDialog.tsx","frontend/src/pages/RollPage/components/RatingView.tsx"]' \
+    --latest-json '["frontend/src/components/ContinuityCorrectionDialog.tsx","frontend/src/unit/ContinuityCorrectionDialog.test.tsx",".github/scripts/classify-fixed-model-run.py",".github/scripts/fixed-model-guard.py"]' \
+    --title "Continuity correction" \
+    --body "Part of #852.")"
+  assert_eq "false" \
+    "$(jq -r .reject <<< "$stale_decision")" \
+    "stale branch guard misses factory-control (vulnerability reproduced)"
+
+  # The model then edits factory-control files on top of the product PR.
+  mkdir -p .github/scripts
+  echo "CONTAMINATED" > .github/scripts/classify-fixed-model-run.py
+  echo "still product" >> frontend/src/pages/RollPage/components/RatingView.tsx
+
+  # The trusted guard (staged from main) must reject despite the stale helper.
+  trusted_decision="$(python3 "$TRUSTED_GUARD" \
+    --previous-json '["frontend/src/components/ContinuityCorrectionDialog.tsx","frontend/src/pages/RollPage/components/RatingView.tsx",".github/scripts/fixed-model-guard.py"]' \
+    --latest-json '["frontend/src/unit/ContinuityCorrectionDialog.test.tsx",".github/scripts/classify-fixed-model-run.py",".github/scripts/fixed-model-guard.py"]' \
+    --git-state '{"merge_in_progress":false,"cherry_pick_in_progress":false,"revert_in_progress":false,"unmerged_entries":false,"conflict_markers":false,"head_changed":false,"foreign_main_commits":false}' \
+    --title "Add in-context continuity correction from the Roll rating screen" \
+    --body "Part of #852.")"
+  assert_eq "true" \
+    "$(jq -r .reject <<< "$trusted_decision")" \
+    "trusted guard rejects factory-control on product task"
+}
+
+# ===========================================================================
+# REGRESSION 2: model runs `git merge origin/main`; persistence must reject.
+# ===========================================================================
+test_regression_merge_main_rejected() {
+  printf '\n--- test_regression_merge_main_rejected ---\n'
+  new_work
+  extract_functions stage_trusted_guard unclean_git_state_json conflict_markers_present branch_folded_main_commits
+
+  # The worker stages the trusted guard while on the main checkout.
+  cd "$TEST_TMPDIR/work"
+  mkdir -p .github/scripts
+  cp "$TRUSTED_GUARD_SRC" .github/scripts/fixed-model-guard.py
+  git add -A && git commit -qm "add trusted guard"
+  git push -q origin main
+  stage_trusted_guard
+
+  git checkout -q -b feature
+  git reset -q --hard origin/main
+  echo "conflict base" > conflicted.txt
+  git add -A && git commit -qm "feature adds conflicted.txt"
+  git push -q -u origin feature
+  EXPECTED_HEAD="$(git rev-parse HEAD)"
+
+  git checkout -q main
+  git reset -q --hard origin/main
+  echo "conflict from main" > conflicted.txt
+  git add -A && git commit -qm "main changes conflicted.txt"
+  git push -q origin main
+
+  # Simulate the model running `git merge origin/main` with a conflicting file.
+  git checkout -q feature
+  git fetch -q origin
+  set +e
+  git merge origin/main >/dev/null 2>&1
+  merge_status=$?
+  set -e
+  assert_eq "1" "$merge_status" "merge produced a conflict"
+  assert_true "MERGE_HEAD exists" test -f .git/MERGE_HEAD
+
+  git_state="$(unclean_git_state_json)"
+  assert_eq "true" "$(jq -r .merge_in_progress <<< "$git_state")" "merge_in_progress detected"
+  assert_eq "true" "$(jq -r .unmerged_entries <<< "$git_state")" "unmerged_entries detected"
+  assert_true "conflict markers detected" conflict_markers_present
+
+  decision="$(python3 "$TRUSTED_GUARD" \
+    --previous-json '[]' \
+    --latest-json '["conflicted.txt"]' \
+    --git-state "$git_state" \
+    --title "Product bug fix" \
+    --body "Normal product issue")"
+  assert_eq "true" "$(jq -r .reject <<< "$decision")" "trusted guard rejects unclean merge state"
+  assert_eq "unclean-git-state" "$(jq -r .reason <<< "$decision")" "rejection reason is unclean-git-state"
+
+  # Persistence must reset without commit or push: HEAD must return to the
+  # checked-out target and no merge state may remain.
+  git reset --hard "$EXPECTED_HEAD" >/dev/null
+  git clean -fd >/dev/null
+  assert_eq "$EXPECTED_HEAD" "$(git rev-parse HEAD)" "HEAD reset to expected target"
+  assert_false "no MERGE_HEAD remains" test -f .git/MERGE_HEAD
+}
+
+# ===========================================================================
+# REGRESSION 3: completed model merge/rebase of main is rejected.
+# ===========================================================================
+test_regression_model_committed_merge() {
+  printf '\n--- test_regression_model_committed_merge ---\n'
+  new_work
+  extract_functions stage_trusted_guard unclean_git_state_json branch_folded_main_commits
+
+  cd "$TEST_TMPDIR/work"
+  mkdir -p .github/scripts
+  cp "$TRUSTED_GUARD_SRC" .github/scripts/fixed-model-guard.py
+  git add -A && git commit -qm "add trusted guard"
+  git push -q origin main
+  stage_trusted_guard
+
+  git checkout -q -b feature
+  git reset -q --hard origin/main
+  echo "feature work" > feature.txt
+  git add -A && git commit -qm "feature work"
+  git push -q -u origin feature
+  EXPECTED_HEAD="$(git rev-parse HEAD)"
+
+  git checkout -q main
+  git reset -q --hard origin/main
+  echo "main work" > mainfile.txt
+  git add -A && git commit -qm "advance main"
+  git push -q origin main
+
+  git checkout -q feature
+  git fetch -q origin
+
+  # A clean merge of origin/main moves HEAD and folds main commits in.
+  git merge origin/main -m "model merges main" >/dev/null 2>&1
+  git_state="$(unclean_git_state_json)"
+  assert_eq "true" "$(jq -r .head_changed <<< "$git_state")" "head_changed detected after model merge"
+  assert_eq "true" "$(jq -r .foreign_main_commits <<< "$git_state")" "foreign_main_commits detected after model merge"
+
+  git reset -q --hard "$EXPECTED_HEAD"
+  git rebase origin/main >/dev/null 2>&1
+  git_state="$(unclean_git_state_json)"
+  assert_eq "true" "$(jq -r .head_changed <<< "$git_state")" "head_changed detected after model rebase"
+  assert_eq "true" "$(jq -r .foreign_main_commits <<< "$git_state")" "foreign_main_commits detected after model rebase"
+  git reset -q --hard "$EXPECTED_HEAD"
+}
+
+test_worker_syntax() {
+  printf '\n--- test_worker_syntax ---\n'
+  bash -n "$WORKER" && pass "worker script has valid bash syntax" || fail "worker script has syntax errors"
+  bash -n "$ROOT/.github/scripts/omniroute-factory-worker.sh" && pass "omniroute worker syntax OK" || fail "omniroute worker syntax"
+  bash -n "$ROOT/.github/scripts/nvidia-factory-worker.sh" && pass "nvidia worker syntax OK" || fail "nvidia worker syntax"
+}
+
+test_worker_syntax
+test_trusted_guard_staging
+test_regression_stale_branch_guard
+test_regression_merge_main_rejected
+test_regression_model_committed_merge
+
+printf '\n==============================\n'
+printf 'Results: %d passed, %d failed\n' "$PASS" "$FAIL"
+printf '==============================\n'
+
+if ((FAIL > 0)); then
+  exit 1
+fi
+exit 0

--- a/scripts/tests/test_free_model_worker_guard.sh
+++ b/scripts/tests/test_free_model_worker_guard.sh
@@ -73,33 +73,33 @@ assert_false() {
 }
 
 # Extract named function definitions from the worker script.
+# The declaration line is matched with grep -F (fixed string, no awk regex
+# escape sequences -- gawk and mawk disagree on \( \) \{). Body extraction
+# counts { } characters in awk, which needs no regex at all, so it is
+# portable across awk flavors.
 extract_functions() {
-  local pattern=""
-  local name
+  local name defs="" start_line="" body=""
   for name in "$@"; do
-    [[ -z "$pattern" ]] || pattern="$pattern|"
-    pattern="$pattern^${name}\\(\\) \\{"
+    start_line="$(grep -n -F "${name}() {" "$WORKER" | head -1 | cut -d: -f1)"
+    if [[ -z "$start_line" ]]; then
+      printf 'function %s not found in %s\n' "$name" "$WORKER" >&2
+      return 1
+    fi
+    body="$(sed -n "${start_line},\$p" "$WORKER" | awk '
+      {
+        print
+        for (i = 1; i <= length($0); i++) {
+          c = substr($0, i, 1)
+          if (c == "{") depth++
+          if (c == "}") depth--
+        }
+        if (depth <= 0) exit
+      }
+    ')"
+    defs="$defs
+$body"
   done
-  eval "$(awk -v re="$pattern" '
-    $0 ~ re {
-      in_func = 1
-      depth = 1
-      printf "%s\n", $0
-      next
-    }
-    in_func {
-      printf "%s\n", $0
-      for (i = 1; i <= length($0); i++) {
-        c = substr($0, i, 1)
-        if (c == "{") depth++
-        if (c == "}") depth--
-      }
-      if (depth <= 0) {
-        in_func = 0
-        printf "\n"
-      }
-    }
-  ' "$WORKER")"
+  eval "$defs"
 }
 
 # Minimal OLD guard implementation: zero-overlap detection only. This mirrors

--- a/scripts/tests/test_free_model_worker_guard.sh
+++ b/scripts/tests/test_free_model_worker_guard.sh
@@ -186,8 +186,9 @@ test_trusted_guard_staging() {
   new_work
   stage_real_guard_on_main
   extract_functions stage_trusted_guard
+  TRUSTED_GUARD="${TEST_TMPDIR}/trusted-fixed-model-guard.py"
   stage_trusted_guard
-  assert_true "trusted guard copy exists in /tmp" test -f "${TRUSTED_GUARD:-}"
+  assert_true "trusted guard copy exists in test workspace" test -f "${TRUSTED_GUARD:-}"
   assert_true "trusted copy carries the new git-state logic" \
     grep -q 'conflict_markers' "${TRUSTED_GUARD}"
 }
@@ -200,6 +201,7 @@ test_regression_stale_branch_guard() {
   new_work
   stage_real_guard_on_main
   extract_functions stage_trusted_guard
+  TRUSTED_GUARD="${TEST_TMPDIR}/trusted-fixed-model-guard.py"
   stage_trusted_guard
 
   cd "$TEST_TMPDIR/work"
@@ -254,6 +256,7 @@ test_regression_merge_main_rejected() {
   cp "$TRUSTED_GUARD_SRC" .github/scripts/fixed-model-guard.py
   git add -A && git commit -qm "add trusted guard"
   git push -q origin main
+  TRUSTED_GUARD="${TEST_TMPDIR}/trusted-fixed-model-guard.py"
   stage_trusted_guard
 
   git checkout -q -b feature
@@ -314,6 +317,7 @@ test_regression_model_committed_merge() {
   cp "$TRUSTED_GUARD_SRC" .github/scripts/fixed-model-guard.py
   git add -A && git commit -qm "add trusted guard"
   git push -q origin main
+  TRUSTED_GUARD="${TEST_TMPDIR}/trusted-fixed-model-guard.py"
   stage_trusted_guard
 
   git checkout -q -b feature

--- a/scripts/tests/test_opencode_review_policy.py
+++ b/scripts/tests/test_opencode_review_policy.py
@@ -40,7 +40,7 @@ class OpenCodeReviewPolicyTests(unittest.TestCase):
         """Reject additive/sequential stage mutation or owner-dropping replacement."""
         workflow = OPENCODE_WORKFLOW.read_text(encoding="utf-8")
         self.assertNotIn("gh api --method DELETE", workflow)
-        self.assertIn('^factory:(unowned|local|[1-5])$', workflow)
+        self.assertIn('^factory:(unowned|local|([1-9]|[1-3][0-9]|4[0-6]))$', workflow)
         self.assertIn('first // "factory:unowned"', workflow)
         self.assertEqual(workflow.count('gh api --method PUT'), 2)
         self.assertNotIn(


### PR DESCRIPTION
Fixes the pre-push guard downgrade that let Factory 6 push factory-control contamination and literal conflict markers to product PR #1153 after #1231/#1232 merged.

## Root cause
`reject_out_of_scope_diff` invoked `python3 .github/scripts/fixed-model-guard.py` from the working tree AFTER `checkout_target` switched onto the adopted PR branch. An old PR branch copy of the guard (zero-overlap detection only) downgraded the decision, so factory-control edits passed.

## Changes
- **Trusted guard**: `stage_trusted_guard` copies `fixed-model-guard.py` from the main checkout to `/tmp` before any branch switch and self-tests it; all pre-push decisions run that copy only.
- **Deterministic git-state rejection** (fail closed): MERGE_HEAD, CHERRY_PICK_HEAD, REVERT_HEAD, unmerged index entries, conflict-marker text, HEAD movement away from the checkout target (model merge/rebase/commit), and main commits folded into the branch all reject persistence before commit/push.
- **Prior-diff factory-control rejection**: a product PR whose cumulative diff already contains factory-control paths is rejected.
- Same dirty-merge rejection added to the omniroute and nvidia worker persist paths.
- Post-push CI repair guard now also rejects merge commits and conflict-marker text.
- Regression coverage: guard unit tests, static worker contract tests, and a functional bash suite reproducing both the stale-branch-helper downgrade and the `git merge origin/main` conflict scenario.

## Verification
- `python .github/scripts/fixed-model-guard.py --self-test` (16 tests)
- `bash scripts/tests/test_free_model_worker_guard.sh` (20 checks)
- `ruff check .`, `ty check --error-on-warning`
- `validate-free-model-factories.py`