### PR TITLE
Add experimental Kilo Auto Free factory lane

### DIFF
--- a/.github/free-model-factories.tsv
+++ b/.github/free-model-factories.tsv
@@ -26,4 +26,4 @@
 43	opencode-free	laguna-s-2.1-free	15	watchdog	OpenCode Laguna S 2.1 Free
 44	opencode-free	hy3-free	30	watchdog	OpenCode Tencent Hy3 Free
 45	opencode-free	nemotron-3.5-lightning-free	45	watchdog	OpenCode Nemotron 3.5 Lightning Free
-60	kilo-auto	kilo-auto/free	30	watchdog	Kilo Auto Free · Forge
+46	kilo-auto	kilo-auto/free	0	watchdog	Kilo Auto Free · Forge

--- a/.github/free-model-factories.tsv
+++ b/.github/free-model-factories.tsv
@@ -26,3 +26,4 @@
 43	opencode-free	laguna-s-2.1-free	15	watchdog	OpenCode Laguna S 2.1 Free
 44	opencode-free	hy3-free	30	watchdog	OpenCode Tencent Hy3 Free
 45	opencode-free	nemotron-3.5-lightning-free	45	watchdog	OpenCode Nemotron 3.5 Lightning Free
+60	kilo-auto	kilo-auto/free	30	watchdog	Kilo Auto Free · Forge

--- a/.github/scripts/free-model-factory-worker.sh
+++ b/.github/scripts/free-model-factory-worker.sh
@@ -260,7 +260,19 @@ run_agent() {
     mission="Implement the full closure-critical acceptance contract for this issue with code and focused tests. Do not stop at planning or optional polish."
   fi
 
-  prompt="You are fixed-model OpenCode Factory ${WORKER} for JoshCLWren/comic-pile. Durable worker ID: ${WORKER_ID}. Source: ${SOURCE}. Pinned model: ${MODEL}. Runtime model: ${RUNTIME_MODEL}. Assigned target: ${target}. Read AGENTS.md, docs/ISSUE_EXECUTION_PROTOCOL.md, docs/AUTONOMOUS_FACTORY_POLICY.md, docs/CHATGPT_FACTORY_PROMPT.md, and docs/FACTORY_GITHUB_VISIBILITY.md first. Follow the canonical product-first factory policy. ${mission} Work only on the assigned target during this agent invocation. Edit the checked-out branch, run focused validation, and use gh/GitHub when needed for review context. Do not commit or push; the wrapper persists changes. Do not switch models, providers, or routes. A provider failure is a result for this model lane, not permission to fall back to another model. Do not enable auto-merge, push main, touch production databases, or alter automation schedules."
+  prompt="You are external-model Factory ${WORKER} for JoshCLWren/comic-pile. Durable worker ID: ${WORKER_ID}. Source: ${SOURCE}. Requested model or route: ${MODEL}. Runtime selector: ${RUNTIME_MODEL}. Assigned target: ${target}. Read AGENTS.md, docs/ISSUE_EXECUTION_PROTOCOL.md, docs/AUTONOMOUS_FACTORY_POLICY.md, docs/CHATGPT_FACTORY_PROMPT.md, and docs/FACTORY_GITHUB_VISIBILITY.md first. Follow the canonical product-first factory policy. ${mission} Work only on the assigned target during this agent invocation. Edit the checked-out branch, run focused validation, and use gh/GitHub when needed for review context. Do not commit or push; the wrapper persists changes. Do not switch models, providers, or routes. A provider failure is a result for this lane, not permission to fall back to another paid or unrequested route. Do not enable auto-merge, push main, touch production databases, or alter automation schedules."
+
+  if [[ "$SOURCE" == 'kilo-auto' ]]; then
+    set +e
+    bash .github/scripts/kilo-auto-factory-run.sh \
+      "$timeout_seconds" \
+      "ComicPile Factory ${WORKER} · ${DISPLAY}" \
+      "$prompt" \
+      "/tmp/opencode-factory-${WORKER}.log"
+    status=$?
+    set -e
+    return "$status"
+  fi
 
   timeout --signal=TERM --kill-after=30s "${timeout_seconds}s" \
     opencode run -m "$RUNTIME_MODEL" --agent build --auto --dir "$GITHUB_WORKSPACE" \
@@ -535,7 +547,8 @@ while (( $(remaining) > 480 )); do
   fi
 
   current="$(git rev-parse HEAD)"
-  if grep -q 'FACTORY_GATE_READY' "/tmp/opencode-factory-${WORKER}.log" && \
+  if [[ "$SOURCE" != 'kilo-auto' ]] && \
+    grep -q 'FACTORY_GATE_READY' "/tmp/opencode-factory-${WORKER}.log" && \
     machine_merge_gates_pass "$NUMBER" "$current"; then
     log "all exact-head gates passed for PR #${NUMBER}; merging ${current}"
     gh pr merge "$NUMBER" --merge --match-head-commit "$current" --delete-branch

--- a/.github/scripts/kilo-auto-factory-run.sh
+++ b/.github/scripts/kilo-auto-factory-run.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+TIMEOUT_SECONDS="${1:?timeout seconds required}"
+TITLE="${2:?title required}"
+PROMPT="${3:?prompt required}"
+LOG_PATH="${4:?log path required}"
+RUNTIME_MODEL="${FACTORY_RUNTIME_MODEL:-kilo/kilo-auto/free}"
+
+# This experiment must prove anonymous/free Kilo routing. Do not inherit an
+# account token or local Kilo state that could make a paid route available.
+unset KILO_API_KEY KILOCODE_API_KEY
+export XDG_CONFIG_HOME="${RUNNER_TEMP:?RUNNER_TEMP is required}/kilo-config"
+export XDG_DATA_HOME="$RUNNER_TEMP/kilo-data"
+export XDG_CACHE_HOME="$RUNNER_TEMP/kilo-cache"
+mkdir -p "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME"
+
+set +e
+timeout --signal=TERM --kill-after=30s "${TIMEOUT_SECONDS}s" \
+  kilo run -m "$RUNTIME_MODEL" --auto --format json --dir "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}" \
+  --title "$TITLE" "$PROMPT" \
+  2>&1 | tee "$LOG_PATH"
+status=${PIPESTATUS[0]}
+set -e
+
+if (( status != 0 )); then
+  exit "$status"
+fi
+
+step_count="$(jq -R -s '[split("\n")[] | fromjson? | select(.type == "step_finish")] | length' "$LOG_PATH")"
+if [[ "$step_count" == "0" ]]; then
+  echo 'Kilo run returned success without observable step_finish telemetry' >&2
+  exit 85
+fi
+
+if jq -R -e -s 'any(split("\n")[] | fromjson? | select(.type == "step_finish"); ((.part.cost // 0) | tonumber) > 0)' "$LOG_PATH" >/dev/null; then
+  echo 'Kilo Auto Free reported non-zero cost; refusing any paid execution path' >&2
+  exit 86
+fi
+
+telemetry="$(jq -R -r '
+  fromjson?
+  | select(.type == "step_finish")
+  | [
+      (.part.model.providerID // "unreported"),
+      (.part.model.modelID // "unreported"),
+      (.part.generationID // "unreported"),
+      ((.part.cost // "unreported") | tostring),
+      ((.part.time.elapsed // "unreported") | tostring)
+    ]
+  | @tsv
+' "$LOG_PATH" | tail -n 1)"
+
+if [[ -n "$telemetry" ]]; then
+  IFS=$'\t' read -r provider model generation cost elapsed <<< "$telemetry"
+  printf 'Kilo telemetry: requested_route=kilo-auto/free runtime_model=%s provider_id=%s resolved_model=%s generation_id=%s cost=%s elapsed_ms=%s\n' \
+    "$RUNTIME_MODEL" "$provider" "$model" "$generation" "$cost" "$elapsed"
+else
+  echo 'Kilo telemetry: requested_route=kilo-auto/free resolved metadata unavailable'
+fi

--- a/.github/scripts/kilo-auto-factory-run.sh
+++ b/.github/scripts/kilo-auto-factory-run.sh
@@ -10,9 +10,10 @@ RUNTIME_MODEL="${FACTORY_RUNTIME_MODEL:-kilo/kilo-auto/free}"
 # This experiment must prove anonymous/free Kilo routing. Do not inherit an
 # account token or local Kilo state that could make a paid route available.
 unset KILO_API_KEY KILOCODE_API_KEY
-export XDG_CONFIG_HOME="${RUNNER_TEMP:?RUNNER_TEMP is required}/kilo-config"
-export XDG_DATA_HOME="$RUNNER_TEMP/kilo-data"
-export XDG_CACHE_HOME="$RUNNER_TEMP/kilo-cache"
+runtime_root="$(mktemp -d "${RUNNER_TEMP:?RUNNER_TEMP is required}/kilo-runtime.XXXXXX")"
+export XDG_CONFIG_HOME="$runtime_root/config"
+export XDG_DATA_HOME="$runtime_root/data"
+export XDG_CACHE_HOME="$runtime_root/cache"
 mkdir -p "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME"
 
 set +e
@@ -33,7 +34,7 @@ if [[ "$step_count" == "0" ]]; then
   exit 85
 fi
 
-if jq -R -e -s 'any(split("\n")[] | fromjson? | select(.type == "step_finish"); ((.part.cost // 0) | tonumber) > 0)' "$LOG_PATH" >/dev/null; then
+if jq -R -e -s 'any(split("\n")[] | fromjson? | select(.type == "step_finish"); (.part.cost // 0) > 0)' "$LOG_PATH" >/dev/null; then
   echo 'Kilo Auto Free reported non-zero cost; refusing any paid execution path' >&2
   exit 86
 fi

--- a/.github/scripts/validate-free-model-factories.py
+++ b/.github/scripts/validate-free-model-factories.py
@@ -111,14 +111,16 @@ def main() -> None:
     assert 'schedule:' not in dispatcher_text, 'dispatcher must not own an independent cron clock'
     assert 'WATCHDOG_RUN_NUMBER' in dispatcher_text
     assert 'slots=(0 15 30 45)' in dispatcher_text
-    assert 'workers=\'["6","39"]\'' in dispatcher_text
+    assert 'workers=\'["6","39","46"]\'' in dispatcher_text
     assert 'contents: read' in dispatcher_text and 'actions: write' in dispatcher_text
     assert 'issues: write' in dispatcher_text and 'pull-requests: write' in dispatcher_text
     assert 'gh workflow run free-model-factory-entry.yml' in dispatcher_text
     assert 'matrix:' not in dispatcher_text
-    assert "'.github/scripts/free-model-factory-worker.sh'" in dispatcher_text, (
-        'worker repairs must trigger an immediate post-merge fleet smoke'
-    )
+    for path in (
+        "'.github/scripts/free-model-factory-worker.sh'",
+        "'.github/scripts/kilo-auto-factory-run.sh'",
+    ):
+        assert path in dispatcher_text, f'factory runtime change must trigger post-merge smoke: {path}'
     for required in (
         'if [[ "$EVENT_NAME" == push ]]',
         'queued in_progress',

--- a/.github/scripts/validate-free-model-factories.py
+++ b/.github/scripts/validate-free-model-factories.py
@@ -11,10 +11,11 @@ MANIFEST = Path('.github/free-model-factories.tsv')
 DISPATCHER = Path('.github/workflows/free-model-factory-dispatch.yml')
 ENTRY = Path('.github/workflows/free-model-factory-entry.yml')
 WATCHDOG = Path('.github/workflows/factory-heartbeat-watchdog.yml')
-EXPECTED_WORKERS = set(range(6, 25)) | {29} | set(range(39, 46))
+EXPECTED_WORKERS = set(range(6, 25)) | {29} | set(range(39, 47))
 EXPECTED_SOURCE_COUNTS = {
     'nvidia': 20,
     'opencode-free': 7,
+    'kilo-auto': 1,
 }
 EXPECTED_OPENCODE_FREE_MODELS = {
     'big-pickle',
@@ -54,7 +55,7 @@ def main() -> None:
             delimiter='\t',
         ))
 
-    assert len(rows) == 27, f'expected 27 fixed model lanes, got {len(rows)}'
+    assert len(rows) == 28, f'expected 28 external factory lanes, got {len(rows)}'
     workers = [int(row['worker']) for row in rows]
     assert set(workers) == EXPECTED_WORKERS
     assert len(workers) == len(set(workers)), 'duplicate worker IDs'
@@ -67,8 +68,13 @@ def main() -> None:
         f'OpenCode free roster changed: missing={sorted(EXPECTED_OPENCODE_FREE_MODELS - opencode_free_models)} '
         f'extra={sorted(opencode_free_models - EXPECTED_OPENCODE_FREE_MODELS)}'
     )
+    kilo_rows = [row for row in rows if row['source'] == 'kilo-auto']
+    assert len(kilo_rows) == 1
+    assert kilo_rows[0]['worker'] == '46'
+    assert kilo_rows[0]['model'] == 'kilo-auto/free'
+    assert kilo_rows[0]['display_name'] == 'Kilo Auto Free · Forge'
     assert not any(row['source'] in {'zen', 'kilo', 'llm7', 'ovhcloud'} for row in rows), (
-        'retired or unrelated provider source returned to the fixed-model roster'
+        'retired or unrelated provider source returned to the external factory roster'
     )
 
     source_models = [(row['source'], row['model']) for row in rows]
@@ -82,7 +88,7 @@ def main() -> None:
         for row in rows
     ), 'Factory 13 retired NVIDIA model returned to the roster'
 
-    expected_batch_counts = Counter({0: 6, 15: 7, 30: 7, 45: 7})
+    expected_batch_counts = Counter({0: 7, 15: 7, 30: 7, 45: 7})
     actual_batch_counts: Counter[int] = Counter()
     for row in rows:
         worker = int(row['worker'])
@@ -163,7 +169,8 @@ def main() -> None:
 
     runner = Path('.github/workflows/free-model-factory-run.yml')
     worker = Path('.github/scripts/free-model-factory-worker.sh')
-    assert runner.exists() and worker.exists()
+    kilo_helper = Path('.github/scripts/kilo-auto-factory-run.sh')
+    assert runner.exists() and worker.exists() and kilo_helper.exists()
     runner_text = runner.read_text(encoding='utf-8')
     assert 'group: fixed-model-factory-${{ inputs.worker }}' in runner_text, (
         'reusable runner must serialize each fixed-model worker lane'
@@ -176,6 +183,13 @@ def main() -> None:
     assert "branch_suffix='opencode-free'" in runner_text
     assert 'OPENCODE_API_KEY' not in runner_text, 'direct OpenCode Free must remain keyless'
     assert all(source not in runner_text for source in ('kilo)', 'llm7)', 'ovhcloud)', 'zen)'))
+    assert 'kilo-auto)' in runner_text
+    assert 'runtime_model="kilo/${model}"' in runner_text
+    assert "branch_suffix='kilo-auto'" in runner_text
+    assert "KILO_VERSION: '7.4.22'" in runner_text
+    assert "KILO_LINUX_X64_BASELINE_SHA256: 'bf817ad53bc95b16abe92e7a2389cc9f509c62c3510c23ecc58e151a4455cb41'" in runner_text
+    assert 'kilo-linux-x64-baseline.tar.gz' in runner_text
+    assert 'Smoke Kilo Auto Free through Kilo CLI' in runner_text
     assert 'secrets.PR_REBASE_TOKEN' in runner_text, (
         'factory pushes must use PR_REBASE_TOKEN so pull_request workflows are not stuck in action_required'
     )
@@ -187,6 +201,16 @@ def main() -> None:
         'git remote must authenticate pushes with PR_REBASE_TOKEN'
     )
 
+    kilo_text = kilo_helper.read_text(encoding='utf-8')
+    for required in (
+        'unset KILO_API_KEY KILOCODE_API_KEY',
+        'kilo run -m "$RUNTIME_MODEL" --auto --format json',
+        'requested_route=kilo-auto/free',
+        'step_finish',
+        'non-zero cost',
+    ):
+        assert required in kilo_text, f'Kilo free-route invariant missing: {required}'
+
     worker_text = worker.read_text(encoding='utf-8')
     assert 'rotate_model' not in worker_text
     assert 'Do not switch models' in worker_text
@@ -195,6 +219,11 @@ def main() -> None:
     )
     assert 'fixed-model-guard.py' in worker_text, (
         'pre-push scope enforcement must use the deterministic fixed-model guard'
+    )
+    assert "[[ \"$SOURCE\" == 'kilo-auto' ]]" in worker_text
+    assert '.github/scripts/kilo-auto-factory-run.sh' in worker_text
+    assert "[[ \"$SOURCE\" != 'kilo-auto' ]]" in worker_text, (
+        'experimental Kilo work must not autonomously merge'
     )
 
     guard = Path('.github/scripts/fixed-model-guard.py')
@@ -246,7 +275,7 @@ def main() -> None:
         'no-work must not masquerade as a successful productive heartbeat'
     )
 
-    print('Validated 27 fixed model factories on the proven 15-minute watchdog clock.')
+    print('Validated 28 external factory lanes on the proven 15-minute watchdog clock.')
     for minute in BATCH_MINUTES:
         print(f'  :{minute:02d} -> {actual_batch_counts[minute]} workers')
     for source, count in EXPECTED_SOURCE_COUNTS.items():

--- a/.github/workflows/free-model-factory-dispatch.yml
+++ b/.github/workflows/free-model-factory-dispatch.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       worker:
-        description: Optional active fixed-model Factory; blank runs the two-lane smoke set
+        description: Optional active external Factory; blank runs the strategy smoke set
         required: false
         type: string
   push:
@@ -17,6 +17,7 @@ on:
       - '.github/workflows/free-model-factory-entry.yml'
       - '.github/workflows/free-model-factory-run.yml'
       - '.github/scripts/free-model-factory-worker.sh'
+      - '.github/scripts/kilo-auto-factory-run.sh'
       - '.github/free-model-factories.tsv'
 
 permissions:
@@ -168,8 +169,8 @@ jobs:
             workers="$(awk -F '\t' -v minute="$minute" '$4 == minute {print $1}' "$manifest" | jq -Rsc 'split("\n") | map(select(length > 0))')"
             echo "Watchdog run ${WATCHDOG_RUN_NUMBER} selected :$(printf '%02d' "$minute") batch"
           else
-            # Immediate post-merge/manual smoke: NVIDIA and OpenCode Free.
-            workers='["6","39"]'
+            # Immediate post-merge/manual smoke: one lane per routing strategy.
+            workers='["6","39","46"]'
           fi
 
           [[ "$workers" != '[]' ]] || { echo 'Dispatcher resolved no workers' >&2; exit 1; }

--- a/.github/workflows/free-model-factory-run.yml
+++ b/.github/workflows/free-model-factory-run.yml
@@ -28,6 +28,8 @@ env:
   FACTORY_BUDGET_SECONDS: '1200'
   OPENCODE_VERSION: '1.18.18'
   OPENCODE_LINUX_X64_SHA256: '0cddc222418b8553669905a8980c0cda7088f00da24d83d6ac76b01c9fdb2aaf'
+  KILO_VERSION: '7.4.22'
+  KILO_LINUX_X64_BASELINE_SHA256: 'bf817ad53bc95b16abe92e7a2389cc9f509c62c3510c23ecc58e151a4455cb41'
   OMNIROUTE_IMAGE: 'diegosouzapw/omniroute:3.8.49@sha256:92c768c56e2de32c51a0621ef182835018b00b288c9bb235c5c5e4514658c1a1'
 
 jobs:
@@ -94,6 +96,12 @@ jobs:
               branch_suffix='opencode-free'
               configured=true
               reason='configured-keyless'
+              ;;
+            kilo-auto)
+              runtime_model="kilo/${model}"
+              branch_suffix='kilo-auto'
+              configured=true
+              reason='configured-anonymous-free'
               ;;
             *)
               echo "Unsupported factory source: ${source}" >&2
@@ -175,7 +183,7 @@ jobs:
           echo "${DISPLAY} lane is installed but inactive: ${REASON}"
 
       - name: Install pinned OpenCode release
-        if: steps.lane.outputs.configured == 'true'
+        if: steps.lane.outputs.configured == 'true' && steps.lane.outputs.source != 'kilo-auto'
         shell: bash
         run: |
           set -Eeuo pipefail
@@ -190,6 +198,25 @@ jobs:
           test -x "$bin_dir/opencode"
           echo "$bin_dir" >> "$GITHUB_PATH"
           "$bin_dir/opencode" --version
+
+      - name: Install pinned Kilo CLI release
+        if: steps.lane.outputs.configured == 'true' && steps.lane.outputs.source == 'kilo-auto'
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          archive="$RUNNER_TEMP/kilo-linux-x64-baseline.tar.gz"
+          bin_dir="$RUNNER_TEMP/kilo-bin"
+          curl -fsSL \
+            "https://github.com/Kilo-Org/kilocode/releases/download/v${KILO_VERSION}/kilo-linux-x64-baseline.tar.gz" \
+            -o "$archive"
+          printf '%s  %s\n' "$KILO_LINUX_X64_BASELINE_SHA256" "$archive" | sha256sum --check -
+          mkdir -p "$bin_dir"
+          tar -xzf "$archive" -C "$bin_dir"
+          kilo_path="$(find "$bin_dir" -type f -name kilo -perm -111 | head -n 1)"
+          [[ -n "$kilo_path" ]] || { echo 'Pinned Kilo archive did not contain an executable kilo binary' >&2; exit 1; }
+          if [[ "$kilo_path" != "$bin_dir/kilo" ]]; then ln -s "$kilo_path" "$bin_dir/kilo"; fi
+          echo "$bin_dir" >> "$GITHUB_PATH"
+          "$bin_dir/kilo" --version
 
       - name: Create ephemeral OmniRoute runtime secrets
         if: steps.lane.outputs.configured == 'true' && steps.lane.outputs.source == 'omniroute-opencode'
@@ -325,7 +352,7 @@ jobs:
           echo "NVIDIA probe succeeded for ${MODEL}"
 
       - name: Smoke exact pinned model through OpenCode
-        if: steps.lane.outputs.configured == 'true'
+        if: steps.lane.outputs.configured == 'true' && steps.lane.outputs.source != 'kilo-auto'
         shell: bash
         env:
           RUNTIME_MODEL: ${{ steps.lane.outputs.runtime_model }}
@@ -344,6 +371,23 @@ jobs:
           (( status == 0 )) || exit "$status"
           grep -q 'FIXED_MODEL_OPENCODE_OK' "$RUNNER_TEMP/fixed-model-smoke.log"
           [[ -z "$(git status --porcelain)" ]] || { echo 'Model smoke modified the worktree' >&2; exit 1; }
+
+      - name: Smoke Kilo Auto Free through Kilo CLI
+        if: steps.lane.outputs.configured == 'true' && steps.lane.outputs.source == 'kilo-auto'
+        shell: bash
+        env:
+          FACTORY_RUNTIME_MODEL: ${{ steps.lane.outputs.runtime_model }}
+        run: |
+          set -Eeuo pipefail
+          before="$(git status --porcelain)"
+          [[ -z "$before" ]] || { echo 'Smoke requires clean worktree' >&2; exit 1; }
+          bash .github/scripts/kilo-auto-factory-run.sh \
+            180 \
+            'ComicPile Kilo Auto Free smoke' \
+            'Reply with exactly KILO_AUTO_FREE_OK. Do not edit files, run commands, or use tools.' \
+            "$RUNNER_TEMP/kilo-auto-smoke.log"
+          grep -q 'KILO_AUTO_FREE_OK' "$RUNNER_TEMP/kilo-auto-smoke.log"
+          [[ -z "$(git status --porcelain)" ]] || { echo 'Kilo smoke modified the worktree' >&2; exit 1; }
 
       - name: Run continuous fixed-model factory session
         if: steps.lane.outputs.configured == 'true'


### PR DESCRIPTION
## Experiment

Add Factory 46 · Forge as a single Kilo Code Auto Free routing lane without replacing the existing NVIDIA or direct OpenCode Free fleet.

## Kilo path

- Pin Kilo CLI v7.4.22 and verify the official Linux x64 baseline archive checksum.
- Invoke the hosted route through Kilo CLI itself as `kilo/kilo-auto/free` with `--auto --format json`.
- Explicitly unset Kilo API-key environment variables and create fresh XDG state for every invocation so this test cannot inherit an authenticated/paid route.
- Fail closed if Kilo reports any non-zero generation cost.
- Capture observable `step_finish` route/model/generation/runtime telemetry without inventing an upstream provider when Kilo does not expose one.

## Factory integration

- Reuse the current fixed-model dispatcher, entry workflow, worker, lease/ownership labels, trusted push path, recovery behavior, contamination guard, and push-before-advance persistence.
- Factory 46 runs at the normal `:00` watchdog slot.
- Kilo may claim work, edit, validate, push, and open/advance PRs, but this experimental lane is explicitly prohibited from wrapper-merging product PRs.
- No existing NVIDIA or OpenCode Free lane is removed.
- Factory-runtime merges smoke one lane from each routing strategy: NVIDIA 6, direct OpenCode Free 39, and Kilo Auto Free 46. This makes the exact merged Kilo implementation launch itself through the normal entry/reusable runner path.

## Validation target

Configuration is not considered success. After this integration is validated and merged, the post-merge strategy smoke must prove a real Kilo response plus useful ComicPile factory work end to end before the lane is considered viable.