### PR TITLE
Drain factory PRs before starting new work

### DIFF
--- a/.github/scripts/.factory-pr-drain-validation
+++ b/.github/scripts/.factory-pr-drain-validation
@@ -1,0 +1,2 @@
+queue-policy-tests: 9 passed
+merge-drain-shell-syntax: passed

--- a/.github/scripts/.factory-pr-drain-validation
+++ b/.github/scripts/.factory-pr-drain-validation
@@ -1,2 +1,0 @@
-queue-policy-tests: 9 passed
-merge-drain-shell-syntax: passed

--- a/.github/scripts/factory_work_policy.py
+++ b/.github/scripts/factory_work_policy.py
@@ -37,7 +37,9 @@ def env_positive_int(name: str, default: int) -> int:
         return default
     return value
 
+
 LOCAL_LEASE_TTL_SECONDS = env_positive_int('FACTORY_LOCAL_LEASE_TTL_SECONDS', 3600)
+FACTORY_PR_WIP_LIMIT = env_positive_int('FACTORY_PR_WIP_LIMIT', 5)
 
 
 @dataclass(frozen=True)
@@ -135,6 +137,29 @@ def item_is_unowned(labels: set[str]) -> bool:
     return owner_of(labels) in (None, 'factory:unowned')
 
 
+def issue_bypasses_wip_limit(issue: dict[str, Any]) -> bool:
+    """Keep genuinely urgent product defects executable while the PR queue drains."""
+    labels = labels_of(issue)
+    return (
+        ('user-reported' in labels and 'bug' in labels)
+        or 'priority:P0' in labels
+        or 'ralph-priority:critical' in labels
+    )
+
+
+def factory_pr_wip_count(prs: Iterable[dict[str, Any]]) -> int:
+    """Count open non-draft factory PRs that still consume delivery capacity."""
+    count = 0
+    for pr in prs:
+        if str(pr.get('state') or 'OPEN').upper() != 'OPEN' or pr.get('isDraft'):
+            continue
+        labels = labels_of(pr)
+        head = str(pr.get('headRefName') or '')
+        if 'factory' in labels or head.startswith('factory/'):
+            count += 1
+    return count
+
+
 def issue_is_static_candidate(issue: dict[str, Any], suppressing_pr_issues: set[int]) -> bool:
     """Return whether an issue is structurally eligible for assignment."""
     number = int(issue['number'])
@@ -192,13 +217,30 @@ def pr_suppresses_issue_candidate(pr: dict[str, Any], issue_map: dict[int, dict[
 def build_candidates(issues: list[dict[str, Any]], prs: list[dict[str, Any]]) -> list[Candidate]:
     """Build and rank executable issue and pull-request candidates."""
     issue_map = {int(issue['number']): issue for issue in issues}
-    suppressing_pr_issues = {linked for pr in prs if (linked := linked_issue_from_branch(pr.get('headRefName'))) is not None and pr_suppresses_issue_candidate(pr, issue_map)}
+    suppressing_pr_issues = {
+        linked
+        for pr in prs
+        if (linked := linked_issue_from_branch(pr.get('headRefName'))) is not None
+        and pr_suppresses_issue_candidate(pr, issue_map)
+    }
+    pr_wip_full = factory_pr_wip_count(prs) >= FACTORY_PR_WIP_LIMIT
     candidates: list[Candidate] = []
     for issue in issues:
         if not issue_is_static_candidate(issue, suppressing_pr_issues):
             continue
+        if pr_wip_full and not issue_bypasses_wip_limit(issue):
+            continue
         labels = labels_of(issue)
-        candidates.append(Candidate(kind='issue', number=int(issue['number']), lane=provenance_lane(labels), priority=priority_rank(labels), created_at=str(issue.get('createdAt') or ''), stage=stage_of(labels)))
+        candidates.append(
+            Candidate(
+                kind='issue',
+                number=int(issue['number']),
+                lane=provenance_lane(labels),
+                priority=priority_rank(labels),
+                created_at=str(issue.get('createdAt') or ''),
+                stage=stage_of(labels),
+            )
+        )
     for pr in prs:
         if not pr_is_static_candidate(pr, issue_map):
             continue
@@ -210,39 +252,60 @@ def build_candidates(issues: list[dict[str, Any]], prs: list[dict[str, Any]]) ->
         lane = provenance_lane(labels)
         if lane == 1:
             lane = 2
-        candidates.append(Candidate(kind='pr', number=int(pr['number']), lane=lane, priority=priority_rank(labels), created_at=str(pr.get('createdAt') or ''), linked_issue=linked, stage=stage_of(pr_labels), producer_worker=producer_worker_from_pr(pr)))
+        candidates.append(
+            Candidate(
+                kind='pr',
+                number=int(pr['number']),
+                lane=lane,
+                priority=priority_rank(labels),
+                created_at=str(pr.get('createdAt') or ''),
+                linked_issue=linked,
+                stage=stage_of(pr_labels),
+                producer_worker=producer_worker_from_pr(pr),
+            )
+        )
     return sorted(candidates, key=Candidate.sort_key)
 
 
 def review_capacity_worker(worker: str) -> bool:
-    """Reserve a stable minority of fixed workers for review-first assignment."""
+    """Compatibility helper retained for older tests and callers."""
     return int(worker) % 4 == 2
 
 
 def candidate_is_independent_for_worker(candidate: Candidate, worker: str) -> bool:
     """Prevent a producing factory from being assigned semantic review of its PR."""
-    return not (candidate.kind == 'pr' and candidate.stage == 'factory:review' and candidate.producer_worker == worker)
+    return not (
+        candidate.kind == 'pr'
+        and candidate.stage == 'factory:review'
+        and candidate.producer_worker == worker
+    )
 
 
 def order_candidates_for_worker(candidates: list[Candidate], worker: str) -> list[Candidate]:
-    """Give review bounded capacity while preserving concurrent product work."""
-    eligible = [candidate for candidate in candidates if candidate_is_independent_for_worker(candidate, worker)]
+    """Drain existing PRs before starting new issue implementation."""
+    eligible = [
+        candidate
+        for candidate in candidates
+        if candidate_is_independent_for_worker(candidate, worker)
+    ]
 
     def work_class(candidate: Candidate) -> int:
-        is_semantic_review = candidate.kind == 'pr' and candidate.stage == 'factory:review'
-        if review_capacity_worker(worker):
-            if is_semantic_review:
+        if candidate.kind == 'pr':
+            if candidate.stage == 'factory:ci':
                 return 0
-            if candidate.kind == 'pr':
+            if candidate.stage == 'factory:changes-requested':
                 return 1
-            return 2
-        if candidate.kind == 'issue':
-            return 0
-        if candidate.kind == 'pr' and candidate.stage != 'factory:review':
-            return 1
-        return 2
+            if candidate.stage == 'factory:review':
+                return 2
+            return 3
+        if candidate.lane == 1:
+            return 4
+        return 5
 
-    return sorted(eligible, key=lambda candidate: (work_class(candidate), candidate.sort_key()))
+    return sorted(
+        eligible,
+        key=lambda candidate: (work_class(candidate), candidate.sort_key()),
+    )
 
 
 def plan_distinct_assignments(candidates: list[Candidate], workers: list[str]) -> dict[str, Candidate]:

--- a/.github/scripts/test_factory_work_policy.py
+++ b/.github/scripts/test_factory_work_policy.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Regression coverage for completion-first factory queue policy."""
+from __future__ import annotations
+
+import unittest
+
+from factory_work_policy import Candidate, build_candidates, order_candidates_for_worker
+
+
+def labels(*names: str) -> list[dict[str, str]]:
+    return [{"name": name} for name in names]
+
+
+def factory_pr(
+    number: int,
+    *,
+    stage: str = "factory:review",
+    worker: int = 20,
+    linked_issue: int | None = None,
+) -> dict[str, object]:
+    issue = linked_issue if linked_issue is not None else 9000 + number
+    return {
+        "number": number,
+        "state": "OPEN",
+        "isDraft": False,
+        "labels": labels("factory", "factory:unowned", stage),
+        "headRefName": f"factory/{worker}-{issue}-test",
+        "body": f"Worker: opencode-free-model-factory-{worker}",
+        "createdAt": "2026-08-17T00:00:00Z",
+    }
+
+
+def issue(number: int, *extra_labels: str) -> dict[str, object]:
+    return {
+        "number": number,
+        "state": "OPEN",
+        "title": f"Issue {number}",
+        "labels": labels("factory", "factory:unowned", *extra_labels),
+        "createdAt": "2026-08-17T00:00:00Z",
+    }
+
+
+class CompletionFirstOrderingTests(unittest.TestCase):
+    def test_review_pr_beats_ordinary_issue_for_non_review_worker(self) -> None:
+        candidates = [
+            Candidate("issue", 1, 3, 4, "2026-08-17T00:00:00Z"),
+            Candidate(
+                "pr",
+                2,
+                3,
+                0,
+                "2026-08-16T00:00:00Z",
+                stage="factory:review",
+                producer_worker="43",
+            ),
+        ]
+        self.assertEqual(order_candidates_for_worker(candidates, "9")[0].number, 2)
+
+    def test_pr_stage_order_is_ci_then_changes_then_review(self) -> None:
+        candidates = [
+            Candidate("pr", 1, 3, 0, "", stage="factory:review"),
+            Candidate("pr", 2, 3, 0, "", stage="factory:changes-requested"),
+            Candidate("pr", 3, 3, 0, "", stage="factory:ci"),
+        ]
+        self.assertEqual(
+            [item.number for item in order_candidates_for_worker(candidates, "9")],
+            [3, 2, 1],
+        )
+
+    def test_urgent_issue_still_waits_behind_pr_completion(self) -> None:
+        candidates = [
+            Candidate("issue", 1, 1, 4, "", stage="factory:building"),
+            Candidate("pr", 2, 5, 0, "", stage="factory:review"),
+        ]
+        self.assertEqual(order_candidates_for_worker(candidates, "9")[0].number, 2)
+
+    def test_producer_cannot_semantically_review_own_pr(self) -> None:
+        candidates = [
+            Candidate(
+                "pr",
+                2,
+                3,
+                0,
+                "",
+                stage="factory:review",
+                producer_worker="9",
+            ),
+            Candidate("issue", 1, 3, 0, ""),
+        ]
+        self.assertEqual(order_candidates_for_worker(candidates, "9")[0].number, 1)
+
+
+class WipCapTests(unittest.TestCase):
+    def full_wip(self) -> list[dict[str, object]]:
+        return [
+            factory_pr(100 + offset, stage="factory:ready", worker=20 + offset)
+            for offset in range(5)
+        ]
+
+    def test_wip_cap_suppresses_ordinary_issue(self) -> None:
+        candidates = build_candidates([issue(1)], self.full_wip())
+        self.assertFalse(any(item.kind == "issue" and item.number == 1 for item in candidates))
+
+    def test_wip_cap_suppresses_infrastructure_issue(self) -> None:
+        candidates = build_candidates(
+            [issue(1, "infrastructure", "ralph-priority:high")],
+            self.full_wip(),
+        )
+        self.assertFalse(any(item.kind == "issue" and item.number == 1 for item in candidates))
+
+    def test_wip_cap_allows_user_reported_bug(self) -> None:
+        candidates = build_candidates(
+            [issue(1, "user-reported", "bug")],
+            self.full_wip(),
+        )
+        self.assertTrue(any(item.kind == "issue" and item.number == 1 for item in candidates))
+
+    def test_wip_cap_allows_critical_issue(self) -> None:
+        candidates = build_candidates(
+            [issue(1, "ralph-priority:critical")],
+            self.full_wip(),
+        )
+        self.assertTrue(any(item.kind == "issue" and item.number == 1 for item in candidates))
+
+    def test_ready_pr_is_not_worker_candidate(self) -> None:
+        candidates = build_candidates([], [factory_pr(1, stage="factory:ready")])
+        self.assertFalse(any(item.kind == "pr" and item.number == 1 for item in candidates))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/factory-ready-merge-drain.yml
+++ b/.github/workflows/factory-ready-merge-drain.yml
@@ -1,0 +1,151 @@
+name: Factory Ready Merge Drain
+
+on:
+  schedule:
+    - cron: '2-57/5 * * * *'
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/factory-ready-merge-drain.yml'
+      - '.github/scripts/factory-review-controller.py'
+      - '.github/scripts/factory_review_policy.py'
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  checks: read
+
+concurrency:
+  group: factory-ready-merge-drain
+  cancel-in-progress: false
+
+jobs:
+  merge-ready:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Drain exact-head ready factory PRs
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          review_controller='.github/scripts/factory-review-controller.py'
+
+          current_head_review_blockers() {
+            local pr="$1" head="$2" changes unresolved
+            changes="$(gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/pulls/${pr}/reviews?per_page=100" \
+              | jq -s --arg head "$head" \
+                '[.[][] | select(.state == "CHANGES_REQUESTED" and .commit_id == $head)] | length')"
+            [[ "$changes" == "0" ]] || return 1
+
+            unresolved="$(gh api graphql \
+              -F owner="${GITHUB_REPOSITORY_OWNER}" \
+              -F name="${GITHUB_REPOSITORY#*/}" \
+              -F number="$pr" \
+              -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100){nodes{isResolved}}}}}' \
+              --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')"
+            [[ "$unresolved" == "0" ]]
+          }
+
+          required_checks_pass() {
+            local pr="$1" output_file="$RUNNER_TEMP/required-checks-${pr}.json"
+            local error_file="$RUNNER_TEMP/required-checks-${pr}.err"
+            local status
+
+            set +e
+            gh pr checks "$pr" --repo "$GITHUB_REPOSITORY" --required --json state \
+              >"$output_file" 2>"$error_file"
+            status=$?
+            set -e
+
+            if [[ -s "$output_file" ]] && ! jq -e 'length == 0' "$output_file" >/dev/null 2>&1; then
+              if jq -e 'all(.[]; (.state | ascii_upcase) == "SUCCESS")' "$output_file" >/dev/null; then
+                return 0
+              fi
+              echo "Required checks for PR #${pr} are not all successful" >&2
+              cat "$output_file" >&2
+              return 1
+            fi
+
+            if (( status == 0 )); then
+              return 0
+            fi
+
+            if grep -Eqi 'no checks reported|no required checks' "$error_file"; then
+              echo "PR #${pr} has no configured/reported required checks; continuing with exact-head semantic gates"
+              return 0
+            fi
+
+            echo "Unable to verify required checks for PR #${pr}" >&2
+            cat "$error_file" >&2 || true
+            return 1
+          }
+
+          mapfile -t ready_prs < <(
+            gh pr list --repo "$GITHUB_REPOSITORY" --state open --limit 200 \
+              --label 'factory:ready' \
+              --json number,isDraft,headRefOid \
+              --jq '.[] | select(.isDraft == false) | [.number, .headRefOid] | @tsv'
+          )
+
+          if (( ${#ready_prs[@]} == 0 )); then
+            echo 'No factory:ready PRs to drain'
+            exit 0
+          fi
+
+          for candidate in "${ready_prs[@]}"; do
+            IFS=$'\t' read -r pr expected_head <<< "$candidate"
+            [[ -n "$pr" && -n "$expected_head" ]] || continue
+
+            authorization="$(python3 "$review_controller" authorized --pr "$pr")" || {
+              echo "Unable to verify semantic authorization for PR #${pr}; leaving it open" >&2
+              continue
+            }
+            [[ "$(jq -r '.authorized // false' <<< "$authorization")" == 'true' ]] || {
+              echo "PR #${pr} lacks semantic authorization; leaving it open"
+              continue
+            }
+            [[ "$(jq -r '.head // empty' <<< "$authorization")" == "$expected_head" ]] || {
+              echo "PR #${pr} authorization is stale; leaving it open"
+              continue
+            }
+
+            info="$(gh pr view "$pr" --repo "$GITHUB_REPOSITORY" \
+              --json state,isDraft,mergeable,headRefOid)"
+            [[ "$(jq -r .state <<< "$info")" == "OPEN" ]] || continue
+            [[ "$(jq -r .isDraft <<< "$info")" == "false" ]] || continue
+            [[ "$(jq -r .mergeable <<< "$info")" == "MERGEABLE" ]] || {
+              echo "PR #${pr} is not mergeable; leaving it open"
+              continue
+            }
+            head="$(jq -r .headRefOid <<< "$info")"
+            [[ "$head" == "$expected_head" ]] || {
+              echo "PR #${pr} head changed; leaving it open for fresh review"
+              continue
+            }
+
+            required_checks_pass "$pr" || continue
+            current_head_review_blockers "$pr" "$head" || {
+              echo "PR #${pr} has current-head review blockers; leaving it open"
+              continue
+            }
+
+            echo "Merging semantically authorized ready PR #${pr} at ${head}"
+            if gh pr merge "$pr" --repo "$GITHUB_REPOSITORY" \
+              --merge --match-head-commit "$head"; then
+              echo "Merged ready PR #${pr}"
+              continue
+            fi
+
+            state="$(gh pr view "$pr" --repo "$GITHUB_REPOSITORY" --json state --jq .state 2>/dev/null || true)"
+            [[ "$state" == "MERGED" ]] || {
+              echo "Unable to merge ready PR #${pr}; it will retry on the next drain" >&2
+            }
+          done


### PR DESCRIPTION
## What changed

- make all fixed-model factories prioritize existing PR completion over new issue implementation
- rank PR work as CI repair, changes requested, semantic review, then other PR work
- add a default WIP cap of 5 open factory PRs; while at/above the cap, ordinary and infrastructure issues do not start
- allow user-reported bugs, P0, and critical work to bypass the WIP cap without outranking existing PR completion
- preserve producer self-review protection
- add focused regression coverage for the new queue behavior
- add a dedicated exact-head ready-PR merge drain that preserves semantic authorization and review-blocker checks while allowing the explicit GitHub no-required-checks case

## Validation

- 9 focused factory queue policy tests pass locally
- merge-drain shell block passes `bash -n`
- branch diff is limited to the queue policy, its tests, and the ready-merge workflow

This is a control-plane throughput fix. It is intended to turn the factory fleet from a PR generator into a PR finisher.