### PR TITLE
Spread external factory launches across the hour

### DIFF
--- a/.github/free-model-factories.tsv
+++ b/.github/free-model-factories.tsv
@@ -1,29 +1,29 @@
 # worker	source	model	minute	scheduler	display_name
-6	nvidia	z-ai/glm-5.2	0	watchdog	GLM 5.2
-7	nvidia	moonshotai/kimi-k2.6	15	watchdog	Kimi K2.6
-8	nvidia	deepseek-ai/deepseek-v4-flash-0731	30	watchdog	DeepSeek V4 Flash
-9	nvidia	stepfun-ai/step-3.7-flash	45	watchdog	Step 3.7 Flash
-10	nvidia	nvidia/nemotron-3-ultra-550b-a55b	0	watchdog	Nemotron 3 Ultra
-11	nvidia	poolside/laguna-xs-2.1	15	watchdog	Laguna XS 2.1
-12	nvidia	openai/gpt-oss-120b	30	watchdog	GPT OSS 120B
-13	nvidia	mistralai/mistral-small-4-119b-2603	45	watchdog	Mistral Small 4 119B
-14	nvidia	minimaxai/minimax-m3	0	watchdog	MiniMax M3
-15	nvidia	mistralai/mistral-nemotron	15	watchdog	Mistral Nemotron
-16	nvidia	nvidia/nemotron-3-super-120b-a12b	30	watchdog	Nemotron 3 Super
-17	nvidia	nvidia/nemotron-3-nano-omni-30b-a3b-reasoning	45	watchdog	Nemotron 3 Omni
-18	nvidia	nvidia/llama-3.3-nemotron-super-49b-v1.5	0	watchdog	Llama 3.3 Nemotron Super 49B
-19	nvidia	nvidia/nemotron-3-nano-30b-a3b	15	watchdog	Nemotron Nano 30B
-20	nvidia	openai/gpt-oss-20b	30	watchdog	GPT OSS 20B
-21	nvidia	google/gemma-4-31b-it	45	watchdog	Gemma 4 31B
-22	nvidia	mistralai/mistral-large-2-instruct	0	watchdog	Mistral Large 2
-23	nvidia	nvidia/nvidia-nemotron-nano-9b-v2	15	watchdog	Nemotron Nano 9B v2
-24	nvidia	meta/llama-3.3-70b-instruct	30	watchdog	Llama 3.3 70B
-29	nvidia	thinkingmachines/inkling	45	watchdog	Inkling
-39	opencode-free	big-pickle	15	watchdog	OpenCode Big Pickle
-40	opencode-free	deepseek-v4-flash-free	30	watchdog	OpenCode DeepSeek V4 Flash Free
-41	opencode-free	mimo-v2.5-free	45	watchdog	OpenCode MiMo V2.5 Free
-42	opencode-free	nemotron-3-ultra-free	0	watchdog	OpenCode Nemotron 3 Ultra Free
-43	opencode-free	laguna-s-2.1-free	15	watchdog	OpenCode Laguna S 2.1 Free
-44	opencode-free	hy3-free	30	watchdog	OpenCode Tencent Hy3 Free
-45	opencode-free	nemotron-3.5-lightning-free	45	watchdog	OpenCode Nemotron 3.5 Lightning Free
-46	kilo-auto	kilo-auto/free	0	watchdog	Kilo Auto Free · Forge
+6	nvidia	z-ai/glm-5.2	0	dispatcher	GLM 5.2
+7	nvidia	moonshotai/kimi-k2.6	5	dispatcher	Kimi K2.6
+8	nvidia	deepseek-ai/deepseek-v4-flash-0731	10	dispatcher	DeepSeek V4 Flash
+9	nvidia	stepfun-ai/step-3.7-flash	15	dispatcher	Step 3.7 Flash
+10	nvidia	nvidia/nemotron-3-ultra-550b-a55b	20	dispatcher	Nemotron 3 Ultra
+11	nvidia	poolside/laguna-xs-2.1	25	dispatcher	Laguna XS 2.1
+12	nvidia	openai/gpt-oss-120b	30	dispatcher	GPT OSS 120B
+13	nvidia	mistralai/mistral-small-4-119b-2603	35	dispatcher	Mistral Small 4 119B
+14	nvidia	minimaxai/minimax-m3	40	dispatcher	MiniMax M3
+15	nvidia	mistralai/mistral-nemotron	45	dispatcher	Mistral Nemotron
+16	nvidia	nvidia/nemotron-3-super-120b-a12b	50	dispatcher	Nemotron 3 Super
+17	nvidia	nvidia/nemotron-3-nano-omni-30b-a3b-reasoning	55	dispatcher	Nemotron 3 Omni
+18	nvidia	nvidia/llama-3.3-nemotron-super-49b-v1.5	0	dispatcher	Llama 3.3 Nemotron Super 49B
+19	nvidia	nvidia/nemotron-3-nano-30b-a3b	5	dispatcher	Nemotron Nano 30B
+20	nvidia	openai/gpt-oss-20b	10	dispatcher	GPT OSS 20B
+21	nvidia	google/gemma-4-31b-it	15	dispatcher	Gemma 4 31B
+22	nvidia	mistralai/mistral-large-2-instruct	20	dispatcher	Mistral Large 2
+23	nvidia	nvidia/nvidia-nemotron-nano-9b-v2	25	dispatcher	Nemotron Nano 9B v2
+24	nvidia	meta/llama-3.3-70b-instruct	30	dispatcher	Llama 3.3 70B
+29	nvidia	thinkingmachines/inkling	35	dispatcher	Inkling
+39	opencode-free	big-pickle	40	dispatcher	OpenCode Big Pickle
+40	opencode-free	deepseek-v4-flash-free	45	dispatcher	OpenCode DeepSeek V4 Flash Free
+41	opencode-free	mimo-v2.5-free	50	dispatcher	OpenCode MiMo V2.5 Free
+42	opencode-free	nemotron-3-ultra-free	55	dispatcher	OpenCode Nemotron 3 Ultra Free
+43	opencode-free	laguna-s-2.1-free	0	dispatcher	OpenCode Laguna S 2.1 Free
+44	opencode-free	hy3-free	5	dispatcher	OpenCode Tencent Hy3 Free
+45	opencode-free	nemotron-3.5-lightning-free	10	dispatcher	OpenCode Nemotron 3.5 Lightning Free
+46	kilo-auto	kilo-auto/free	15	dispatcher	Kilo Auto Free · Forge

--- a/.github/scripts/validate-free-model-factories.py
+++ b/.github/scripts/validate-free-model-factories.py
@@ -31,7 +31,7 @@ EXPECTED_OPENCODE_FREE_MODELS = {
     'nemotron-3-ultra-free',
     'nemotron-3.5-lightning-free',
 }
-BATCH_MINUTES = (0, 15, 30, 45)
+SCHEDULE_MINUTES = tuple(range(0, 60, 5))
 ENTRY_PERMISSIONS = ('contents: write', 'issues: write', 'pull-requests: write', 'actions: write', 'checks: read')
 
 
@@ -65,22 +65,26 @@ def main() -> None:
     assert kilo[0]['display_name'] == 'Kilo Auto Free · Forge'
 
     counts: Counter[int] = Counter()
-    for row in rows:
-        worker = int(row['worker'])
+    for index, row in enumerate(rows):
         minute = int(row['minute'])
-        assert row['scheduler'] == 'watchdog'
-        assert minute == BATCH_MINUTES[(worker - 6) % 4]
+        assert row['scheduler'] == 'dispatcher'
+        assert minute == SCHEDULE_MINUTES[index % len(SCHEDULE_MINUTES)]
         counts[minute] += 1
-    assert counts == Counter({0: 7, 15: 7, 30: 7, 45: 7})
+    assert set(counts) == set(SCHEDULE_MINUTES)
+    assert max(counts.values()) - min(counts.values()) <= 1
+    assert sum(counts.values()) == 28
 
     watchdog = WATCHDOG.read_text(encoding='utf-8')
     assert "cron: '*/15 * * * *'" in watchdog
 
     dispatcher = DISPATCHER.read_text(encoding='utf-8')
-    assert 'workflow_run:' in dispatcher
-    assert "workflows: ['Factory heartbeat watchdog']" in dispatcher
-    assert 'schedule:' not in dispatcher
-    assert 'slots=(0 15 30 45)' in dispatcher
+    assert 'workflow_run:' not in dispatcher
+    assert 'schedule:' in dispatcher
+    for minute in SCHEDULE_MINUTES:
+        assert f"cron: '{minute} * * * *'" in dispatcher
+    assert 'SCHEDULE_EXPR: ${{ github.event.schedule }}' in dispatcher
+    assert 'elif [[ "$EVENT_NAME" == schedule ]]; then' in dispatcher
+    assert 'minute="${SCHEDULE_EXPR%% *}"' in dispatcher
     assert 'workers=\'["6","39","46"]\'' in dispatcher
     assert 'gh workflow run free-model-factory-entry.yml' in dispatcher
     assert "'.github/scripts/free-model-factory-worker.sh'" in dispatcher
@@ -229,8 +233,8 @@ def main() -> None:
         classifier,
     ), 'discovery classifier issue comment call missing'
 
-    print('Validated 28 external factory lanes, shared-pool selection, and daily Chromium discovery.')
-    for minute in BATCH_MINUTES:
+    print('Validated 28 external factory lanes, staggered scheduling, shared-pool selection, and daily Chromium discovery.')
+    for minute in SCHEDULE_MINUTES:
         print(f'  :{minute:02d} -> {counts[minute]} workers')
     for source, count in EXPECTED_SOURCE_COUNTS.items():
         print(f'  {source}: {count}')

--- a/.github/workflows/free-model-factory-dispatch.yml
+++ b/.github/workflows/free-model-factory-dispatch.yml
@@ -1,9 +1,19 @@
 name: Fixed Model Factory Dispatcher
 
 on:
-  workflow_run:
-    workflows: ['Factory heartbeat watchdog']
-    types: [completed]
+  schedule:
+    - cron: '0 * * * *'
+    - cron: '5 * * * *'
+    - cron: '10 * * * *'
+    - cron: '15 * * * *'
+    - cron: '20 * * * *'
+    - cron: '25 * * * *'
+    - cron: '30 * * * *'
+    - cron: '35 * * * *'
+    - cron: '40 * * * *'
+    - cron: '45 * * * *'
+    - cron: '50 * * * *'
+    - cron: '55 * * * *'
   workflow_dispatch:
     inputs:
       worker:
@@ -28,7 +38,6 @@ permissions:
 
 jobs:
   dispatch:
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -40,7 +49,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
           DEPLOY_SHA: ${{ github.sha }}
-          WATCHDOG_RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
+          SCHEDULE_EXPR: ${{ github.event.schedule }}
           DISPATCH_WORKER: ${{ inputs.worker }}
         run: |
           set -Eeuo pipefail
@@ -162,12 +171,14 @@ jobs:
           if [[ "$EVENT_NAME" == workflow_dispatch && -n "${DISPATCH_WORKER:-}" ]]; then
             awk -F '\t' -v worker="$DISPATCH_WORKER" '$1 == worker {found=1} END {exit !found}' "$manifest"
             workers="$(jq -nc --arg worker "$DISPATCH_WORKER" '[$worker]')"
-          elif [[ "$EVENT_NAME" == workflow_run ]]; then
-            slots=(0 15 30 45)
-            index=$((WATCHDOG_RUN_NUMBER % 4))
-            minute="${slots[$index]}"
+          elif [[ "$EVENT_NAME" == schedule ]]; then
+            minute="${SCHEDULE_EXPR%% *}"
+            [[ "$minute" =~ ^(0|5|10|15|20|25|30|35|40|45|50|55)$ ]] || {
+              echo "Unexpected factory schedule expression: ${SCHEDULE_EXPR:-<empty>}" >&2
+              exit 1
+            }
             workers="$(awk -F '\t' -v minute="$minute" '$4 == minute {print $1}' "$manifest" | jq -Rsc 'split("\n") | map(select(length > 0))')"
-            echo "Watchdog run ${WATCHDOG_RUN_NUMBER} selected :$(printf '%02d' "$minute") batch"
+            echo "Scheduled :$(printf '%02d' "$minute") batch"
           else
             # Immediate post-merge/manual smoke: one lane per routing strategy.
             workers='["6","39","46"]'


### PR DESCRIPTION
## What changed

- move the 28 external fixed-model factories from four quarter-hour batches to 12 five-minute slots
- reduce simultaneous launches from 7 workers to 2–3 workers per slot
- let the fixed-model dispatcher own its schedule directly instead of piggybacking on the heartbeat watchdog
- keep the heartbeat watchdog on its existing 15-minute monitoring cadence
- update the factory invariant validator to enforce the staggered schedule

## New cadence

External workers now launch at `:00`, `:05`, `:10`, `:15`, `:20`, `:25`, `:30`, `:35`, `:40`, `:45`, `:50`, and `:55`, with each external lane still receiving one scheduled run per hour.

The five ChatGPT factories are unchanged at their existing staggered slots.

## Why

The previous schedule intentionally grouped all 28 external lanes into four batches of seven at `:00/:15/:30/:45`. That created unnecessary bursts of concurrent factory startup. This keeps the same hourly frequency while smoothing those launches across the full hour.