### PR TITLE
Incident: re-register fixed-model dispatcher cron

### DIFF
--- a/.github/workflows/free-model-factory-dispatch.yml
+++ b/.github/workflows/free-model-factory-dispatch.yml
@@ -2,18 +2,18 @@ name: Fixed Model Factory Dispatcher
 
 on:
   schedule:
-    - cron: '0 * * * *'
-    - cron: '5 * * * *'
-    - cron: '10 * * * *'
-    - cron: '15 * * * *'
-    - cron: '20 * * * *'
-    - cron: '25 * * * *'
-    - cron: '30 * * * *'
-    - cron: '35 * * * *'
-    - cron: '40 * * * *'
-    - cron: '45 * * * *'
-    - cron: '50 * * * *'
-    - cron: '55 * * * *'
+    - cron: '0 0-23 * * *'
+    - cron: '5 0-23 * * *'
+    - cron: '10 0-23 * * *'
+    - cron: '15 0-23 * * *'
+    - cron: '20 0-23 * * *'
+    - cron: '25 0-23 * * *'
+    - cron: '30 0-23 * * *'
+    - cron: '35 0-23 * * *'
+    - cron: '40 0-23 * * *'
+    - cron: '45 0-23 * * *'
+    - cron: '50 0-23 * * *'
+    - cron: '55 0-23 * * *'
   workflow_dispatch:
     inputs:
       worker:


### PR DESCRIPTION
Refs #1393

## Root cause being repaired

During the Actions incident the fixed-model dispatcher workflow was removed from the default branch and then re-added with the exact same cron strings. The workflow object reports `active`, but no new scheduled dispatcher event has been created since the pause/resume churn.

GitHub documents that changing cron syntax reactivates scheduled workflows. This makes the smallest possible semantic no-op cron rewrite to force schedule registration to refresh while preserving the dispatcher’s existing `github.event.schedule` minute routing.

## Change

Rewrite each hourly wildcard from `*` to the equivalent `0-23` range:

- `0 * * * *` → `0 0-23 * * *`
- same transformation for :05 through :55

The first cron token remains unchanged, so delayed scheduled events still resolve the correct worker batch from `github.event.schedule`.

## Acceptance

Do not close #1393 based on this PR alone. After merge, require a brand-new `Fixed Model Factory Dispatcher` run with `event=schedule`, inspect its jobs/logs, and trace any resulting fresh `Fixed Model Factory Entry` run.