### PR TITLE
Incident: let fresh dispatcher runs cancel stale queued dispatchers

### DIFF
--- a/.github/workflows/free-model-factory-dispatch.yml
+++ b/.github/workflows/free-model-factory-dispatch.yml
@@ -40,7 +40,7 @@ permissions:
 
 concurrency:
   group: fixed-model-factory-dispatch
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   dispatch:


### PR DESCRIPTION
Refs #1393

The REST hotfix from #1394 is merged, but its post-merge dispatcher is stuck behind an older queued dispatcher run from the previous broken SHA because the shared dispatcher concurrency group had `cancel-in-progress: false`.

This incident follow-up changes that group to `cancel-in-progress: true` so the newest control-plane run wins and stale queued/in-progress dispatcher runs cannot block rollout of a repair.

This is safe for the dispatcher because fixed-model worker entry runs have their own per-worker concurrency, and the next dispatcher reconciliation is authoritative for abandoned numeric leases.

Incident handling: do not wait for automated reviewer approval. Merge immediately if the exact diff is only this concurrency change, then prove the newest dispatcher can actually reconcile, assign, and launch a worker.