### PR TITLE
Factory: allow zero required checks on unprotected base

### DIFF
--- a/.github/scripts/factory-gh-rest-shim.sh
+++ b/.github/scripts/factory-gh-rest-shim.sh
@@ -178,4 +178,67 @@ if [[ "$command_group" == issue && "$command_name" == view ]]; then
   exit 0
 fi
 
+# `gh pr checks --required` exits 1 both when required checks fail and when
+# GitHub reports that a PR simply has no checks. The latter is not a failed
+# gate when the base branch is explicitly unprotected. Normalize only that
+# narrow case so the controller and dispatcher share the same fail-closed
+# interpretation without weakening protected-branch behavior.
+if [[ "$command_group" == pr && "$command_name" == checks ]]; then
+  set +e
+  checks_output="$("$REAL_GH" "${original[@]}" 2>&1)"
+  checks_status=$?
+  set -e
+
+  if (( checks_status == 0 )); then
+    [[ -z "$checks_output" ]] || printf '%s\n' "$checks_output"
+    exit 0
+  fi
+
+  is_required=0
+  repo="${GITHUB_REPOSITORY:-}"
+  number=''
+  for (( index=2; index < ${#original[@]}; index++ )); do
+    arg="${original[$index]}"
+    case "$arg" in
+      --required)
+        is_required=1 ;;
+      --repo)
+        if (( index + 1 < ${#original[@]} )); then
+          repo="${original[$((index + 1))]}"
+          index=$((index + 1))
+        fi
+        ;;
+      *)
+        if [[ -z "$number" && "$arg" =~ ^[0-9]+$ ]]; then
+          number="$arg"
+        fi
+        ;;
+    esac
+  done
+
+  no_checks=0
+  if grep -Eq '^no (required )?checks reported on the .+ branch$' <<< "$checks_output"; then
+    no_checks=1
+  fi
+
+  if (( is_required == 1 && no_checks == 1 )) && [[ -n "$repo" && -n "$number" ]]; then
+    if pr_raw="$("$REAL_GH" api "repos/${repo}/pulls/${number}" 2>/dev/null)"; then
+      base_ref="$(jq -r '.base.ref // empty' <<< "$pr_raw")"
+      if [[ -n "$base_ref" ]]; then
+        encoded_base="$(jq -rn --arg value "$base_ref" '$value | @uri')"
+        if branch_raw="$("$REAL_GH" api "repos/${repo}/branches/${encoded_base}" 2>/dev/null)"; then
+          protected="$(jq -r '.protected // true' <<< "$branch_raw")"
+          if [[ "$protected" == false ]]; then
+            echo "factory gh REST shim: no required checks configured on unprotected base ${base_ref}; treating required-check gate as satisfied" >&2
+            exit 0
+          fi
+        fi
+      fi
+    fi
+  fi
+
+  [[ -z "$checks_output" ]] || printf '%s\n' "$checks_output" >&2
+  exit "$checks_status"
+fi
+
 exec "$REAL_GH" "${original[@]}"

--- a/tests/test_factory_gh_rest_shim.py
+++ b/tests/test_factory_gh_rest_shim.py
@@ -60,6 +60,66 @@ def _run(tmp_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _fake_checks_gh(
+    tmp_path: Path,
+    *,
+    checks_message: str,
+    checks_status: int,
+    protected: bool,
+) -> Path:
+    """Create a gh stand-in for required-check normalization tests."""
+    fake = tmp_path / "gh-checks-real"
+    protected_json = "true" if protected else "false"
+    fake.write_text(
+        f"""#!/usr/bin/env bash
+set -Eeuo pipefail
+if [[ "$1" == pr && "$2" == checks ]]; then
+  printf '%s\\n' {checks_message!r} >&2
+  exit {checks_status}
+fi
+if [[ "$1" == api && "$2" == repos/JoshCLWren/comic-pile/pulls/1390 ]]; then
+  printf '%s\\n' '{{"base":{{"ref":"main"}}}}'
+  exit 0
+fi
+if [[ "$1" == api && "$2" == repos/JoshCLWren/comic-pile/branches/main ]]; then
+  printf '%s\\n' '{{"protected":{protected_json}}}'
+  exit 0
+fi
+printf 'unexpected command: %s\\n' "$*" >&2
+exit 97
+""",
+        encoding="utf-8",
+    )
+    fake.chmod(0o755)
+    return fake
+
+
+def _run_checks(fake_gh: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "FACTORY_REAL_GH": str(fake_gh),
+            "GITHUB_REPOSITORY": "JoshCLWren/comic-pile",
+        }
+    )
+    return subprocess.run(
+        [
+            "bash",
+            str(SHIM),
+            "pr",
+            "checks",
+            "1390",
+            "--repo",
+            "JoshCLWren/comic-pile",
+            "--required",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+
+
 def test_rest_shim_lists_only_matching_issues(tmp_path: Path) -> None:
     """Issue enumeration avoids GraphQL and excludes pull-request rows."""
     result = _run(
@@ -121,6 +181,75 @@ def test_rest_shim_normalizes_issue_view_state(tmp_path: Path) -> None:
         ".state",
     )
     assert viewed.stdout.strip() == "OPEN"
+
+
+def test_no_checks_are_satisfied_on_explicitly_unprotected_base(tmp_path: Path) -> None:
+    """GitHub CLI's no-check error is not a failed gate when the base is unprotected."""
+    fake = _fake_checks_gh(
+        tmp_path,
+        checks_message="no checks reported on the 'factory/43-1386-opencode-free' branch",
+        checks_status=1,
+        protected=False,
+    )
+    result = _run_checks(fake)
+    assert result.returncode == 0
+    assert "no required checks configured on unprotected base main" in result.stderr
+
+
+def test_no_required_checks_are_satisfied_on_unprotected_base(tmp_path: Path) -> None:
+    """The CLI's alternate no-required-checks message receives the same narrow exception."""
+    fake = _fake_checks_gh(
+        tmp_path,
+        checks_message=(
+            "no required checks reported on the 'factory/43-1386-opencode-free' branch"
+        ),
+        checks_status=1,
+        protected=False,
+    )
+    result = _run_checks(fake)
+    assert result.returncode == 0
+
+
+def test_no_required_checks_still_fail_on_protected_base(tmp_path: Path) -> None:
+    """Protected branches remain fail-closed even when GitHub reports no checks."""
+    message = "no required checks reported on the 'factory/43-1386-opencode-free' branch"
+    fake = _fake_checks_gh(
+        tmp_path,
+        checks_message=message,
+        checks_status=1,
+        protected=True,
+    )
+    result = _run_checks(fake)
+    assert result.returncode == 1
+    assert message in result.stderr
+
+
+def test_real_required_check_failure_is_never_normalized(tmp_path: Path) -> None:
+    """Only the CLI's specific no-check result may receive the exception."""
+    message = "Unit Tests\tfail\t42s"
+    fake = _fake_checks_gh(
+        tmp_path,
+        checks_message=message,
+        checks_status=1,
+        protected=False,
+    )
+    result = _run_checks(fake)
+    assert result.returncode == 1
+    assert message in result.stderr
+
+
+def test_successful_required_checks_pass_through(tmp_path: Path) -> None:
+    """Normal successful check execution remains untouched."""
+    message = "Unit Tests\tpass\t38s"
+    fake = _fake_checks_gh(
+        tmp_path,
+        checks_message=message,
+        checks_status=0,
+        protected=True,
+    )
+    result = _run_checks(fake)
+    assert result.returncode == 0
+    assert message in result.stdout
 
 
 def test_dispatcher_and_worker_install_rest_shim() -> None:

--- a/tests/test_factory_gh_rest_shim.py
+++ b/tests/test_factory_gh_rest_shim.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -70,11 +71,12 @@ def _fake_checks_gh(
     """Create a gh stand-in for required-check normalization tests."""
     fake = tmp_path / "gh-checks-real"
     protected_json = "true" if protected else "false"
+    checks_shell = shlex.quote(checks_message)
     fake.write_text(
         f"""#!/usr/bin/env bash
 set -Eeuo pipefail
 if [[ "$1" == pr && "$2" == checks ]]; then
-  printf '%s\\n' {checks_message!r} >&2
+  printf '%s\\n' {checks_shell} >&2
   exit {checks_status}
 fi
 if [[ "$1" == api && "$2" == repos/JoshCLWren/comic-pile/pulls/1390 ]]; then
@@ -255,7 +257,7 @@ def test_successful_required_checks_pass_through(tmp_path: Path) -> None:
 def test_dispatcher_and_worker_install_rest_shim() -> None:
     """Both control-plane assignment and lease consumption use the REST shim."""
     dispatcher = (
-        REPO_ROOT / ".github/workflows/free-model-factory-dispatch.yml"
+        REPO_ROOT / ".github/workflows/fixed-model-factory-dispatch.yml"
     ).read_text(encoding="utf-8")
     worker = (
         REPO_ROOT / ".github/scripts/free-model-factory-worker.sh"


### PR DESCRIPTION
## What changed

- Normalize `gh pr checks --required` only when GitHub reports no checks/no required checks and the PR base branch is explicitly unprotected.
- Preserve fail-closed behavior for protected branches, real failing checks, lookup failures, and every non-matching CLI error.
- Add regression coverage for both no-check message variants, protected-base behavior, real failures, successful pass-through, and shim installation in the fixed-model dispatcher/worker.
- Repair the regression harness to track the current fixed-model dispatcher filename and preserve literal tabbed `gh pr checks` output.

## Why

Factory-zero merge draining was treating GitHub CLI's exit-1 `no required checks` result as a failed gate even when `main` is explicitly unprotected and has no required checks configured. That leaves otherwise mergeable, semantically authorized factory PRs stranded.

## Validation

Focused regression tests are included in `tests/test_factory_gh_rest_shim.py`; PR CI should exercise the branch in the repository's normal test environment.