### PR TITLE
Pause autonomous factory producers for queue-drain evaluation

### DIFF
--- a/.github/workflows/factory-automation-freeze.yml
+++ b/.github/workflows/factory-automation-freeze.yml
@@ -1,0 +1,103 @@
+name: Factory automation freeze controller
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Freeze or resume autonomous factory workflows
+        required: false
+        default: auto
+        type: choice
+        options:
+          - auto
+          - freeze
+          - resume
+  push:
+    branches: [main]
+    paths:
+      - '.github/FACTORY_AUTOMATION_PAUSED'
+      - '.github/workflows/factory-automation-freeze.yml'
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: factory-automation-freeze-controller
+  cancel-in-progress: true
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Resolve desired factory automation state
+        id: desired
+        shell: bash
+        env:
+          REQUESTED_MODE: ${{ inputs.mode || 'auto' }}
+        run: |
+          set -Eeuo pipefail
+          mode="$REQUESTED_MODE"
+          if [[ "$mode" == auto ]]; then
+            if [[ -f .github/FACTORY_AUTOMATION_PAUSED ]]; then
+              mode=freeze
+            else
+              mode=resume
+            fi
+          fi
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+          echo "Factory automation mode: $mode"
+
+      - name: Freeze autonomous factory producers
+        if: steps.desired.outputs.mode == 'freeze'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          workflows=(
+            free-model-factory-dispatch.yml
+            free-model-factory-entry.yml
+            chromium-discovery.yml
+            factory-heartbeat-watchdog.yml
+          )
+
+          for workflow in "${workflows[@]}"; do
+            echo "Freezing $workflow"
+            for status in queued in_progress waiting pending requested; do
+              gh run list --repo "$GITHUB_REPOSITORY" --workflow "$workflow" --status "$status" --limit 100 \
+                --json databaseId --jq '.[].databaseId' 2>/dev/null \
+                | while IFS= read -r run_id; do
+                    [[ -n "$run_id" ]] || continue
+                    echo "Cancelling $workflow run $run_id"
+                    gh run cancel "$run_id" --repo "$GITHUB_REPOSITORY" || true
+                  done
+            done
+            gh api --method PUT \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow}/disable"
+          done
+
+      - name: Resume autonomous factory producers
+        if: steps.desired.outputs.mode == 'resume'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          workflows=(
+            free-model-factory-dispatch.yml
+            free-model-factory-entry.yml
+            chromium-discovery.yml
+            factory-heartbeat-watchdog.yml
+          )
+
+          for workflow in "${workflows[@]}"; do
+            echo "Enabling $workflow"
+            gh api --method PUT \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow}/enable"
+          done

--- a/.github/workflows/factory-automation-freeze.yml
+++ b/.github/workflows/factory-automation-freeze.yml
@@ -69,14 +69,15 @@ jobs:
 
           for workflow in "${workflows[@]}"; do
             echo "Freezing $workflow"
-            for status in queued in_progress waiting pending requested; do
-              gh run list --repo "$GITHUB_REPOSITORY" --workflow "$workflow" --status "$status" --limit 100 \
-                --json databaseId --jq '.[].databaseId' 2>/dev/null \
-                | while IFS= read -r run_id; do
-                    [[ -n "$run_id" ]] || continue
-                    echo "Cancelling $workflow run $run_id"
-                    gh run cancel "$run_id" --repo "$GITHUB_REPOSITORY" || true
-                  done
+            for status in queued in_progress; do
+              while IFS= read -r run_id; do
+                [[ -n "$run_id" ]] || continue
+                echo "Cancelling $workflow run $run_id"
+                gh run cancel "$run_id" --repo "$GITHUB_REPOSITORY" || true
+              done < <(
+                gh run list --repo "$GITHUB_REPOSITORY" --workflow "$workflow" --status "$status" --limit 100 \
+                  --json databaseId --jq '.[].databaseId'
+              )
             done
             gh api --method PUT \
               "repos/${GITHUB_REPOSITORY}/actions/workflows/${workflow}/disable"


### PR DESCRIPTION
Refs #1393

Controlled freeze requested by Josh while the Actions backlog drains.

This adds a small reversible freeze controller keyed off `.github/FACTORY_AUTOMATION_PAUSED`.

While the marker exists it:
- disables the fixed-model dispatcher
- disables fixed-model entry dispatches
- disables Chromium discovery
- disables the factory heartbeat watchdog
- cancels queued/in-progress runs for those workflows

It intentionally does NOT touch normal CI, TestDriver PR checks, deploys, release writer, production performance, or other production monitoring.

Removing the pause marker later re-enables the same four workflows.

ChatGPT Factories 1–5 are already paused separately for the same evaluation window.