### PR TITLE
Retire Factory 12 GPT OSS 120B

### DIFF
--- a/.github/free-model-factories.tsv
+++ b/.github/free-model-factories.tsv
@@ -3,7 +3,6 @@
 9	nvidia	stepfun-ai/step-3.7-flash	15	dispatcher	Step 3.7 Flash
 10	nvidia	nvidia/nemotron-3-ultra-550b-a55b	20	dispatcher	Nemotron 3 Ultra
 11	nvidia	poolside/laguna-xs-2.1	25	dispatcher	Laguna XS 2.1
-12	nvidia	openai/gpt-oss-120b	30	dispatcher	GPT OSS 120B
 14	nvidia	minimaxai/minimax-m3	40	dispatcher	MiniMax M3
 16	nvidia	nvidia/nemotron-3-super-120b-a12b	50	dispatcher	Nemotron 3 Super
 17	nvidia	nvidia/nemotron-3-nano-omni-30b-a3b-reasoning	55	dispatcher	Nemotron 3 Omni


### PR DESCRIPTION
Remove Factory 12 / NVIDIA GPT OSS 120B from the active fixed-model roster after poor production performance and a misleading incomplete implementation on PR #1495. Preserve all other factory numbers and schedules unchanged.