### PR TITLE
Prioritize merge-conflicted PR repair

### DIFF
--- a/.github/scripts/factory-work-controller.py
+++ b/.github/scripts/factory-work-controller.py
@@ -23,6 +23,7 @@ __all__ = ["linked_issue_from_branch", "plan_distinct_assignments"]
 
 
 def run_gh(args: list[str], *, input_json: object | None = None, check: bool = True) -> str:
+    """Run a bounded GitHub CLI command and return stdout."""
     command = ['gh', *args]
     try:
         proc = subprocess.run(command, input=None if input_json is None else json.dumps(input_json), text=True, capture_output=True, check=False, timeout=GH_TIMEOUT_SECONDS)
@@ -34,24 +35,34 @@ def run_gh(args: list[str], *, input_json: object | None = None, check: bool = T
 
 
 def gh_json(args: list[str], *, input_json: object | None = None) -> object | None:
+    """Run GitHub CLI and decode JSON stdout."""
     output = run_gh(args, input_json=input_json)
     return json.loads(output) if output.strip() else None
 
 
 def list_issues() -> list[dict[str, Any]]:
+    """List open issues visible to the assignment controller."""
     return cast(list[dict[str, Any]], gh_json(['issue', 'list', '--repo', REPO, '--state', 'open', '--limit', '1000', '--json', 'number,title,labels,createdAt,updatedAt']))
 
 
 def list_prs() -> list[dict[str, Any]]:
-    """List open PRs including GitHub's current merge-conflict assessment."""
+    """List open pull requests including current mergeability."""
     return cast(list[dict[str, Any]], gh_json(['pr', 'list', '--repo', REPO, '--state', 'open', '--limit', '500', '--json', 'number,title,body,labels,headRefName,createdAt,updatedAt,isDraft,mergeable,mergeStateStatus']))
 
 
 def target_json(number: int) -> dict[str, Any]:
+    """Fetch one issue-compatible GitHub target payload."""
     return cast(dict[str, Any], gh_json(['api', f'repos/{REPO}/issues/{number}']))
 
 
 def replace_factory_labels(number: int, owner: str, stage: str | None=None) -> None:
+    """Atomically reconcile one target to exactly one owner and workflow stage.
+
+    The repository policy requires a single full label-set replacement rather
+    than sequential add/remove mutations, which would expose contradictory
+    intermediate owner states. A post-write claim verification is performed by
+    ``assign_candidate``.
+    """
     target = target_json(number)
     current = [label['name'] for label in target.get('labels', [])]
     existing_stage = next((label for label in current if label in STAGE_LABELS), None)
@@ -62,6 +73,7 @@ def replace_factory_labels(number: int, owner: str, stage: str | None=None) -> N
 
 
 def issue_has_open_blocker(number: int) -> bool:
+    """Return whether an issue has an open dependency blocker."""
     try:
         blockers = cast(list[dict[str, Any]], gh_json(['api', f'repos/{REPO}/issues/{number}/dependencies/blocked_by?per_page=100']) or [])
     except RuntimeError:
@@ -70,6 +82,7 @@ def issue_has_open_blocker(number: int) -> bool:
 
 
 def required_checks_failed(pr_number: int) -> bool:
+    """Return whether any required pull-request check has failed."""
     try:
         output = run_gh(['pr', 'checks', str(pr_number), '--repo', REPO, '--required', '--json', 'state'], check=False)
     except RuntimeError:
@@ -85,6 +98,7 @@ def required_checks_failed(pr_number: int) -> bool:
 
 
 def candidate_is_live_executable(candidate: Candidate) -> bool:
+    """Return whether a ranked candidate has an executable next action."""
     if candidate.kind == 'issue':
         return not issue_has_open_blocker(candidate.number)
     target = target_json(candidate.number)
@@ -97,17 +111,20 @@ def candidate_is_live_executable(candidate: Candidate) -> bool:
 
 
 def target_still_unowned(number: int) -> bool:
+    """Return whether a target remains safely claimable."""
     labels = {label['name'] for label in target_json(number).get('labels', [])}
     return item_is_unowned(labels) and not bool(labels & BLOCKED_LABELS)
 
 
 def target_owned_by(number: int, owner: str) -> bool:
+    """Return whether exactly one expected active owner holds a target."""
     labels = {label['name'] for label in target_json(number).get('labels', [])}
     active_owners = {label for label in labels if OWNER_RE.fullmatch(label) and label != 'factory:unowned'}
     return active_owners == {owner}
 
 
 def assign_candidate(candidate: Candidate, worker: str) -> bool:
+    """Claim a candidate and any linked issue for one fixed-model worker."""
     owner = f'factory:{worker}'
     numbers = [candidate.number]
     if candidate.kind == 'pr' and candidate.linked_issue is not None:
@@ -122,6 +139,7 @@ def assign_candidate(candidate: Candidate, worker: str) -> bool:
             return False
 
     def release_verified_claims(claimed_numbers: list[int]) -> None:
+        """Release only labels this worker can still prove it owns."""
         for claimed_number in claimed_numbers:
             try:
                 if target_owned_by(claimed_number, owner):
@@ -149,6 +167,7 @@ def assign_candidate(candidate: Candidate, worker: str) -> bool:
 
 
 def flatten_pages(pages: object | None) -> list[dict[str, Any]]:
+    """Flatten paginated GitHub API responses into object rows."""
     result: list[dict[str, Any]] = []
     for page in pages or []:
         if isinstance(page, list):
@@ -159,6 +178,7 @@ def flatten_pages(pages: object | None) -> list[dict[str, Any]]:
 
 
 def latest_lease_activity_epoch(number: int) -> int | None:
+    """Return the latest trusted lease activity marker for a target."""
     try:
         pages = gh_json(['api', '--paginate', '--slurp', f'repos/{REPO}/issues/{number}/comments?per_page=100'])
     except RuntimeError:
@@ -176,6 +196,7 @@ def latest_lease_activity_epoch(number: int) -> int | None:
 
 
 def active_fixed_workers() -> set[int]:
+    """Return worker IDs with queued or running fixed-model entry runs."""
     workers: set[int] = set()
     runs: list[dict[str, Any]] = []
     for status in ('queued', 'in_progress'):
@@ -210,6 +231,7 @@ def active_fixed_workers() -> set[int]:
 
 
 def owned_targets(issues: list[dict[str, Any]] | None=None, prs: list[dict[str, Any]] | None=None) -> list[tuple[int, str]]:
+    """List open targets that currently have an active factory owner."""
     targets: list[tuple[int, str]] = []
     issue_items = list_issues() if issues is None else issues
     pr_items = list_prs() if prs is None else prs
@@ -221,6 +243,7 @@ def owned_targets(issues: list[dict[str, Any]] | None=None, prs: list[dict[str, 
 
 
 def reconcile_stale_leases(now_epoch: int | None=None) -> list[int]:
+    """Release fixed-model and proven-stale local leases safely."""
     now_epoch = int(time.time()) if now_epoch is None else now_epoch
     active = active_fixed_workers()
     released: list[int] = []
@@ -235,11 +258,13 @@ def reconcile_stale_leases(now_epoch: int | None=None) -> list[int]:
 
 
 def worker_has_active_lease(worker: str) -> bool:
+    """Return whether a fixed-model worker already owns open work."""
     owner = f'factory:{worker}'
     return any(current_owner == owner for _, current_owner in owned_targets())
 
 
 def assign(worker: str) -> Candidate | None:
+    """Assign the highest-ranked executable work to one fixed-model worker."""
     if not re.fullmatch('(?:[6-9]|[1-3][0-9]|4[0-6])', worker):
         raise SystemExit(f'unsupported fixed-model worker: {worker}')
     if worker_has_active_lease(worker):
@@ -257,6 +282,7 @@ def assign(worker: str) -> Candidate | None:
 
 
 def release_worker(worker: str) -> list[int]:
+    """Release all targets still owned by one fixed-model worker."""
     owner = f'factory:{worker}'
     released: list[int] = []
     for number, current_owner in owned_targets():
@@ -268,6 +294,7 @@ def release_worker(worker: str) -> list[int]:
 
 
 def main() -> int:
+    """Run the factory controller command-line interface."""
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest='command', required=True)
     subparsers.add_parser('reconcile')

--- a/.github/scripts/factory-work-controller.py
+++ b/.github/scripts/factory-work-controller.py
@@ -23,7 +23,6 @@ __all__ = ["linked_issue_from_branch", "plan_distinct_assignments"]
 
 
 def run_gh(args: list[str], *, input_json: object | None = None, check: bool = True) -> str:
-    """Run a bounded GitHub CLI command and return stdout."""
     command = ['gh', *args]
     try:
         proc = subprocess.run(command, input=None if input_json is None else json.dumps(input_json), text=True, capture_output=True, check=False, timeout=GH_TIMEOUT_SECONDS)
@@ -35,34 +34,24 @@ def run_gh(args: list[str], *, input_json: object | None = None, check: bool = T
 
 
 def gh_json(args: list[str], *, input_json: object | None = None) -> object | None:
-    """Run GitHub CLI and decode its JSON output."""
     output = run_gh(args, input_json=input_json)
     return json.loads(output) if output.strip() else None
 
 
 def list_issues() -> list[dict[str, Any]]:
-    """List open issues visible to the assignment controller."""
     return cast(list[dict[str, Any]], gh_json(['issue', 'list', '--repo', REPO, '--state', 'open', '--limit', '1000', '--json', 'number,title,labels,createdAt,updatedAt']))
 
 
 def list_prs() -> list[dict[str, Any]]:
-    """List open pull requests visible to the assignment controller."""
-    return cast(list[dict[str, Any]], gh_json(['pr', 'list', '--repo', REPO, '--state', 'open', '--limit', '500', '--json', 'number,title,body,labels,headRefName,createdAt,updatedAt,isDraft']))
+    """List open PRs including GitHub's current merge-conflict assessment."""
+    return cast(list[dict[str, Any]], gh_json(['pr', 'list', '--repo', REPO, '--state', 'open', '--limit', '500', '--json', 'number,title,body,labels,headRefName,createdAt,updatedAt,isDraft,mergeable,mergeStateStatus']))
 
 
 def target_json(number: int) -> dict[str, Any]:
-    """Fetch one issue-compatible GitHub target payload."""
     return cast(dict[str, Any], gh_json(['api', f'repos/{REPO}/issues/{number}']))
 
 
 def replace_factory_labels(number: int, owner: str, stage: str | None=None) -> None:
-    """Atomically reconcile one target to exactly one owner and workflow stage.
-
-    The repository policy requires a single full label-set replacement rather
-    than sequential add/remove mutations, which would expose contradictory
-    intermediate owner states. A post-write claim verification is performed by
-    ``assign_candidate``.
-    """
     target = target_json(number)
     current = [label['name'] for label in target.get('labels', [])]
     existing_stage = next((label for label in current if label in STAGE_LABELS), None)
@@ -73,7 +62,6 @@ def replace_factory_labels(number: int, owner: str, stage: str | None=None) -> N
 
 
 def issue_has_open_blocker(number: int) -> bool:
-    """Return whether an issue has an open dependency blocker."""
     try:
         blockers = cast(list[dict[str, Any]], gh_json(['api', f'repos/{REPO}/issues/{number}/dependencies/blocked_by?per_page=100']) or [])
     except RuntimeError:
@@ -82,7 +70,6 @@ def issue_has_open_blocker(number: int) -> bool:
 
 
 def required_checks_failed(pr_number: int) -> bool:
-    """Return whether any required pull-request check has failed."""
     try:
         output = run_gh(['pr', 'checks', str(pr_number), '--repo', REPO, '--required', '--json', 'state'], check=False)
     except RuntimeError:
@@ -98,31 +85,29 @@ def required_checks_failed(pr_number: int) -> bool:
 
 
 def candidate_is_live_executable(candidate: Candidate) -> bool:
-    """Return whether a ranked candidate has an executable next action."""
     if candidate.kind == 'issue':
         return not issue_has_open_blocker(candidate.number)
     target = target_json(candidate.number)
     labels = {label['name'] for label in target.get('labels', [])}
+    if candidate.conflicted:
+        return True
     if 'factory:ci' in labels:
         return required_checks_failed(candidate.number)
     return True
 
 
 def target_still_unowned(number: int) -> bool:
-    """Return whether a target remains safely claimable."""
     labels = {label['name'] for label in target_json(number).get('labels', [])}
     return item_is_unowned(labels) and not bool(labels & BLOCKED_LABELS)
 
 
 def target_owned_by(number: int, owner: str) -> bool:
-    """Return whether exactly one expected active owner holds a target."""
     labels = {label['name'] for label in target_json(number).get('labels', [])}
     active_owners = {label for label in labels if OWNER_RE.fullmatch(label) and label != 'factory:unowned'}
     return active_owners == {owner}
 
 
 def assign_candidate(candidate: Candidate, worker: str) -> bool:
-    """Claim a candidate and any linked issue for one fixed-model worker."""
     owner = f'factory:{worker}'
     numbers = [candidate.number]
     if candidate.kind == 'pr' and candidate.linked_issue is not None:
@@ -137,7 +122,6 @@ def assign_candidate(candidate: Candidate, worker: str) -> bool:
             return False
 
     def release_verified_claims(claimed_numbers: list[int]) -> None:
-        """Release only labels this worker can still prove it owns."""
         for claimed_number in claimed_numbers:
             try:
                 if target_owned_by(claimed_number, owner):
@@ -147,7 +131,12 @@ def assign_candidate(candidate: Candidate, worker: str) -> bool:
     claimed: list[int] = []
     try:
         for number in numbers:
-            stage = 'factory:building' if candidate.kind == 'issue' else None
+            if candidate.kind == 'issue':
+                stage = 'factory:building'
+            elif candidate.conflicted:
+                stage = 'factory:changes-requested'
+            else:
+                stage = None
             replace_factory_labels(number, owner, stage)
             if not target_owned_by(number, owner):
                 release_verified_claims(claimed)
@@ -160,7 +149,6 @@ def assign_candidate(candidate: Candidate, worker: str) -> bool:
 
 
 def flatten_pages(pages: object | None) -> list[dict[str, Any]]:
-    """Flatten paginated GitHub API responses into object rows."""
     result: list[dict[str, Any]] = []
     for page in pages or []:
         if isinstance(page, list):
@@ -171,7 +159,6 @@ def flatten_pages(pages: object | None) -> list[dict[str, Any]]:
 
 
 def latest_lease_activity_epoch(number: int) -> int | None:
-    """Return the latest trusted lease activity marker for a target."""
     try:
         pages = gh_json(['api', '--paginate', '--slurp', f'repos/{REPO}/issues/{number}/comments?per_page=100'])
     except RuntimeError:
@@ -189,7 +176,6 @@ def latest_lease_activity_epoch(number: int) -> int | None:
 
 
 def active_fixed_workers() -> set[int]:
-    """Return worker IDs with queued or running fixed-model entry runs."""
     workers: set[int] = set()
     runs: list[dict[str, Any]] = []
     for status in ('queued', 'in_progress'):
@@ -224,7 +210,6 @@ def active_fixed_workers() -> set[int]:
 
 
 def owned_targets(issues: list[dict[str, Any]] | None=None, prs: list[dict[str, Any]] | None=None) -> list[tuple[int, str]]:
-    """List open targets that currently have an active factory owner."""
     targets: list[tuple[int, str]] = []
     issue_items = list_issues() if issues is None else issues
     pr_items = list_prs() if prs is None else prs
@@ -236,7 +221,6 @@ def owned_targets(issues: list[dict[str, Any]] | None=None, prs: list[dict[str, 
 
 
 def reconcile_stale_leases(now_epoch: int | None=None) -> list[int]:
-    """Release fixed-model and proven-stale local leases safely."""
     now_epoch = int(time.time()) if now_epoch is None else now_epoch
     active = active_fixed_workers()
     released: list[int] = []
@@ -251,13 +235,11 @@ def reconcile_stale_leases(now_epoch: int | None=None) -> list[int]:
 
 
 def worker_has_active_lease(worker: str) -> bool:
-    """Return whether a fixed-model worker already owns open work."""
     owner = f'factory:{worker}'
     return any(current_owner == owner for _, current_owner in owned_targets())
 
 
 def assign(worker: str) -> Candidate | None:
-    """Assign the highest-ranked executable work to one fixed-model worker."""
     if not re.fullmatch('(?:[6-9]|[1-3][0-9]|4[0-6])', worker):
         raise SystemExit(f'unsupported fixed-model worker: {worker}')
     if worker_has_active_lease(worker):
@@ -268,13 +250,13 @@ def assign(worker: str) -> Candidate | None:
         if not candidate_is_live_executable(candidate):
             continue
         if assign_candidate(candidate, worker):
-            print(f'[factory-controller] assigned {candidate.kind} #{candidate.number} lane={candidate.lane} priority={candidate.priority} to Factory {worker}', file=sys.stderr)
+            reason = ' conflict-repair' if candidate.conflicted else ''
+            print(f'[factory-controller] assigned {candidate.kind} #{candidate.number} lane={candidate.lane} priority={candidate.priority}{reason} to Factory {worker}', file=sys.stderr)
             return candidate
     return None
 
 
 def release_worker(worker: str) -> list[int]:
-    """Release all targets still owned by one fixed-model worker."""
     owner = f'factory:{worker}'
     released: list[int] = []
     for number, current_owner in owned_targets():
@@ -286,7 +268,6 @@ def release_worker(worker: str) -> list[int]:
 
 
 def main() -> int:
-    """Run the factory controller command-line interface."""
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest='command', required=True)
     subparsers.add_parser('reconcile')
@@ -303,7 +284,7 @@ def main() -> int:
         if candidate is None:
             print(json.dumps({'kind': 'none'}))
             return 0
-        print(json.dumps({'kind': candidate.kind, 'number': candidate.number, 'lane': candidate.lane, 'priority': candidate.priority, 'linked_issue': candidate.linked_issue}))
+        print(json.dumps({'kind': candidate.kind, 'number': candidate.number, 'lane': candidate.lane, 'priority': candidate.priority, 'linked_issue': candidate.linked_issue, 'conflicted': candidate.conflicted}))
         return 0
     print(json.dumps({'released': release_worker(args.worker)}))
     return 0

--- a/.github/scripts/factory_work_policy.py
+++ b/.github/scripts/factory_work_policy.py
@@ -11,14 +11,19 @@ from factory_review_policy import producer_worker_from_pr as producer_worker_fro
 NON_EXECUTABLE_ISSUES = {679, 1093, 1109}
 
 OWNER_RE = re.compile('^factory:(?:unowned|local|[1-9]|[1-3][0-9]|4[0-6])$')
+
 FIXED_OWNER_RE = re.compile('^factory:(?P<worker>[6-9]|[1-3][0-9]|4[0-6])$')
+
 STAGE_LABELS = {'factory:building', 'factory:review', 'factory:changes-requested', 'factory:ci', 'factory:ready', 'factory:blocked'}
 STAGE_PRECEDENCE = ('factory:blocked', 'factory:ready', 'factory:review', 'factory:changes-requested', 'factory:ci', 'factory:building')
+
 INFRA_LABELS = {'infrastructure', 'e2e-infrastructure', 'policy-change', 'docs', 'documentation', 'quality-control'}
+
 BLOCKED_LABELS = {'factory:blocked', 'ralph-status:blocked', 'wontfix', 'invalid', 'duplicate'}
 
 
 def env_positive_int(name: str, default: int) -> int:
+    """Return a positive integer environment setting or its safe default."""
     raw = os.environ.get(name)
     if raw is None:
         return default
@@ -39,6 +44,7 @@ FACTORY_PR_WIP_LIMIT = env_positive_int('FACTORY_PR_WIP_LIMIT', 5)
 
 @dataclass(frozen=True)
 class Candidate:
+    """A ranked unit of executable factory work."""
     kind: str
     number: int
     lane: int
@@ -50,10 +56,12 @@ class Candidate:
     conflicted: bool = False
 
     def sort_key(self) -> tuple[int, int, float, int]:
+        """Return the deterministic queue ordering key."""
         return (self.lane, -self.priority, -parse_time(self.created_at), -self.number)
 
 
 def parse_time(value: str | None) -> float:
+    """Parse an ISO timestamp into a sortable epoch value."""
     if not value:
         return 0.0
     try:
@@ -63,6 +71,7 @@ def parse_time(value: str | None) -> float:
 
 
 def labels_of(item: dict[str, Any]) -> set[str]:
+    """Return the normalized label names from a GitHub item."""
     result: set[str] = set()
     for label in item.get('labels') or []:
         name = label.get('name') if isinstance(label, dict) else label
@@ -72,6 +81,7 @@ def labels_of(item: dict[str, Any]) -> set[str]:
 
 
 def owner_of(labels: Iterable[str]) -> str | None:
+    """Return the active factory owner represented by a label set."""
     owners = [label for label in labels if OWNER_RE.fullmatch(label)]
     active = [label for label in owners if label != 'factory:unowned']
     if active:
@@ -80,6 +90,7 @@ def owner_of(labels: Iterable[str]) -> str | None:
 
 
 def priority_rank(labels: Iterable[str]) -> int:
+    """Map explicit priority labels to a deterministic numeric rank."""
     labels = set(labels)
     if 'ralph-priority:critical' in labels or 'priority:P0' in labels:
         return 4
@@ -93,6 +104,7 @@ def priority_rank(labels: Iterable[str]) -> int:
 
 
 def linked_issue_from_branch(branch: str | None) -> int | None:
+    """Extract an issue number from the canonical factory branch shape."""
     if not branch:
         return None
     match = re.match('^factory/\\d+-(\\d+)-', branch)
@@ -100,15 +112,18 @@ def linked_issue_from_branch(branch: str | None) -> int | None:
 
 
 def producer_worker_from_pr(pr: dict[str, Any]) -> str | None:
+    """Recover producer identity using the shared review provenance policy."""
     return producer_worker_from_values(branch=str(pr.get('headRefName') or ''), body=str(pr.get('body') or ''))
 
 
 def stage_of(labels: Iterable[str]) -> str | None:
+    """Return the deterministic current factory lifecycle stage."""
     present = set(labels)
     return next((label for label in STAGE_PRECEDENCE if label in present), None)
 
 
 def provenance_lane(labels: set[str]) -> int:
+    """Return the deterministic assignment lane for a label set."""
     if 'e2e-discovered' in labels:
         return 4
     if labels & INFRA_LABELS:
@@ -119,15 +134,22 @@ def provenance_lane(labels: set[str]) -> int:
 
 
 def item_is_unowned(labels: set[str]) -> bool:
+    """Return whether a label set has no active factory owner."""
     return owner_of(labels) in (None, 'factory:unowned')
 
 
 def issue_bypasses_wip_limit(issue: dict[str, Any]) -> bool:
+    """Keep genuinely urgent product defects executable while the PR queue drains."""
     labels = labels_of(issue)
-    return (('user-reported' in labels and 'bug' in labels) or 'priority:P0' in labels or 'ralph-priority:critical' in labels)
+    return (
+        ('user-reported' in labels and 'bug' in labels)
+        or 'priority:P0' in labels
+        or 'ralph-priority:critical' in labels
+    )
 
 
 def factory_pr_wip_count(prs: Iterable[dict[str, Any]]) -> int:
+    """Count open non-draft factory PRs that still consume delivery capacity."""
     count = 0
     for pr in prs:
         if str(pr.get('state') or 'OPEN').upper() != 'OPEN' or pr.get('isDraft'):
@@ -147,6 +169,7 @@ def pr_is_conflicted(pr: dict[str, Any]) -> bool:
 
 
 def issue_is_static_candidate(issue: dict[str, Any], suppressing_pr_issues: set[int]) -> bool:
+    """Return whether an issue is structurally eligible for assignment."""
     number = int(issue['number'])
     labels = labels_of(issue)
     title = str(issue.get('title') or '')
@@ -164,6 +187,7 @@ def issue_is_static_candidate(issue: dict[str, Any], suppressing_pr_issues: set[
 
 
 def pr_is_static_candidate(pr: dict[str, Any], issue_map: dict[int, dict[str, Any]]) -> bool:
+    """Return whether an open factory PR is structurally eligible for work."""
     if str(pr.get('state') or 'OPEN').upper() != 'OPEN' or pr.get('isDraft'):
         return False
     labels = labels_of(pr)
@@ -183,6 +207,13 @@ def pr_is_static_candidate(pr: dict[str, Any], issue_map: dict[int, dict[str, An
 
 
 def pr_suppresses_issue_candidate(pr: dict[str, Any], issue_map: dict[int, dict[str, Any]]) -> bool:
+    """Return whether this PR should stand in for its linked issue in the queue.
+
+    Ready PRs are owned by the merge controller. Other PRs suppress duplicate
+    issue implementation only when the PR itself is executable. Draft, blocked,
+    closed, or otherwise ineligible PRs must never make the linked issue
+    disappear.
+    """
     if str(pr.get('state') or 'OPEN').upper() != 'OPEN':
         return False
     labels = labels_of(pr)
@@ -192,9 +223,11 @@ def pr_suppresses_issue_candidate(pr: dict[str, Any], issue_map: dict[int, dict[
 
 
 def build_candidates(issues: list[dict[str, Any]], prs: list[dict[str, Any]]) -> list[Candidate]:
+    """Build and rank executable issue and pull-request candidates."""
     issue_map = {int(issue['number']): issue for issue in issues}
     suppressing_pr_issues = {
-        linked for pr in prs
+        linked
+        for pr in prs
         if (linked := linked_issue_from_branch(pr.get('headRefName'))) is not None
         and pr_suppresses_issue_candidate(pr, issue_map)
     }
@@ -206,7 +239,16 @@ def build_candidates(issues: list[dict[str, Any]], prs: list[dict[str, Any]]) ->
         if pr_wip_full and not issue_bypasses_wip_limit(issue):
             continue
         labels = labels_of(issue)
-        candidates.append(Candidate(kind='issue', number=int(issue['number']), lane=provenance_lane(labels), priority=priority_rank(labels), created_at=str(issue.get('createdAt') or ''), stage=stage_of(labels)))
+        candidates.append(
+            Candidate(
+                kind='issue',
+                number=int(issue['number']),
+                lane=provenance_lane(labels),
+                priority=priority_rank(labels),
+                created_at=str(issue.get('createdAt') or ''),
+                stage=stage_of(labels),
+            )
+        )
     for pr in prs:
         if not pr_is_static_candidate(pr, issue_map):
             continue
@@ -218,21 +260,43 @@ def build_candidates(issues: list[dict[str, Any]], prs: list[dict[str, Any]]) ->
         lane = provenance_lane(labels)
         if lane == 1:
             lane = 2
-        candidates.append(Candidate(kind='pr', number=int(pr['number']), lane=lane, priority=priority_rank(labels), created_at=str(pr.get('createdAt') or ''), linked_issue=linked, stage=stage_of(pr_labels), producer_worker=producer_worker_from_pr(pr), conflicted=pr_is_conflicted(pr)))
+        candidates.append(
+            Candidate(
+                kind='pr',
+                number=int(pr['number']),
+                lane=lane,
+                priority=priority_rank(labels),
+                created_at=str(pr.get('createdAt') or ''),
+                linked_issue=linked,
+                stage=stage_of(pr_labels),
+                producer_worker=producer_worker_from_pr(pr),
+                conflicted=pr_is_conflicted(pr),
+            )
+        )
     return sorted(candidates, key=Candidate.sort_key)
 
 
 def review_capacity_worker(worker: str) -> bool:
+    """Compatibility helper retained for older tests and callers."""
     return int(worker) % 4 == 2
 
 
 def candidate_is_independent_for_worker(candidate: Candidate, worker: str) -> bool:
-    return not (candidate.kind == 'pr' and candidate.stage == 'factory:review' and candidate.producer_worker == worker)
+    """Prevent a producing factory from being assigned semantic review of its PR."""
+    return not (
+        candidate.kind == 'pr'
+        and candidate.stage == 'factory:review'
+        and candidate.producer_worker == worker
+    )
 
 
 def order_candidates_for_worker(candidates: list[Candidate], worker: str) -> list[Candidate]:
-    """Drain conflicted PRs first, then other existing PR work, before new issues."""
-    eligible = [candidate for candidate in candidates if candidate_is_independent_for_worker(candidate, worker)]
+    """Drain merge conflicts and other existing PR work before new issues."""
+    eligible = [
+        candidate
+        for candidate in candidates
+        if candidate_is_independent_for_worker(candidate, worker)
+    ]
 
     def work_class(candidate: Candidate) -> int:
         if candidate.kind == 'pr':
@@ -249,10 +313,14 @@ def order_candidates_for_worker(candidates: list[Candidate], worker: str) -> lis
             return 5
         return 6
 
-    return sorted(eligible, key=lambda candidate: (work_class(candidate), candidate.sort_key()))
+    return sorted(
+        eligible,
+        key=lambda candidate: (work_class(candidate), candidate.sort_key()),
+    )
 
 
 def plan_distinct_assignments(candidates: list[Candidate], workers: list[str]) -> dict[str, Candidate]:
+    """Pure helper used by regression coverage for one dispatcher batch."""
     remaining = list(candidates)
     assignments: dict[str, Candidate] = {}
     for worker in workers:
@@ -266,6 +334,7 @@ def plan_distinct_assignments(candidates: list[Candidate], workers: list[str]) -
 
 
 def lease_is_stale(owner: str, *, active_fixed_workers: set[int], latest_activity_epoch: int | None, now_epoch: int, local_ttl_seconds: int=LOCAL_LEASE_TTL_SECONDS) -> bool:
+    """Return whether a factory lease can be proven stale."""
     if owner == 'factory:local':
         return latest_activity_epoch is not None and now_epoch - latest_activity_epoch > local_ttl_seconds
     match = FIXED_OWNER_RE.fullmatch(owner)

--- a/.github/scripts/factory_work_policy.py
+++ b/.github/scripts/factory_work_policy.py
@@ -11,19 +11,14 @@ from factory_review_policy import producer_worker_from_pr as producer_worker_fro
 NON_EXECUTABLE_ISSUES = {679, 1093, 1109}
 
 OWNER_RE = re.compile('^factory:(?:unowned|local|[1-9]|[1-3][0-9]|4[0-6])$')
-
 FIXED_OWNER_RE = re.compile('^factory:(?P<worker>[6-9]|[1-3][0-9]|4[0-6])$')
-
 STAGE_LABELS = {'factory:building', 'factory:review', 'factory:changes-requested', 'factory:ci', 'factory:ready', 'factory:blocked'}
 STAGE_PRECEDENCE = ('factory:blocked', 'factory:ready', 'factory:review', 'factory:changes-requested', 'factory:ci', 'factory:building')
-
 INFRA_LABELS = {'infrastructure', 'e2e-infrastructure', 'policy-change', 'docs', 'documentation', 'quality-control'}
-
 BLOCKED_LABELS = {'factory:blocked', 'ralph-status:blocked', 'wontfix', 'invalid', 'duplicate'}
 
 
 def env_positive_int(name: str, default: int) -> int:
-    """Return a positive integer environment setting or its safe default."""
     raw = os.environ.get(name)
     if raw is None:
         return default
@@ -44,7 +39,6 @@ FACTORY_PR_WIP_LIMIT = env_positive_int('FACTORY_PR_WIP_LIMIT', 5)
 
 @dataclass(frozen=True)
 class Candidate:
-    """A ranked unit of executable factory work."""
     kind: str
     number: int
     lane: int
@@ -53,14 +47,13 @@ class Candidate:
     linked_issue: int | None = None
     stage: str | None = None
     producer_worker: str | None = None
+    conflicted: bool = False
 
     def sort_key(self) -> tuple[int, int, float, int]:
-        """Return the deterministic queue ordering key."""
         return (self.lane, -self.priority, -parse_time(self.created_at), -self.number)
 
 
 def parse_time(value: str | None) -> float:
-    """Parse an ISO timestamp into a sortable epoch value."""
     if not value:
         return 0.0
     try:
@@ -70,7 +63,6 @@ def parse_time(value: str | None) -> float:
 
 
 def labels_of(item: dict[str, Any]) -> set[str]:
-    """Return the normalized label names from a GitHub item."""
     result: set[str] = set()
     for label in item.get('labels') or []:
         name = label.get('name') if isinstance(label, dict) else label
@@ -80,7 +72,6 @@ def labels_of(item: dict[str, Any]) -> set[str]:
 
 
 def owner_of(labels: Iterable[str]) -> str | None:
-    """Return the active factory owner represented by a label set."""
     owners = [label for label in labels if OWNER_RE.fullmatch(label)]
     active = [label for label in owners if label != 'factory:unowned']
     if active:
@@ -89,7 +80,6 @@ def owner_of(labels: Iterable[str]) -> str | None:
 
 
 def priority_rank(labels: Iterable[str]) -> int:
-    """Map explicit priority labels to a deterministic numeric rank."""
     labels = set(labels)
     if 'ralph-priority:critical' in labels or 'priority:P0' in labels:
         return 4
@@ -103,7 +93,6 @@ def priority_rank(labels: Iterable[str]) -> int:
 
 
 def linked_issue_from_branch(branch: str | None) -> int | None:
-    """Extract an issue number from the canonical factory branch shape."""
     if not branch:
         return None
     match = re.match('^factory/\\d+-(\\d+)-', branch)
@@ -111,18 +100,15 @@ def linked_issue_from_branch(branch: str | None) -> int | None:
 
 
 def producer_worker_from_pr(pr: dict[str, Any]) -> str | None:
-    """Recover producer identity using the shared review provenance policy."""
     return producer_worker_from_values(branch=str(pr.get('headRefName') or ''), body=str(pr.get('body') or ''))
 
 
 def stage_of(labels: Iterable[str]) -> str | None:
-    """Return the deterministic current factory lifecycle stage."""
     present = set(labels)
     return next((label for label in STAGE_PRECEDENCE if label in present), None)
 
 
 def provenance_lane(labels: set[str]) -> int:
-    """Return the deterministic assignment lane for a label set."""
     if 'e2e-discovered' in labels:
         return 4
     if labels & INFRA_LABELS:
@@ -133,22 +119,15 @@ def provenance_lane(labels: set[str]) -> int:
 
 
 def item_is_unowned(labels: set[str]) -> bool:
-    """Return whether a label set has no active factory owner."""
     return owner_of(labels) in (None, 'factory:unowned')
 
 
 def issue_bypasses_wip_limit(issue: dict[str, Any]) -> bool:
-    """Keep genuinely urgent product defects executable while the PR queue drains."""
     labels = labels_of(issue)
-    return (
-        ('user-reported' in labels and 'bug' in labels)
-        or 'priority:P0' in labels
-        or 'ralph-priority:critical' in labels
-    )
+    return (('user-reported' in labels and 'bug' in labels) or 'priority:P0' in labels or 'ralph-priority:critical' in labels)
 
 
 def factory_pr_wip_count(prs: Iterable[dict[str, Any]]) -> int:
-    """Count open non-draft factory PRs that still consume delivery capacity."""
     count = 0
     for pr in prs:
         if str(pr.get('state') or 'OPEN').upper() != 'OPEN' or pr.get('isDraft'):
@@ -160,8 +139,14 @@ def factory_pr_wip_count(prs: Iterable[dict[str, Any]]) -> int:
     return count
 
 
+def pr_is_conflicted(pr: dict[str, Any]) -> bool:
+    """Return whether GitHub reports the current PR head as merge-conflicted."""
+    mergeable = str(pr.get('mergeable') or '').upper()
+    merge_state = str(pr.get('mergeStateStatus') or '').upper()
+    return mergeable == 'CONFLICTING' or merge_state == 'DIRTY'
+
+
 def issue_is_static_candidate(issue: dict[str, Any], suppressing_pr_issues: set[int]) -> bool:
-    """Return whether an issue is structurally eligible for assignment."""
     number = int(issue['number'])
     labels = labels_of(issue)
     title = str(issue.get('title') or '')
@@ -179,7 +164,6 @@ def issue_is_static_candidate(issue: dict[str, Any], suppressing_pr_issues: set[
 
 
 def pr_is_static_candidate(pr: dict[str, Any], issue_map: dict[int, dict[str, Any]]) -> bool:
-    """Return whether an open factory PR is structurally eligible for work."""
     if str(pr.get('state') or 'OPEN').upper() != 'OPEN' or pr.get('isDraft'):
         return False
     labels = labels_of(pr)
@@ -199,13 +183,6 @@ def pr_is_static_candidate(pr: dict[str, Any], issue_map: dict[int, dict[str, An
 
 
 def pr_suppresses_issue_candidate(pr: dict[str, Any], issue_map: dict[int, dict[str, Any]]) -> bool:
-    """Return whether this PR should stand in for its linked issue in the queue.
-
-    Ready PRs are owned by the merge controller. Other PRs suppress duplicate
-    issue implementation only when the PR itself is executable. Draft, blocked,
-    closed, or otherwise ineligible PRs must never make the linked issue
-    disappear.
-    """
     if str(pr.get('state') or 'OPEN').upper() != 'OPEN':
         return False
     labels = labels_of(pr)
@@ -215,11 +192,9 @@ def pr_suppresses_issue_candidate(pr: dict[str, Any], issue_map: dict[int, dict[
 
 
 def build_candidates(issues: list[dict[str, Any]], prs: list[dict[str, Any]]) -> list[Candidate]:
-    """Build and rank executable issue and pull-request candidates."""
     issue_map = {int(issue['number']): issue for issue in issues}
     suppressing_pr_issues = {
-        linked
-        for pr in prs
+        linked for pr in prs
         if (linked := linked_issue_from_branch(pr.get('headRefName'))) is not None
         and pr_suppresses_issue_candidate(pr, issue_map)
     }
@@ -231,16 +206,7 @@ def build_candidates(issues: list[dict[str, Any]], prs: list[dict[str, Any]]) ->
         if pr_wip_full and not issue_bypasses_wip_limit(issue):
             continue
         labels = labels_of(issue)
-        candidates.append(
-            Candidate(
-                kind='issue',
-                number=int(issue['number']),
-                lane=provenance_lane(labels),
-                priority=priority_rank(labels),
-                created_at=str(issue.get('createdAt') or ''),
-                stage=stage_of(labels),
-            )
-        )
+        candidates.append(Candidate(kind='issue', number=int(issue['number']), lane=provenance_lane(labels), priority=priority_rank(labels), created_at=str(issue.get('createdAt') or ''), stage=stage_of(labels)))
     for pr in prs:
         if not pr_is_static_candidate(pr, issue_map):
             continue
@@ -252,64 +218,41 @@ def build_candidates(issues: list[dict[str, Any]], prs: list[dict[str, Any]]) ->
         lane = provenance_lane(labels)
         if lane == 1:
             lane = 2
-        candidates.append(
-            Candidate(
-                kind='pr',
-                number=int(pr['number']),
-                lane=lane,
-                priority=priority_rank(labels),
-                created_at=str(pr.get('createdAt') or ''),
-                linked_issue=linked,
-                stage=stage_of(pr_labels),
-                producer_worker=producer_worker_from_pr(pr),
-            )
-        )
+        candidates.append(Candidate(kind='pr', number=int(pr['number']), lane=lane, priority=priority_rank(labels), created_at=str(pr.get('createdAt') or ''), linked_issue=linked, stage=stage_of(pr_labels), producer_worker=producer_worker_from_pr(pr), conflicted=pr_is_conflicted(pr)))
     return sorted(candidates, key=Candidate.sort_key)
 
 
 def review_capacity_worker(worker: str) -> bool:
-    """Compatibility helper retained for older tests and callers."""
     return int(worker) % 4 == 2
 
 
 def candidate_is_independent_for_worker(candidate: Candidate, worker: str) -> bool:
-    """Prevent a producing factory from being assigned semantic review of its PR."""
-    return not (
-        candidate.kind == 'pr'
-        and candidate.stage == 'factory:review'
-        and candidate.producer_worker == worker
-    )
+    return not (candidate.kind == 'pr' and candidate.stage == 'factory:review' and candidate.producer_worker == worker)
 
 
 def order_candidates_for_worker(candidates: list[Candidate], worker: str) -> list[Candidate]:
-    """Drain existing PRs before starting new issue implementation."""
-    eligible = [
-        candidate
-        for candidate in candidates
-        if candidate_is_independent_for_worker(candidate, worker)
-    ]
+    """Drain conflicted PRs first, then other existing PR work, before new issues."""
+    eligible = [candidate for candidate in candidates if candidate_is_independent_for_worker(candidate, worker)]
 
     def work_class(candidate: Candidate) -> int:
         if candidate.kind == 'pr':
-            if candidate.stage == 'factory:ci':
+            if candidate.conflicted:
                 return 0
-            if candidate.stage == 'factory:changes-requested':
+            if candidate.stage == 'factory:ci':
                 return 1
-            if candidate.stage == 'factory:review':
+            if candidate.stage == 'factory:changes-requested':
                 return 2
-            return 3
-        if candidate.lane == 1:
+            if candidate.stage == 'factory:review':
+                return 3
             return 4
-        return 5
+        if candidate.lane == 1:
+            return 5
+        return 6
 
-    return sorted(
-        eligible,
-        key=lambda candidate: (work_class(candidate), candidate.sort_key()),
-    )
+    return sorted(eligible, key=lambda candidate: (work_class(candidate), candidate.sort_key()))
 
 
 def plan_distinct_assignments(candidates: list[Candidate], workers: list[str]) -> dict[str, Candidate]:
-    """Pure helper used by regression coverage for one dispatcher batch."""
     remaining = list(candidates)
     assignments: dict[str, Candidate] = {}
     for worker in workers:
@@ -323,7 +266,6 @@ def plan_distinct_assignments(candidates: list[Candidate], workers: list[str]) -
 
 
 def lease_is_stale(owner: str, *, active_fixed_workers: set[int], latest_activity_epoch: int | None, now_epoch: int, local_ttl_seconds: int=LOCAL_LEASE_TTL_SECONDS) -> bool:
-    """Return whether a factory lease can be proven stale."""
     if owner == 'factory:local':
         return latest_activity_epoch is not None and now_epoch - latest_activity_epoch > local_ttl_seconds
     match = FIXED_OWNER_RE.fullmatch(owner)

--- a/.github/scripts/test_factory_work_policy.py
+++ b/.github/scripts/test_factory_work_policy.py
@@ -17,6 +17,8 @@ def factory_pr(
     stage: str = "factory:review",
     worker: int = 20,
     linked_issue: int | None = None,
+    mergeable: str = "MERGEABLE",
+    merge_state: str = "CLEAN",
 ) -> dict[str, object]:
     issue = linked_issue if linked_issue is not None else 9000 + number
     return {
@@ -27,6 +29,8 @@ def factory_pr(
         "headRefName": f"factory/{worker}-{issue}-test",
         "body": f"Worker: opencode-free-model-factory-{worker}",
         "createdAt": "2026-08-17T00:00:00Z",
+        "mergeable": mergeable,
+        "mergeStateStatus": merge_state,
     }
 
 
@@ -41,6 +45,33 @@ def issue(number: int, *extra_labels: str) -> dict[str, object]:
 
 
 class CompletionFirstOrderingTests(unittest.TestCase):
+    def test_conflicted_pr_beats_ci_changes_and_review(self) -> None:
+        candidates = [
+            Candidate("pr", 1, 3, 0, "", stage="factory:review"),
+            Candidate("pr", 2, 3, 0, "", stage="factory:changes-requested"),
+            Candidate("pr", 3, 3, 0, "", stage="factory:ci"),
+            Candidate("pr", 4, 3, 0, "", stage="factory:review", conflicted=True),
+        ]
+        self.assertEqual(
+            [item.number for item in order_candidates_for_worker(candidates, "9")],
+            [4, 3, 2, 1],
+        )
+
+    def test_build_candidates_marks_github_conflict_state(self) -> None:
+        candidates = build_candidates(
+            [],
+            [factory_pr(5, mergeable="CONFLICTING", merge_state="DIRTY")],
+        )
+        self.assertEqual(len(candidates), 1)
+        self.assertTrue(candidates[0].conflicted)
+
+    def test_dirty_merge_state_is_enough_to_mark_conflict(self) -> None:
+        candidates = build_candidates(
+            [],
+            [factory_pr(5, mergeable="UNKNOWN", merge_state="DIRTY")],
+        )
+        self.assertTrue(candidates[0].conflicted)
+
     def test_review_pr_beats_ordinary_issue_for_non_review_worker(self) -> None:
         candidates = [
             Candidate("issue", 1, 3, 4, "2026-08-17T00:00:00Z"),

--- a/docs/CHATGPT_FACTORY_PROMPT.md
+++ b/docs/CHATGPT_FACTORY_PROMPT.md
@@ -1,19 +1,21 @@
 # ChatGPT Scheduled Factory Prompt
 
-Version: 22
+Version: 23
 
 Use this template for every scheduled ComicPile ChatGPT factory. Replace `<WORKER_NUMBER>`, `<WORKER_ID>`, and `<CALL_SIGN>` with the worker-specific values. The worker-specific identity is the only intended difference between scheduled factory prompts.
 
 ```text
-FACTORY POLICY V22 + GITHUB VISIBILITY + DURABLE RESUME PACKET V1. Act as one high-ownership autonomous software-delivery work session for JoshCLWren/comic-pile. Durable worker ID: `<WORKER_ID>`. Factory call sign: `<CALL_SIGN>`.
+FACTORY POLICY V23 + GITHUB VISIBILITY + DURABLE RESUME PACKET V1. Act as one high-ownership autonomous software-delivery work session for JoshCLWren/comic-pile. Durable worker ID: `<WORKER_ID>`. Factory call sign: `<CALL_SIGN>`.
 
 Read and follow current-main `docs/AUTONOMOUS_FACTORY_POLICY.md`, `docs/ISSUE_EXECUTION_PROTOCOL.md`, relevant `AGENTS.md`, `docs/CHATGPT_FACTORY_PROMPT.md`, and `docs/FACTORY_GITHUB_VISIBILITY.md` when present. Canonical policy wins over conflicting instructions.
 
-PRODUCT-FIRST PRIORITY. Choose work in this order: (1) highest-priority unclaimed open issue labeled both `user-reported` and `bug`, newest first within equal priority; (2) a branch-caused CI/conflict/actionable-review blocker only when the PR directly delivers an equal-or-higher-priority product bug or clearing the blocker can immediately finish/merge that product fix; (3) other branch-caused blockers on substantive product-delivery PRs; (4) reproducible E2E-discovered product bugs; (5) highest-value unclaimed executable product issue, honoring explicit priority and dependencies; (6) required existing-PR work; (7) factory/test infrastructure only when it blocks product delivery. Test-only defects, stale selectors, optional validation, E2E plumbing, docs, release-note work, and CI cosmetics NEVER outrank an executable user-reported/product bug unless they directly block safe validation or merge of that same higher-priority bug.
+FINISH-WORK-FIRST PRIORITY. The controller owns assignment. When assigned an existing PR, finish that PR before considering new issue implementation. Within PR work, resolve merge conflicts first, then failing CI, requested changes, semantic review, and other closure work. When the repository already has five or more open factory PRs, ordinary and infrastructure issues must not start; user-reported bugs, P0, and critical issues may remain executable but still do not outrank already-open PR completion.
 
-The full maintained Chromium discovery suite is an independent daily workflow, not factory fallback work. It preserves traces, screenshots, video, JSON results, backend logs, and run metadata after failures, then creates or updates focused GitHub issues for reproducible product defects. Those issues re-enter this same shared factory pool as normal executable work. Firefox and WebKit are optional diagnostics. Never launch the full discovery suite merely because your current work pool is empty. Never treat an empty or blocked backlog as a reason to self-pause or self-disable. Only Josh, or an interactive session acting on Josh's direct instruction, may pause or disable this factory.
+MERGE CONFLICTS ARE ACTIVE REPAIR WORK, NOT A WAIT STATE. At the start of every assigned PR session, inspect GitHub mergeability against current `main`. If the PR is conflicting or dirty, fetch current `main`, merge or rebase it into the PR branch using the repository's normal branch policy, resolve every conflict by preserving the intended product behavior from both sides, run focused validation for the touched surfaces, and push the repaired PR head. Never abandon a conflicted PR merely because GitHub cannot merge it. Never open a replacement PR for the same work solely to escape conflicts. After any conflict-resolution push, prior review conclusions are stale and the PR must return through exact-head review/CI before merge.
 
-A HEARTBEAT IS A WORK SESSION, NOT A ONE-TICKET PUNCH. After every fix, PR open, merge, blocker, or completed issue, immediately rerun selection and continue the next highest-priority executable work in the SAME scheduled run. Do not end merely because you achieved one valid outcome, because CI/review is pending, or because the current item became blocked. Preserve/release ownership as appropriate and move to the next item. Continue until the runtime/tool budget makes further safe substantive work impossible. If no executable work remains, release any active lease, record a truthful no-work completion, and end the current session cleanly; the independent daily Chromium discovery workflow owns backlog replenishment.
+RAW E2E FAILURES ARE NOT FACTORY WORK ITEMS. Do not select a failing Playwright/Chromium test, create an executable issue merely because a test failed, or treat E2E maintenance as idle fallback work. Browser failures are evidence for triage. Only a canonical product issue that has already been intentionally admitted to the shared work queue may become factory work. Test-only defects, stale selectors, optional validation, E2E plumbing, docs, release-note work, and CI cosmetics never outrank existing PR completion or executable user-reported/product bugs unless they directly block safe validation or merge of that same higher-priority work.
+
+A HEARTBEAT IS A WORK SESSION, NOT A ONE-TICKET PUNCH. After every fix, PR open, merge, blocker, or completed issue, immediately rerun controller selection and continue the next highest-priority executable work in the SAME scheduled run. Do not end merely because you achieved one valid outcome, because CI/review is pending, or because the current item became blocked. Preserve/release ownership as appropriate and move to the next item. Continue until the runtime/tool budget makes further safe substantive work impossible. If no executable work remains, release any active lease, record a truthful no-work completion, and end the current session cleanly.
 
 Keep workers separate and respect truthful GitHub ownership. An interactive session that pauses/disables a worker must release that worker's open claims to `factory:unowned` while preserving the truthful workflow-stage label and resume packet; paused workers must not strand work. Scheduled workers should not infer pause solely from a missed heartbeat, but may take over explicitly unowned/released work.
 
@@ -25,9 +27,9 @@ Keep canonical GitHub marker comments exact. Maintain `factory`, exactly one own
 
 Release notes are post-merge infrastructure. Implementation workers must not create, repair, or gate delivery on `docs/changelog.d` fragments or `/changelog.md`. The dedicated release writer publishes merged user-facing work to the database-backed release ledger and reconciliation owns missed records. A release-writer outage may become its own delivery bug, but it never turns Markdown release-note work back into an implementation merge gate.
 
-Use formal GitHub review state only when truthful and technically possible. Never fake self-approval. Before merging, inspect the exact current head, required checks, reviews, and inline threads. Fix or resolve every actionable finding. Every push invalidates earlier conclusions.
+Use formal GitHub review state only when truthful and technically possible. Never fake self-approval. Before merging, inspect the exact current head, required checks, reviews, inline threads, and mergeability. Fix or resolve every actionable finding. Every push invalidates earlier conclusions.
 
-Merge without asking again only when the current PR is open, non-draft, conflict-free, mergeable, fully green, complete, safe, and free of unresolved actionable findings. Never enable auto-merge or merge a moved head. Verify issue closure afterward.
+Merge without asking again only when the current PR is open, non-draft, conflict-free, mergeable, fully green where required checks exist, complete, safe, and free of unresolved actionable findings. Never enable auto-merge or merge a moved head. Verify issue closure afterward.
 
 Substantive progress is the minimum for a heartbeat while executable work exists, not a stop condition. Continue selecting and delivering work until the run's runtime/tool budget is exhausted or the shared executable pool is genuinely empty. Never push directly to main, create drafts without Josh's request, weaken checks, fabricate evidence, or count metadata-only work as progress.
 
@@ -50,7 +52,7 @@ Every user-visible update must use this exact structure:
 `## 🏭 Factory <WORKER_NUMBER> · <CALL_SIGN>`
 `Worked on: <PR #N, issue #N, factory workflow, or multiple items> · Outcome: <merged, fixed, opened, blocked, or still running>`
 
-Then write 2-4 short, natural sentences in plain English summarizing the most important truthful outcomes from the whole work session, not merely the final ticket. Include factory workflow repairs, E2E evidence, and blocked or still-running outcomes when no product change occurred.
+Then write 2-4 short, natural sentences in plain English summarizing the most important truthful outcomes from the whole work session, not merely the final ticket. Include factory workflow repairs and blocked or still-running outcomes when no product change occurred.
 
 Rules:
 - Maximum 90 words after the two header lines.


### PR DESCRIPTION
## What changed

- fetch GitHub mergeability in the factory controller
- classify `CONFLICTING` / `DIRTY` PRs as explicit conflict-repair candidates
- rank conflicted PRs ahead of CI failures, requested changes, semantic review, and all new issue work
- move a claimed conflicted PR into `factory:changes-requested` so the lease truthfully represents repair work
- return the `conflicted` reason in controller assignment output
- update the canonical factory prompt to require resolving current-main conflicts rather than abandoning or replacing the PR
- remove the stale raw-E2E-as-fallback guidance from the canonical prompt
- add regression coverage proving conflict-first ordering and GitHub conflict-state detection

This builds directly on PR #1485's PR-drain-first policy and closes the merge-conflict starvation gap.