### PR TITLE
Preserve cross-worker factory ownership handoffs

### DIFF
--- a/.github/scripts/fixed-model-owner-normalize.cjs
+++ b/.github/scripts/fixed-model-owner-normalize.cjs
@@ -23,8 +23,19 @@ async function normalize({ github, context, core }) {
     per_page: 100,
   });
   const names = labels.map(label => label.name);
+  const numericOwners = names.filter(name => /^factory:[1-9][0-9]?$/.test(name));
 
-  let worker = pr.head?.ref?.match(WORKER_BRANCH_RE)?.[1] || '';
+  // A current lease is authoritative. Branch names record provenance only and
+  // must not steal a PR back after another factory adopts it.
+  let worker = numericOwners.length === 1 ? numericOwners[0].split(':')[1] : '';
+
+  // An explicit handoff to unowned is also authoritative. Do not resurrect a
+  // historical owner from the branch name or an older ownership marker.
+  if (!worker && names.includes('factory:unowned')) {
+    core.info(`Preserving factory:unowned on PR #${number}`);
+    return;
+  }
+
   if (!worker) {
     const comments = await github.paginate(github.rest.issues.listComments, {
       owner: context.repo.owner,
@@ -36,10 +47,7 @@ async function normalize({ github, context, core }) {
       for (const match of (comment.body || '').matchAll(MARKER_RE)) worker = match[1];
     }
   }
-  if (!worker) {
-    const numericOwners = names.filter(name => /^factory:[1-9][0-9]?$/.test(name));
-    if (numericOwners.length === 1) worker = numericOwners[0].split(':')[1];
-  }
+  if (!worker) worker = pr.head?.ref?.match(WORKER_BRANCH_RE)?.[1] || '';
   if (!worker) return;
 
   const owner = `factory:${worker}`;

--- a/.github/scripts/fixed-model-owner-normalize.test.cjs
+++ b/.github/scripts/fixed-model-owner-normalize.test.cjs
@@ -1,0 +1,89 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const normalize = require('./fixed-model-owner-normalize.cjs');
+
+function harness({ labels, comments = [], branch = 'factory/39-1070-opencode-free' }) {
+  const calls = { comments: 0, labels: [] };
+  const listLabelsOnIssue = async () => {};
+  const listComments = async () => {};
+  const github = {
+    paginate: async (fn) => {
+      if (fn === listLabelsOnIssue) return labels.map((name) => ({ name }));
+      if (fn === listComments) {
+        calls.comments += 1;
+        return comments.map((body) => ({ body }));
+      }
+      throw new Error('unexpected paginate function');
+    },
+    rest: {
+      pulls: {
+        get: async () => ({ data: { head: { ref: branch } } }),
+      },
+      issues: {
+        listLabelsOnIssue,
+        listComments,
+        setLabels: async ({ labels: next }) => {
+          calls.labels.push(next);
+        },
+      },
+    },
+  };
+  const context = {
+    payload: { issue: { number: 1230, pull_request: {} } },
+    repo: { owner: 'JoshCLWren', repo: 'comic-pile' },
+  };
+  const core = { info: () => {} };
+  return { github, context, core, calls };
+}
+
+test('current numeric owner outranks branch provenance during cross-worker handoff', async () => {
+  const state = harness({
+    labels: ['factory', 'factory:46', 'factory:changes-requested'],
+    comments: ['<!-- free-model-factory-owner:46 -->'],
+  });
+
+  await normalize(state);
+
+  assert.equal(state.calls.comments, 0);
+  assert.equal(state.calls.labels.length, 1);
+  assert.ok(state.calls.labels[0].includes('factory:46'));
+  assert.ok(!state.calls.labels[0].includes('factory:39'));
+});
+
+test('explicit unowned handoff is not resurrected from branch provenance', async () => {
+  const state = harness({
+    labels: ['factory', 'factory:unowned', 'factory:review'],
+    comments: ['<!-- free-model-factory-owner:39 -->'],
+  });
+
+  await normalize(state);
+
+  assert.equal(state.calls.comments, 0);
+  assert.equal(state.calls.labels.length, 0);
+});
+
+test('ownership marker bootstraps an unlabeled PR before branch provenance', async () => {
+  const state = harness({
+    labels: ['factory:review'],
+    comments: [
+      '<!-- free-model-factory-owner:39 -->',
+      '<!-- free-model-factory-owner:46 -->',
+    ],
+  });
+
+  await normalize(state);
+
+  assert.equal(state.calls.comments, 1);
+  assert.ok(state.calls.labels[0].includes('factory:46'));
+  assert.ok(!state.calls.labels[0].includes('factory:39'));
+});
+
+test('branch provenance remains a last-resort bootstrap', async () => {
+  const state = harness({ labels: ['factory:review'] });
+
+  await normalize(state);
+
+  assert.equal(state.calls.comments, 1);
+  assert.ok(state.calls.labels[0].includes('factory:39'));
+});

--- a/.github/workflows/factory-visibility.yml
+++ b/.github/workflows/factory-visibility.yml
@@ -28,7 +28,10 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Run factory visibility regression tests
-        run: node --test .github/scripts/factory-visibility.test.cjs
+        run: >-
+          node --test
+          .github/scripts/factory-visibility.test.cjs
+          .github/scripts/fixed-model-owner-normalize.test.cjs
 
       - name: Synchronize factory owner and stage labels
         uses: actions/github-script@v7


### PR DESCRIPTION
## Bug

The fixed-model owner normalizer treated `factory/<worker>-...` branch provenance as authoritative before reading the live owner label. When another factory legitimately adopted an unowned PR, the adoption comment triggered Factory visibility and the normalizer could immediately steal the lease back for the branch creator.

This surfaced during the Kilo Auto Free experiment: Factory 46 adopted PR #1230, then the PR snapped back to `factory:39` because its branch was originally created by Factory 39.

## Fix

- Treat exactly one current numeric `factory:<n>` owner label as authoritative.
- Preserve explicit `factory:unowned` handoffs rather than resurrecting a historical owner.
- Use ownership markers only to bootstrap genuinely unlabeled PRs.
- Use branch provenance only as the final bootstrap fallback.
- Add regression tests for cross-worker adoption, unowned release, marker bootstrap, and branch bootstrap.

This is intentionally limited to the ownership-normalization boundary. It does not change factory selection, schedules, model routing, or lease mechanics.