### PR TITLE
Incident: let deployments preempt dispatcher schedules without starvation

### DIFF
--- a/.github/workflows/free-model-factory-dispatch.yml
+++ b/.github/workflows/free-model-factory-dispatch.yml
@@ -40,7 +40,7 @@ permissions:
 
 concurrency:
   group: fixed-model-factory-dispatch
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 jobs:
   dispatch:


### PR DESCRIPTION
Refs #1393

The unconditional `cancel-in-progress: true` follow-up proved too aggressive: while GitHub Actions is heavily queued, a later scheduled tick cancelled the repaired push run before it could get a runner.

This incident correction makes cancellation event-sensitive:
- push / workflow_dispatch can preempt stale dispatcher work
- scheduled ticks serialize and do not cancel the run ahead of them

That lets a control-plane deployment cut through stale schedule backlog without the 5-minute schedule repeatedly starving itself.

Incident mode: merge immediately if the diff is exactly this concurrency expression, then keep #1393 open until a real dispatcher assigns and launches a worker.