### PR TITLE
Prune six low-signal fixed-model factory lanes

### DIFF
--- a/.github/free-model-factories.tsv
+++ b/.github/free-model-factories.tsv
@@ -1,23 +1,17 @@
 # worker	source	model	minute	scheduler	display_name
 6	nvidia	z-ai/glm-5.2	0	dispatcher	GLM 5.2
-7	nvidia	moonshotai/kimi-k2.6	5	dispatcher	Kimi K2.6
-8	nvidia	deepseek-ai/deepseek-v4-flash-0731	10	dispatcher	DeepSeek V4 Flash
 9	nvidia	stepfun-ai/step-3.7-flash	15	dispatcher	Step 3.7 Flash
 10	nvidia	nvidia/nemotron-3-ultra-550b-a55b	20	dispatcher	Nemotron 3 Ultra
 11	nvidia	poolside/laguna-xs-2.1	25	dispatcher	Laguna XS 2.1
 12	nvidia	openai/gpt-oss-120b	30	dispatcher	GPT OSS 120B
-13	nvidia	mistralai/mistral-small-4-119b-2603	35	dispatcher	Mistral Small 4 119B
 14	nvidia	minimaxai/minimax-m3	40	dispatcher	MiniMax M3
-15	nvidia	mistralai/mistral-nemotron	45	dispatcher	Mistral Nemotron
 16	nvidia	nvidia/nemotron-3-super-120b-a12b	50	dispatcher	Nemotron 3 Super
 17	nvidia	nvidia/nemotron-3-nano-omni-30b-a3b-reasoning	55	dispatcher	Nemotron 3 Omni
 18	nvidia	nvidia/llama-3.3-nemotron-super-49b-v1.5	0	dispatcher	Llama 3.3 Nemotron Super 49B
 19	nvidia	nvidia/nemotron-3-nano-30b-a3b	5	dispatcher	Nemotron Nano 30B
 20	nvidia	openai/gpt-oss-20b	10	dispatcher	GPT OSS 20B
 21	nvidia	google/gemma-4-31b-it	15	dispatcher	Gemma 4 31B
-22	nvidia	mistralai/mistral-large-2-instruct	20	dispatcher	Mistral Large 2
 23	nvidia	nvidia/nvidia-nemotron-nano-9b-v2	25	dispatcher	Nemotron Nano 9B v2
-24	nvidia	meta/llama-3.3-70b-instruct	30	dispatcher	Llama 3.3 70B
 29	nvidia	thinkingmachines/inkling	35	dispatcher	Inkling
 39	opencode-free	big-pickle	40	dispatcher	OpenCode Big Pickle
 40	opencode-free	deepseek-v4-flash-free	45	dispatcher	OpenCode DeepSeek V4 Flash Free


### PR DESCRIPTION
Reduce the fixed-model fleet based on observed ComicPile delivery evidence from the past week.

Retire these six lanes:
- Factory 7 · Kimi K2.6
- Factory 8 · NVIDIA DeepSeek V4 Flash
- Factory 13 · Mistral Small 4 119B
- Factory 15 · Mistral Nemotron
- Factory 22 · Mistral Large 2
- Factory 24 · Llama 3.3 70B

Rationale:
- They have the weakest independent issue-to-PR/merge delivery evidence in the current fleet.
- Factory 8 is also redundant with the direct OpenCode DeepSeek V4 Flash Free lane, which has demonstrated useful delivery.
- Factory 24's fresh runtime proof reached NVIDIA but timed out with zero bytes for 120 seconds, adding provider reliability concerns on top of its weak delivery record.

This intentionally does NOT prune thin-but-promising lanes such as MiniMax M3, Gemma 4 31B, GPT OSS 120B, or Kilo Auto Free. Those remain on probation so we can collect more evidence.

No worker renumbering, model substitutions, controller changes, prioritization changes, or scheduler changes.