### PR TITLE
Drain ready factory PRs from the dispatcher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -473,7 +473,7 @@ jobs:
               echo "PostgreSQL is ready"
               exit 0
             fi
-            echo "Waiting for backend... ($i/30)"
+            echo "Waiting for PostgreSQL... ($i/30)"
             sleep 2
             i=$((i + 1))
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/${{ github.event.repository.name }}
@@ -469,7 +473,7 @@ jobs:
               echo "PostgreSQL is ready"
               exit 0
             fi
-            echo "Waiting for PostgreSQL... ($i/30)"
+            echo "Waiting for backend... ($i/30)"
             sleep 2
             i=$((i + 1))
           done

--- a/.github/workflows/fixed-model-pr-repair-guard.yml
+++ b/.github/workflows/fixed-model-pr-repair-guard.yml
@@ -12,6 +12,10 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: fixed-model-pr-repair-guard-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   guard-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/free-model-factory-dispatch.yml
+++ b/.github/workflows/free-model-factory-dispatch.yml
@@ -37,14 +37,17 @@ permissions:
   pull-requests: write
 
 jobs:
-  drain-ready:
+  dispatch:
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       checks: read
       contents: write
+      issues: write
       pull-requests: write
     steps:
-      - name: Merge exact-head ready factory PRs
+      - name: Drain exact-head ready factory PRs
+        continue-on-error: true
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -117,9 +120,6 @@ jobs:
             fi
           done
 
-  dispatch:
-    runs-on: ubuntu-latest
-    steps:
       - uses: actions/checkout@v6
         with:
           ref: main

--- a/.github/workflows/free-model-factory-dispatch.yml
+++ b/.github/workflows/free-model-factory-dispatch.yml
@@ -40,6 +40,7 @@ jobs:
   drain-ready:
     runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: write
       pull-requests: write
     steps:

--- a/.github/workflows/free-model-factory-dispatch.yml
+++ b/.github/workflows/free-model-factory-dispatch.yml
@@ -37,6 +37,85 @@ permissions:
   pull-requests: write
 
 jobs:
+  drain-ready:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Merge exact-head ready factory PRs
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+
+          current_head_review_blockers() {
+            local pr="$1" head="$2" changes unresolved
+            changes="$(gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/pulls/${pr}/reviews?per_page=100" \
+              | jq -s --arg head "$head" \
+                '[.[][] | select(.state == "CHANGES_REQUESTED" and .commit_id == $head)] | length')"
+            [[ "$changes" == "0" ]] || return 1
+
+            unresolved="$(gh api graphql \
+              -F owner="${GITHUB_REPOSITORY_OWNER}" \
+              -F name="${GITHUB_REPOSITORY#*/}" \
+              -F number="$pr" \
+              -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100){nodes{isResolved}}}}}' \
+              --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')"
+            [[ "$unresolved" == "0" ]]
+          }
+
+          ready_to_merge() {
+            local pr="$1" expected_head="$2" info head
+            info="$(gh pr view "$pr" --repo "$GITHUB_REPOSITORY" \
+              --json state,isDraft,mergeable,headRefOid)"
+            [[ "$(jq -r .state <<< "$info")" == "OPEN" ]] || return 1
+            [[ "$(jq -r .isDraft <<< "$info")" == "false" ]] || return 1
+            [[ "$(jq -r .mergeable <<< "$info")" == "MERGEABLE" ]] || return 1
+            head="$(jq -r .headRefOid <<< "$info")"
+            [[ "$head" == "$expected_head" ]] || return 1
+            gh pr checks "$pr" --repo "$GITHUB_REPOSITORY" --required >/tmp/factory-ready-checks 2>&1 || return 1
+            current_head_review_blockers "$pr" "$head"
+          }
+
+          mapfile -t ready_prs < <(
+            gh pr list --repo "$GITHUB_REPOSITORY" --state open --limit 100 \
+              --label 'factory:ready' \
+              --json number,isDraft,headRefOid \
+              --jq '.[] | select(.isDraft == false) | [.number, .headRefOid] | @tsv'
+          )
+
+          if (( ${#ready_prs[@]} == 0 )); then
+            echo 'No factory:ready PRs to drain'
+            exit 0
+          fi
+
+          for candidate in "${ready_prs[@]}"; do
+            IFS=$'\t' read -r pr head <<< "$candidate"
+            [[ -n "$pr" && -n "$head" ]] || continue
+
+            if ! ready_to_merge "$pr" "$head"; then
+              echo "PR #${pr} is labeled ready but exact-head gates are no longer satisfied; leaving it open"
+              continue
+            fi
+
+            echo "Merging ready PR #${pr} at ${head}"
+            if gh pr merge "$pr" --repo "$GITHUB_REPOSITORY" \
+              --merge --match-head-commit "$head"; then
+              echo "Merged ready PR #${pr}"
+              continue
+            fi
+
+            state="$(gh pr view "$pr" --repo "$GITHUB_REPOSITORY" --json state --jq .state 2>/dev/null || true)"
+            if [[ "$state" == "MERGED" ]]; then
+              echo "PR #${pr} was merged concurrently"
+            else
+              echo "Unable to merge ready PR #${pr}; it will be retried on the next dispatcher tick" >&2
+            fi
+          done
+
   dispatch:
     runs-on: ubuntu-latest
     steps:

--- a/tests/test_factory_ready_drain.py
+++ b/tests/test_factory_ready_drain.py
@@ -4,8 +4,9 @@ from pathlib import Path
 def test_dispatcher_drains_ready_factory_prs_with_exact_head_gates() -> None:
     dispatcher = Path('.github/workflows/free-model-factory-dispatch.yml').read_text(encoding='utf-8')
 
-    assert 'drain-ready:' in dispatcher
+    assert 'Drain exact-head ready factory PRs' in dispatcher
     assert "--label 'factory:ready'" in dispatcher
+    assert 'checks: read' in dispatcher
     assert 'contents: write' in dispatcher
     assert 'current_head_review_blockers' in dispatcher
     assert '.state == "CHANGES_REQUESTED" and .commit_id == $head' in dispatcher
@@ -15,9 +16,10 @@ def test_dispatcher_drains_ready_factory_prs_with_exact_head_gates() -> None:
     assert '--merge --match-head-commit "$head"' in dispatcher
 
 
-def test_ready_drain_does_not_gate_worker_dispatch() -> None:
+def test_ready_drain_reuses_dispatch_runner_without_blocking_dispatch() -> None:
     dispatcher = Path('.github/workflows/free-model-factory-dispatch.yml').read_text(encoding='utf-8')
 
-    assert '\n  drain-ready:\n' in dispatcher
     assert '\n  dispatch:\n' in dispatcher
-    assert 'needs: drain-ready' not in dispatcher
+    assert '\n  drain-ready:\n' not in dispatcher
+    assert 'continue-on-error: true' in dispatcher
+    assert dispatcher.index('Drain exact-head ready factory PRs') < dispatcher.index('Resolve and dispatch fixed workers')

--- a/tests/test_factory_ready_drain.py
+++ b/tests/test_factory_ready_drain.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+def test_dispatcher_drains_ready_factory_prs_with_exact_head_gates() -> None:
+    dispatcher = Path('.github/workflows/free-model-factory-dispatch.yml').read_text(encoding='utf-8')
+
+    assert 'drain-ready:' in dispatcher
+    assert "--label 'factory:ready'" in dispatcher
+    assert 'contents: write' in dispatcher
+    assert 'current_head_review_blockers' in dispatcher
+    assert '.state == "CHANGES_REQUESTED" and .commit_id == $head' in dispatcher
+    assert 'reviewThreads(first:100)' in dispatcher
+    assert 'gh pr checks "$pr" --repo "$GITHUB_REPOSITORY" --required' in dispatcher
+    assert '[[ "$head" == "$expected_head" ]]' in dispatcher
+    assert '--merge --match-head-commit "$head"' in dispatcher
+
+
+def test_ready_drain_does_not_gate_worker_dispatch() -> None:
+    dispatcher = Path('.github/workflows/free-model-factory-dispatch.yml').read_text(encoding='utf-8')
+
+    assert '\n  drain-ready:\n' in dispatcher
+    assert '\n  dispatch:\n' in dispatcher
+    assert 'needs: drain-ready' not in dispatcher

--- a/tests/test_factory_ready_drain.py
+++ b/tests/test_factory_ready_drain.py
@@ -23,3 +23,10 @@ def test_ready_drain_reuses_dispatch_runner_without_blocking_dispatch() -> None:
     assert '\n  drain-ready:\n' not in dispatcher
     assert 'continue-on-error: true' in dispatcher
     assert dispatcher.index('Drain exact-head ready factory PRs') < dispatcher.index('Resolve and dispatch fixed workers')
+
+
+def test_pr_ci_cancels_superseded_heads_without_canceling_main() -> None:
+    ci = Path('.github/workflows/ci.yml').read_text(encoding='utf-8')
+
+    assert 'group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}' in ci
+    assert "cancel-in-progress: ${{ github.event_name == 'pull_request' }}" in ci

--- a/tests/test_factory_ready_drain.py
+++ b/tests/test_factory_ready_drain.py
@@ -1,7 +1,10 @@
+"""Regression coverage for the factory ready-drain and stale-head cancellation."""
+
 from pathlib import Path
 
 
 def test_dispatcher_drains_ready_factory_prs_with_exact_head_gates() -> None:
+    """Ready PRs are drained only after exact-head merge gates pass."""
     dispatcher = Path('.github/workflows/free-model-factory-dispatch.yml').read_text(encoding='utf-8')
 
     assert 'Drain exact-head ready factory PRs' in dispatcher
@@ -17,6 +20,7 @@ def test_dispatcher_drains_ready_factory_prs_with_exact_head_gates() -> None:
 
 
 def test_ready_drain_reuses_dispatch_runner_without_blocking_dispatch() -> None:
+    """The drain reuses the dispatcher runner and cannot block dispatch."""
     dispatcher = Path('.github/workflows/free-model-factory-dispatch.yml').read_text(encoding='utf-8')
 
     assert '\n  dispatch:\n' in dispatcher
@@ -26,6 +30,7 @@ def test_ready_drain_reuses_dispatch_runner_without_blocking_dispatch() -> None:
 
 
 def test_pr_ci_cancels_superseded_heads_without_canceling_main() -> None:
+    """PR CI cancels stale heads while main-branch CI stays non-canceling."""
     ci = Path('.github/workflows/ci.yml').read_text(encoding='utf-8')
 
     assert 'group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}' in ci
@@ -33,6 +38,7 @@ def test_pr_ci_cancels_superseded_heads_without_canceling_main() -> None:
 
 
 def test_repair_guard_cancels_superseded_pr_heads() -> None:
+    """Repair-guard runs collapse to the latest PR head."""
     guard = Path('.github/workflows/fixed-model-pr-repair-guard.yml').read_text(encoding='utf-8')
 
     assert 'group: fixed-model-pr-repair-guard-${{ github.event.pull_request.number || github.ref }}' in guard

--- a/tests/test_factory_ready_drain.py
+++ b/tests/test_factory_ready_drain.py
@@ -30,3 +30,10 @@ def test_pr_ci_cancels_superseded_heads_without_canceling_main() -> None:
 
     assert 'group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}' in ci
     assert "cancel-in-progress: ${{ github.event_name == 'pull_request' }}" in ci
+
+
+def test_repair_guard_cancels_superseded_pr_heads() -> None:
+    guard = Path('.github/workflows/fixed-model-pr-repair-guard.yml').read_text(encoding='utf-8')
+
+    assert 'group: fixed-model-pr-repair-guard-${{ github.event.pull_request.number || github.ref }}' in guard
+    assert 'cancel-in-progress: true' in guard


### PR DESCRIPTION
## What changed

- add a `continue-on-error` drain step to the existing five-minute fixed-model dispatcher
- reuse the dispatcher runner instead of adding another scheduled job
- select only open PRs already marked `factory:ready`
- re-check exact-head mergeability, required CI, current-head change requests, and unresolved review threads before merging
- merge with `--match-head-commit` so a moved branch is never merged from stale evidence
- keep worker dispatch independent from the drain so a drain failure cannot stop scheduled factories from launching
- add native CI concurrency for pull requests so a new PR head cancels superseded CI before stale jobs consume runners; `main` CI is intentionally not canceled
- add native head supersession to Fixed Model PR Repair Guard so stale synchronize checks do not queue behind the current head
- add regression coverage for the drain safety gates, single-runner shape, PR-only CI cancellation, and repair-guard supersession

## Why

The factory fleet is producing implementations faster than the finish loop is draining them. During live cleanup, PRs #1253 and #1248 were both `factory:ready`, mergeable, green, and review-clear but remained open. PR #1239 was similarly stranded behind stale `factory:changes-requested` state despite an exact-head PASS and green CI.

The Actions queue also reached 76 queued runs. Investigation proved this was not just one current CI per PR: this branch alone accumulated multiple queued CI runs for superseded heads while the runner queue was congested. CI and the repair guard are both exact-head gates, so stale runs can be canceled safely at GitHub's scheduler instead of waiting for the runner-based cleanup path.

This gives already-ready work one deterministic finishing path and prevents stale exact-head validation from amplifying runner congestion, without adding another scheduler, another recurring runner, or changing model cadence.