### PR TITLE
Incident: keep factory control plane alive under GraphQL rate limits

### DIFF
--- a/.github/scripts/factory-gh-rest-shim.sh
+++ b/.github/scripts/factory-gh-rest-shim.sh
@@ -63,7 +63,7 @@ if [[ "$command_group" == issue && "$command_name" == list ]]; then
       .[][]
       | select(.pull_request == null)
       | select([.labels[]?.name] as $item_labels
-          | all($labels[] as $wanted; ($item_labels | index($wanted)) != null))
+          | ($labels | all(. as $wanted | ($item_labels | index($wanted)) != null)))
       | {
           number,
           title,
@@ -92,7 +92,7 @@ if [[ "$command_group" == pr && "$command_name" == list ]]; then
     [
       .[][]
       | select([.labels[]?.name] as $item_labels
-          | all($labels[] as $wanted; ($item_labels | index($wanted)) != null))
+          | ($labels | all(. as $wanted | ($item_labels | index($wanted)) != null)))
       | {
           number,
           title,

--- a/.github/scripts/factory-gh-rest-shim.sh
+++ b/.github/scripts/factory-gh-rest-shim.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REAL_GH="${FACTORY_REAL_GH:-/usr/bin/gh}"
+[[ -x "$REAL_GH" ]] || {
+  echo "factory gh REST shim: real gh executable not found at ${REAL_GH}" >&2
+  exit 127
+}
+
+original=("$@")
+command_group="${1:-}"
+command_name="${2:-}"
+
+emit_with_optional_jq() {
+  local payload="$1" jq_expr="${2:-}"
+  if [[ -n "$jq_expr" ]]; then
+    jq -r "$jq_expr" <<< "$payload"
+  else
+    printf '%s\n' "$payload"
+  fi
+}
+
+parse_list_args() {
+  local -n out_repo=$1 out_state=$2 out_limit=$3 out_jq=$4 out_labels=$5
+  shift 5
+  out_repo="${GITHUB_REPOSITORY:-}"
+  out_state='open'
+  out_limit=100
+  out_jq=''
+  out_labels=()
+  while (( $# )); do
+    case "$1" in
+      --repo)
+        out_repo="$2"; shift 2 ;;
+      --state)
+        out_state="$2"; shift 2 ;;
+      --limit)
+        out_limit="$2"; shift 2 ;;
+      --label)
+        out_labels+=("$2"); shift 2 ;;
+      --json)
+        shift 2 ;;
+      --jq)
+        out_jq="$2"; shift 2 ;;
+      *)
+        return 2 ;;
+    esac
+  done
+  [[ -n "$out_repo" && "$out_limit" =~ ^[0-9]+$ ]] || return 2
+}
+
+if [[ "$command_group" == issue && "$command_name" == list ]]; then
+  shift 2
+  repo='' state='' limit='' jq_expr=''
+  labels=()
+  if ! parse_list_args repo state limit jq_expr labels "$@"; then
+    exec "$REAL_GH" "${original[@]}"
+  fi
+  pages="$("$REAL_GH" api --paginate --slurp "repos/${repo}/issues?state=${state}&per_page=100")"
+  labels_json="$(printf '%s\n' "${labels[@]:-}" | jq -Rsc 'split("\n") | map(select(length > 0))')"
+  payload="$(jq -c --argjson labels "$labels_json" --argjson limit "$limit" '
+    [
+      .[][]
+      | select(.pull_request == null)
+      | select([.labels[]?.name] as $item_labels
+          | all($labels[] as $wanted; ($item_labels | index($wanted)) != null))
+      | {
+          number,
+          title,
+          body,
+          labels,
+          createdAt: .created_at,
+          updatedAt: .updated_at,
+          state: (if .state == "open" then "OPEN" else "CLOSED" end)
+        }
+    ][: $limit]
+  ' <<< "$pages")"
+  emit_with_optional_jq "$payload" "$jq_expr"
+  exit 0
+fi
+
+if [[ "$command_group" == pr && "$command_name" == list ]]; then
+  shift 2
+  repo='' state='' limit='' jq_expr=''
+  labels=()
+  if ! parse_list_args repo state limit jq_expr labels "$@"; then
+    exec "$REAL_GH" "${original[@]}"
+  fi
+  pages="$("$REAL_GH" api --paginate --slurp "repos/${repo}/pulls?state=${state}&per_page=100")"
+  labels_json="$(printf '%s\n' "${labels[@]:-}" | jq -Rsc 'split("\n") | map(select(length > 0))')"
+  payload="$(jq -c --argjson labels "$labels_json" --argjson limit "$limit" '
+    [
+      .[][]
+      | select([.labels[]?.name] as $item_labels
+          | all($labels[] as $wanted; ($item_labels | index($wanted)) != null))
+      | {
+          number,
+          title,
+          body,
+          labels,
+          headRefName: .head.ref,
+          headRefOid: .head.sha,
+          createdAt: .created_at,
+          updatedAt: .updated_at,
+          isDraft: (.draft // false),
+          state: (if .state == "open" then "OPEN" else "CLOSED" end)
+        }
+    ][: $limit]
+  ' <<< "$pages")"
+  emit_with_optional_jq "$payload" "$jq_expr"
+  exit 0
+fi
+
+parse_view_args() {
+  local -n out_number=$1 out_repo=$2 out_jq=$3
+  shift 3
+  out_number="${1:-}"
+  shift || true
+  out_repo="${GITHUB_REPOSITORY:-}"
+  out_jq=''
+  [[ "$out_number" =~ ^[0-9]+$ ]] || return 2
+  while (( $# )); do
+    case "$1" in
+      --repo)
+        out_repo="$2"; shift 2 ;;
+      --json)
+        shift 2 ;;
+      --jq)
+        out_jq="$2"; shift 2 ;;
+      *)
+        return 2 ;;
+    esac
+  done
+  [[ -n "$out_repo" ]] || return 2
+}
+
+if [[ "$command_group" == pr && "$command_name" == view ]]; then
+  shift 2
+  number='' repo='' jq_expr=''
+  if ! parse_view_args number repo jq_expr "$@"; then
+    exec "$REAL_GH" "${original[@]}"
+  fi
+  raw="$("$REAL_GH" api "repos/${repo}/pulls/${number}")"
+  payload="$(jq -c '
+    {
+      number,
+      title,
+      body,
+      labels,
+      state: (if .merged_at != null then "MERGED" elif .state == "open" then "OPEN" else "CLOSED" end),
+      isDraft: (.draft // false),
+      mergeable: (if .mergeable == true then "MERGEABLE" elif .mergeable == false then "CONFLICTING" else "UNKNOWN" end),
+      headRefOid: .head.sha,
+      headRefName: .head.ref
+    }
+  ' <<< "$raw")"
+  emit_with_optional_jq "$payload" "$jq_expr"
+  exit 0
+fi
+
+if [[ "$command_group" == issue && "$command_name" == view ]]; then
+  shift 2
+  number='' repo='' jq_expr=''
+  if ! parse_view_args number repo jq_expr "$@"; then
+    exec "$REAL_GH" "${original[@]}"
+  fi
+  raw="$("$REAL_GH" api "repos/${repo}/issues/${number}")"
+  payload="$(jq -c '
+    {
+      number,
+      title,
+      body,
+      labels,
+      state: (if .state == "open" then "OPEN" else "CLOSED" end)
+    }
+  ' <<< "$raw")"
+  emit_with_optional_jq "$payload" "$jq_expr"
+  exit 0
+fi
+
+exec "$REAL_GH" "${original[@]}"

--- a/.github/scripts/free-model-factory-worker.sh
+++ b/.github/scripts/free-model-factory-worker.sh
@@ -8,6 +8,21 @@ set -Eeuo pipefail
 : "${FACTORY_MODEL:?FACTORY_MODEL is required}"
 : "${FACTORY_RUNTIME_MODEL:?FACTORY_RUNTIME_MODEL is required}"
 
+# Factory selection and lease handoff must keep working even when GitHub's
+# GraphQL installation bucket is exhausted. Route the small set of gh list/view
+# reads used by the wrapper through REST while forwarding every other gh command
+# to the real CLI unchanged.
+install_factory_rest_gh() {
+  local real_gh shim_dir
+  real_gh="$(command -v gh)"
+  shim_dir="$(mktemp -d /tmp/comic-pile-factory-gh.XXXXXX)"
+  cp .github/scripts/factory-gh-rest-shim.sh "$shim_dir/gh"
+  chmod +x "$shim_dir/gh"
+  export FACTORY_REAL_GH="$real_gh"
+  export PATH="$shim_dir:$PATH"
+}
+install_factory_rest_gh
+
 # These four tiny bridges preserve the existing regression harness, which
 # extracts named helper functions directly from this file. In the real worker
 # they are immediately replaced when the tracked primitives are sourced below.

--- a/.github/workflows/free-model-factory-dispatch.yml
+++ b/.github/workflows/free-model-factory-dispatch.yml
@@ -27,6 +27,7 @@ on:
       - '.github/workflows/free-model-factory-entry.yml'
       - '.github/workflows/free-model-factory-run.yml'
       - '.github/scripts/factory-work-controller.py'
+      - '.github/scripts/factory-gh-rest-shim.sh'
       - '.github/scripts/free-model-factory-worker.sh'
       - '.github/scripts/kilo-auto-factory-run.sh'
       - '.github/free-model-factories.tsv'
@@ -51,6 +52,22 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Install REST-backed factory GitHub reads
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          real_gh="$(command -v gh)"
+          shim_dir="$RUNNER_TEMP/factory-gh-rest"
+          mkdir -p "$shim_dir"
+          cp .github/scripts/factory-gh-rest-shim.sh "$shim_dir/gh"
+          chmod +x "$shim_dir/gh"
+          echo "FACTORY_REAL_GH=$real_gh" >> "$GITHUB_ENV"
+          echo "$shim_dir" >> "$GITHUB_PATH"
+
       - name: Drain exact-head ready factory PRs
         continue-on-error: true
         shell: bash
@@ -61,18 +78,24 @@ jobs:
 
           current_head_review_blockers() {
             local pr="$1" head="$2" changes unresolved
-            changes="$(gh api --paginate \
+            if ! changes="$(gh api --paginate \
               "repos/${GITHUB_REPOSITORY}/pulls/${pr}/reviews?per_page=100" \
               | jq -s --arg head "$head" \
-                '[.[][] | select(.state == "CHANGES_REQUESTED" and .commit_id == $head)] | length')"
+                '[.[][] | select(.state == "CHANGES_REQUESTED" and .commit_id == $head)] | length')"; then
+              echo "Unable to inspect current-head review submissions for PR #${pr}" >&2
+              return 1
+            fi
             [[ "$changes" == "0" ]] || return 1
 
-            unresolved="$(gh api graphql \
+            if ! unresolved="$(gh api graphql \
               -F owner="${GITHUB_REPOSITORY_OWNER}" \
               -F name="${GITHUB_REPOSITORY#*/}" \
               -F number="$pr" \
               -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100){nodes{isResolved}}}}}' \
-              --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')"
+              --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')"; then
+              echo "Unable to inspect unresolved review threads for PR #${pr}; leaving it open" >&2
+              return 1
+            fi
             [[ "$unresolved" == "0" ]]
           }
 
@@ -85,16 +108,24 @@ jobs:
             [[ "$(jq -r .mergeable <<< "$info")" == "MERGEABLE" ]] || return 1
             head="$(jq -r .headRefOid <<< "$info")"
             [[ "$head" == "$expected_head" ]] || return 1
-            gh pr checks "$pr" --repo "$GITHUB_REPOSITORY" --required >/tmp/factory-ready-checks 2>&1 || return 1
+            if ! gh pr checks "$pr" --repo "$GITHUB_REPOSITORY" --required >/tmp/factory-ready-checks 2>&1; then
+              echo "Required checks for PR #${pr} are unavailable or not green; leaving it open" >&2
+              cat /tmp/factory-ready-checks >&2 || true
+              return 1
+            fi
             current_head_review_blockers "$pr" "$head"
           }
 
-          mapfile -t ready_prs < <(
-            gh pr list --repo "$GITHUB_REPOSITORY" --state open --limit 100 \
-              --label 'factory:ready' \
-              --json number,isDraft,headRefOid \
-              --jq '.[] | select(.isDraft == false) | [.number, .headRefOid] | @tsv'
-          )
+          ready_file="$RUNNER_TEMP/factory-ready-prs.tsv"
+          if ! gh pr list --repo "$GITHUB_REPOSITORY" --state open --limit 100 \
+            --label 'factory:ready' \
+            --json number,isDraft,headRefOid \
+            --jq '.[] | select(.isDraft == false) | [.number, .headRefOid] | @tsv' \
+            > "$ready_file"; then
+            echo 'Unable to enumerate factory:ready PRs; merge drain will retry on the next dispatcher tick' >&2
+            exit 1
+          fi
+          mapfile -t ready_prs < "$ready_file"
 
           if (( ${#ready_prs[@]} == 0 )); then
             echo 'No factory:ready PRs to drain'
@@ -106,7 +137,7 @@ jobs:
             [[ -n "$pr" && -n "$head" ]] || continue
 
             if ! ready_to_merge "$pr" "$head"; then
-              echo "PR #${pr} is labeled ready but exact-head gates are no longer satisfied; leaving it open"
+              echo "PR #${pr} is labeled ready but exact-head gates are not currently satisfied; leaving it open"
               continue
             fi
 
@@ -124,10 +155,6 @@ jobs:
               echo "Unable to merge ready PR #${pr}; it will be retried on the next dispatcher tick" >&2
             fi
           done
-
-      - uses: actions/checkout@v6
-        with:
-          ref: main
 
       - name: Resolve and dispatch fixed workers
         shell: bash

--- a/docs/issue-plans/1393.md
+++ b/docs/issue-plans/1393.md
@@ -1,0 +1,9 @@
+# Issue #1393 incident repair
+
+The fixed-model dispatcher is blocked by exhaustion of the GitHub Actions installation GraphQL rate limit.
+
+This incident repair keeps assignment and lease consumption operational by routing the factory wrapper's `gh issue/pr list` and `gh issue/pr view` reads through REST, while forwarding all other GitHub CLI commands unchanged. The dispatcher installs the same REST compatibility path before lease reconciliation and ready-PR enumeration.
+
+The ready-PR drain now distinguishes an enumeration failure from an actually empty ready queue. Review/check API failures leave a PR open and emit an explicit diagnostic instead of being reported as an empty queue.
+
+Runtime exit criterion: a post-merge dispatcher run must reconcile leases, produce at least one controller assignment when eligible work exists, dispatch the assigned worker, and the entry run must consume that lease without failing on the exhausted GraphQL list path.

--- a/tests/test_factory_gh_rest_shim.py
+++ b/tests/test_factory_gh_rest_shim.py
@@ -1,0 +1,139 @@
+"""Regression coverage for the factory GitHub REST compatibility shim."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SHIM = REPO_ROOT / ".github/scripts/factory-gh-rest-shim.sh"
+
+
+def _fake_gh(tmp_path: Path) -> Path:
+    fake = tmp_path / "gh-real"
+    fake.write_text(
+        """#!/usr/bin/env bash
+set -Eeuo pipefail
+[[ "$1" == api ]] || { echo "unexpected command: $*" >&2; exit 9; }
+shift
+[[ "${1:-}" == --paginate ]] && shift || true
+[[ "${1:-}" == --slurp ]] && shift || true
+endpoint="$1"
+case "$endpoint" in
+  *'/issues?'*)
+    printf '%s\\n' '[[{"number":10,"title":"Issue","body":"body","state":"open","created_at":"2026-08-16T00:00:00Z","updated_at":"2026-08-16T01:00:00Z","labels":[{"name":"factory:13"},{"name":"bug"}]},{"number":11,"title":"PR row","body":"body","state":"open","pull_request":{},"created_at":"2026-08-16T00:00:00Z","updated_at":"2026-08-16T01:00:00Z","labels":[{"name":"factory:13"}]}]]'
+    ;;
+  *'/pulls?'*)
+    printf '%s\\n' '[[{"number":20,"title":"PR","body":"pbody","state":"open","draft":false,"created_at":"2026-08-16T00:00:00Z","updated_at":"2026-08-16T01:00:00Z","labels":[{"name":"factory:13"}],"head":{"ref":"factory/13-10-x","sha":"abc"}}]]'
+    ;;
+  *'/pulls/20')
+    printf '%s\\n' '{"number":20,"title":"PR","body":"pbody","state":"open","merged_at":null,"mergeable":true,"draft":false,"labels":[{"name":"factory:13"}],"head":{"ref":"factory/13-10-x","sha":"abc"}}'
+    ;;
+  *'/issues/10')
+    printf '%s\\n' '{"number":10,"title":"Issue","body":"body","state":"open","labels":[{"name":"factory:13"}]}'
+    ;;
+  *) echo "unknown endpoint: $endpoint" >&2; exit 8 ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    fake.chmod(0o755)
+    return fake
+
+
+def _run(tmp_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "FACTORY_REAL_GH": str(_fake_gh(tmp_path)),
+            "GITHUB_REPOSITORY": "JoshCLWren/comic-pile",
+        }
+    )
+    return subprocess.run(
+        ["bash", str(SHIM), *args],
+        text=True,
+        capture_output=True,
+        check=True,
+        env=env,
+    )
+
+
+def test_rest_shim_lists_only_matching_issues(tmp_path: Path) -> None:
+    """Issue enumeration avoids GraphQL and excludes pull-request rows."""
+    result = _run(
+        tmp_path,
+        "issue",
+        "list",
+        "--state",
+        "open",
+        "--limit",
+        "300",
+        "--label",
+        "factory:13",
+        "--json",
+        "number",
+    )
+    assert [item["number"] for item in json.loads(result.stdout)] == [10]
+
+
+def test_rest_shim_normalizes_pr_list_and_view(tmp_path: Path) -> None:
+    """PR enumeration and view expose the fields used by factory wrappers."""
+    listed = _run(
+        tmp_path,
+        "pr",
+        "list",
+        "--state",
+        "open",
+        "--limit",
+        "200",
+        "--label",
+        "factory:13",
+        "--json",
+        "number,labels",
+    )
+    assert [item["number"] for item in json.loads(listed.stdout)] == [20]
+
+    viewed = _run(
+        tmp_path,
+        "pr",
+        "view",
+        "20",
+        "--json",
+        "headRefName",
+        "--jq",
+        ".headRefName",
+    )
+    assert viewed.stdout.strip() == "factory/13-10-x"
+
+
+def test_rest_shim_normalizes_issue_view_state(tmp_path: Path) -> None:
+    """Issue view preserves the uppercase state contract expected by workers."""
+    viewed = _run(
+        tmp_path,
+        "issue",
+        "view",
+        "10",
+        "--json",
+        "state",
+        "--jq",
+        ".state",
+    )
+    assert viewed.stdout.strip() == "OPEN"
+
+
+def test_dispatcher_and_worker_install_rest_shim() -> None:
+    """Both control-plane assignment and lease consumption use the REST shim."""
+    dispatcher = (
+        REPO_ROOT / ".github/workflows/free-model-factory-dispatch.yml"
+    ).read_text(encoding="utf-8")
+    worker = (
+        REPO_ROOT / ".github/scripts/free-model-factory-worker.sh"
+    ).read_text(encoding="utf-8")
+
+    assert "Install REST-backed factory GitHub reads" in dispatcher
+    assert "factory-gh-rest-shim.sh" in dispatcher
+    assert "Unable to enumerate factory:ready PRs" in dispatcher
+    assert "install_factory_rest_gh" in worker
+    assert "factory-gh-rest-shim.sh" in worker


### PR DESCRIPTION
Closes #1393

## Incident fix
- route the factory wrapper's `gh issue/pr list` and `gh issue/pr view` reads through REST while forwarding all other `gh` commands unchanged
- install the REST compatibility path in the dispatcher before lease reconciliation and ready-PR enumeration
- install the same path in active fixed-model workers so consuming an assigned lease does not immediately hit the exhausted GraphQL bucket
- make ready-PR enumeration failures explicit instead of reporting an empty ready queue
- leave ready PRs open with explicit diagnostics when review/check APIs are unavailable

## Validation so far
- `bash -n` on the REST shim
- fake paginated REST smoke: controller-style issue/PR enumeration passes
- fake paginated REST smoke: worker-style owner-filtered enumeration passes
- PR and issue view normalization passes

Incident handling: do not wait for automated reviewer approval. Merge after focused CI/static checks, then require a real post-merge dispatcher + worker run as the exit criterion.