### PR TITLE
Thin fixed-model factory fleet to productive lanes

### DIFF
--- a/.github/free-model-factories.tsv
+++ b/.github/free-model-factories.tsv
@@ -18,20 +18,7 @@
 22	nvidia	mistralai/mistral-large-2-instruct	0	watchdog	Mistral Large 2
 23	nvidia	nvidia/nvidia-nemotron-nano-9b-v2	15	watchdog	Nemotron Nano 9B v2
 24	nvidia	meta/llama-3.3-70b-instruct	30	watchdog	Llama 3.3 70B
-25	nvidia	deepseek-ai/deepseek-coder-6.7b-instruct	45	watchdog	DeepSeek Coder 6.7B
-26	nvidia	meta/codellama-70b	0	watchdog	CodeLlama 70B
-27	nvidia	mistralai/codestral-22b-instruct-v0.1	15	watchdog	Codestral 22B
-28	nvidia	ibm/granite-34b-code-instruct	30	watchdog	Granite 34B Code
 29	nvidia	thinkingmachines/inkling	45	watchdog	Inkling
-30	nvidia	meta/llama-3.2-11b-vision-instruct	0	watchdog	Llama 3.2 11B Vision
-31	nvidia	nvidia/nemotron-mini-4b-instruct	15	watchdog	Nemotron Mini 4B
-32	omniroute-opencode	oc/big-pickle	30	watchdog	OmniRoute Big Pickle
-33	omniroute-opencode	oc/deepseek-v4-flash-free	45	watchdog	OmniRoute DeepSeek V4 Flash Free
-34	omniroute-opencode	oc/mimo-v2.5-free	0	watchdog	OmniRoute MiMo V2.5 Free
-35	omniroute-opencode	oc/nemotron-3-ultra-free	15	watchdog	OmniRoute Nemotron 3 Ultra Free
-36	omniroute-opencode	oc/laguna-s-2.1-free	30	watchdog	OmniRoute Laguna S 2.1 Free
-37	omniroute-opencode	oc/hy3-free	45	watchdog	OmniRoute Tencent Hy3 Free
-38	omniroute-opencode	oc/nemotron-3.5-lightning-free	0	watchdog	OmniRoute Nemotron 3.5 Lightning Free
 39	opencode-free	big-pickle	15	watchdog	OpenCode Big Pickle
 40	opencode-free	deepseek-v4-flash-free	30	watchdog	OpenCode DeepSeek V4 Flash Free
 41	opencode-free	mimo-v2.5-free	45	watchdog	OpenCode MiMo V2.5 Free
@@ -39,4 +26,3 @@
 43	opencode-free	laguna-s-2.1-free	15	watchdog	OpenCode Laguna S 2.1 Free
 44	opencode-free	hy3-free	30	watchdog	OpenCode Tencent Hy3 Free
 45	opencode-free	nemotron-3.5-lightning-free	45	watchdog	OpenCode Nemotron 3.5 Lightning Free
-46	opencode-free	ling-3.0-tiny-free	0	watchdog	OpenCode Ling 3.0 Tiny Free

--- a/.github/scripts/validate-free-model-factories.py
+++ b/.github/scripts/validate-free-model-factories.py
@@ -11,18 +11,16 @@ MANIFEST = Path('.github/free-model-factories.tsv')
 DISPATCHER = Path('.github/workflows/free-model-factory-dispatch.yml')
 ENTRY = Path('.github/workflows/free-model-factory-entry.yml')
 WATCHDOG = Path('.github/workflows/factory-heartbeat-watchdog.yml')
-EXPECTED_WORKERS = set(range(6, 47))
+EXPECTED_WORKERS = set(range(6, 25)) | {29} | set(range(39, 46))
 EXPECTED_SOURCE_COUNTS = {
-    'nvidia': 26,
-    'omniroute-opencode': 7,
-    'opencode-free': 8,
+    'nvidia': 20,
+    'opencode-free': 7,
 }
 EXPECTED_OPENCODE_FREE_MODELS = {
     'big-pickle',
     'deepseek-v4-flash-free',
     'hy3-free',
     'laguna-s-2.1-free',
-    'ling-3.0-tiny-free',
     'mimo-v2.5-free',
     'nemotron-3-ultra-free',
     'nemotron-3.5-lightning-free',
@@ -56,7 +54,7 @@ def main() -> None:
             delimiter='\t',
         ))
 
-    assert len(rows) == 41, f'expected 41 fixed model lanes, got {len(rows)}'
+    assert len(rows) == 27, f'expected 27 fixed model lanes, got {len(rows)}'
     workers = [int(row['worker']) for row in rows]
     assert set(workers) == EXPECTED_WORKERS
     assert len(workers) == len(set(workers)), 'duplicate worker IDs'
@@ -84,7 +82,7 @@ def main() -> None:
         for row in rows
     ), 'Factory 13 retired NVIDIA model returned to the roster'
 
-    expected_batch_counts = Counter({0: 11, 15: 10, 30: 10, 45: 10})
+    expected_batch_counts = Counter({0: 6, 15: 7, 30: 7, 45: 7})
     actual_batch_counts: Counter[int] = Counter()
     for row in rows:
         worker = int(row['worker'])
@@ -107,7 +105,7 @@ def main() -> None:
     assert 'schedule:' not in dispatcher_text, 'dispatcher must not own an independent cron clock'
     assert 'WATCHDOG_RUN_NUMBER' in dispatcher_text
     assert 'slots=(0 15 30 45)' in dispatcher_text
-    assert 'workers=\'["6","32","39"]\'' in dispatcher_text
+    assert 'workers=\'["6","39"]\'' in dispatcher_text
     assert 'contents: read' in dispatcher_text and 'actions: write' in dispatcher_text
     assert 'issues: write' in dispatcher_text and 'pull-requests: write' in dispatcher_text
     assert 'gh workflow run free-model-factory-entry.yml' in dispatcher_text
@@ -126,7 +124,7 @@ def main() -> None:
 
     # GitHub can terminate a cancelled runner before its EXIT trap runs. The
     # deploy fence must therefore wait for terminal cancellation and recover
-    # only that run's worker leases from the registry heartbeat.
+    # that run's worker leases even if its lane was just retired from the roster.
     for required in (
         'heartbeat_worker_for_run',
         'issues/1093/comments?per_page=100',
@@ -141,10 +139,11 @@ def main() -> None:
         'gh api --method PUT',
         'another worker already owns it',
         'takeover observed',
+        'unknown historical fixed-model worker',
     ):
         assert required in dispatcher_text, f'cancelled-run handoff invariant missing: {required}'
     assert "owner_pattern='^factory:(local|([1-9]|[1-3][0-9]|4[0-6]))$'" in dispatcher_text, (
-        'cancelled-run recovery must recognize every active fixed-model owner without treating unowned as a takeover'
+        'cancelled-run recovery must recognize historical fixed-model owners without treating unowned as a takeover'
     )
 
     assert ENTRY.exists(), 'dispatchable fixed-model entry workflow is missing'
@@ -247,7 +246,7 @@ def main() -> None:
         'no-work must not masquerade as a successful productive heartbeat'
     )
 
-    print('Validated 41 fixed model factories on the proven 15-minute watchdog clock.')
+    print('Validated 27 fixed model factories on the proven 15-minute watchdog clock.')
     for minute in BATCH_MINUTES:
         print(f'  :{minute:02d} -> {actual_batch_counts[minute]} workers')
     for source, count in EXPECTED_SOURCE_COUNTS.items():

--- a/.github/workflows/free-model-factory-dispatch.yml
+++ b/.github/workflows/free-model-factory-dispatch.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       worker:
-        description: Optional single Factory 6-46; blank runs the three-lane smoke set
+        description: Optional active fixed-model Factory; blank runs the two-lane smoke set
         required: false
         type: string
   push:
@@ -65,8 +65,8 @@ jobs:
             local owner="factory:${worker}"
             local number current_labels other_owner latest_labels target_labels
 
-            awk -F '\t' -v worker="$worker" '$1 == worker {found=1} END {exit !found}' "$manifest" || {
-              echo "Refusing lease recovery for unknown fixed-model worker ${worker}" >&2
+            [[ "$worker" =~ ^[0-9]+$ ]] && (( worker >= 6 && worker <= 46 )) || {
+              echo "Refusing lease recovery for unknown historical fixed-model worker ${worker}" >&2
               return 1
             }
 
@@ -168,8 +168,8 @@ jobs:
             workers="$(awk -F '\t' -v minute="$minute" '$4 == minute {print $1}' "$manifest" | jq -Rsc 'split("\n") | map(select(length > 0))')"
             echo "Watchdog run ${WATCHDOG_RUN_NUMBER} selected :$(printf '%02d' "$minute") batch"
           else
-            # Immediate post-merge/manual smoke: NVIDIA, OmniRoute, OpenCode.
-            workers='["6","32","39"]'
+            # Immediate post-merge/manual smoke: NVIDIA and OpenCode Free.
+            workers='["6","39"]'
           fi
 
           [[ "$workers" != '[]' ]] || { echo 'Dispatcher resolved no workers' >&2; exit 1; }

--- a/.github/workflows/free-model-factory-entry.yml
+++ b/.github/workflows/free-model-factory-entry.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       worker:
-        description: Fixed-model Factory number (6-46)
+        description: Active fixed-model Factory number from the roster
         required: true
         type: string
 


### PR DESCRIPTION
## What changed
- Retire 14 low-signal fixed-model lanes, reducing the fleet from 41 to 27.
- Remove NVIDIA factories 25, 26, 27, 28, 30, and 31.
- Remove OmniRoute factories 32 through 38.
- Remove OpenCode Free factory 46 (Ling 3.0 Tiny Free).
- Keep the remaining 20 NVIDIA and 7 direct OpenCode Free lanes on the existing 15-minute watchdog cadence.
- Update the post-merge smoke set to active workers 6 and 39.
- Keep cancelled-run lease cleanup valid for historical workers 6-46 so retirement cannot strand an issue lease.
- Update the deterministic roster validator for the intentional 27-lane fleet.

## Why
Today's runtime audit showed a lot of failure/noise from the retired lanes. In particular, OmniRoute Laguna was no longer exposed, other OmniRoute lanes duplicated direct OpenCode Free routes, and the retired NVIDIA/code-model tail was producing red runs without enough useful work to justify its Actions churn.

## Validation
- Branch diff is limited to the roster, dispatcher/entry metadata, and deterministic roster validation.
- The roster now contains exactly 27 active lanes: 20 NVIDIA and 7 OpenCode Free.
- Batch distribution remains deterministic on :00/:15/:30/:45 via the existing worker-number slot rule.
